### PR TITLE
fix: yaml dumper, indentless parameter hard-coded

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/input/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/yaml/yaml_models/pyyaml_yaml_model.py
@@ -107,8 +107,8 @@ class PyYamlYamlModel(YamlValidator, YamlModel):
     class IndentationDumper(yaml.Dumper):
         """In order to increase indentation of nested elements."""
 
-        def increase_indent(self, flow=False, indentless=False):
-            return super(PyYamlYamlModel.IndentationDumper, self).increase_indent(flow, False)
+        def increase_indent(self, flow: bool = False, indentless: bool = False):
+            return super(PyYamlYamlModel.IndentationDumper, self).increase_indent(flow=flow, indentless=indentless)
 
     class YamlReader:
         def __init__(


### PR DESCRIPTION
## Why is this pull request needed?

Found a dead-parameter, could not find it being used anywhere, so not sure if it was actually a bug. Still confusing with unused parameters

## What does this pull request change?

Use indentless parameter instead of hard-coding False

## Issues related to this change:
