### PR TITLE
ci: remove duplicate build of docs

### DIFF
--- a/.github/workflows/on-push-main-branch.yml
+++ b/.github/workflows/on-push-main-branch.yml
@@ -11,13 +11,9 @@ jobs:
   lib-ci:
     uses: ./.github/workflows/lib-ci.yml
 
-  docs-ci:
-    uses: ./.github/workflows/docs-ci.yml
-
   docs-publish:
     uses: ./.github/workflows/docs-publish.yml
     secrets: inherit
-    needs: [docs-ci]
 
 # We want/need to reserve patch bump in case we need to
 # patch a release that is deployed and active. Therefore


### PR DESCRIPTION
## Why is this pull request needed?

Main CI runs both `docs-ci` and `docs-publish`.
`docs-publish` does the same as `docs-ci` + publish.
No need to run both.

## What does this pull request change?

Removes the call to `docs-ci` from the main pipeline

## Issues related to this change:
