### PR TITLE
fix: json schema allow stages to have control_margin and control_marg…

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/input/validation/json_schemas/models-compressor-train-simplified.json
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/validation/json_schemas/models-compressor-train-simplified.json
@@ -81,6 +81,12 @@
               },
               "INLET_TEMPERATURE": {
                 "$ref": "#/definitions/INLET_TEMPERATURE"
+              },
+              "CONTROL_MARGIN": {
+                    "$ref": "$SERVER_NAME/api/v1/schema-validation/models-variable-speed-compressor-train.json#definitions/CONTROL_MARGIN"
+                  },
+              "CONTROL_MARGIN_UNIT": {
+                "$ref": "$SERVER_NAME/api/v1/schema-validation/models-variable-speed-compressor-train.json#definitions/CONTROL_MARGIN_UNIT"
               }
             },
             "additionalProperties": false,

--- a/src/ecalc/libraries/libecalc/common/tests/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
+++ b/src/ecalc/libraries/libecalc/common/tests/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
@@ -2337,6 +2337,12 @@
                                     "COMPRESSOR_CHART": {
                                         "$ref": "#/definitions/COMPRESSOR_CHART"
                                     },
+                                    "CONTROL_MARGIN": {
+                                        "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/models-variable-speed-compressor-train.json#definitions/CONTROL_MARGIN"
+                                    },
+                                    "CONTROL_MARGIN_UNIT": {
+                                        "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/models-variable-speed-compressor-train.json#definitions/CONTROL_MARGIN_UNIT"
+                                    },
                                     "INLET_TEMPERATURE": {
                                         "$ref": "#/definitions/INLET_TEMPERATURE"
                                     }


### PR DESCRIPTION
…in_unit

for SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN


## What does this pull request change?

JSON Schema for SIPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN should allow for stages to have CONTROL_MARGIN
