### PR TITLE
chore: enforce unique fuel type names, and unique emission names within one fuel type

### DIFF
--- a/src/ecalc/cli/tests/test_app.py
+++ b/src/ecalc/cli/tests/test_app.py
@@ -40,6 +40,11 @@ def simple_duplicate_names_yaml_path():
 
 
 @pytest.fixture(scope="session")
+def simple_duplicate_emissions_yaml_path():
+    return (Path(simple.__file__).parent / "model_duplicate_emissions_in_fuel.yaml").absolute()
+
+
+@pytest.fixture(scope="session")
 def advanced_yaml_path():
     return (Path(advanced.__file__).parent / "model.yaml").absolute()
 
@@ -684,9 +689,6 @@ class TestYamlFile:
         """
         TEST SCOPE: Check that duplicate fuel type names are not allowed in Yaml file.
 
-        A file name with ´.´ in the file stem should not be accepted. The error message
-        should be understandable for the user.
-
         Args:
             simple model file with duplicate fuel names:
 
@@ -707,3 +709,30 @@ class TestYamlFile:
             )
 
         assert "Duplicated names are: fuel_gas" in str(exc_info.value)
+
+    def test_yaml_duplicate_emissions_in_fuel(self, simple_duplicate_emissions_yaml_path, tmp_path):
+        """
+        TEST SCOPE: Check that duplicate emission names for one fuel type are not allowed in Yaml file.
+
+        Args:
+            simple model file with duplicate emission names:
+
+        Returns:
+
+        """
+        with pytest.raises(ValueError) as exc_info:
+            runner.invoke(
+                main.app,
+                _get_args(
+                    model_file=simple_duplicate_emissions_yaml_path,
+                    csv=True,
+                    output_folder=tmp_path,
+                    name_prefix="test",
+                    output_frequency="YEAR",
+                ),
+                catch_exceptions=False,
+            )
+
+        assert "Emission names must be unique for each fuel type. " "Duplicated names are: CO2,CH4" in str(
+            exc_info.value
+        )

--- a/src/ecalc/cli/tests/test_app.py
+++ b/src/ecalc/cli/tests/test_app.py
@@ -682,26 +682,28 @@ class TestYamlFile:
 
     def test_yaml_duplicate_fuel(self, simple_duplicate_names_yaml_path, tmp_path):
         """
-        TEST SCOPE: Check error message when Yaml file name is wrong.
+        TEST SCOPE: Check that duplicate fuel type names are not allowed in Yaml file.
 
         A file name with ´.´ in the file stem should not be accepted. The error message
         should be understandable for the user.
 
         Args:
