### PR TITLE
chore!: force one energy model type within one consumer

### DIFF
--- a/src/ecalc/cli/tests/test_app.py
+++ b/src/ecalc/cli/tests/test_app.py
@@ -40,6 +40,11 @@ def simple_duplicate_names_yaml_path():
 
 
 @pytest.fixture(scope="session")
+def simple_multiple_energy_models_yaml_path():
+    return (Path(simple.__file__).parent / "model_multiple_energy_models_one_consumer.yaml").absolute()
+
+
+@pytest.fixture(scope="session")
 def simple_duplicate_emissions_yaml_path():
     return (Path(simple.__file__).parent / "model_duplicate_emissions_in_fuel.yaml").absolute()
 
@@ -735,4 +740,32 @@ class TestYamlFile:
 
         assert "Emission names must be unique for each fuel type. " "Duplicated names are: CO2,CH4" in str(
             exc_info.value
+        )
+
+    def test_yaml_multiple_energy_models_one_consumer(self, simple_multiple_energy_models_yaml_path, tmp_path):
+        """
+        TEST SCOPE: Check that multiple energy models for one consumer are not allowed in Yaml file.
+
+        Args:
+            simple model file with energy models for one consumer:
+
+        Returns:
+
+        """
+        with pytest.raises(ValueError) as exc_info:
+            runner.invoke(
+                main.app,
+                _get_args(
+                    model_file=simple_multiple_energy_models_yaml_path,
+                    csv=True,
+                    output_folder=tmp_path,
+                    name_prefix="test",
+                    output_frequency="YEAR",
+                ),
+                catch_exceptions=False,
+            )
+
+        assert (
+            "Energy model type cannot change over time within a single consumer. "
+            "The model type is changed for gasinj: ['DIRECT', 'COMPRESSOR']" in str(exc_info.value)
         )

--- a/src/ecalc/libraries/libecalc/common/libecalc/examples/simple/model_multiple_energy_models_one_consumer.yaml
+++ b/src/ecalc/libraries/libecalc/common/libecalc/examples/simple/model_multiple_energy_models_one_consumer.yaml
@@ -1,0 +1,47 @@
+TIME_SERIES:
+  - NAME: SIM
+    FILE: production_data.csv
+    TYPE: DEFAULT
+FACILITY_INPUTS:
+  - NAME: genset
+    FILE: genset.csv
+    TYPE: ELECTRICITY2FUEL
+  - NAME: compressor_sampled
+    FILE: compressor_sampled.csv
+    TYPE: COMPRESSOR_TABULAR
+
+FUEL_TYPES:
+  - NAME: fuel_gas
+    PRICE: 1.5  # NOK/Sm3
+    EMISSIONS:
+      - NAME: CO2
+        FACTOR: 2.19  # CO2/Sm3 fuel gas burned
+        TAX: 1.5  # NOK/Sm3 fuel gas burned
+        QUOTA: 260  # NOK/ton
+
+
+VARIABLES:
+  hydrocarbon_export_sm3_per_day:
+    VALUE: SIM;OIL_PROD {+} SIM;GAS_SALES {/} 1000  # divide the gas rate by 1000 to get oil equivalent
+  gas_injection_rate_sm3_per_day:
+    VALUE: SIM;GAS_INJ {+} SIM;GAS_LIFT
+
+INSTALLATIONS:
+  - NAME: Installation A
+    HCEXPORT: $var.hydrocarbon_export_sm3_per_day
+    FUEL: fuel_gas
+    GENERATORSETS:
+      - NAME: Generator set A
+        ELECTRICITY2FUEL: genset
+        CATEGORY: TURBINE-GENERATOR
+        CONSUMERS:
+          - NAME: gasinj
+            CATEGORY: BASE-LOAD
+            ENERGY_USAGE_MODEL:
+              2020-01-01:
+                TYPE: DIRECT
+                LOAD: 11.8 # MW
+              2022-01-01:
+                TYPE: COMPRESSOR
+                ENERGYFUNCTION: compressor_sampled
+                RATE: $var.gas_injection_rate_sm3_per_day

--- a/src/ecalc/libraries/libecalc/common/tests/output/flow_diagram/snapshots/test_ecalc_model_mapper/test_all_energy_usage_models/all_energy_usage_models_fde.json
+++ b/src/ecalc/libraries/libecalc/common/tests/output/flow_diagram/snapshots/test_ecalc_model_mapper/test_all_energy_usage_models/all_energy_usage_models_fde.json
@@ -1130,7 +1130,7 @@
                             "id": "MAIN_INSTALLATION-consumer-late_start_consumer_evolving_type",
                             "subdiagram": null,
                             "title": "late_start_consumer_evolving_type",
-                            "type": "direct"
+                            "type": "tabulated"
                         },
                         {
                             "id": "MAIN_INSTALLATION-consumer-salt_water_injection_tabular",

--- a/src/ecalc/libraries/libecalc/fixtures/libecalc/fixtures/cases/all_energy_usage_models/all_models_dto.py
+++ b/src/ecalc/libraries/libecalc/fixtures/libecalc/fixtures/cases/all_energy_usage_models/all_models_dto.py
@@ -435,11 +435,7 @@ def late_start_consumer_evolving_type(regularity) -> dto.ElectricityConsumer:
         user_defined_category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.PUMP},
         regularity=regularity,
         energy_usage_model={
-            datetime(2018, 1, 1): dto.DirectConsumerFunction(
-                load=Expression.setup_from_expression(value=1),
-                energy_usage_type=dto.types.EnergyUsageType.POWER,
-            ),
-            datetime(2019, 1, 1): dto.TabulatedConsumerFunction(
+            datetime(2018, 1, 1): dto.TabulatedConsumerFunction(
                 model=dto.TabulatedData(
                     headers=["RATE", "POWER"],
                     data=[

--- a/src/ecalc/libraries/libecalc/fixtures/libecalc/fixtures/cases/all_energy_usage_models/data/all_energy_usage_models.yaml
+++ b/src/ecalc/libraries/libecalc/fixtures/libecalc/fixtures/cases/all_energy_usage_models/data/all_energy_usage_models.yaml
@@ -401,9 +401,6 @@ INSTALLATIONS:
             CATEGORY: PUMP
             ENERGY_USAGE_MODEL:
               2018-01-01:
-                TYPE: DIRECT
-                LOAD: 1 # MW
-              2019-01-01:
                 TYPE: TABULATED
                 ENERGYFUNCTION: swinj
                 VARIABLES:


### PR DESCRIPTION
BREAKING CHANGE: Not possible to change energy model `TYPE` over time within one consumer.

## Why is this pull request needed?

eCalc web is not yet ready to handle results with multiple energy model types, hence it should not be allowed to specify in the yaml model file.

## What does this pull request change?

- [x] Add yaml model file check for multiple energy model types within one consumer. Raise value error if found.
- [x] Add test
- [x] Modify some yaml model test files to remove multiple energy model types within one consumer

## Issues related to this change:
https://github.com/equinor/ecalc-engine/issues/4635