### PR TITLE
chore: add installation filter to flare nmvoc

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/output/results/configs/configs.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/output/results/configs/configs.py
@@ -347,6 +347,7 @@ class LTPConfig(ResultConfig):
                     title="NMVOC From Flare",
                     unit=Unit.TONS,
                     query=EmissionQuery(
+                        installation_category="FIXED",
                         consumer_categories=["FLARE"],
                         emission_type="nmvoc",
                     ),


### PR DESCRIPTION
## Why is this pull request needed?

All flare variables reported to ltp have installation filter, except for nmvoc. It should be consistent.