-            simple model file with bad name:
+            simple model file with duplicate fuel names:
 
         Returns:
 
         """
+        with pytest.raises(ValueError) as exc_info:
+            runner.invoke(
+                main.app,
+                _get_args(
+                    model_file=simple_duplicate_names_yaml_path,
+                    csv=True,
+                    output_folder=tmp_path,
+                    name_prefix="test",
+                    output_frequency="YEAR",
+                ),
+                catch_exceptions=False,
+            )
 
-        runner.invoke(
-            main.app,
-            _get_args(
-                model_file=simple_duplicate_names_yaml_path,
-                csv=True,
-                output_folder=tmp_path,
-                name_prefix="test",
-                output_frequency="YEAR",
-            ),
-            catch_exceptions=False,
-        )
+        assert "Duplicated names are: fuel_gas" in str(exc_info.value)

--- a/src/ecalc/cli/tests/test_app.py
+++ b/src/ecalc/cli/tests/test_app.py
@@ -35,6 +35,11 @@ def simple_temporal_yaml_path():
 
 
 @pytest.fixture(scope="session")
+def simple_duplicate_names_yaml_path():
+    return (Path(simple.__file__).parent / "model_duplicate_names.yaml").absolute()
+
+
+@pytest.fixture(scope="session")
 def advanced_yaml_path():
     return (Path(advanced.__file__).parent / "model.yaml").absolute()
 
@@ -673,4 +678,30 @@ class TestYamlFile:
         assert (
             f"The model file, {yaml_wrong_name.name}, contains illegal special characters. "
             f"Allowed characters are {COMPONENT_NAME_ALLOWED_CHARS}" in str(ee.value)
+        )
+
+    def test_yaml_duplicate_fuel(self, simple_duplicate_names_yaml_path, tmp_path):
+        """
+        TEST SCOPE: Check error message when Yaml file name is wrong.
+
+        A file name with ´.´ in the file stem should not be accepted. The error message
+        should be understandable for the user.
+
+        Args:
+            simple model file with bad name:
+
+        Returns:
+
+        """
+
+        runner.invoke(
+            main.app,
+            _get_args(
+                model_file=simple_duplicate_names_yaml_path,
+                csv=True,
+                output_folder=tmp_path,
+                name_prefix="test",
+                output_frequency="YEAR",
+            ),
+            catch_exceptions=False,
         )

--- a/src/ecalc/libraries/libecalc/common/libecalc/dto/components.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/dto/components.py
@@ -456,8 +456,8 @@ class Asset(Component):
     def validate_unique_names(cls, values):
         """Ensure unique component names within installation."""
         names = [values["name"]]
-        fuel_types = []
-        fuel_names = []
+        fuel_types = [dto.FuelType]
+        fuel_names = [str]
         for installation in values["installations"]:
             names.append(installation.name)
             fuel_consumers = installation.fuel_consumers

--- a/src/ecalc/libraries/libecalc/common/libecalc/dto/components.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/dto/components.py
@@ -457,6 +457,7 @@ class Asset(Component):
         """Ensure unique component names within installation."""
         names = [values["name"]]
         fuel_types = []
+        fuel_names = []
         for installation in values["installations"]:
             names.append(installation.name)
             fuel_consumers = installation.fuel_consumers
@@ -473,14 +474,22 @@ class Asset(Component):
                         # Need to verify that it is a different fuel
                         if fuel_type is not None and fuel_type not in fuel_types:
                             fuel_types.append(fuel_type)
-                            names.append(fuel_type.name)
+                            fuel_names.append(fuel_type.name)
 
         duplicated_names = get_duplicates(names)
+        duplicated_fuel_names = get_duplicates(fuel_names)
+
         if len(duplicated_names) > 0:
             raise ValueError(
-                "Component- and fuel type names must be unique. Components include asset/ecalc-model, installations,"
-                " generator sets, electricity consumers, fuel consumers, direct emitters and fuel types."
+                "Component names must be unique. Components include asset/ecalc-model, installations,"
+                " generator sets, electricity consumers, fuel consumers and direct emitters."
                 f" Duplicated names are: {', '.join(duplicated_names)}"
+            )
+
+        if len(duplicated_fuel_names) > 0:
+            raise ValueError(
+                "Fuel type names must be unique across installations."
+                f" Duplicated names are: {', '.join(duplicated_fuel_names)}"
             )
         return values
 

--- a/src/ecalc/libraries/libecalc/common/libecalc/dto/components.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/dto/components.py
@@ -456,6 +456,7 @@ class Asset(Component):
     def validate_unique_names(cls, values):
         """Ensure unique component names within installation."""
         names = [values["name"]]
+        fuel_types = []
         for installation in values["installations"]:
             names.append(installation.name)
             fuel_consumers = installation.fuel_consumers
@@ -467,12 +468,18 @@ class Asset(Component):
                 if isinstance(fuel_consumer, GeneratorSet):
                     for electricity_consumer in fuel_consumer.consumers:
                         names.append(electricity_consumer.name)
+                if fuel_consumer.fuel is not None:
+                    for fuel_type in fuel_consumer.fuel.values():
+                        # Need to verify that it is a different fuel
+                        if fuel_type is not None and fuel_type not in fuel_types:
+                            fuel_types.append(fuel_type)
+                            names.append(fuel_type.name)
 
         duplicated_names = get_duplicates(names)
         if len(duplicated_names) > 0:
             raise ValueError(
-                "Component names must be unique. Components include asset/ecalc-model, installations,"
-                " generator sets, electricity consumers, fuel consumers and direct emitters."
+                "Component- and fuel type names must be unique. Components include asset/ecalc-model, installations,"
+                " generator sets, electricity consumers, fuel consumers, direct emitters and fuel types."
                 f" Duplicated names are: {', '.join(duplicated_names)}"
             )
         return values

--- a/src/ecalc/libraries/libecalc/common/libecalc/examples/simple/model_duplicate_emissions_in_fuel.yaml
+++ b/src/ecalc/libraries/libecalc/common/libecalc/examples/simple/model_duplicate_emissions_in_fuel.yaml
@@ -8,21 +8,29 @@ FACILITY_INPUTS:
     TYPE: ELECTRICITY2FUEL
 
 FUEL_TYPES:
-  - NAME: fuel_gas
+  - NAME: fuel_gas1
     PRICE: 1.5  # NOK/Sm3
     EMISSIONS:
       - NAME: CO2
         FACTOR: 2.19  # CO2/Sm3 fuel gas burned
         TAX: 1.5  # NOK/Sm3 fuel gas burned
         QUOTA: 260  # NOK/ton
-  - NAME: fuel_gas
-    PRICE: 1.5  # NOK/Sm3
-    EMISSIONS:
       - NAME: CO2
-        FACTOR: 5.19  # CO2/Sm3 fuel gas burned
+        FACTOR: 2.19  # CO2/Sm3 fuel gas burned
         TAX: 1.5  # NOK/Sm3 fuel gas burned
         QUOTA: 260  # NOK/ton
 
+  - NAME: fuel_gas2
+    PRICE: 1.5  # NOK/Sm3
+    EMISSIONS:
+      - NAME: CH4
+        FACTOR: 5.19  # CO2/Sm3 fuel gas burned
+        TAX: 1.5  # NOK/Sm3 fuel gas burned
+        QUOTA: 260  # NOK/ton
+      - NAME: CH4
+        FACTOR: 5.19  # CO2/Sm3 fuel gas burned
+        TAX: 1.5  # NOK/Sm3 fuel gas burned
+        QUOTA: 260  # NOK/ton
 
 VARIABLES:
   hydrocarbon_export_sm3_per_day:
@@ -42,3 +50,4 @@ INSTALLATIONS:
             ENERGY_USAGE_MODEL:
               TYPE: DIRECT
               LOAD: 11.8 # MW
+

--- a/src/ecalc/libraries/libecalc/common/libecalc/examples/simple/model_duplicate_names.yaml
+++ b/src/ecalc/libraries/libecalc/common/libecalc/examples/simple/model_duplicate_names.yaml
@@ -1,0 +1,111 @@
+TIME_SERIES:
+  - NAME: SIM
+    FILE: production_data.csv
+    TYPE: DEFAULT
+FACILITY_INPUTS:
+  - NAME: genset
+    FILE: genset.csv
+    TYPE: ELECTRICITY2FUEL
+  - NAME: compressor_sampled
+    FILE: compressor_sampled.csv
+    TYPE: COMPRESSOR_TABULAR
+  - NAME: compressor_with_turbine_sampled
+    FILE: compressor_sampled_with_turbine.csv
+    TYPE: COMPRESSOR_TABULAR
+  - NAME: pump_sampled
+    FILE: pump_sampled.csv #!include, commented !include is now supported
+    TYPE: TABULAR
+  - NAME: pump_chart
+    FILE: pump_chart.csv
+    TYPE: PUMP_CHART_SINGLE_SPEED
+    UNITS:
+      HEAD: M
+      RATE: AM3_PER_HOUR
+      EFFICIENCY: PERCENTAGE
+
+FUEL_TYPES:
+  - NAME: fuel_gas
+    PRICE: 1.5  # NOK/Sm3
+    EMISSIONS:
+      - NAME: CO2
+        FACTOR: 2.19  # CO2/Sm3 fuel gas burned
+        TAX: 1.5  # NOK/Sm3 fuel gas burned
+        QUOTA: 260  # NOK/ton
+  - NAME: fuel_gas
+    PRICE: 1.5  # NOK/Sm3
+    EMISSIONS:
+      - NAME: CO2
+        FACTOR: 5.19  # CO2/Sm3 fuel gas burned
+        TAX: 1.5  # NOK/Sm3 fuel gas burned
+        QUOTA: 260  # NOK/ton
+
+
+VARIABLES:
+  hydrocarbon_export_sm3_per_day:
+    VALUE: SIM;OIL_PROD {+} SIM;GAS_SALES {/} 1000  # divide the gas rate by 1000 to get oil equivalent
+  salt_water_injection_rate_m3_per_day:
+    VALUE: SIM;WATER_INJ {-} SIM;WATER_PROD {+} SIM;WATER_PROD {*} (SIM;WATER_PROD < 1500) {+} (SIM;WATER_PROD {-} 17000) {*} (SIM;WATER_PROD > 17000) {*} (SIM;WATER_PROD < 18500)
+  gas_export_rate_sm3_per_day:
+    VALUE: SIM;GAS_SALES
+  gas_injection_rate_sm3_per_day:
+    VALUE: SIM;GAS_INJ {+} SIM;GAS_LIFT
+  produced_water_reinjection_condition:
+    VALUE: SIM;WATER_PROD > 1500
+  produced_water_reinjection_total_system_rate_m3_per_day:
+    VALUE: SIM;WATER_PROD
+  flare_fuel_rate_sm3_day:
+    1995-10-01:
+      VALUE: 10000
+    2005-01-01:
+      VALUE: 7000
+
+INSTALLATIONS:
+  - NAME: Installation A
+    HCEXPORT: $var.hydrocarbon_export_sm3_per_day
+    FUEL: fuel_gas
+    GENERATORSETS:
+      - NAME: Generator set A
+        ELECTRICITY2FUEL: genset
+        CATEGORY: TURBINE-GENERATOR
+        CONSUMERS:
+          - NAME: Base production load
+            CATEGORY: BASE-LOAD
+            ENERGY_USAGE_MODEL:
+              TYPE: DIRECT
+              LOAD: 11.8 # MW
+          - NAME: Gas injection compressor
+            CATEGORY: COMPRESSOR
+            ENERGY_USAGE_MODEL:
+              TYPE: COMPRESSOR
+              ENERGYFUNCTION: compressor_sampled
+              RATE: $var.gas_injection_rate_sm3_per_day
+          - NAME: Produced water reinjection pump
+            CATEGORY: PUMP
+            ENERGY_USAGE_MODEL:
+              TYPE: PUMP
+              CONDITION: $var.produced_water_reinjection_condition
+              ENERGYFUNCTION: pump_chart
+              RATE: $var.produced_water_reinjection_total_system_rate_m3_per_day
+              FLUID_DENSITY: 1010
+              SUCTION_PRESSURE: 10  # bara
+              DISCHARGE_PRESSURE: 200  # bara
+          - NAME: Sea water injection pump
+            CATEGORY: PUMP
+            ENERGY_USAGE_MODEL:
+              TYPE: TABULATED
+              ENERGYFUNCTION: pump_sampled
+              VARIABLES:
+                - NAME: RATE
+                  EXPRESSION: $var.salt_water_injection_rate_m3_per_day
+    FUELCONSUMERS:
+      - NAME: Flare
+        CATEGORY: FLARE
+        ENERGY_USAGE_MODEL:
+          TYPE: DIRECT
+          FUELRATE: $var.flare_fuel_rate_sm3_day
+      - NAME: Gas export compressor
+        CATEGORY: COMPRESSOR
+        ENERGY_USAGE_MODEL:
+          TYPE: COMPRESSOR
+          ENERGYFUNCTION: compressor_with_turbine_sampled
+          RATE: $var.gas_export_rate_sm3_per_day

--- a/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/create_references.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/create_references.py
@@ -38,6 +38,20 @@ def create_references(configuration: PyYamlYamlModel, resources: Resources) -> R
             f" Duplicated names are: {', '.join(duplicated_fuel_names)}"
         )
 
+    fuel_types_emissions = [list(fuel_data[EcalcYamlKeywords.emissions]) for fuel_data in configuration.fuel_types]
+
+    # Check each fuel for duplicated emissions
+    duplicated_emissions = []
+    for emissions in fuel_types_emissions:
+        duplicated_emissions.append(get_duplicates([emission.get(EcalcYamlKeywords.name) for emission in emissions]))
+
+    duplicated_emissions_names = ",".join(name for string in duplicated_emissions for name in string if len(string) > 0)
+
+    if len(duplicated_emissions_names) > 0:
+        raise ValueError(
+            "Emission names must be unique for each fuel type." f" Duplicated names are: {duplicated_emissions_names}"
+        )
+
     fuel_types = {
         fuel_data.get(EcalcYamlKeywords.name): FuelMapper.from_yaml_to_dto(fuel_data)
         for fuel_data in configuration.fuel_types

--- a/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/create_references.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/create_references.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from libecalc.common.logger import logger
+from libecalc.dto.utils.string_utils import get_duplicates
 from libecalc.input.mappers.facility_input import FacilityInputMapper
 from libecalc.input.mappers.fuel_and_emission_mapper import FuelMapper
 from libecalc.input.mappers.model import ModelMapper
@@ -26,6 +27,17 @@ def create_references(configuration: PyYamlYamlModel, resources: Resources) -> R
         facility_inputs=facility_inputs_from_files,
         resources=resources,
     )
+
+    duplicated_fuel_names = get_duplicates(
+        [fuel_data.get(EcalcYamlKeywords.name) for fuel_data in configuration.fuel_types]
+    )
+
+    if len(duplicated_fuel_names) > 0:
+        raise ValueError(
+            "Fuel type names must be unique across installations."
+            f" Duplicated names are: {', '.join(duplicated_fuel_names)}"
+        )
+
     fuel_types = {
         fuel_data.get(EcalcYamlKeywords.name): FuelMapper.from_yaml_to_dto(fuel_data)
         for fuel_data in configuration.fuel_types

--- a/src/ecalc/libraries/libecalc/common/tests/dto/test_fuel_consumer.py
+++ b/src/ecalc/libraries/libecalc/common/tests/dto/test_fuel_consumer.py
@@ -21,7 +21,7 @@ def get_fuel(fuel_name: str, price: float, emission_name: str) -> Dict[datetime,
         emission_name: name of emission, e.g. co2
 
     Returns:
-        dict[datetime, dto.types.FuelType]
+        Dict[datetime, dto.types.FuelType]
     """
     return {
         datetime(2000, 1, 1): dto.types.FuelType(
@@ -61,8 +61,8 @@ def get_installation(installation_name: str, fuel_consumer: dto.FuelConsumer) ->
 
 def get_fuel_consumer(
     consumer_name: str,
-    fuel_type: dict[datetime, dto.types.FuelType],
-    category: dict[datetime, dto.base.ConsumerUserDefinedCategoryType],
+    fuel_type: Dict[datetime, dto.types.FuelType],
+    category: Dict[datetime, dto.base.ConsumerUserDefinedCategoryType],
 ) -> dto.FuelConsumer:
     """
     Generates a fuel consumer dto for use in testing

--- a/src/ecalc/libraries/libecalc/common/tests/dto/test_fuel_consumer.py
+++ b/src/ecalc/libraries/libecalc/common/tests/dto/test_fuel_consumer.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Dict
 
 import pytest
 from libecalc import dto
@@ -10,7 +11,7 @@ from pydantic import ValidationError
 regularity = {datetime(2000, 1, 1): Expression.setup_from_expression(1)}
 
 
-def get_fuel(fuel_name: str, price: float, emission_name: str) -> dict[datetime, dto.types.FuelType]:
+def get_fuel(fuel_name: str, price: float, emission_name: str) -> Dict[datetime, dto.types.FuelType]:
     """
     Generates a fuel type dto for use in testing
 

--- a/src/ecalc/libraries/libecalc/common/tests/dto/test_fuel_consumer.py
+++ b/src/ecalc/libraries/libecalc/common/tests/dto/test_fuel_consumer.py
@@ -7,6 +7,87 @@ from libecalc.dto.types import EnergyUsageType
 from libecalc.expression import Expression
 from pydantic import ValidationError
 
+regularity = {datetime(2000, 1, 1): Expression.setup_from_expression(1)}
+
+
+def get_fuel(fuel_name: str, price: float, emission_name: str) -> dict[datetime, dto.types.FuelType]:
+    """
+    Generates a fuel type dto for use in testing
+
+    Args:
+        fuel_name: name of fuel
+        price: cost of fuel
+        emission_name: name of emission, e.g. co2
+
+    Returns:
+        dict[datetime, dto.types.FuelType]
+    """
+    return {
+        datetime(2000, 1, 1): dto.types.FuelType(
+            name=fuel_name,
+            price=Expression.setup_from_expression(value=price),
+            emissions=[
+                dto.Emission(
+                    name=emission_name,
+                    factor=Expression.setup_from_expression(value=1),
+                    tax=Expression.setup_from_expression(value=1),
+                ),
+            ],
+            user_defined_category=dto.types.FuelTypeUserDefinedCategoryType.FUEL_GAS,
+        )
+    }
+
+
+def get_installation(installation_name: str, fuel_consumer: dto.FuelConsumer) -> dto.Installation:
+    """
+    Generates an installation dto for use in testing
+
+    Args:
+        installation_name: name of installation
+        fuel_consumer: a fuel consumer object, e.g. a generator, compressor or boiler
+
+    Returns:
+        dto.Installation
+    """
+    return dto.Installation(
+        name=installation_name,
+        regularity=regularity,
+        hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression("sim1;var1")},
+        fuel_consumers=[fuel_consumer],
+        user_defined_category=dto.base.InstallationUserDefinedCategoryType.FIXED,
+    )
+
+
+def get_fuel_consumer(
+    consumer_name: str,
+    fuel_type: dict[datetime, dto.types.FuelType],
+    category: dict[datetime, dto.base.ConsumerUserDefinedCategoryType],
+) -> dto.FuelConsumer:
+    """
+    Generates a fuel consumer dto for use in testing
+
+    Args:
+        consumer_name: name of fuel consumer
+        fuel_type: fuel type, e.g. FUEL_GAS or DIESEL
+        category: user defined consumer category
+
+    Returns:
+        dto.FuelConsumer
+    """
+    return dto.FuelConsumer(
+        name=consumer_name,
+        fuel=fuel_type,
+        component_type=ComponentType.GENERIC,
+        energy_usage_model={
+            datetime(2000, 1, 1): dto.DirectConsumerFunction(
+                fuel_rate=Expression.setup_from_expression(1),
+                energy_usage_type=EnergyUsageType.FUEL,
+            )
+        },
+        regularity=regularity,
+        user_defined_category=category,
+    )
+
 
 class TestFuelConsumer:
     def test_missing_fuel(self):
@@ -21,23 +102,83 @@ class TestFuelConsumer:
                         energy_usage_type=EnergyUsageType.FUEL,
                     )
                 },
