### PR TITLE
[Merge Queue] Refactor: replace bare exit

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/output/utils/file_utils.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/output/utils/file_utils.py
@@ -1,4 +1,5 @@
 import enum
+import sys
 from typing import Callable, Optional, Union
 
 import pandas as pd
@@ -155,7 +156,7 @@ def get_component_output(
         print()
         selected_component_index = input("Enter the index of the component you want to select (q to quit): ")
         if selected_component_index == "q":
-            exit(0)
+            sys.exit(0)
 
         component = components[int(selected_component_index)]
 


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because no guarantee that the exit() from site module is available at runtime (from Ruf rule PLR1772)

## What does this pull request change?

Prefer sys.exit(), as the sys module is guaranteed to exist in all contexts.

