### PR TITLE
ci: avoid conflicting releases

### DIFF
--- a/.github/workflows/on-push-any-branch.yml
+++ b/.github/workflows/on-push-any-branch.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'main'
+      - 'release/*'
     tags-ignore:
       - '**'
 

--- a/.github/workflows/on-push-main-branch.yml
+++ b/.github/workflows/on-push-main-branch.yml
@@ -18,8 +18,15 @@ jobs:
     uses: ./.github/workflows/docs-publish.yml
     secrets: inherit
     needs: [docs-ci]
+
+# We want/need to reserve patch bump in case we need to
+# patch a release that is deployed and active. Therefore
+# we bump minor here. Major bumps to versioning is currently
+# reserved to manual invocation of release-please.
     
   release-please:
     uses: ./.github/workflows/release-please.yml
+    with:
+      versioning_strategy: 'always-bump-minor'
     secrets: inherit
     needs: [lib-ci]

--- a/.github/workflows/on-push-release-branch.yml
+++ b/.github/workflows/on-push-release-branch.yml
@@ -1,0 +1,22 @@
+name: "Release CI/CD - to patch a release"
+on:
+  push:
+    branches:
+      - release/*
+
+jobs:
+  pre-ci:
+    uses: ./.github/workflows/pre-ci.yml
+
+  lib-ci:
+    uses: ./.github/workflows/lib-ci.yml
+
+# We want/need to reserve patch bump in case we need to
+# patch a release that is deployed and active
+
+  release-please:
+    uses: ./.github/workflows/release-please.yml
+    with:
+      versioning_strategy: 'always-bump-patch'
+    secrets: inherit
+    needs: [lib-ci]

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,7 +5,20 @@ on:
   workflow_dispatch:
   # Workflow call is used for called from another workflow
   workflow_call:
+    inputs:
+      versioning_strategy:
+        required: true
+        type: choice
+        description: Which version strategy to use. See release-please documentation for options.
+        default: "default"
+        options:
+          - default
+          - always-bump-patch
+          - always-bump-minor
+          - always-bump-major
 
+env:
+  VERSIONING_STRATEGY: ${{ inputs.versioning_strategy }}
 
 jobs:
   release-please:
@@ -16,12 +29,19 @@ jobs:
         id: release
         with:
           release-type: simple
+          versioning-strategy: ${{ env.VERSIONING_STRATEGY }}
           package-name: libecalc
           changelog-path: docs/docs/changelog/changelog.md
           changelog-types: '[{ "type": "feat", "section": "Features", "hidden": false },{ "type": "feature", "section": "Features", "hidden": false },{ "type": "fix", "section": "Bug Fixes", "hidden": false },{ "type": "perf", "section": "Performance Improvements", "hidden": false },{ "type": "revert", "section": "Reverts", "hidden": false },{ "type": "docs", "section": "Documentation", "hidden": false },{ "type": "style", "section": "Styles", "hidden": false },{ "type": "chore", "section": "Miscellaneous Chores", "hidden": false },{ "type": "refactor", "section": "Code Refactoring", "hidden": false },{ "type": "test", "section": "Tests", "hidden": false },{ "type": "build", "section": "Build System", "hidden": false },{ "type": "ci", "section": "Continuous Integration", "hidden": false }]'
           extra-files: |
             pyproject.toml
             src/ecalc/libraries/libecalc/common/libecalc/version.py
+      - uses: actions/checkout@v2
+      - name: Create vX.Y release branch (for simpler patching) - if normal release (not patching)
+        if: ${{ steps.release.outputs.release_created && env.VERSIONING_STRATEGY != 'always-bump-patch' }}
+        run: |
+            git checkout -b release/v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} ${{ steps.release.outputs.sha }}
+            git push -u origin release/v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
To allow both for easy patching of a release on a separate release branch we need to create a release branch that we can patch and only bump patch versions to when needed.

The patch bump should therefore be reserved for that branch to avoid that a new release on main branch will get a conflicting version. Main will therefore in general only have minor bumps, and a release to release should be a minor bump.

If we want to have a major bump, due to breaking changes or many changes and improvements since a previous major version we should do a manual trigger of release-please with that specified as an argument.