-                regularity={datetime(2000, 1, 1): Expression.setup_from_expression(1)},
+                regularity=regularity,
                 user_defined_category="category",
             )
         assert "Missing fuel for fuel consumer 'test'" in str(exc_info.value)
 
+    def test_duplicate_fuel_names(self):
+        """
+        TEST SCOPE: Check that duplicate fuel type names are not allowed.
+
+        Duplicate fuel type names should not be allowed across installations.
+        Duplicate names may lead to debug problems and overriding of previous
+        values without user noticing. This test checks that different fuels cannot
+        have same name.
+        """
+        fuel_consumer1 = get_fuel_consumer(
+            consumer_name="flare",
+            fuel_type=get_fuel("fuel1", price=100, emission_name="co2"),
+            category={datetime(2000, 1, 1): dto.base.ConsumerUserDefinedCategoryType.FLARE},
+        )
+
+        fuel_consumer2 = get_fuel_consumer(
+            consumer_name="boiler",
+            fuel_type=get_fuel("fuel1", price=1000, emission_name="ch4"),
+            category={datetime(2000, 1, 1): dto.base.ConsumerUserDefinedCategoryType.BOILER},
+        )
+
+        installation1 = get_installation("INST1", fuel_consumer1)
+        installation2 = get_installation("INST2", fuel_consumer2)
+
         with pytest.raises(ValidationError) as exc_info:
