### PR TITLE
Handle dates corectly in yaml

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/input/yaml_types/yaml_temporal_model.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/yaml_types/yaml_temporal_model.py
@@ -1,11 +1,6 @@
 from typing import Dict, TypeVar, Union
 
-from pydantic import ConstrainedStr
-
-
-class DatetimeString(ConstrainedStr):
-    regex = "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$"
-
+from libecalc.input.yaml_types.yaml_variable import YamlDefaultDatetime
 
 TModel = TypeVar("TModel")
-YamlTemporalModel = Union[TModel, Dict[DatetimeString, TModel]]
+YamlTemporalModel = Union[TModel, Dict[YamlDefaultDatetime, TModel]]

--- a/src/ecalc/libraries/libecalc/common/libecalc/input/yaml_types/yaml_variable.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/yaml_types/yaml_variable.py
@@ -9,6 +9,10 @@ from pydantic.datetime_parse import parse_date, parse_datetime
 
 
 class YamlSingleVariable(YamlBase):
+    """
+    A variable in YAML that can be set to a valid eCalc Expression
+    """
+
     value: Expression
 
     def to_dto(self):
@@ -16,12 +20,25 @@ class YamlSingleVariable(YamlBase):
 
 
 class YamlDefaultDatetime(datetime):
+    """
+    PyYAML is smart and detects datetime.date and datetime.datetime differently in YAML, and parses usually
+    dates to datetime.date. However, in eCalc we required datetime.datetime, and there is a subtle difference
+    in behaviour between those too. Therefore we need to cast to datetime.datetime as early as possible to make
+    sure eCalc behaves correctly.
+    """
+
     @classmethod
     def __get_validators__(cls):
         yield cls.date_to_datetime
 
     @classmethod
     def date_to_datetime(cls, value) -> datetime:
+        """
+        Handles both datetimes and dates supported formats, and converts them to
+        datetime.datetime internally to avoid problems with mixing datetime.date and datetime.datetime
+        :param value: string with a PyYAML supported date or datetime format
+        :return: the corresponding datetime.datetime. datetime.date will have HH:MM:SS set to 00:00:00
+        """
         try:
             date = parse_date(value)
             return convert_date_to_datetime(date)

--- a/src/ecalc/libraries/libecalc/common/tests/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
+++ b/src/ecalc/libraries/libecalc/common/tests/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
@@ -55,11 +55,6 @@
                                     "additionalProperties": {
                                         "type": "string"
                                     },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "type": "string"
-                                        }
-                                    },
                                     "type": "object"
                                 }
                             ],
@@ -112,14 +107,6 @@
                                             "$ref": "#/definitions/YamlCompressorSystemOperationalSettings"
                                         },
                                         "type": "array"
-                                    },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "items": {
-                                                "$ref": "#/definitions/YamlCompressorSystemOperationalSettings"
-                                            },
-                                            "type": "array"
-                                        }
                                     },
                                     "type": "object"
                                 }
@@ -353,11 +340,6 @@
                                     "additionalProperties": {
                                         "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/energy-usage-model.json#properties/ENERGY_USAGE_MODEL"
                                     },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/energy-usage-model.json#properties/ENERGY_USAGE_MODEL"
-                                        }
-                                    },
                                     "type": "object"
                                 }
                             ],
@@ -399,11 +381,6 @@
                                     "additionalProperties": {
                                         "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/energy-usage-model.json#properties/ENERGY_USAGE_MODEL"
                                     },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/energy-usage-model.json#properties/ENERGY_USAGE_MODEL"
-                                        }
-                                    },
                                     "type": "object"
                                 }
                             ],
@@ -418,11 +395,6 @@
                                 {
                                     "additionalProperties": {
                                         "type": "string"
-                                    },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "type": "string"
-                                        }
                                     },
                                     "type": "object"
                                 }
@@ -483,11 +455,6 @@
                                     "additionalProperties": {
                                         "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/energy-usage-model-common.json#definitions/number_or_string"
                                     },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/energy-usage-model-common.json#definitions/number_or_string"
-                                        }
-                                    },
                                     "type": "object"
                                 }
                             ],
@@ -502,11 +469,6 @@
                                 {
                                     "additionalProperties": {
                                         "type": "string"
-                                    },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "type": "string"
-                                        }
                                     },
                                     "type": "object"
                                 }
