### PR TITLE
fix: make sure that suction pressure is less than or equal to dischar…

### DIFF
--- a/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_compressor_train_base.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/models/compressor_modelling/test_compressor_train_base.py
@@ -190,3 +190,25 @@ def test_validate_operational_conditions(compressor_train):
     assert np.all(intermediate_pressure == 2)
     assert np.all(discharge_pressure == 3)
     assert failure_status == [CompressorTrainCommonShaftFailureStatus.INVALID_RATE_INPUT, None]
+
+    # test that suction_pressure, when suction_pressure > discharge_pressure, is set to discharge_pressure,
+    # and that rate at the same time is set to 0.
+    [
+        rate,
+        suction_pressure,
+        discharge_pressure,
+        intermediate_pressure,
+        failure_status,
+    ] = compressor_train.validate_operational_conditions(
+        rate=np.asarray([1000, 1000]),
+        suction_pressure=np.asarray([4, 3]),
+        intermediate_pressure=np.asarray([2, 2]),
+        discharge_pressure=np.asarray([3, 3]),
+    )
+    assert rate[0] == 0
+    assert rate[1] == 1000
+    assert suction_pressure[0] == 4
+    assert suction_pressure[1] == 3
+    assert np.all(intermediate_pressure == 2)
+    assert np.all(discharge_pressure == 3)
+    assert failure_status == [CompressorTrainCommonShaftFailureStatus.INVALID_SUCTION_PRESSURE_INPUT, None]


### PR DESCRIPTION
…ge pressure for compressor train

## Why is this pull request needed?

Suction pressure higher than discharge pressure gave negative enthalpy change over a compressor train and hence negative power. 

## What does this pull request change?

Validates that suction pressure is less than or equal to the discharge pressure for a compressor train. If the suction pressure is higher than the discharge pressure a failure status INVALID_SUCTION_PRESSURE_INPUT is given. In reality it could be either the suction pressure being too high or the discharge pressure being too low, but that will be up to the user to figure out...it can be hard to automatically detect which one it is.