### PR TITLE
ECALC-21 chore: improve dto validation error message

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/input/validation_errors.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/validation_errors.py
@@ -7,6 +7,7 @@ import pydantic
 import yaml
 from libecalc.common.logger import logger
 from libecalc.input.yaml_entities import Resource, YamlDict, YamlList
+from libecalc.input.yaml_keywords import EcalcYamlKeywords
 from yaml import Dumper, Mark
 
 Loc = Tuple[Union[int, str], ...]
@@ -116,6 +117,7 @@ class DtoValidationError(DataValidationError):
     ):
         errors = validation_error.errors()
 
+        component_name = data[EcalcYamlKeywords.name]
         messages = []
         error_locs = []
         try:
@@ -126,7 +128,7 @@ class DtoValidationError(DataValidationError):
                 error_location_info = " -> ".join(
                     [str(s).capitalize().replace("__root__", "General error").replace("_", " ") for s in error_loc]
                 )
-                messages.append(f"{error_location_info}:\n\t{error_message}\n")
+                messages.append(f"{component_name} - {error_location_info}:\n\t{error_message}\n")
         except Exception as e:
             logger.debug(f"Failed to add location specific error messages: {str(e)}")
 

--- a/src/ecalc/libraries/libecalc/common/libecalc/input/validation_errors.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/validation_errors.py
@@ -127,8 +127,7 @@ class DtoValidationError(DataValidationError):
                 error_location_info = " -> ".join(
                     [str(s).capitalize().replace("__root__", "General error").replace("_", " ") for s in error_loc]
                 )
-                if data.get(EcalcYamlKeywords.name):
-                    component_name = data.get(EcalcYamlKeywords.name)
+                if component_name := data.get(EcalcYamlKeywords.name):
                     messages.append(f"{component_name} - {error_location_info}:\n\t{error_message}\n")
                 else:
                     messages.append(f"{error_location_info}:\n\t{error_message}\n")

--- a/src/ecalc/libraries/libecalc/common/libecalc/input/validation_errors.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/validation_errors.py
@@ -117,7 +117,6 @@ class DtoValidationError(DataValidationError):
     ):
         errors = validation_error.errors()
 
-        component_name = data.get(EcalcYamlKeywords.name, "Missing Component Name")
         messages = []
         error_locs = []
         try:
@@ -128,7 +127,11 @@ class DtoValidationError(DataValidationError):
                 error_location_info = " -> ".join(
                     [str(s).capitalize().replace("__root__", "General error").replace("_", " ") for s in error_loc]
                 )
-                messages.append(f"{component_name} - {error_location_info}:\n\t{error_message}\n")
+                if data.get(EcalcYamlKeywords.name):
+                    component_name = data.get(EcalcYamlKeywords.name)
+                    messages.append(f"{component_name} - {error_location_info}:\n\t{error_message}\n")
+                else:
+                    messages.append(f"{error_location_info}:\n\t{error_message}\n")
         except Exception as e:
             logger.debug(f"Failed to add location specific error messages: {str(e)}")
 

--- a/src/ecalc/libraries/libecalc/common/libecalc/input/validation_errors.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/validation_errors.py
@@ -117,7 +117,7 @@ class DtoValidationError(DataValidationError):
     ):
         errors = validation_error.errors()
 
-        component_name = data[EcalcYamlKeywords.name]
+        component_name = data.get(EcalcYamlKeywords.name, "Missing Component Name")
         messages = []
         error_locs = []
         try:


### PR DESCRIPTION
## Why is this pull request needed?

Difficult to understand what the dto validation is related to when there is no reference to the consumer name.

## What does this pull request change?

Improve dto validation error to include consumer/component name.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-21?atlOrigin=eyJpIjoiNjhhMzljMTg5YTk3NDViODgyZGM2ZWY0ZjM0YjM1ODIiLCJwIjoiaiJ9