### PR TITLE
Fix: return of mix in fluid

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: v1.2.0
     hooks:
       - id: mypy
-        files: ^(src/ecalc/libraries/libecalc)
+        files: ^(src/ecalc/libraries/)
         exclude: tests|src/ecalc/libraries/libecalc/common/libecalc/input/yaml
         args: ['--config-file=./pyproject.toml']
         additional_dependencies:

--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/fluid.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/fluid.py
@@ -179,7 +179,7 @@ class FluidStream:
         new_fluid_stream = self.copy()
         new_fluid_stream._neqsim_fluid_stream = new_fluid_stream._neqsim_fluid_stream.set_new_pressure_and_enthalpy(
             new_pressure=new_pressure,
-            new_enthalpy_J_per_kg=new_fluid_stream._neqsim_fluid_stream.enthalpy_joule_per_kg
+            new_enthalpy_joule_per_kg=new_fluid_stream._neqsim_fluid_stream.enthalpy_joule_per_kg
             + enthalpy_change_J_per_kg,
             remove_liquid=remove_liquid,
         )

--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/fluid.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/fluid.py
@@ -67,7 +67,7 @@ class FluidStream:
 
         self._neqsim_fluid_stream = NeqsimFluid.create_thermo_system(
             composition=self._map_fluid_composition_to_neqsim(fluid_composition=self.fluid_model.composition),
-            temperature_Kelvin=temperature_kelvin,
+            temperature_kelvin=temperature_kelvin,
             pressure_bara=pressure_bara,
             eos_model=_map_eos_model_to_neqsim[self.fluid_model.eos_model],
         )
@@ -81,7 +81,7 @@ class FluidStream:
         else:
             _neqsim_fluid_at_standard_conditions = NeqsimFluid.create_thermo_system(
                 composition=self._map_fluid_composition_to_neqsim(fluid_composition=self.fluid_model.composition),
-                temperature_Kelvin=UnitConstants.STANDARD_TEMPERATURE_KELVIN,
+                temperature_kelvin=UnitConstants.STANDARD_TEMPERATURE_KELVIN,
                 pressure_bara=UnitConstants.STANDARD_PRESSURE_BARA,
                 eos_model=_map_eos_model_to_neqsim[self.fluid_model.eos_model],
             )
@@ -179,7 +179,8 @@ class FluidStream:
         new_fluid_stream = self.copy()
         new_fluid_stream._neqsim_fluid_stream = new_fluid_stream._neqsim_fluid_stream.set_new_pressure_and_enthalpy(
             new_pressure=new_pressure,
-            new_enthalpy_J_per_kg=new_fluid_stream._neqsim_fluid_stream.enthalpy_J_per_kg + enthalpy_change_J_per_kg,
+            new_enthalpy_J_per_kg=new_fluid_stream._neqsim_fluid_stream.enthalpy_joule_per_kg
+            + enthalpy_change_J_per_kg,
             remove_liquid=remove_liquid,
         )
         return new_fluid_stream

