### PR TITLE
Evaluate conditions before calculations

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/core/consumers/legacy_consumer/consumer_function/results.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/consumers/legacy_consumer/consumer_function/results.py
@@ -33,7 +33,6 @@ class ConsumerFunctionResultBase(BaseModel):
     time_vector: np.ndarray
     is_valid: np.ndarray
     energy_usage: np.ndarray
-    energy_usage_before_conditioning: Optional[np.ndarray]
     energy_usage_before_power_loss_factor: Optional[np.ndarray]
     condition: Optional[np.ndarray]
     power_loss_factor: Optional[np.ndarray]
@@ -54,6 +53,7 @@ class ConsumerFunctionResult(ConsumerFunctionResultBase):
     typ: Literal[ConsumerFunctionType.SINGLE] = ConsumerFunctionType.SINGLE  # type: ignore[valid-type]
 
     def extend(self, other) -> ConsumerFunctionResult:
+        """This is used when merging different time slots when the energy function of a consumer changes over time."""
         if not isinstance(self, type(other)):
             msg = f"{self.__repr_name__()} Mixing CONSUMER_SYSTEM with non-CONSUMER_SYSTEM is no longer supported."
             logger.warning(msg)
@@ -88,4 +88,5 @@ class ConsumerFunctionResult(ConsumerFunctionResultBase):
 
     @classmethod
     def create_empty(cls) -> ConsumerFunctionResult:
+        """Create empty consumer function result"""
         return cls(time_vector=np.array([]), is_valid=np.array([]), energy_usage=np.array([]))

--- a/src/ecalc/libraries/libecalc/common/libecalc/core/consumers/legacy_consumer/consumer_function/utils.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/consumers/legacy_consumer/consumer_function/utils.py
@@ -16,7 +16,7 @@ def calculate_energy_usage_with_conditions_and_power_loss(
     power_loss_factor_expression: Expression,
     power_usage: Optional[np.ndarray] = None,
 ) -> ConditionsAndPowerLossResult:
