### PR TITLE
fix: do not validate operational conditions when rate is zero

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/base.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/base.py
@@ -54,6 +54,73 @@ class CompressorModel(BaseModel):
         """
         raise NotImplementedError
 
+    def validate_operational_conditions(
+        self,
+        rate: NDArray[np.float64],
+        suction_pressure: NDArray[np.float64],
+        discharge_pressure: NDArray[np.float64],
+        intermediate_pressure: Optional[NDArray[np.float64]] = None,
+    ) -> Tuple[
+        NDArray[np.float64],
+        NDArray[np.float64],
+        NDArray[np.float64],
+        NDArray[np.float64],
+        List[CompressorTrainCommonShaftFailureStatus],
+    ]:
+        indices_to_validate = self._find_indices_to_validate(rate=rate)
+        validated_failure_status = [None] * len(suction_pressure)
+        validated_rate = rate.copy()
+        validated_suction_pressure = suction_pressure.copy()
+        validated_discharge_pressure = discharge_pressure.copy()
+        if intermediate_pressure is not None:
+            validated_intermediate_pressure = intermediate_pressure
+        if len(indices_to_validate) >= 1:
+            (
+                tmp_rate,
+                tmp_suction_pressure,
+                tmp_discharge_pressure,
+                tmp_intermediate_pressure,
+                tmp_failure_status,
+            ) = self._validate_operational_conditions(
+                rate=rate[:, indices_to_validate] if np.ndim(rate) == 2 else rate[indices_to_validate],
+                suction_pressure=suction_pressure[indices_to_validate],
+                discharge_pressure=discharge_pressure[indices_to_validate],
+                intermediate_pressure=intermediate_pressure[indices_to_validate]
+                if intermediate_pressure is not None
+                else None,
+            )
+
+            if np.ndim(rate) == 2:
+                validated_rate[:, indices_to_validate] = tmp_rate
+            else:
+                validated_rate[indices_to_validate] = tmp_rate
+            validated_suction_pressure[indices_to_validate] = tmp_suction_pressure
+            validated_discharge_pressure[indices_to_validate] = tmp_discharge_pressure
+            if intermediate_pressure is not None:
+                validated_intermediate_pressure[indices_to_validate] = tmp_intermediate_pressure
+            for i, failure in enumerate(tmp_failure_status):
+                validated_failure_status[indices_to_validate[i]] = failure
+
+        # any remaining zero or negative suction pressures (for unvalidated time steps, others are already changed)
+        # must be set to 1 (for neqsim to initiate fluid streams)
+        validated_suction_pressure = np.where(validated_suction_pressure <= 0, 1, validated_suction_pressure)
+
+        return (
+            validated_rate,
+            validated_suction_pressure,
+            validated_discharge_pressure,
+            validated_intermediate_pressure if intermediate_pressure is not None else None,
+            validated_failure_status,
+        )
+
+    @staticmethod
+    def _find_indices_to_validate(rate: NDArray[np.float64]) -> List[int]:
+        """Find indices of array where rate(s) are positive.
+        For a 1D array, this means returning the indices where rate is positive.
+        For a 2D array, this means returning the indices where at least one rate is positive (along 0-axis).
+        """
+        return np.where(np.any(rate > 0, axis=0) if np.ndim(rate) == 2 else rate > 0)[0].tolist()
+
     @staticmethod
     def _validate_operational_conditions(
         rate: NDArray[np.float64],
@@ -71,7 +138,9 @@ class CompressorModel(BaseModel):
         Checks for negative or zero values in the input values to the compressor train.
 
         The following is done:
-            - Any pressures that are negative or zero are set to one, and all rates for that time step is set to zero
+            - Time steps where rate is zero are not checked for validity
+              (but zero or negative pressures will still be changed to 1)
+            - Any pressures that are negative or zero are set to one, and all rates for that time step are set to zero
             - Any negative rates are set to zero
             - A failure_status describing the first failure encountered is returned
 
@@ -100,14 +169,13 @@ class CompressorModel(BaseModel):
 
         input_rate = rate.copy()
         input_suction_pressure = suction_pressure.copy()
-        if intermediate_pressure is not None:
-            input_intermediate_pressure = intermediate_pressure.copy()
+        input_intermediate_pressure = intermediate_pressure.copy() if intermediate_pressure is not None else None
         input_discharge_pressure = discharge_pressure.copy()
 
         if not np.all(rate >= 0):
             logger.warning(
-                f"The rate(s) in the compressor train must have non negative values. Given values [Sm3/sd]: {rate.tolist()}."
-                f" The affected time steps will not be calculated, and rate is set to zero."
+                f"The rate(s) in the compressor train must have non negative values. Given values [Sm3/sd]: "
+                f"{rate.tolist()}. The affected time steps will not be calculated, and rate is set to zero."
             )
             rate = (
                 np.where(np.any(rate < 0, axis=0), 0, rate) if np.ndim(rate) == 2 else np.where(rate < 0, 0, rate)

--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/base.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/base.py
@@ -83,7 +83,7 @@ class CompressorTrainModel(CompressorModel, ABC, Generic[TModel]):
         """
         logger.debug(f"Evaluating {type(self).__name__} given rate, suction and discharge pressure.")
 
