### PR TITLE
fix: cast float to numpy array in function call

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/single_speed_compressor_train_common_shaft.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/single_speed_compressor_train_common_shaft.py
@@ -947,7 +947,7 @@ class SingleSpeedCompressorTrainCommonShaft(CompressorTrainModel):
         # If solution not found along max speed curve, run at max_mass_rate, but using the defined pressure control.
         elif self.data_transfer_object.pressure_control is not None:
             if self._evaluate_rate_ps_pd(
-                rate=inlet_stream.mass_rate_to_standard_rate(mass_rate_kg_per_hour=max_mass_rate),
+                rate=np.asarray([inlet_stream.mass_rate_to_standard_rate(mass_rate_kg_per_hour=max_mass_rate)]),
                 suction_pressure=np.asarray([inlet_stream.pressure_bara]),
                 discharge_pressure=np.asarray([target_discharge_pressure]),
             )[0].is_valid:


### PR DESCRIPTION
The compressor code expects numpy arrays, here a single float was passed.