### PR TITLE
refactor: improve error message when wrong CURVE-keyword input to single speed compressor

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/model.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/model.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 from libecalc import dto
 from libecalc.common.units import Unit
@@ -65,16 +65,13 @@ def _get_curve_data_from_resource(resource: Resource, speed: float = 0.0):
 
 def _single_speed_compressor_chart_mapper(model_config: Dict, resources: Resources) -> dto.SingleSpeedChart:
     units = get_units_from_chart_config(chart_config=model_config)
-    curve_config: Optional[Dict] = model_config.get(EcalcYamlKeywords.consumer_chart_curve)
+    curve_config = model_config.get(EcalcYamlKeywords.consumer_chart_curve)
     name = model_config.get(EcalcYamlKeywords.name)
-    curves_instead_of_curve = (
-        True if isinstance(model_config.get(EcalcYamlKeywords.consumer_chart_curves), dict) else False
-    )
 
     # Check if user has used CURVES (reserved for variable speed compressors)
     # instead of CURVE (should be used for single speed compressors),
     # and give clear error message.
-    if curves_instead_of_curve:
+    if EcalcYamlKeywords.consumer_chart_curves in model_config:
         raise DataValidationError(
             data=model_config,
             message=f"Compressor model {name}:\n"
@@ -84,7 +81,7 @@ def _single_speed_compressor_chart_mapper(model_config: Dict, resources: Resourc
             f"{EcalcYamlKeywords.consumer_chart_curve}.",
         )
 
-    if not isinstance(curve_config, dict):
+    if EcalcYamlKeywords.consumer_chart_curve not in model_config:
         raise DataValidationError(
             data=model_config,
             message=f"The keyword {EcalcYamlKeywords.consumer_chart_curve} is not specified "
@@ -93,7 +90,7 @@ def _single_speed_compressor_chart_mapper(model_config: Dict, resources: Resourc
             f"single speed compressor models.",
         )
 
-    if EcalcYamlKeywords.file in curve_config:
+    if EcalcYamlKeywords.file in curve_config:  # type: ignore
         resource_name = curve_config.get(EcalcYamlKeywords.file)
         resource = resources.get(resource_name)
 

--- a/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/model.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/model.py
@@ -90,7 +90,15 @@ def _single_speed_compressor_chart_mapper(model_config: Dict, resources: Resourc
             f"single speed compressor models.",
         )
 
-    if EcalcYamlKeywords.file in curve_config:  # type: ignore
+    if not isinstance(curve_config, dict):
+        raise DataValidationError(
+            data=model_config,
+            message=f"Compressor model {name}:"
+            f"{EcalcYamlKeywords.consumer_chart_curve}"
+            f" should be an object. Type given: {type(curve_config)}.",
+        )
+
+    if EcalcYamlKeywords.file in curve_config:
         resource_name = curve_config.get(EcalcYamlKeywords.file)
         resource = resources.get(resource_name)
 


### PR DESCRIPTION
## Why is this pull request needed?

Keyword `CURVES` is reserved for _variable_ speed compressors only. _Single_ speed compressors should use the keyword `CURVE`. Due to the obvious similarity it is a risk that the user mixes the two, e.g. using `CURVES` for single speed compressors. When this happens the error message is difficult to understand.

## What does this pull request change?

- Improve error message when `CURVES` is used for single speed compressor models
- Improve error message when the keyword CURVE is not found (typo etc.) in general, for single speed compressor models.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-20?atlOrigin=eyJpIjoiOTBjOWU5M2VjOGQwNDdmOWFkOWIxYjlhM2ExYThmNTQiLCJwIjoiaiJ9