### PR TITLE
fix: extend lists within lists in compressor train results with multiple streams properly

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/results/compressor.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/results/compressor.py
@@ -90,6 +90,7 @@ class CompressorStageResult(EnergyModelBaseResult):
 
     @classmethod
     def create_empty(cls, number_of_timesteps: int) -> CompressorStageResult:
+        """Create empty CompressorStageResult"""
         nans = [np.nan] * number_of_timesteps
         return cls(
             energy_usage=nans,
@@ -163,7 +164,12 @@ class CompressorTrainResult(EnergyFunctionResult):
                 # In case of nested models such as compressor with turbine
                 values.extend(other_values)
             elif isinstance(values, list):
-                if isinstance(other_values, list):
+                # in case of list of lists
+                if isinstance(values[0], list):
+                    self.__setattr__(
+                        attribute, [value + other_value for value, other_value in zip(values, other_values)]
+                    )
+                elif isinstance(other_values, list):
                     self.__setattr__(attribute, values + other_values)
                 else:
                     self.__setattr__(attribute, values + [other_values])

--- a/src/ecalc/libraries/libecalc/common/tests/core/models/test_energy_function_results.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/models/test_energy_function_results.py
@@ -108,3 +108,34 @@ def test_extend_mismatching_compressor_stage_results():
     assert len(result.stage_results) == 2
     for stage_result in result.stage_results:
         assert len(stage_result.energy_usage) == 9
+
+
+def test_extend_compressor_train_result_from_multiple_streams() -> None:
+    """For a compressor train with multiple inlet/outlet streams rate_sm3_day will be a list of lists
+    Make sure that extend preserves this by extending each list within a list.
+    """
+    result_1 = CompressorTrainResult(
+        energy_usage=[1.0] * 3,
+        energy_usage_unit=Unit.MEGA_WATT,
+        power=[np.nan] * 3,
+        power_unit=Unit.MEGA_WATT,
+        stage_results=[],
+        rate_sm3_day=[[1] * 3] * 3,
+        failure_status=[None] * 3,
+    )
+    result_2 = CompressorTrainResult(
+        energy_usage=[2.0] * 3,
+        energy_usage_unit=Unit.MEGA_WATT,
+        power=[np.nan] * 3,
+        power_unit=Unit.MEGA_WATT,
+        stage_results=[
+            CompressorStageResult.create_empty(number_of_timesteps=3),
+            CompressorStageResult.create_empty(number_of_timesteps=3),
+        ],
+        rate_sm3_day=[[2] * 3] * 3,
+        failure_status=[None] * 3,
+    )
+    result = result_1.copy()
+    result.extend(result_2)
+
+    assert result.rate_sm3_day == [[1, 1, 1, 2, 2, 2], [1, 1, 1, 2, 2, 2], [1, 1, 1, 2, 2, 2]]


### PR DESCRIPTION
A VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures have some results (or more specifically return of rate input) that are lists within lists. The extend method does not handle these results properly. Currently the extend method will add more lists within a list, but it should extend each of the lists inside a list instead.