### PR TITLE
chore: remove limiting dependency typer-cli

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2873,23 +2873,6 @@ doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1
 test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
-name = "typer-cli"
-version = "0.0.13"
-description = "Run Typer scripts with completion, without having to create a package, using Typer CLI."
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "typer_cli-0.0.13-py3-none-any.whl", hash = "sha256:5ae0f99dce8f8f9669137a2c98eb42485cd4412e0ec225c8eb29ce8ac3378731"},
-    {file = "typer_cli-0.0.13.tar.gz", hash = "sha256:f5b85764e56fb3fe835ed008ad5bc7db4961f7bcce1f1c1698ac46b6c5d9b86f"},
-]
-
-[package.dependencies]
-colorama = ">=0.4.3,<=0.5.0"
-shellingham = ">=1.3.2,<=1.4.0"
-typer = ">=0.4.0,<=0.7.0"
-
-[[package]]
 name = "typing-extensions"
 version = "4.6.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -3034,4 +3017,4 @@ notebooks = ["jupyter", "matplotlib"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "17d0c3be14d49251c296f876f9e7b5efd507311eefd485a25535cd1aa63b048c"
+content-hash = "a095936feb80e2ef1bdf14eacde0e91cf81a9e9ed32f501a60903e0067792715"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ typer = {version = "^0.7.0", extras = ["all"]}
 rich = "^12.6.0"
 jupyter = {version = "^1.0.0", optional = true}
 matplotlib = {version = "^3.7.1", optional = true}
-typer-cli = "0.0.13"
 
 [tool.poetry.dev-dependencies]
 pytest-snapshot = "^0.9"

--- a/src/ecalc/cli/generate_docs.py
+++ b/src/ecalc/cli/generate_docs.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import typer
 import typer.core
-import typer_cli.main as typer_cli
+import typer_cli_stub as typer_cli
 
 app = typer.Typer()
 

--- a/src/ecalc/cli/typer_cli_stub.py
+++ b/src/ecalc/cli/typer_cli_stub.py
@@ -1,0 +1,112 @@
+from typing import cast
+
+import typer
+from click import Command, Group
+
+"""
+The code gist in this file is extracted from https://github.com/tiangolo/typer-cli/tree/master
+
+Due to lack of compatibility of newer Typer releases we saw the need to extract the small portion
+of the code that we use to generate API documentation for the CLI, instead of being forced to
+use old versions of Typer.
+
+The code is provided under the following copyright statement and license:
+
+The MIT License (MIT)
+
+Copyright (c) 2020 Sebastián Ramírez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+
+def get_docs_for_click(
+    *,
+    obj: Command,
+    ctx: typer.Context,
+    indent: int = 0,
+    name: str = "",
+    call_prefix: str = "",
+) -> str:
+    docs = "#" * (1 + indent)
+    command_name = name or obj.name
+    if call_prefix:
+        command_name = f"{call_prefix} {command_name}"
+    title = f"`{command_name}`" if command_name else "CLI"
+    docs += f" {title}\n\n"
+    if obj.help:
+        docs += f"{obj.help}\n\n"
+    usage_pieces = obj.collect_usage_pieces(ctx)
+    if usage_pieces:
+        docs += "**Usage**:\n\n"
+        docs += "```console\n"
+        docs += "$ "
+        if command_name:
+            docs += f"{command_name} "
+        docs += f"{' '.join(usage_pieces)}\n"
+        docs += "```\n\n"
+    args = []
+    opts = []
+    for param in obj.get_params(ctx):
+        rv = param.get_help_record(ctx)
+        if rv is not None:
+            if param.param_type_name == "argument":
+                args.append(rv)
+            elif param.param_type_name == "option":
+                opts.append(rv)
+    if args:
+        docs += "**Arguments**:\n\n"
+        for arg_name, arg_help in args:
+            docs += f"* `{arg_name}`"
+            if arg_help:
+                docs += f": {arg_help}"
+            docs += "\n"
+        docs += "\n"
+    if opts:
+        docs += "**Options**:\n\n"
+        for opt_name, opt_help in opts:
+            docs += f"* `{opt_name}`"
+            if opt_help:
+                docs += f": {opt_help}"
+            docs += "\n"
+        docs += "\n"
+    if obj.epilog:
+        docs += f"{obj.epilog}\n\n"
+    if isinstance(obj, Group):
+        group: Group = cast(Group, obj)
+        commands = group.list_commands(ctx)
+        if commands:
+            docs += "**Commands**:\n\n"
+            for command in commands:
+                command_obj = group.get_command(ctx, command)
+                assert command_obj
+                docs += f"* `{command_obj.name}`"
+                command_help = command_obj.get_short_help_str()
+                if command_help:
+                    docs += f": {command_help}"
+                docs += "\n"
+            docs += "\n"
+        for command in commands:
+            command_obj = group.get_command(ctx, command)
+            assert command_obj
+            use_prefix = ""
+            if command_name:
+                use_prefix += f"{command_name}"
+            docs += get_docs_for_click(obj=command_obj, ctx=ctx, indent=indent + 1, call_prefix=use_prefix)
+    return docs


### PR DESCRIPTION
We use typer-cli to auto-generate the CLI reference for the eCalc CLI. However typer-cli is rarely upgraded and is currently limited to use typer 0.7.0 while typer is at 0.9.0. This restricts us unnecessarily to use the latest typer and is potentially a security concern.

The small portion of the code that we were using in typer-cli have been extracted together with the license details to still be able to use the functionality and avoid the limitation of the typer dependency.

Additionally, this is also a potential problem and limitation in order to have eCalc as a part of Komodo, as it will potentially heavily restrict other packages wrt. Typer version.