--- a/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_fluid.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_fluid.py
@@ -34,7 +34,7 @@ def test_set_new_pressure_and_enthalpy_or_temperature(fluid_streams: List[List[F
     pressure_increase_factor = 3.0
 
     inlet_enthalpies_all_fluids = [
-        np.asarray([s._neqsim_fluid_stream.enthalpy_J_per_kg for s in stream]) for stream in fluid_streams
+        np.asarray([s._neqsim_fluid_stream.enthalpy_joule_per_kg for s in stream]) for stream in fluid_streams
     ]
 
     new_enthalpies_all_fluids = [
@@ -128,7 +128,7 @@ def test_set_new_pressure_and_enthalpy_or_temperature(fluid_streams: List[List[F
         )
     ]
     new_enthalpies_all_fluids_after_setting_new_temperature = [
-        np.asarray([s._neqsim_fluid_stream.enthalpy_J_per_kg for s in streams])
+        np.asarray([s._neqsim_fluid_stream.enthalpy_joule_per_kg for s in streams])
         for streams in streams_with_new_pressure_and_temperature
     ]
     np.testing.assert_allclose(

--- a/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
+++ b/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
@@ -52,7 +52,7 @@ class NeqsimFluid:
         eos_model: NeqsimEoSModelType = NeqsimEoSModelType.SRK,
         mixing_rule: int = NEQSIM_MIXING_RULE,
     ) -> NeqsimFluid:
-        """Initates a NeqsimFluid that wrapps both a Neqsim thermodynamic system and operations.
+        """Initiates a NeqsimFluid that wraps both a Neqsim thermodynamic system and operations.
 
         TPflash: computes composition in each phase and densities
         init(3): computes all higher order thermodynamic properties, e.g. Cp/Cv,
@@ -63,7 +63,7 @@ class NeqsimFluid:
         :param composition: A dict with the composition of the thermodynamic_system components name: molar fraction.
         :param temperature_kelvin: The initial system temperature in Kelvin
         :param pressure_bara: The initial system pressure in absolute bar
-        :param eos_model: The name of the underlaying EOS model
+        :param eos_model: The name of the underlying EOS model
         :param mixing_rule: The Neqsim mixing rule.
         :return:
         """
@@ -92,20 +92,12 @@ class NeqsimFluid:
     def _init_thermo_system(
         components: List[str],
         molar_fraction: List[float],
-        eos_model,
-        temperature_kelvin,
-        pressure_bara,
-        mixing_rule,
+        eos_model: NeqsimEoSModelType,
+        temperature_kelvin: float,
+        pressure_bara: float,
+        mixing_rule: int,
     ) -> ThermodynamicSystem:
-        """LRU cache maxsize based on running all e2e test cases. 256, 512, 1024, 2048 and 4096 as of 2021-12-07.
-            4096: 1:33
-            2048: 1:22
-            1024: 1:23
-            512: 1:21
-            256: 1:21.
-
-        For the web service we would like to consider a larger maxsize such as 2048, but this we need to consider later.
-        """
+        """Initialize thermodynamic system"""
         use_gerg = "gerg" in eos_model.name.lower()
 
         thermodynamic_system = eos_model.value(float(temperature_kelvin), float(pressure_bara))
@@ -269,14 +261,14 @@ class NeqsimFluid:
         return NeqsimFluid(thermodynamic_system=self._thermodynamic_system.clone(), use_gerg=self._use_gerg)
 
     def set_new_pressure_and_enthalpy(
-        self, new_pressure: float, new_enthalpy_J_per_kg: float, remove_liquid: bool = True
+        self, new_pressure: float, new_enthalpy_joule_per_kg: float, remove_liquid: bool = True
     ) -> NeqsimFluid:
         new_thermodynamic_system = self._thermodynamic_system.clone()
         new_thermodynamic_system.setPressure(float(new_pressure), "bara")
 
         new_thermodynamic_system = NeqsimFluid._ph_flash(
             thermodynamic_system=new_thermodynamic_system,
-            enthalpy=new_enthalpy_J_per_kg,
+            enthalpy=new_enthalpy_joule_per_kg,
             use_gerg=self._use_gerg,
         )
 

--- a/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
+++ b/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
@@ -215,19 +215,25 @@ class NeqsimFluid:
         pressure: float,
         temperature: float,
         eos_model: NeqsimEoSModelType = NeqsimEoSModelType.SRK,
-    ) -> Tuple[dict, NeqsimFluid]:
+    ) -> Tuple[Dict, NeqsimFluid]:
         """Mixing two streams (NeqsimFluids) with same pressure and temperature."""
         if stream_1 is None:
-            return stream_2.set_new_pressure_and_temperature(
-                new_pressure_bara=pressure, new_temperature_kelvin=temperature
+            return (
+                {},  # Fixme: Need to return composition dict
+                stream_2.set_new_pressure_and_temperature(
+                    new_pressure_bara=pressure, new_temperature_kelvin=temperature
+                ),
             )
         if stream_2 is None:
-            return stream_1.set_new_pressure_and_temperature(
-                new_pressure_bara=pressure,
-                new_temperature_kelvin=temperature,
+            return (
+                {},  # Fixme: Need to return composition dict
+                stream_1.set_new_pressure_and_temperature(
+                    new_pressure_bara=pressure,
+                    new_temperature_kelvin=temperature,
+                ),
             )
 
-        composition_dict = {}
+        composition_dict: Dict[str, float] = {}
 
         mol_per_hour_1 = mass_rate_stream_1 / stream_1.molar_mass
         mol_per_hour_2 = mass_rate_stream_2 / stream_2.molar_mass

--- a/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
+++ b/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
@@ -47,7 +47,7 @@ class NeqsimFluid:
     def create_thermo_system(
         cls,
         composition: Dict[str, float],
-        temperature_Kelvin: float = STANDARD_TEMPERATURE_KELVIN,
+        temperature_kelvin: float = STANDARD_TEMPERATURE_KELVIN,
         pressure_bara: float = STANDARD_PRESSURE_BARA,
         eos_model: NeqsimEoSModelType = NeqsimEoSModelType.SRK,
         mixing_rule: int = NEQSIM_MIXING_RULE,
@@ -61,7 +61,7 @@ class NeqsimFluid:
         Not necessary here because compressor.run-method does flash on inlet and outlet.
 
         :param composition: A dict with the composition of the thermodynamic_system components name: molar fraction.
-        :param temperature_Kelvin: The initial system temperature in Kelvin
+        :param temperature_kelvin: The initial system temperature in Kelvin
         :param pressure_bara: The initial system pressure in absolute bar
         :param eos_model: The name of the underlaying EOS model
         :param mixing_rule: The Neqsim mixing rule.
@@ -80,7 +80,7 @@ class NeqsimFluid:
             components=components,
             molar_fraction=molar_fractions,
             eos_model=eos_model,
-            temperature_Kelvin=temperature_Kelvin,
+            temperature_kelvin=temperature_kelvin,
             pressure_bara=pressure_bara,
             mixing_rule=mixing_rule,
         )
@@ -93,7 +93,7 @@ class NeqsimFluid:
         components: List[str],
         molar_fraction: List[float],
         eos_model,
-        temperature_Kelvin,
+        temperature_kelvin,
         pressure_bara,
         mixing_rule,
     ) -> ThermodynamicSystem:
@@ -108,7 +108,7 @@ class NeqsimFluid:
         """
         use_gerg = "gerg" in eos_model.name.lower()
 
-        thermodynamic_system = eos_model.value(float(temperature_Kelvin), float(pressure_bara))
+        thermodynamic_system = eos_model.value(float(temperature_kelvin), float(pressure_bara))
 
         [
             thermodynamic_system.addComponent(component, float(value))
@@ -150,7 +150,7 @@ class NeqsimFluid:
             return self._thermodynamic_system.getZ()
 
     @property
-    def enthalpy_J_per_kg(self) -> float:
+    def enthalpy_joule_per_kg(self) -> float:
         if self._use_gerg:
             return self._gerg_properties.enthalpy_joule_per_kg
         else:
@@ -194,7 +194,7 @@ class NeqsimFluid:
         """
         thermodynamic_operations = ThermodynamicOperations(thermodynamic_system)
         if use_gerg:
-            enthalpy_joule = _get_enthalpy_joule_for_GERG2008_Joule_per_kg(
+            enthalpy_joule = _get_enthalpy_joule_for_GERG2008_joule_per_kg(
                 enthalpy=enthalpy, thermodynamic_system=thermodynamic_system
             )
             thermodynamic_operations.PHflashGERG2008(float(enthalpy_joule))
@@ -248,7 +248,7 @@ class NeqsimFluid:
             composition_dict,
             NeqsimFluid.create_thermo_system(
                 composition=composition_dict,
-                temperature_Kelvin=temperature,
+                temperature_kelvin=temperature,
                 pressure_bara=pressure,
                 eos_model=eos_model,
             ),
@@ -346,5 +346,5 @@ def get_GERG2008_properties(thermodynamic_system: ThermodynamicSystem):
     )
 
 
-def _get_enthalpy_joule_for_GERG2008_Joule_per_kg(enthalpy: float, thermodynamic_system: ThermodynamicSystem) -> float:
+def _get_enthalpy_joule_for_GERG2008_joule_per_kg(enthalpy: float, thermodynamic_system: ThermodynamicSystem) -> float:
     return enthalpy * thermodynamic_system.getTotalNumberOfMoles() * thermodynamic_system.getMolarMass()

--- a/src/ecalc/libraries/neqsim/tests/integration_tests/test_gerg_fluid.py
+++ b/src/ecalc/libraries/neqsim/tests/integration_tests/test_gerg_fluid.py
@@ -31,12 +31,12 @@ def test_gerg_model_against_unisim(medium_fluid_with_gerg: NeqsimFluid) -> None:
     assert math.isclose(very_high_pressure.z, 1.65, rel_tol=0.01)
 
     assert math.isclose(
-        low_pressure.enthalpy_J_per_kg - medium_pressure.enthalpy_J_per_kg, 17634 - -93366, rel_tol=0.01
+        low_pressure.enthalpy_joule_per_kg - medium_pressure.enthalpy_joule_per_kg, 17634 - -93366, rel_tol=0.01
     )
     assert math.isclose(
-        medium_pressure.enthalpy_J_per_kg - high_pressure.enthalpy_J_per_kg, -93366 - -219900, rel_tol=0.02
+        medium_pressure.enthalpy_joule_per_kg - high_pressure.enthalpy_joule_per_kg, -93366 - -219900, rel_tol=0.02
     )
 
     assert math.isclose(
-        high_pressure.enthalpy_J_per_kg - very_high_pressure.enthalpy_J_per_kg, -219900 - -194900, rel_tol=0.02
+        high_pressure.enthalpy_joule_per_kg - very_high_pressure.enthalpy_joule_per_kg, -219900 - -194900, rel_tol=0.02
     )

--- a/src/ecalc/libraries/neqsim/tests/integration_tests/test_remove_liquid.py
+++ b/src/ecalc/libraries/neqsim/tests/integration_tests/test_remove_liquid.py
@@ -72,7 +72,7 @@ def inlet_fluid() -> NeqsimFluid:
     See outlet fluid below.
     """
     return NeqsimFluid.create_thermo_system(
-        composition=INLET_FLUID_COMPOSITION, temperature_Kelvin=36.0 + 273.15, pressure_bara=1700 / 100
+        composition=INLET_FLUID_COMPOSITION, temperature_kelvin=36.0 + 273.15, pressure_bara=1700 / 100
     )
 
 
@@ -80,7 +80,7 @@ def inlet_fluid() -> NeqsimFluid:
 def outlet_fluid() -> NeqsimFluid:
     """Inlet liquid to test liquids takeoff compared to UniSim. see inlet conditions above."""
     return NeqsimFluid.create_thermo_system(
-        composition=OUTLET_FLUID_COMPOSITION, temperature_Kelvin=38 + 273.15, pressure_bara=4327.67395 / 100
+        composition=OUTLET_FLUID_COMPOSITION, temperature_kelvin=38 + 273.15, pressure_bara=4327.67395 / 100
     )
 
 
@@ -129,4 +129,6 @@ def test_liquid_takeoff(inlet_fluid, outlet_fluid) -> None:
     assert math.isclose(outlet_fluid.density, fluid_after_liquid_takeoff.density, rel_tol=0.01)
     assert math.isclose(outlet_fluid.pressure_bara, fluid_after_liquid_takeoff.pressure_bara, rel_tol=0.01)
     assert math.isclose(outlet_fluid.molar_mass, fluid_after_liquid_takeoff.molar_mass, rel_tol=0.01)
-    assert math.isclose(outlet_fluid.enthalpy_J_per_kg, fluid_after_liquid_takeoff.enthalpy_J_per_kg, rel_tol=0.5)
+    assert math.isclose(
+        outlet_fluid.enthalpy_joule_per_kg, fluid_after_liquid_takeoff.enthalpy_joule_per_kg, rel_tol=0.5
+    )

--- a/src/ecalc/libraries/neqsim/tests/unit_tests/test_neqsim_fluid.py
+++ b/src/ecalc/libraries/neqsim/tests/unit_tests/test_neqsim_fluid.py
@@ -5,10 +5,10 @@ from neqsim_ecalc_wrapper.thermo import NeqsimFluid
 
 def test_gerg_properties(medium_fluid: NeqsimFluid, medium_fluid_with_gerg: NeqsimFluid) -> None:
     medium_fluid_np_ne = medium_fluid.set_new_pressure_and_enthalpy(
-        new_pressure=20.0, new_enthalpy_J_per_kg=medium_fluid.enthalpy_joule_per_kg + 10000
+        new_pressure=20.0, new_enthalpy_joule_per_kg=medium_fluid.enthalpy_joule_per_kg + 10000
     )
     medium_fluid_with_gerg_np_ne = medium_fluid_with_gerg.set_new_pressure_and_enthalpy(
-        new_pressure=20.0, new_enthalpy_J_per_kg=medium_fluid_with_gerg.enthalpy_joule_per_kg + 10000
+        new_pressure=20.0, new_enthalpy_joule_per_kg=medium_fluid_with_gerg.enthalpy_joule_per_kg + 10000
     )
     assert (
         medium_fluid_with_gerg_np_ne.enthalpy_joule_per_kg - medium_fluid_with_gerg.enthalpy_joule_per_kg
@@ -92,19 +92,19 @@ def test_fluid_set_new_pressure_and_enthalpy(heavy_fluid: NeqsimFluid) -> None:
     fluid = heavy_fluid
 
     increase_enthalpy = fluid.set_new_pressure_and_enthalpy(
-        new_pressure=fluid.pressure_bara, new_enthalpy_J_per_kg=fluid.enthalpy_joule_per_kg * 2
+        new_pressure=fluid.pressure_bara, new_enthalpy_joule_per_kg=fluid.enthalpy_joule_per_kg * 2
     )
 
     decrease_enthalpy = fluid.set_new_pressure_and_enthalpy(
-        new_pressure=fluid.pressure_bara, new_enthalpy_J_per_kg=fluid.enthalpy_joule_per_kg / 2
+        new_pressure=fluid.pressure_bara, new_enthalpy_joule_per_kg=fluid.enthalpy_joule_per_kg / 2
     )
 
     increase_pressure = fluid.set_new_pressure_and_enthalpy(
-        new_pressure=fluid.pressure_bara * 2, new_enthalpy_J_per_kg=fluid.enthalpy_joule_per_kg
+        new_pressure=fluid.pressure_bara * 2, new_enthalpy_joule_per_kg=fluid.enthalpy_joule_per_kg
     )
 
     decrease_pressure = fluid.set_new_pressure_and_enthalpy(
-        new_pressure=fluid.pressure_bara / 2, new_enthalpy_J_per_kg=fluid.enthalpy_joule_per_kg
+        new_pressure=fluid.pressure_bara / 2, new_enthalpy_joule_per_kg=fluid.enthalpy_joule_per_kg
     )
 
     assert (

--- a/src/ecalc/libraries/neqsim/tests/unit_tests/test_neqsim_fluid.py
+++ b/src/ecalc/libraries/neqsim/tests/unit_tests/test_neqsim_fluid.py
@@ -5,27 +5,28 @@ from neqsim_ecalc_wrapper.thermo import NeqsimFluid
 
 def test_gerg_properties(medium_fluid: NeqsimFluid, medium_fluid_with_gerg: NeqsimFluid) -> None:
     medium_fluid_np_ne = medium_fluid.set_new_pressure_and_enthalpy(
-        new_pressure=20.0, new_enthalpy_J_per_kg=medium_fluid.enthalpy_J_per_kg + 10000
+        new_pressure=20.0, new_enthalpy_J_per_kg=medium_fluid.enthalpy_joule_per_kg + 10000
     )
     medium_fluid_with_gerg_np_ne = medium_fluid_with_gerg.set_new_pressure_and_enthalpy(
-        new_pressure=20.0, new_enthalpy_J_per_kg=medium_fluid_with_gerg.enthalpy_J_per_kg + 10000
+        new_pressure=20.0, new_enthalpy_J_per_kg=medium_fluid_with_gerg.enthalpy_joule_per_kg + 10000
     )
-    assert medium_fluid_with_gerg_np_ne.enthalpy_J_per_kg - medium_fluid_with_gerg.enthalpy_J_per_kg == pytest.approx(
-        10000
+    assert (
+        medium_fluid_with_gerg_np_ne.enthalpy_joule_per_kg - medium_fluid_with_gerg.enthalpy_joule_per_kg
+        == pytest.approx(10000)
     )
-    assert medium_fluid_np_ne.enthalpy_J_per_kg - medium_fluid.enthalpy_J_per_kg == pytest.approx(10000)
+    assert medium_fluid_np_ne.enthalpy_joule_per_kg - medium_fluid.enthalpy_joule_per_kg == pytest.approx(10000)
 
     # Pinning properties to ensure stability:
     # Before flash
     assert np.isclose(medium_fluid_with_gerg.density, 0.8249053143219223)
     assert np.isclose(medium_fluid_with_gerg.z, 0.9971825132713872)
-    assert np.isclose(medium_fluid_with_gerg.enthalpy_J_per_kg, -21220.02998198086)
+    assert np.isclose(medium_fluid_with_gerg.enthalpy_joule_per_kg, -21220.02998198086)
     assert np.isclose(medium_fluid_with_gerg._gerg_properties.kappa, 1.2719274851916846)
 
     # After flash
     assert np.isclose(medium_fluid_with_gerg_np_ne.density, 16.182809350995125)
     assert np.isclose(medium_fluid_with_gerg_np_ne.z, 0.9532768832922157)
-    assert np.isclose(medium_fluid_with_gerg_np_ne.enthalpy_J_per_kg, -11220.029982279037)
+    assert np.isclose(medium_fluid_with_gerg_np_ne.enthalpy_joule_per_kg, -11220.029982279037)
     assert np.isclose(medium_fluid_with_gerg_np_ne._gerg_properties.kappa, 1.2451895327851366)
 
 
@@ -54,7 +55,7 @@ def test_fluid_z(heavy_fluid: NeqsimFluid) -> None:
 
 
 def test_fluid_enthalpy_J_per_kg(heavy_fluid: NeqsimFluid) -> None:
-    enthalpy_J_per_kg = heavy_fluid.enthalpy_J_per_kg
+    enthalpy_J_per_kg = heavy_fluid.enthalpy_joule_per_kg
     assert isinstance(enthalpy_J_per_kg, float)
     assert np.isclose(enthalpy_J_per_kg, 27365.875930712697)  # Ensure stability in estimate
 
@@ -91,22 +92,24 @@ def test_fluid_set_new_pressure_and_enthalpy(heavy_fluid: NeqsimFluid) -> None:
     fluid = heavy_fluid
 
     increase_enthalpy = fluid.set_new_pressure_and_enthalpy(
-        new_pressure=fluid.pressure_bara, new_enthalpy_J_per_kg=fluid.enthalpy_J_per_kg * 2
+        new_pressure=fluid.pressure_bara, new_enthalpy_J_per_kg=fluid.enthalpy_joule_per_kg * 2
     )
 
     decrease_enthalpy = fluid.set_new_pressure_and_enthalpy(
-        new_pressure=fluid.pressure_bara, new_enthalpy_J_per_kg=fluid.enthalpy_J_per_kg / 2
+        new_pressure=fluid.pressure_bara, new_enthalpy_J_per_kg=fluid.enthalpy_joule_per_kg / 2
     )
 
     increase_pressure = fluid.set_new_pressure_and_enthalpy(
-        new_pressure=fluid.pressure_bara * 2, new_enthalpy_J_per_kg=fluid.enthalpy_J_per_kg
+        new_pressure=fluid.pressure_bara * 2, new_enthalpy_J_per_kg=fluid.enthalpy_joule_per_kg
     )
 
     decrease_pressure = fluid.set_new_pressure_and_enthalpy(
-        new_pressure=fluid.pressure_bara / 2, new_enthalpy_J_per_kg=fluid.enthalpy_J_per_kg
+        new_pressure=fluid.pressure_bara / 2, new_enthalpy_J_per_kg=fluid.enthalpy_joule_per_kg
     )
 
-    assert increase_enthalpy.enthalpy_J_per_kg > fluid.enthalpy_J_per_kg > decrease_enthalpy.enthalpy_J_per_kg
+    assert (
+        increase_enthalpy.enthalpy_joule_per_kg > fluid.enthalpy_joule_per_kg > decrease_enthalpy.enthalpy_joule_per_kg
+    )
 
     assert increase_pressure.pressure_bara > fluid.pressure_bara > decrease_pressure.pressure_bara
 
@@ -144,7 +147,11 @@ def test_fluid_set_new_pressure_and_temperature(heavy_fluid: NeqsimFluid) -> Non
     )
 
     assert increase_temperature.temperature_kelvin > fluid.temperature_kelvin > decrease_temperature.temperature_kelvin
-    assert increase_temperature.enthalpy_J_per_kg > fluid.enthalpy_J_per_kg > decrease_temperature.enthalpy_J_per_kg
+    assert (
+        increase_temperature.enthalpy_joule_per_kg
+        > fluid.enthalpy_joule_per_kg
+        > decrease_temperature.enthalpy_joule_per_kg
+    )
 
     assert increase_pressure.pressure_bara > fluid.pressure_bara > decrease_pressure.pressure_bara
 


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because the function 'mix_in_fluid' returned both 'NeqSimFluid' and 'Tuple[dict, NeqSimFluid]' leading to a potential bug if you don't know if you get a dict or a NeqSimFluid as output of the function

## What does this pull request change?

- Turn on mypy for the neqsimwrapper to avoid future mistakes
- Make consitent casing for units in variable names and functions
- Fix inconsistent return type 

## Issues related to this change:
