### PR TITLE
fix: parse scientific notation numbers in expression

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/expression/expression_evaluator.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/expression/expression_evaluator.py
@@ -325,6 +325,7 @@ def lexer(expression: Union[str, int, float]) -> List[Token]:
         (r"while", TokenTag.operator),
         (r"do", TokenTag.operator),
         (r"end", TokenTag.operator),
+        (r"[0-9](\.[0-9]+)?e[-+]?[0-9]+", TokenTag.numeric),  # Scientific notation, e.g. 1.23e-05, 3.4e7, 1e+1
         (r"[0-9.]+", TokenTag.numeric),
         (r"[A-Za-z][A-Za-z0-9._;:+*/-]*", TokenTag.reference),
         (r"\$var\.[A-Za-z][A-Za-z0-9_]*", TokenTag.reference),
@@ -356,7 +357,7 @@ def check_tokens(tokens):
     if str(first_token) in list(OPERATORS.keys()):
         raise ValueError(f"Expression ({var}) can not start with an operator")
     if str(last_token) in list(OPERATORS.keys()):
-        raise ValueError(f"Expression ({var}) can not start with an operator")
+        raise ValueError(f"Expression ({var}) can not end with an operator")
     for idx, token in enumerate(tokens):
         prev_token = tokens[idx - 1]
         if str(prev_token) in list(OPERATORS.keys()) and str(token) in list(OPERATORS.keys()):

--- a/src/ecalc/libraries/libecalc/common/tests/expression/test_expression_evaluator.py
+++ b/src/ecalc/libraries/libecalc/common/tests/expression/test_expression_evaluator.py
@@ -94,6 +94,55 @@ def test_lexer():
     assert token_values == compare
 
 
+# disable formatting to prevent black from removing '+' from numbers with scientific notation
+# fmt: off
+scientific_expressions = [
+    ("1.1e1", [1.1e1], [TokenTag.numeric]),
+    ("1.1e111", [1.1e111], [TokenTag.numeric]),
+    ("1.1e+1", [1.1e+1], [TokenTag.numeric]),
+    ("1.1e-1", [1.1e-1], [TokenTag.numeric]),
+    ("1.1e-000001", [1.1e-000001], [TokenTag.numeric]),
+    ("1.1e+111", [1.1e+111], [TokenTag.numeric]),
+    ("1.1e-111", [1.1e-111], [TokenTag.numeric]),
+    ("1.111e1", [1.111e1], [TokenTag.numeric]),
+    ("1.111e+1", [1.111e+1], [TokenTag.numeric]),
+    ("1.111e-1", [1.111e-1], [TokenTag.numeric]),
+    ("1.111e-111", [1.111e-111], [TokenTag.numeric]),
+    ("1e1", [1e1], [TokenTag.numeric]),
+    ("1e+1", [1e+1], [TokenTag.numeric]),
+    ("1e-1", [1e-1], [TokenTag.numeric]),
+    ("1e-111", [1e-111], [TokenTag.numeric]),
+    (
+        "2.4e6 {/} 100 {*} 1.35e-05{+}  2e14 {-} 6.543e+11 {^} VARIABLE;VAL1",
+        [2.4e6, "{/}", 100.0, "{*}", 1.35e-05, "{+}", 2e14, "{-}", 6.543e+11, "{^}", "VARIABLE;VAL1"],
+        [
+            TokenTag.numeric,
+            TokenTag.operator,
+            TokenTag.numeric,
+            TokenTag.operator,
+            TokenTag.numeric,
+            TokenTag.operator,
+            TokenTag.numeric,
+            TokenTag.operator,
+            TokenTag.numeric,
+            TokenTag.operator,
+            TokenTag.reference,
+        ],
+    ),
+]
+# fmt: on
+
+
+@pytest.mark.parametrize(
+    "expression, expected, expected_token_tags",
+    scientific_expressions,
+)
+def test_lexer_scientific(expression, expected, expected_token_tags):
+    tokens = lexer(expression)
+    assert [token.value for token in tokens] == expected
+    assert [token.tag for token in tokens] == expected_token_tags
+
+
 def test_Powers(caplog):
     caplog.set_level("CRITICAL")
     with pytest.raises(Exception):


### PR DESCRIPTION
The expression lexer was missing parsing for scientific notation (e.g. `1.23e-05` or `3.4e7`) for numbers part of an expressions with multiple tokens.

Ex. expression `2 {*} 3.4e-05` would be parsed as tokens `[2, {*}, 3.4, e-05]`, which would give issues as there are no variables named e-05.