### PR TITLE
fix: parse spaces as thousand separators from excel

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/input/file_io.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/file_io.py
@@ -419,10 +419,22 @@ def _dataframe_to_resource(df: pd.DataFrame) -> Resource:
 
 
 def read_csv(csv_data: Union[str, TextIO, BytesIO]) -> pandas.DataFrame:
+    """Wrapper of pandas read csv function
+
+    Settings used:
+        float_precision="round_trip" to avoid reading inaccurate floats, i.e. 0.724 becomes 0.7240000000000001
+        skipinitialspace=True converts "  10" to 10,
+        thousands=" " removes spaces used as thousand separators (normal in excel)
+
+    Args:
+        csv_data:
+
+    Returns:
+
+    """
     stream = StringIO(csv_data) if isinstance(csv_data, str) else csv_data
 
-    # float_precision="round_trip" to avoid reading inaccurate floats, i.e. 0.724 becomes 0.7240000000000001
-    return pd.read_csv(stream, comment="#", float_precision="round_trip")
+    return pd.read_csv(stream, comment="#", float_precision="round_trip", skipinitialspace=True, thousands=" ")
 
 
 def read_resource_from_string(resource_string: str) -> Resource:

--- a/src/ecalc/libraries/libecalc/common/tests/input/test_file_io.py
+++ b/src/ecalc/libraries/libecalc/common/tests/input/test_file_io.py
@@ -28,6 +28,17 @@ def timeseries_content_missing_value() -> str:
 
 
 @pytest.fixture
+def timeseries_resource_with_thousand_spacing(tmp_path):
+    file = tmp_path / "timeseries.csv"
+    file.write_text(
+        """DATE,          GAS_LIFT
+           01.01.2019,    10
+           01.01.2020,    10 000 """
+    )
+    return file
+
+
+@pytest.fixture
 def float_precise_csv():
     return io.StringIO(
         """SPEED
@@ -71,6 +82,12 @@ class TestReadTimeseriesResource:
         assert resource.data[0] == ["01.01.2019", "01.01.2020"]
         assert resource.data[1][0] == 1
         assert math.isnan(resource.data[1][1])
+
+    def test_read_timeseries_with_thousand_spacing(self, timeseries_resource_with_thousand_spacing):
+        resource = file_io.read_timeseries_resource(
+            resource_input=timeseries_resource_with_thousand_spacing, timeseries_type=YamlTimeseriesType.DEFAULT
+        )
+        assert resource.data[1] == [10, 10000]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because of wierd bug reported where thousand spacer was used and the error was not catched until NeqSim threw an NaN error

## What does this pull request change?

Removes initial and separator spaces when reading csvs

## Issues related to this change:

closes: https://github.com/equinor/ecalc-engine/issues/4661