### PR TITLE
fix: component type set to component level in asset dto

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/core/graph_result.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/graph_result.py
@@ -425,7 +425,7 @@ class GraphResult:
             id=asset.id,
             name=asset_node_info.name,
             component_level=asset_node_info.component_level,
-            componentType=asset_node_info.component_level,
+            componentType=asset_node_info.component_type,
             timesteps=self.variables_map.time_vector,
             is_valid=TimeSeriesBoolean(
                 timesteps=self.variables_map.time_vector,


### PR DESCRIPTION
## Why is this pull request needed?

componentType is set to component level in asset_result_dto (get_asset_result). Should be set to component type.

## What does this pull request change?

Update componentType in asset_result_dto.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-179