### PR TITLE
feat: add input compressor pressures to output

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/common/component_info/compressor.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/common/component_info/compressor.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class CompressorInputPressures(str, Enum):
+    inlet_pressure = "inlet_pressure"
+    outlet_pressure = "outlet_pressure"

--- a/src/ecalc/libraries/libecalc/common/libecalc/dto/result/results.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/dto/result/results.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from operator import attrgetter
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -107,6 +108,8 @@ class CompressorResult(EquipmentResultBase):
     recirculation_loss: TimeSeriesRate
     rate_exceeds_maximum: TimeSeriesBoolean
     outlet_pressure_before_choking: TimeSeriesFloat
+    requested_inlet_pressure: Dict[datetime, TimeSeriesFloat]
+    requested_outlet_pressure: Dict[datetime, TimeSeriesFloat]
 
 
 class DirectEmitterResult(EquipmentResultBase):


### PR DESCRIPTION
## Why is this pull request needed?

Add compressor inlet- and outlet pressures from input data to output results, as requested inlet- and outlet pressures. When implemented in web, the input pressures can be plotted together with calculated pressures. Make it easier to understand that in case of pressure control mechanisms are active, the requested (input) inlet and outlet pressures may differ from what is actually calculated by eCalc.

## What does this pull request change?
- [x] Extend eCalc-result object with compressor inlet- and outlet pressures from input data
- [x] Write the input pressures to dto.result.results.CompressorResult object
- [x] Update snapshots

## Issues related to this change:
https://github.com/equinor/ecalc-engine/issues/4431
