### PR TITLE
fix: json schema accepts MAXIMUM_DISCHARGE_PRESSURE for single speed …

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/input/validation/json_schemas/models-single-speed-compressor-train.json
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/validation/json_schemas/models-single-speed-compressor-train.json
@@ -30,6 +30,9 @@
         "PRESSURE_CONTROL": {
           "$ref": "#/definitions/PRESSURE_CONTROL"
         },
+        "MAXIMUM_DISCHARGE_PRESSURE": {
+          "type": "number"
+        },
         "COMPRESSOR_TRAIN": {
           "title": "COMPRESSOR_TRAIN",
           "description": "Specification of variable speed compressor train model with stages.\n\n$ECALC_DOCS_KEYWORDS_URL/MODELS",
@@ -77,6 +80,21 @@
           "description": "Maximum power delivered by electrical motor",
           "type": "number"
         }
+      },
+      "if": {
+         "properties": {
+          "PRESSURE_CONTROL": {
+            "const": "DOWNSTREAM_CHOKE"
+          }
+        }
+      },
+      "then": {
+        "unevaluatedProperties": {"MAXIMUM_DISCHARGE_PRESSURE": {
+          "type": "number"
+        }}
+      },
+      "else": {
+        "not": {"required": ["MAXIMUM_DISCHARGE_PRESSURE"]}
       },
       "additionalProperties": false,
       "required": [

--- a/src/ecalc/libraries/libecalc/common/tests/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
+++ b/src/ecalc/libraries/libecalc/common/tests/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
@@ -2697,6 +2697,20 @@
                 },
                 "SINGLE_SPEED_COMPRESSOR_TRAIN": {
                     "additionalProperties": false,
+                    "else": {
+                        "not": {
+                            "required": [
+                                "MAXIMUM_DISCHARGE_PRESSURE"
+                            ]
+                        }
+                    },
+                    "if": {
+                        "properties": {
+                            "PRESSURE_CONTROL": {
+                                "const": "DOWNSTREAM_CHOKE"
+                            }
+                        }
+                    },
                     "properties": {
                         "CALCULATE_MAX_RATE": {
                             "description": "Will return compressor train max standard rate [Sm3/day] in result if set to true.",
@@ -2748,6 +2762,9 @@
                                 }
                             ]
                         },
+                        "MAXIMUM_DISCHARGE_PRESSURE": {
+                            "type": "number"
+                        },
                         "MAXIMUM_POWER": {
                             "description": "Maximum power delivered by electrical motor",
                             "title": "MAXIMUM_POWER",
@@ -2779,7 +2796,14 @@
                         "FLUID_MODEL",
                         "COMPRESSOR_TRAIN",
                         "PRESSURE_CONTROL"
-                    ]
+                    ],
+                    "then": {
+                        "unevaluatedProperties": {
+                            "MAXIMUM_DISCHARGE_PRESSURE": {
+                                "type": "number"
+                            }
+                        }
+                    }
                 }
             },
             "description": "Experimental feature: Single speed compressor train.\n\nhttps://test.ecalc.equinor.com/docs/docs/modelling/keywords/_MODELS_",


### PR DESCRIPTION
…train

when PRESSURE_CONTROL is DOWNSTREAM_CHOKE

## Why is this pull request needed?

To fix bug in json schema, that gives wiggly line when using MAXIMUM_DISCHARGE_PRESSURE. This is an allowed property for single speed compressor trains if PRESSURE_CONTROL is set to DOWNSTREAM_CHOKE



