### PR TITLE
chore: count parantheses in list of tokens only among the elements th…

### DIFF
--- a/src/ecalc/libraries/libecalc/common/tests/expression/test_expression_evaluator.py
+++ b/src/ecalc/libraries/libecalc/common/tests/expression/test_expression_evaluator.py
@@ -1,10 +1,12 @@
+import numpy as np
 import pytest
 from libecalc.expression.expression_evaluator import (
     TokenTag,
+    count_parentheses,
     eval_additions,
     eval_logicals,
     eval_mults,
-    eval_parenteses,
+    eval_parentheses,
     eval_powers,
     lex,
     lexer,
@@ -177,28 +179,41 @@ def test_logicals():
     assert eval_logicals(["10", "{/}", "4"]) == 2.5
 
 
-def test_Parenteses():
-    assert eval_parenteses(["(", "5", ")"]) == 5
-    assert eval_parenteses(["(", "5", "{+}", "4", ")", "{*}", "2"]) == 18
+def test_eval_parentheses():
+    assert eval_parentheses(["(", "5", ")"]) == 5
+    assert eval_parentheses(["(", "5", "{+}", "4", ")", "{*}", "2"]) == 18
     assert (
-        eval_parenteses(
+        eval_parentheses(
             ["(", "5", ">", "4", ")", "{+}", "(", "3", ">=", "3", ")"],
         )
         == 2
     )
-    assert eval_parenteses(["(", "5", "{+}", "4", ")", "==", "9"]) == 1
+    assert eval_parentheses(["(", "5", "{+}", "4", ")", "==", "9"]) == 1
     assert (
-        eval_parenteses(
+        eval_parentheses(
             ["(", "(", "5", "{+}", "4", ")", "{*}", "2", "{-}", "3", ")", "{+}", "1"],
         )
         == 16
     )
-    assert eval_parenteses(["12", ">=", "7"]) == 1
-    assert eval_parenteses(["12", "<", "7"]) == 0
-    assert eval_parenteses(["12", "<", "7", "{+}", "6"]) == 1
-    assert eval_parenteses(["12", "{-}", "7", "==", "5"]) == 1
+    assert eval_parentheses(["12", ">=", "7"]) == 1
+    assert eval_parentheses(["12", "<", "7"]) == 0
+    assert eval_parentheses(["12", "<", "7", "{+}", "6"]) == 1
+    assert eval_parentheses(["12", "{-}", "7", "==", "5"]) == 1
 
-    assert eval_parenteses(["12", "{+}", "7"]) == 19
-    assert eval_parenteses(["12", "{-}", "7"]) == 5
-    assert eval_parenteses(["12", "{*}", "7"]) == 84
-    assert eval_parenteses(["10", "{/}", "4"]) == 2.5
+    assert eval_parentheses(["12", "{+}", "7"]) == 19
+    assert eval_parentheses(["12", "{-}", "7"]) == 5
+    assert eval_parentheses(["12", "{*}", "7"]) == 84
+    assert eval_parentheses(["10", "{/}", "4"]) == 2.5
+
+
+def test_count_parentheses():
+    assert count_parentheses(
+        ["(", "5", ">", "4", ")", "{+}", "(", "3", ">=", "3", ")"],
+    ) == (2, 2)
+    assert count_parentheses(
+        ["(", np.asarray([1, 2, 3]), ">", "4", ")", "{+}", "(", "3", ">=", "3", ")"],
+    ) == (2, 2)
+    assert count_parentheses(
+        [["("], np.asarray([1, 2, 3]), ">", "4", ")", "{+}", "(", "3", ">=", "3", ")"],
+    ) == (1, 2)
+    assert count_parentheses([1, 2, 3]) == (0, 0)


### PR DESCRIPTION
…at are strings

From release notes of numpy 1.25:
```
== and != warnings have been finalized. The == and != operators on arrays now always:

    raise errors that occur during comparisons such as when the arrays have incompatible shapes (np.array([1, 2]) == np.array([1, 2, 3])).

    return an array of all True or all False when values are fundamentally not comparable (e.g. have different dtypes). An example is np.array(["a"]) == np.array([1]).

    This mimics the Python behavior of returning False and True when comparing incompatible types like "a" == 1 and "a" != 1. For a long time these gave DeprecationWarning or FutureWarning.

```

This will make the current use of the list.count() method to count the number of parentheses when elements in the list are numpy arrays. This pull request make sure that we count parentheses only among elements that can contain then, namely strings.