-        rate, suction_pressure, discharge_pressure, _, input_failure_status = self._validate_operational_conditions(
+        rate, suction_pressure, discharge_pressure, _, input_failure_status = self.validate_operational_conditions(
             rate=rate,
             suction_pressure=suction_pressure,
             discharge_pressure=discharge_pressure,

--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -723,7 +723,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
             discharge_pressure,
             intermediate_pressure,
             input_failure_status,
-        ) = self._validate_operational_conditions(
+        ) = self.validate_operational_conditions(
             rate=rate,
             suction_pressure=suction_pressure,
             discharge_pressure=discharge_pressure,

--- a/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
@@ -361,7 +361,7 @@ def test_calculate_single_speed_train_zero_mass_rate(medium_fluid, single_speed_
     )
 
     # Ensuring that first stage returns zero energy usage and no failure.
-    assert result.is_valid == [False, True, True]
+    assert result.is_valid == [True, True, True]
     assert result.energy_usage == pytest.approx([0.0, 0.14898322782599177, 0.14898322782599177])
 
     assert result.mass_rate_kg_per_hr[0] == 0
@@ -384,10 +384,10 @@ def test_calculate_single_speed_train_zero_pressure_non_zero_rate(medium_fluid, 
         rate=np.array([0, 0, 1, 1]), suction_pressure=np.array([0, 1, 1, 0]), discharge_pressure=np.array([0, 1, 0, 1])
     )
 
-    # All should be valid
-    assert result.is_valid == [False, True, False, False]
+    # Results with zero rate should be valid
+    assert result.is_valid == [True, True, False, False]
     assert result.failure_status == [
-        CompressorTrainCommonShaftFailureStatus.INVALID_SUCTION_PRESSURE_INPUT,
+        None,
         None,
         CompressorTrainCommonShaftFailureStatus.INVALID_DISCHARGE_PRESSURE_INPUT,
         CompressorTrainCommonShaftFailureStatus.INVALID_SUCTION_PRESSURE_INPUT,

--- a/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
@@ -143,10 +143,10 @@ class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:
             discharge_pressure=np.array([0, 2, 2]),
         )
 
-        # Ensuring that first stage returns zero energy usage and no failure.
-        assert result.is_valid == [False, True, True]
+        # Ensuring that first stage returns zero energy usage and no failure (zero rate should always be valid).
+        assert result.is_valid == [True, True, True]
         assert result.failure_status == [
-            CompressorTrainCommonShaftFailureStatus.INVALID_SUCTION_PRESSURE_INPUT,
+            None,
             None,
             None,
         ]

--- a/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
@@ -13,9 +13,6 @@ from libecalc.core.models.compressor.train.variable_speed_compressor_train_commo
 from libecalc.core.models.compressor.train.variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures import (
     VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures,
 )
-from libecalc.core.models.results.compressor import (
-    CompressorTrainCommonShaftFailureStatus,
-)
 from libecalc.dto import InterstagePressureControl
 from libecalc.dto.types import ChartAreaFlag, FixedSpeedPressureControl
 
@@ -539,10 +536,10 @@ def test_zero_rate_zero_pressure_multiple_streams(variable_speed_compressor_trai
         discharge_pressure=np.array([0, 5, 5, 5]),
     )
 
-    # Ensuring that first stage returns zero energy usage and no failure.
-    assert result.is_valid == [False, True, True, True]
+    # Ensuring that first stage returns zero energy usage and no failure (zero rate should always be valid).
+    assert result.is_valid == [True, True, True, True]
     assert result.failure_status == [
-        CompressorTrainCommonShaftFailureStatus.INVALID_SUCTION_PRESSURE_INPUT,
+        None,
         None,
         None,
         None,


### PR DESCRIPTION
## Why is this pull request needed?

User experienced extrapolation of results when CONDITION(S) imply that no calculations should be done.

## What does this pull request change?

When CONDITION(S) imply that no calculations should be performed for a model, the rate(s) are set to zero for that time step. The time step should still be valid - we do not want extrapolation of results. This means that results for time steps with zero rate(s) should always be considered as valid.

This PR changes the validation of the operational conditions (rate(s), suction/discharge pressures) such that time steps with zero rate(s) are always considered valid, and no failure status will be returned for that time step (even if pressures are zero or negative). Any invalid pressures will still be set to 1, because the may be used in a call to neqsim.