@@ -554,11 +516,6 @@
                                 {
                                     "additionalProperties": {
                                         "type": "string"
-                                    },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "type": "string"
-                                        }
                                     },
                                     "type": "object"
                                 }
@@ -633,27 +590,6 @@
                                         ],
                                         "title": "Expression"
                                     },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "anyOf": [
-                                                {
-                                                    "type": "integer"
-                                                },
-                                                {
-                                                    "type": "number"
-                                                },
-                                                {
-                                                    "pattern": "^[\\w * ^ . : ; () {} = > < + \\- /]+$",
-                                                    "type": "string"
-                                                }
-                                            ],
-                                            "examples": [
-                                                "SIM1;OIL_PROD {+} 1000",
-                                                5
-                                            ],
-                                            "title": "Expression"
-                                        }
-                                    },
                                     "type": "object"
                                 }
                             ],
@@ -706,27 +642,6 @@
                                         ],
                                         "title": "Expression"
                                     },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "anyOf": [
-                                                {
-                                                    "type": "integer"
-                                                },
-                                                {
-                                                    "type": "number"
-                                                },
-                                                {
-                                                    "pattern": "^[\\w * ^ . : ; () {} = > < + \\- /]+$",
-                                                    "type": "string"
-                                                }
-                                            ],
-                                            "examples": [
-                                                "SIM1;OIL_PROD {+} 1000",
-                                                5
-                                            ],
-                                            "title": "Expression"
-                                        }
-                                    },
                                     "type": "object"
                                 }
                             ],
@@ -757,11 +672,6 @@
                                 {
                                     "additionalProperties": {
                                         "type": "string"
-                                    },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "type": "string"
-                                        }
                                     },
                                     "type": "object"
                                 }
@@ -815,14 +725,6 @@
                                             "$ref": "#/definitions/YamlPumpSystemOperationalSettings"
                                         },
                                         "type": "array"
-                                    },
-                                    "patternProperties": {
-                                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                                            "items": {
-                                                "$ref": "#/definitions/YamlPumpSystemOperationalSettings"
-                                            },
-                                            "type": "array"
-                                        }
                                     },
                                     "type": "object"
                                 }
@@ -1070,6 +972,7 @@
                 },
                 "YamlSingleVariable": {
                     "additionalProperties": false,
+                    "description": "A variable in YAML that can be set to a valid eCalc Expression",
                     "properties": {
                         "VALUE": {
                             "anyOf": [

--- a/src/ecalc/libraries/libecalc/common/tests/input/validation/test_validation_json_schemas.py
+++ b/src/ecalc/libraries/libecalc/common/tests/input/validation/test_validation_json_schemas.py
@@ -47,11 +47,12 @@ class TestSchemas:
             },
             {
                 "type": "object",
-                "patternProperties": {
-                    "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
-                        "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/energy-usage-model.json#properties/ENERGY_USAGE_MODEL"
-                    }
-                },
+                # TODO: We need to make a trade off now, either make parsing fail, or that the Open API JSON Schema does not indicate the date pattern we require as key
+                # "patternProperties": {
+                # "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {
+                # "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/energy-usage-model.json#properties/ENERGY_USAGE_MODEL"
+                # }
+                # },
                 "additionalProperties": {
                     "$ref": "https://test.ecalc.equinor.com/api/v1/schema-validation/energy-usage-model.json#properties/ENERGY_USAGE_MODEL"
                 },

--- a/src/ecalc/libraries/libecalc/common/tests/input/yaml_types/test_yaml_temporal_model.py
+++ b/src/ecalc/libraries/libecalc/common/tests/input/yaml_types/test_yaml_temporal_model.py
@@ -16,9 +16,9 @@ class TestSchema:
                 },
                 {
                     "type": "object",
-                    "patternProperties": {
-                        "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {"type": "string"}
-                    },
+                    # "patternProperties": {
+                    #     "^\\d{4}\\-(0?[1-9]|1[012])\\-(0?[1-9]|[12][0-9]|3[01])$": {"type": "string"}
+                    # },
                     "additionalProperties": {"type": "string"},
                 },
             ],


### PR DESCRIPTION
See the commits separately.

1:
[fix: handle dates in yaml correctly](https://github.com/equinor/ecalc/pull/154/commits/ea31a24f31fecd35108c62eeb522904e6c3d31dd)

if we dont explicitly handle dates with our own date type, then
PyYAML will change to datetime.date for what we want to have
datetime.datetime. To make sure that all are converted to
datetime.datetime, we set all dates in yaml as our date type.
