### PR TITLE
[Merge Queue]Refactor: NeqSim mapping

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/fluid.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/fluid.py
@@ -1,50 +1,12 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 import numpy as np
 from libecalc import dto
-from libecalc.common.exceptions import EcalcError
-from libecalc.common.logger import logger
 from libecalc.common.units import UnitConstants
-from libecalc.dto.types import EoSModel
-from neqsim_ecalc_wrapper import NeqsimEoSModelType, NeqsimFluid
+from neqsim_ecalc_wrapper import NeqsimFluid
 from numpy.typing import NDArray
-
-_map_eos_model_to_neqsim = {
-    EoSModel.SRK: NeqsimEoSModelType.SRK,
-    EoSModel.PR: NeqsimEoSModelType.PR,
-    EoSModel.GERG_SRK: NeqsimEoSModelType.GERG_SRK,
-    EoSModel.GERG_PR: NeqsimEoSModelType.GERG_PR,
-}
-
-_map_fluid_component_to_neqsim = {
-    "water": "water",
-    "nitrogen": "nitrogen",
-    "CO2": "CO2",
-    "methane": "methane",
-    "ethane": "ethane",
-    "propane": "propane",
-    "i_butane": "i-butane",
-    "n_butane": "n-butane",
-    "i_pentane": "i-pentane",
-    "n_pentane": "n-pentane",
-    "n_hexane": "n-hexane",
-}
-
-_map_fluid_component_from_neqsim = {
-    "water": "water",
-    "nitrogen": "nitrogen",
-    "CO2": "CO2",
-    "methane": "methane",
-    "ethane": "ethane",
-    "propane": "propane",
-    "i-butane": "i_butane",
-    "n-butane": "n_butane",
-    "i-pentane": "i_pentane",
-    "n-pentane": "n_pentane",
-    "n-hexane": "n_hexane",
-}
 
 
 class FluidStream:
@@ -70,10 +32,10 @@ class FluidStream:
             raise ValueError("FluidStream pressure needs to be above 0.")
         if existing_fluid is None:
             _neqsim_fluid_stream = NeqsimFluid.create_thermo_system(
-                composition=self._map_fluid_composition_to_neqsim(fluid_composition=self.fluid_model.composition),
+                composition=self.fluid_model.composition,
                 temperature_kelvin=temperature_kelvin,
                 pressure_bara=pressure_bara,
-                eos_model=_map_eos_model_to_neqsim[self.fluid_model.eos_model],
+                eos_model=self.fluid_model.eos_model,
             )
         else:
             _neqsim_fluid_stream = existing_fluid
@@ -93,10 +55,10 @@ class FluidStream:
             self.molar_mass_kg_per_mol = _neqsim_fluid_stream.molar_mass
         else:
             _neqsim_fluid_at_standard_conditions = NeqsimFluid.create_thermo_system(
-                composition=self._map_fluid_composition_to_neqsim(fluid_composition=self.fluid_model.composition),
+                composition=self.fluid_model.composition,
                 temperature_kelvin=UnitConstants.STANDARD_TEMPERATURE_KELVIN,
                 pressure_bara=UnitConstants.STANDARD_PRESSURE_BARA,
-                eos_model=_map_eos_model_to_neqsim[self.fluid_model.eos_model],
+                eos_model=self.fluid_model.eos_model,
             )
 
             self.standard_conditions_density = _neqsim_fluid_at_standard_conditions.density
@@ -125,21 +87,6 @@ class FluidStream:
     @property
     def enthalpy_joule_per_kg(self) -> float:
         return self._enthalpy_joule_per_kg
