### PR TITLE
fix: validate operational conditions when rate is zero

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/base.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/base.py
@@ -83,7 +83,7 @@ class CompressorTrainModel(CompressorModel, ABC, Generic[TModel]):
         """
         logger.debug(f"Evaluating {type(self).__name__} given rate, suction and discharge pressure.")
 
-        rate, suction_pressure, discharge_pressure, _, input_failure_status = self._validate_operational_conditions(
+        rate, suction_pressure, discharge_pressure, _, input_failure_status = self.validate_operational_conditions(
             rate=rate,
             suction_pressure=suction_pressure,
             discharge_pressure=discharge_pressure,

--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -723,7 +723,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
             discharge_pressure,
             intermediate_pressure,
             input_failure_status,
-        ) = self._validate_operational_conditions(
+        ) = self.validate_operational_conditions(
             rate=rate,
             suction_pressure=suction_pressure,
             discharge_pressure=discharge_pressure,

--- a/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
@@ -361,7 +361,7 @@ def test_calculate_single_speed_train_zero_mass_rate(medium_fluid, single_speed_
     )
 
     # Ensuring that first stage returns zero energy usage and no failure.
-    assert result.is_valid == [False, True, True]
+    assert result.is_valid == [True, True, True]
     assert result.energy_usage == pytest.approx([0.0, 0.14898322782599177, 0.14898322782599177])
 
     assert result.mass_rate_kg_per_hr[0] == 0
@@ -384,10 +384,10 @@ def test_calculate_single_speed_train_zero_pressure_non_zero_rate(medium_fluid, 
         rate=np.array([0, 0, 1, 1]), suction_pressure=np.array([0, 1, 1, 0]), discharge_pressure=np.array([0, 1, 0, 1])
     )
 
-    # All should be valid
-    assert result.is_valid == [False, True, False, False]
+    # Results with zero rate should be valid
+    assert result.is_valid == [True, True, False, False]
     assert result.failure_status == [
-        CompressorTrainCommonShaftFailureStatus.INVALID_SUCTION_PRESSURE_INPUT,
+        None,
         None,
         CompressorTrainCommonShaftFailureStatus.INVALID_DISCHARGE_PRESSURE_INPUT,
         CompressorTrainCommonShaftFailureStatus.INVALID_SUCTION_PRESSURE_INPUT,

--- a/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
@@ -143,10 +143,10 @@ class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:
             discharge_pressure=np.array([0, 2, 2]),
         )
 
-        # Ensuring that first stage returns zero energy usage and no failure.
-        assert result.is_valid == [False, True, True]
+        # Ensuring that first stage returns zero energy usage and no failure (zero rate should always be valid).
+        assert result.is_valid == [True, True, True]
         assert result.failure_status == [
-            CompressorTrainCommonShaftFailureStatus.INVALID_SUCTION_PRESSURE_INPUT,
+            None,
             None,
             None,
         ]

--- a/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
@@ -13,9 +13,6 @@ from libecalc.core.models.compressor.train.variable_speed_compressor_train_commo
 from libecalc.core.models.compressor.train.variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures import (
     VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures,
 )
-from libecalc.core.models.results.compressor import (
-    CompressorTrainCommonShaftFailureStatus,
-)
 from libecalc.dto import InterstagePressureControl
 from libecalc.dto.types import ChartAreaFlag, FixedSpeedPressureControl
 
@@ -539,10 +536,10 @@ def test_zero_rate_zero_pressure_multiple_streams(variable_speed_compressor_trai
         discharge_pressure=np.array([0, 5, 5, 5]),
     )
 
-    # Ensuring that first stage returns zero energy usage and no failure.
-    assert result.is_valid == [False, True, True, True]
+    # Ensuring that first stage returns zero energy usage and no failure (zero rate should always be valid).
+    assert result.is_valid == [True, True, True, True]
     assert result.failure_status == [
-        CompressorTrainCommonShaftFailureStatus.INVALID_SUCTION_PRESSURE_INPUT,
+        None,
         None,
         None,
         None,


### PR DESCRIPTION
If rate is zero, do not perform validation of operational conditions. Disregard any potential invalid rates/pressures to avoid getting into a situation were results are extrapolated when they should not be calculated at all.