-            dto.FuelConsumer(
-                name="test",
-                fuel={},
-                component_type=ComponentType.GENERIC,
-                energy_usage_model={
-                    datetime(2000, 1, 1): dto.DirectConsumerFunction(
-                        fuel_rate=Expression.setup_from_expression(1),
-                        energy_usage_type=EnergyUsageType.FUEL,
-                    )
-                },
-                regularity={datetime(2000, 1, 1): Expression.setup_from_expression(1)},
-                user_defined_category="category",
+            dto.Asset(
+                name="multiple_installations_asset",
+                installations=[
+                    installation1,
+                    installation2,
+                ],
             )
-        assert "Missing fuel for fuel consumer 'test'" in str(exc_info.value)
+
+        assert "Duplicated names are: fuel1" in str(exc_info.value)
+
+    def test_same_fuel(self):
+        """
+        TEST SCOPE: Check that validation of duplicate fuel type names do not reject
+        when same fuel is used across installations.
+
+        Even though duplicate fuel type names are not allowed across installations,
+        it should be possible to re-use the same fuel. This test verifies that this still
+        works.
+        """
+
+        fuel_consumer1 = get_fuel_consumer(
+            consumer_name="flare",
+            fuel_type=get_fuel("fuel1", price=100, emission_name="co2"),
+            category={datetime(2000, 1, 1): dto.base.ConsumerUserDefinedCategoryType.FLARE},
+        )
+
+        fuel_consumer2 = get_fuel_consumer(
+            consumer_name="boiler",
+            fuel_type=get_fuel("fuel1", price=100, emission_name="co2"),
+            category={datetime(2000, 1, 1): dto.base.ConsumerUserDefinedCategoryType.BOILER},
+        )
+
+        installation1 = get_installation("INST1", fuel_consumer1)
+        installation2 = get_installation("INST2", fuel_consumer2)
+
+        asset = dto.Asset(
+            name="multiple_installations_asset",
+            installations=[
+                installation1,
+                installation2,
+            ],
+        )
+        fuel_types = []
+        for inst in asset.installations:
+            for fuel_consumer in inst.fuel_consumers:
+                for fuel_type in fuel_consumer.fuel.values():
+                    if fuel_type not in fuel_types:
+                        fuel_types.append(fuel_type)
+
+        assert len(fuel_types) == 1


### PR DESCRIPTION
## Why is this pull request needed?

- Names for `FUEL_TYPE` must be unique across installations in an eCalc model file
- Names for `EMISSIONS` must be unique within one `FUEL_TYPE`

Duplicate names may lead to debug problems e.g. for vector lengths etc. It may also override previous value without the user noticing (e.g. when Ctrl-C Ctrl-V syntax)

## What does this pull request change?

- [x] Add extra verification for duplicate fuel type names in Asset-class in components.py (library)
- [x] Add extra verifications in create_references.py for duplicate fuel type names in Yaml-file
- [x] Add extra verifications in create_references.py for duplicate emission names in Yaml-file
- [x] Add test for duplicate fuel type names using dto and library (no yaml)
- [x] Add test for duplicate fuel type names using yaml-file
- [x] Add test for duplicate emission names within one fuel, using yaml-file

## Issues related to this change:
https://github.com/equinor/ecalc-engine/issues/3401