-
-    @staticmethod
-    def _map_fluid_composition_to_neqsim(fluid_composition: dto.FluidComposition) -> Dict[str, float]:
-        component_dict = {}
-        for component_name, value in fluid_composition.dict().items():
-            if value is not None and value > 0:
-                neqsim_name = _map_fluid_component_to_neqsim[component_name]
-                component_dict[neqsim_name] = float(value)
-
-        if len(component_dict) < 1:
-            msg = "Can not run pvt calculations for fluid without components"
-            logger.error(msg)
-            raise EcalcError(msg)
-
-        return component_dict
 
     def standard_to_mass_rate(
         self, standard_rates: Union[NDArray[np.float64], float]
@@ -210,10 +157,10 @@ class FluidStream:
         self, new_pressure_bara: float, new_temperature_kelvin: float, remove_liquid: bool = True
     ) -> FluidStream:
         fluid_stream = NeqsimFluid.create_thermo_system(
-            composition=self._map_fluid_composition_to_neqsim(fluid_composition=self.fluid_model.composition),
+            composition=self.fluid_model.composition,
             temperature_kelvin=self.temperature_kelvin,
             pressure_bara=self.pressure_bara,
-            eos_model=_map_eos_model_to_neqsim[self.fluid_model.eos_model],
+            eos_model=self.fluid_model.eos_model,
         )
 
         fluid_stream = fluid_stream.set_new_pressure_and_temperature(
@@ -227,10 +174,10 @@ class FluidStream:
         self, new_pressure: float, enthalpy_change_joule_per_kg: float, remove_liquid: bool = True
     ) -> FluidStream:
         fluid_stream = NeqsimFluid.create_thermo_system(
-            composition=self._map_fluid_composition_to_neqsim(fluid_composition=self.fluid_model.composition),
+            composition=self.fluid_model.composition,
             temperature_kelvin=self.temperature_kelvin,
             pressure_bara=self.pressure_bara,
-            eos_model=_map_eos_model_to_neqsim[self.fluid_model.eos_model],
+            eos_model=self.fluid_model.eos_model,
         )
 
         fluid_stream = fluid_stream.set_new_pressure_and_enthalpy(
@@ -263,36 +210,34 @@ class FluidStream:
         """
 
         new_fluid = NeqsimFluid.create_thermo_system(
-            composition=self._map_fluid_composition_to_neqsim(fluid_composition=self.fluid_model.composition),
+            composition=self.fluid_model.composition,
             temperature_kelvin=temperature_kelvin,
             pressure_bara=pressure_bara,
-            eos_model=_map_eos_model_to_neqsim[self.fluid_model.eos_model],
+            eos_model=self.fluid_model.eos_model,
         )
 
         other_fluid = NeqsimFluid.create_thermo_system(
-            composition=self._map_fluid_composition_to_neqsim(
-                fluid_composition=other_fluid_stream.fluid_model.composition
-            ),
+            composition=other_fluid_stream.fluid_model.composition,
             temperature_kelvin=other_fluid_stream.temperature_kelvin,
             pressure_bara=other_fluid_stream.pressure_bara,
-            eos_model=_map_eos_model_to_neqsim[other_fluid_stream.fluid_model.eos_model],
+            eos_model=other_fluid_stream.fluid_model.eos_model,
         )
 
-        composition_dict, _neqsim_fluid_stream = new_fluid.mix_streams(
+        new_fluid_composition, _neqsim_fluid_stream = new_fluid.mix_streams(
             stream_1=new_fluid,
             stream_2=other_fluid,
             mass_rate_stream_1=self_mass_rate,
             mass_rate_stream_2=other_mass_rate,
             pressure=pressure_bara,
             temperature=temperature_kelvin,
-            eos_model=_map_eos_model_to_neqsim[self.fluid_model.eos_model],
+            eos_model=self.fluid_model.eos_model,
         )
-        new_fluid_stream = FluidStream(existing_fluid=_neqsim_fluid_stream, fluid_model=self.fluid_model)
 
-        new_composition_dict = {
-            _map_fluid_component_from_neqsim[key]: value for (key, value) in composition_dict.items()
-        }
+        mixed_fluid = FluidStream(
+            existing_fluid=_neqsim_fluid_stream,
+            fluid_model=self.fluid_model,
+        )
 
-        new_fluid_stream.fluid_model.composition = dto.FluidComposition.parse_obj(new_composition_dict)
+        mixed_fluid.fluid_model.composition = new_fluid_composition
 
-        return new_fluid_stream
+        return mixed_fluid

--- a/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/__init__.py
+++ b/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/__init__.py
@@ -3,7 +3,7 @@ from neqsim_ecalc_wrapper.java_service import start_server
 java_gateway = start_server()
 neqsim = java_gateway.jvm.neqsim
 
-from neqsim_ecalc_wrapper.thermo import NeqsimEoSModelType, NeqsimFluid
+from neqsim_ecalc_wrapper.thermo import NeqsimFluid
 
 
 def methods(check_class):

--- a/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/mappings.py
+++ b/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/mappings.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict
+
+from libecalc import dto
+from libecalc.common.exceptions import EcalcError
+from libecalc.common.logger import logger
+from libecalc.dto.types import EoSModel
+
+from neqsim_ecalc_wrapper import neqsim
+
+
+class NeqsimEoSModelType(Enum):
+    SRK = neqsim.thermo.system.SystemSrkEos
+    PR = neqsim.thermo.system.SystemPrEos
+    GERG_SRK = neqsim.thermo.system.SystemSrkEos
+    GERG_PR = neqsim.thermo.system.SystemPrEos
+
+
+_map_eos_model_to_neqsim = {
+    EoSModel.SRK: NeqsimEoSModelType.SRK,
+    EoSModel.PR: NeqsimEoSModelType.PR,
+    EoSModel.GERG_SRK: NeqsimEoSModelType.GERG_SRK,
+    EoSModel.GERG_PR: NeqsimEoSModelType.GERG_PR,
+}
+_map_fluid_component_to_neqsim = {
+    "water": "water",
+    "nitrogen": "nitrogen",
+    "CO2": "CO2",
+    "methane": "methane",
+    "ethane": "ethane",
+    "propane": "propane",
+    "i_butane": "i-butane",
+    "n_butane": "n-butane",
+    "i_pentane": "i-pentane",
+    "n_pentane": "n-pentane",
+    "n_hexane": "n-hexane",
+}
+_map_fluid_component_from_neqsim = {
+    "water": "water",
+    "nitrogen": "nitrogen",
+    "CO2": "CO2",
+    "methane": "methane",
+    "ethane": "ethane",
+    "propane": "propane",
+    "i-butane": "i_butane",
+    "n-butane": "n_butane",
+    "i-pentane": "i_pentane",
+    "n-pentane": "n_pentane",
+    "n-hexane": "n_hexane",
+}
+
+
+def map_fluid_composition_to_neqsim(fluid_composition: dto.FluidComposition) -> Dict[str, float]:
+    component_dict = {}
+    for component_name, value in fluid_composition.dict().items():
+        if value is not None and value > 0:
+            neqsim_name = _map_fluid_component_to_neqsim[component_name]
+            component_dict[neqsim_name] = float(value)
+
+    if len(component_dict) < 1:
+        msg = "Can not run pvt calculations for fluid without components"
+        logger.error(msg)
+        raise EcalcError(title="Failed to create NeqSim fluid", message=msg)
+
+    return component_dict
+
+
+def map_eos_model_to_neqsim(ecalc_eos_model: EoSModel) -> NeqsimEoSModelType:
+    try:
+        return _map_eos_model_to_neqsim[ecalc_eos_model]
+    except KeyError as e:
+        raise EcalcError(title="Failed to create NeqSim fluid", message=str(e)) from e

--- a/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
+++ b/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
@@ -2,19 +2,26 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from enum import Enum
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
+from libecalc import dto
 from libecalc.common.capturer import Capturer
 from libecalc.common.logger import logger
+from libecalc.dto.types import EoSModel
 from py4j.protocol import Py4JJavaError
 from pydantic import BaseModel
 
 from neqsim_ecalc_wrapper import neqsim
 from neqsim_ecalc_wrapper.components import COMPONENTS
 from neqsim_ecalc_wrapper.exceptions import NeqsimPhaseError
+from neqsim_ecalc_wrapper.mappings import (
+    NeqsimEoSModelType,
+    _map_fluid_component_from_neqsim,
+    map_eos_model_to_neqsim,
+    map_fluid_composition_to_neqsim,
+)
 
 STANDARD_TEMPERATURE_KELVIN = 288.15
 STANDARD_PRESSURE_BARA = 1.01325
@@ -23,13 +30,6 @@ NEQSIM_MIXING_RULE = 2
 
 ThermodynamicSystem = neqsim.thermo.system.SystemEos
 ThermodynamicOperations = neqsim.thermodynamicOperations.ThermodynamicOperations
-
-
-class NeqsimEoSModelType(Enum):
-    SRK = neqsim.thermo.system.SystemSrkEos
-    PR = neqsim.thermo.system.SystemPrEos
-    GERG_SRK = neqsim.thermo.system.SystemSrkEos
-    GERG_PR = neqsim.thermo.system.SystemPrEos
 
 
 class NeqsimFluidComponent(BaseModel):
@@ -120,10 +120,10 @@ class NeqsimFluid:
     @classmethod
     def create_thermo_system(
         cls,
-        composition: Dict[str, float],
+        composition: dto.FluidComposition,
         temperature_kelvin: float = STANDARD_TEMPERATURE_KELVIN,
         pressure_bara: float = STANDARD_PRESSURE_BARA,
-        eos_model: NeqsimEoSModelType = NeqsimEoSModelType.SRK,
+        eos_model: EoSModel = EoSModel.SRK,
         mixing_rule: int = NEQSIM_MIXING_RULE,
     ) -> NeqsimFluid:
         """Initiates a NeqsimFluid that wraps both a Neqsim thermodynamic system and operations.
@@ -142,6 +142,9 @@ class NeqsimFluid:
         :return:
         """
         use_gerg = "gerg" in eos_model.name.lower()
+
+        composition = map_fluid_composition_to_neqsim(fluid_composition=composition)
+        eos_model = map_eos_model_to_neqsim(eos_model)
         non_existing_components = [
             component for component, value in composition.items() if (component not in COMPONENTS) and (value > 0.0)
         ]
@@ -280,24 +283,9 @@ class NeqsimFluid:
         mass_rate_stream_2: float,
         pressure: float,
         temperature: float,
-        eos_model: NeqsimEoSModelType = NeqsimEoSModelType.SRK,
-    ) -> Tuple[Dict, NeqsimFluid]:
+        eos_model: EoSModel = EoSModel.SRK,
+    ) -> Tuple[dto.FluidComposition, NeqsimFluid]:
         """Mixing two streams (NeqsimFluids) with same pressure and temperature."""
-        if stream_1 is None:
-            return (
-                {},  # Fixme: Need to return composition dict
-                stream_2.set_new_pressure_and_temperature(
-                    new_pressure_bara=pressure, new_temperature_kelvin=temperature
-                ),
-            )
-        if stream_2 is None:
-            return (
-                {},  # Fixme: Need to return composition dict
-                stream_1.set_new_pressure_and_temperature(
-                    new_pressure_bara=pressure,
-                    new_temperature_kelvin=temperature,
-                ),
-            )
 
         composition_dict: Dict[str, float] = {}
 
@@ -316,10 +304,14 @@ class NeqsimFluid:
                 else:
                     composition_dict[composition_name] = composition_moles
 
+        ecalc_fluid_composition = dto.FluidComposition.parse_obj(
+            {_map_fluid_component_from_neqsim[key]: value for (key, value) in composition_dict.items()}
+        )
+
         return (
-            composition_dict,
+            ecalc_fluid_composition,
             NeqsimFluid.create_thermo_system(
-                composition=composition_dict,
+                composition=ecalc_fluid_composition,
                 temperature_kelvin=temperature,
                 pressure_bara=pressure,
                 eos_model=eos_model,

--- a/src/ecalc/libraries/neqsim/tests/conftest.py
+++ b/src/ecalc/libraries/neqsim/tests/conftest.py
@@ -1,33 +1,37 @@
 import pytest
-from neqsim_ecalc_wrapper.thermo import NeqsimEoSModelType, NeqsimFluid
+from libecalc import dto
+from libecalc.dto.types import EoSModel
+from neqsim_ecalc_wrapper.thermo import NeqsimFluid
 
-HEAVY_FLUID_COMPOSITION = {
-    "nitrogen": 0.682785869,
-    "CO2": 2.466921329,
-    "methane": 79.57192993,
-    "ethane": 5.153816223,
-    "propane": 9.679747581,
-    "i-butane": 0.691399336,
-    "n-butane": 1.174334645,
-    "i-pentane": 0.208390206,
-    "n-pentane": 0.201853022,
-    "n-hexane": 0.16881974,
-}
+HEAVY_FLUID_COMPOSITION = dto.FluidComposition(
+    nitrogen=0.682785869,
+    CO2=2.466921329,
+    methane=79.57192993,
+    ethane=5.153816223,
+    propane=9.679747581,
+    i_butane=0.691399336,
+    n_butane=1.174334645,
+    i_pentane=0.208390206,
+    n_pentane=0.201853022,
+    n_hexane=0.16881974,
+)
 
-MEDIUM_MW_19P4_COMPOSITION = {
-    "nitrogen": 0.74373,
-    "CO2": 2.415619,
-    "methane": 85.60145,
-    "ethane": 6.707826,
-    "propane": 2.611471,
-    "i-butane": 0.45077,
-    "n-butane": 0.691702,
-    "i-pentane": 0.210714,
-    "n-pentane": 0.197937,
-    "n-hexane": 0.368786,
-}
+MEDIUM_MW_19P4_COMPOSITION = dto.FluidComposition(
+    nitrogen=0.74373,
+    CO2=2.415619,
+    methane=85.60145,
+    ethane=6.707826,
+    propane=2.611471,
+    i_butane=0.45077,
+    n_butane=0.691702,
+    i_pentane=0.210714,
+    n_pentane=0.197937,
+    n_hexane=0.368786,
+)
 
-LIGHT_FLUID_COMPOSITION = {"methane": 10.0, "ethane": 1.0, "propane": 0.1, "n-heptane": 10.1}
+LIGHT_FLUID_COMPOSITION = dto.FluidComposition(
+    methane=10.0, ethane=1.0, propane=0.1, n_hexane=10.1
+)  # Heptane not used in eCalc, on ly care about C1-C6
 
 
 @pytest.fixture
@@ -42,9 +46,7 @@ def medium_fluid() -> NeqsimFluid:
 
 @pytest.fixture
 def medium_fluid_with_gerg() -> NeqsimFluid:
-    return NeqsimFluid.create_thermo_system(
-        composition=MEDIUM_MW_19P4_COMPOSITION, eos_model=NeqsimEoSModelType.GERG_SRK
-    )
+    return NeqsimFluid.create_thermo_system(composition=MEDIUM_MW_19P4_COMPOSITION, eos_model=EoSModel.GERG_SRK)
 
 
 @pytest.fixture

--- a/src/ecalc/libraries/neqsim/tests/conftest.py
+++ b/src/ecalc/libraries/neqsim/tests/conftest.py
@@ -31,7 +31,7 @@ MEDIUM_MW_19P4_COMPOSITION = dto.FluidComposition(
 
 LIGHT_FLUID_COMPOSITION = dto.FluidComposition(
     methane=10.0, ethane=1.0, propane=0.1, n_hexane=10.1
-)  # Heptane not used in eCalc, on ly care about C1-C6
+)  # Heptane not used in eCalc, only care about C1-C6
 
 
 @pytest.fixture

--- a/src/ecalc/libraries/neqsim/tests/integration_tests/test_remove_liquid.py
+++ b/src/ecalc/libraries/neqsim/tests/integration_tests/test_remove_liquid.py
@@ -1,43 +1,36 @@
 import math
 
 import pytest
+from libecalc import dto
 from neqsim_ecalc_wrapper.thermo import NeqsimFluid
 
-INLET_FLUID_COMPOSITION = {
-    "nitrogen": 6.78e-03,
-    "CO2": 5.74e-03,
-    "methane": 0.795667071,
-    "ethane": 9.82e-02,
-    "propane": 5.95e-02,
-    "i-butane": 6.25e-03,
-    "n-butane": 1.60e-02,
-    "i-pentane": 3.23e-03,
-    "n-pentane": 4.20e-03,
-    "n-hexane": 9.11e-08,
-    "n-heptane": 6.15e-04,
-    "n-octane": 1.40e-04,
-    "n-nonane": 1.50e-05,
-    "nC10": 3.14e-07,
-    "water": 3.69e-03,
-}
+INLET_FLUID_COMPOSITION = dto.FluidComposition(
+    nitrogen=6.78e-03,
+    CO2=5.74e-03,
+    methane=0.795667071,
+    ethane=9.82e-02,
+    propane=5.95e-02,
+    i_butane=6.25e-03,
+    n_butane=1.60e-02,
+    i_pentane=3.23e-03,
+    n_pentane=4.20e-03,
+    n_hexane=9.11e-08,
+    water=3.69e-03,
+)
 
-OUTLET_FLUID_COMPOSITION = {
-    "nitrogen": 6.79e-03,
-    "CO2": 5.75e-03,
-    "methane": 0.797181663,
-    "ethane": 0.098415785,
-    "propane": 5.96e-02,
-    "i-butane": 6.26e-03,
-    "n-butane": 1.60e-02,
-    "i-pentane": 3.24e-03,
-    "n-pentane": 4.21e-03,
-    "n-hexane": 9.13e-08,
-    "n-heptane": 6.16e-04,
-    "n-octane": 1.41e-04,
-    "n-nonane": 1.51e-05,
-    "nC10": 3.15e-07,
-    "water": 1.79e-03,
-}
+OUTLET_FLUID_COMPOSITION = dto.FluidComposition(
+    nitrogen=6.79e-03,
+    CO2=5.75e-03,
+    methane=0.797181663,
+    ethane=0.098415785,
+    propane=5.96e-02,
+    i_butane=6.26e-03,
+    n_butane=1.60e-02,
+    i_pentane=3.24e-03,
+    n_pentane=4.21e-03,
+    n_hexane=9.13e-08,
+    water=1.79e-03,
+)
 
 
 @pytest.fixture
@@ -92,7 +85,7 @@ def test_liquid_takeoff(inlet_fluid, outlet_fluid) -> None:
     """
     assert inlet_fluid.pressure_bara == 1700 / 100
     assert inlet_fluid.temperature_kelvin == 36.0 + 273.15
-    assert math.isclose(inlet_fluid.density, 14.50851117, rel_tol=0.01)  # 1 % tolerance
+    assert math.isclose(inlet_fluid.density, 14.343437, rel_tol=0.01)  # 1 % tolerance
 
     fluid_after_compressor = inlet_fluid.set_new_pressure_and_temperature(
         new_pressure_bara=4547.67395 / 100,


### PR DESCRIPTION
Part 3 of NeqSim Interface

## Why is this pull request needed?

When more EOS pacakges are added, the mapping unique to a EoS library should be contained inside that package. eCalc should be agnostic


## Issues related to this change:

Need to figure out why all-energy-usage-models change