-    condition = compute_condition(
+    condition = get_condition_from_expression(
         variables_map=variables_map,
         condition_expression=condition_expression,
     )
@@ -61,15 +61,18 @@ def calculate_energy_usage_with_conditions_and_power_loss(
     )
 
 
-def compute_condition(
+def get_condition_from_expression(
     variables_map: VariablesMap,
     condition_expression: Expression,
 ) -> Optional[np.ndarray]:
     """Evaluate condition expression and compute resulting condition vector.
 
-    :param variables_map: A map of all numeric arrays used in expressions
-    :param condition_expression: The condition expression
-    :return: assembled condition vector
+    Args:
+        variables_map: A map of all numeric arrays used in expressions
+        condition_expression: The condition expression
+
+    Returns:
+        Assembled condition vector
     """
     if condition_expression is not None:
         condition = condition_expression.evaluate(
@@ -82,12 +85,61 @@ def compute_condition(
     return condition
 
 
+def apply_condition(input_array: np.ndarray, condition: Optional[np.ndarray]) -> np.ndarray:
+    """Apply condition to input array in the following way:
+        - Input values kept as is if condition is 1
+        - Input values set to 0 if condition is 0
+
+    Args:
+        input_array: Array with input values
+        condition: Array of 1 or 0 describing wether or not conditions are met
+
+    Returns:
+        Returns the input_array where conditions are applied (values set to 0 where condition is 0)
+    """
+    if condition is None:
+        return deepcopy(input_array)
+    else:
+        return (
+            np.where(np.any(condition, axis=0), input_array, 0)
+            if np.ndim(input_array) == 2
+            else np.where(condition, input_array, 0)
+        )
+
+
+def get_power_loss_factor_from_expression(
+    variables_map: VariablesMap,
+    power_loss_factor_expression: Expression,
+) -> Optional[np.ndarray]:
+    """Evaluate power loss factor expression and compute resulting power loss factor vector.
+
+    Args:
+        variables_map: A map of all numeric arrays used in expressions
+        power_loss_factor_expression: The condition expression
+
+    Returns:
+        Assembled power loss factor vector
+    """
+    power_loss_factor = (
+        power_loss_factor_expression.evaluate(
+            variables=variables_map.variables, fill_length=len(variables_map.time_vector)
+        )
+        if power_loss_factor_expression is not None
+        else None
+    )
+
+    return power_loss_factor
+
+
 def apply_power_loss_factor(energy_usage: np.ndarray, power_loss_factor: Optional[np.ndarray]) -> np.ndarray:
     """Apply resulting required power taking a (cable/motor...) power loss factor into account.
 
-    :param energy_usage: initial required energy usage [MW]
-    :param power_loss_factor: Optional factor of the power (cable) loss.
-    :return: energy usage where power loss is accounted for, i.e. energy_usage/(1-power_loss_factor)
+    Args:
+        energy_usage: initial required energy usage [MW]
+        power_loss_factor: Optional factor of the power (cable) loss.
+
+    Returns:
+        energy usage where power loss is accounted for, i.e. energy_usage/(1-power_loss_factor)
     """
     if power_loss_factor is None:
         return deepcopy(energy_usage)

--- a/src/ecalc/libraries/libecalc/common/tests/core/consumers/consumer_function/test_consumer_function.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/consumers/consumer_function/test_consumer_function.py
@@ -17,7 +17,6 @@ def test_consumer_function_result_append():
         time_vector=np.array([datetime(2018, 1, 1, 0, 0)]),
         is_valid=~np.isnan(np.array([1.0])),
         energy_usage=np.array([1.0]),
-        energy_usage_before_conditioning=np.array([1.0]),
         energy_usage_before_power_loss_factor=np.array([1.0]),
         condition=None,
         power_loss_factor=None,
@@ -34,7 +33,6 @@ def test_consumer_function_result_append():
         time_vector=np.array([datetime(2019, 1, 1, 0, 0)]),
         is_valid=~np.isnan(np.array([2.0])),
         energy_usage=np.array([2.0]),
-        energy_usage_before_conditioning=np.array([2.0]),
         energy_usage_before_power_loss_factor=np.array([2.0]),
         condition=None,
         power_loss_factor=None,
@@ -53,7 +51,6 @@ def test_consumer_function_result_append():
         updated_result.time_vector, np.array([datetime(2018, 1, 1, 0, 0), datetime(2019, 1, 1, 0, 0)])
     )
     np.testing.assert_equal(updated_result.energy_usage, np.array([1.0, 2.0]))
-    np.testing.assert_equal(updated_result.energy_usage_before_conditioning, np.array([1.0, 2.0]))
     np.testing.assert_equal(updated_result.energy_usage_before_power_loss_factor, np.array([1.0, 2.0]))
     assert updated_result.condition is None
     assert updated_result.power_loss_factor is None

--- a/src/ecalc/libraries/libecalc/common/tests/core/consumers/system/conftest.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/consumers/system/conftest.py
@@ -245,7 +245,6 @@ def consumer_system_result() -> ConsumerSystemConsumerFunctionResult:
         time_vector=np.array([Mock(datetime)] * 3),
         is_valid=np.array([True, True, True]),
         energy_usage=a,
-        energy_usage_before_conditioning=a,
         energy_usage_before_power_loss_factor=a,
         condition=a,
         power_loss_factor=a,

--- a/src/ecalc/libraries/libecalc/common/tests/core/consumers/system/test_consumer_system.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/consumers/system/test_consumer_system.py
@@ -505,6 +505,26 @@ class TestCompressorSystemConsumerFunction:
             result_with_power_loss.energy_usage,
             result.energy_usage / (1 - np.array(gas_prod_values) / 10.0),
         )
+
+        consumer_system_function_with_condition = CompressorSystemConsumerFunction(
+            consumer_components=compressor_system_sampled_2.consumers,
+            operational_settings_expressions=[
+                operational_setting1_expressions,
+                operational_setting2_expressions,
+                operational_setting3_expressions,
+            ],
+            condition_expression=Expression.setup_from_expression("SIM1;GAS_PROD > 2"),
+            power_loss_factor_expression=None,
+        )
+
+        result_with_condition = consumer_system_function_with_condition.evaluate(
+            variables_map=variables_map,
+            regularity=[1.0] * len(variables_map.time_vector),
+        )
+
+        assert np.all(result_with_condition.condition == [0, 0, 1, 1, 1, 1, 1, 1, 1, 1])
+        assert np.all(result_with_condition.energy_usage[0:2] == 0)
+
         # GAS_PROD=0.005: one compressor, midway between 1 and second entry - in the "jump" when the first compressor is turned on, operational setting should be 0
         # GAS_PROD=1.5 - midway between 11 and 12, should be 11.5 and operational setting should be 0
         # GAS_PROD=4 - to compressors on max capacity, using 12 each, thus 24 in total. Operational setting should be 1 (when two compressors are used)

--- a/src/ecalc/libraries/libecalc/common/tests/core/consumers/system/test_system_results.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/consumers/system/test_system_results.py
@@ -48,7 +48,6 @@ class TestConsumerSystemConsumerFunctionResult:
         assert len(appended_consumer_system_result.time_vector) == 6
         assert np.all(appended_consumer_system_result.is_valid)
         assert appended_consumer_system_result.energy_usage.tolist() == [1, 2, 3, 1, 2, 3]
-        assert appended_consumer_system_result.energy_usage_before_conditioning.tolist() == [1, 2, 3, 1, 2, 3]
         assert appended_consumer_system_result.energy_usage_before_power_loss_factor.tolist() == [1, 2, 3, 1, 2, 3]
         assert appended_consumer_system_result.condition.tolist() == [1, 2, 3, 1, 2, 3]
         assert appended_consumer_system_result.power_loss_factor.tolist() == [1, 2, 3, 1, 2, 3]


### PR DESCRIPTION
## Why is this pull request needed?

Today all conditions are applied **after** calculations. Conditions should be applied prior to calculations, so that we don't calculate results we are not interested in - both because those results can be confusing, and to save CPU time.

## What does this pull request change?

Tasks:
- [x] Move conditioning for compressor consumer function
- [x] Move conditioning for direct consumer function
- [x] Move conditioning for pump consumer function
- [x] Move conditioning for pump/compressor system
- [x] Conditioning for tabular consumer function
- [x] Remove `energy_usage_before_conditioning` from results object and tests


## Issues related to this change:
