### PR TITLE
refactor: only do tp-flash once

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/fluid.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/models/compressor/train/fluid.py
@@ -191,16 +191,12 @@ class FluidStream:
         """
         fluid_stream = NeqsimFluid.create_thermo_system(
             composition=self.fluid_model.composition,
-            temperature_kelvin=self.temperature_kelvin,
-            pressure_bara=self.pressure_bara,
+            temperature_kelvin=new_temperature_kelvin,
+            pressure_bara=new_pressure_bara,
             eos_model=self.fluid_model.eos_model,
-        )
-
-        fluid_stream = fluid_stream.set_new_pressure_and_temperature(
-            new_pressure_bara=new_pressure_bara,
-            new_temperature_kelvin=new_temperature_kelvin,
             remove_liquid=remove_liquid,
         )
+
         return FluidStream(existing_fluid=fluid_stream, fluid_model=self.fluid_model)
 
     def set_new_pressure_and_enthalpy_change(

--- a/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
+++ b/src/ecalc/libraries/neqsim/neqsim_ecalc_wrapper/thermo.py
@@ -126,6 +126,7 @@ class NeqsimFluid:
         pressure_bara: float = STANDARD_PRESSURE_BARA,
         eos_model: EoSModel = EoSModel.SRK,
         mixing_rule: int = NEQSIM_MIXING_RULE,
+        remove_liquid: bool = False,
     ) -> NeqsimFluid:
         """Initiates a NeqsimFluid that wraps both a Neqsim thermodynamic system and operations.
 
@@ -141,6 +142,9 @@ class NeqsimFluid:
         :param eos_model: The name of the underlying EOS model
         :param mixing_rule: The Neqsim mixing rule.
         :return:
+
+        Args:
+            remove_liquid:
         """
         use_gerg = "gerg" in eos_model.name.lower()
 
@@ -162,6 +166,9 @@ class NeqsimFluid:
             pressure_bara=pressure_bara,
             mixing_rule=mixing_rule,
         )
+
+        if remove_liquid:
+            thermodynamic_system = NeqsimFluid._remove_liquid(thermodynamic_system=thermodynamic_system)
 
         return NeqsimFluid(thermodynamic_system=thermodynamic_system, use_gerg=use_gerg)
 


### PR DESCRIPTION
Wierd thing:When doing this all tests pass, but entire test suite takes 30s longer, 33% increase in time. 

From 1:37 to 2:07 on my MacBook

Any input on why this would slow down performance?