### PR TITLE
docs: update docs and changelog for energy models

### DIFF
--- a/docs/docs/about/references/keywords/ENERGY_USAGE_MODEL.md
+++ b/docs/docs/about/references/keywords/ENERGY_USAGE_MODEL.md
@@ -33,9 +33,8 @@ on the calculated energy usage after the calculated energy usage from the model 
 
 ## Temporal energy usage model
 
-It is possible to change the energy model within a consumer over time. It is highly recommended that the
-`ENERGY_USAGE_MODEL` stays within one type. TYPE evolution, while supported, may create challenges when interpreting
-the results. In this case, if possible, we recommend that you split the model into two [CONSUMERS](CONSUMERS.md).
+It is possible to update the energy model within a consumer over time, as long as the
+`ENERGY_USAGE_MODEL` stays within one type. The `TYPE` cannot change over time. In case `TYPE` evolution is needed, we recommend that you split the model into two [CONSUMERS](CONSUMERS.md).
 
 ~~~~~~~~yaml
 ENERGY_USAGE_MODEL:

--- a/docs/docs/changelog/v8-3.md
+++ b/docs/docs/changelog/v8-3.md
@@ -14,3 +14,9 @@ the migration guide for details on changes, where relevant.
 
 ## Fixes
 - A bug in the mixing of fluid-streams in compressor trains were fixed. This bug caused the density at standard conditions not to be updated, leading to the standard rates being wrong. This is expected to change the results of some eCalc Models
+
+## Breaking changes
+Some breaking changes are needed to keep improving eCalc, remove ambiguity and prepare eCalc for the future:
+
+### Input: YAML / Resource files
+1. It is no longer accepted to change ENERGY_USAGE_MODEL TYPE over time, within one consumer. In case TYPE evolution is needed, the model can be split in two consumers. 


### PR DESCRIPTION
## Why is this pull request needed?

Update documentation for `ENERGY_USAGE_MODEL`, and update changelog with breaking change: energy model type is not allowed to change over time within a consumer.


## Issues related to this change:
https://github.com/equinor/ecalc-engine/issues/4635