### PR TITLE
refactor: improve error message when wrong CURVES-keyword input to variable speed compressor

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/model.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/mappers/model.py
@@ -117,8 +117,8 @@ def _variable_speed_compressor_chart_mapper(model_config: Dict, resources: Resou
 
     name = model_config.get(EcalcYamlKeywords.name)
 
-    # Check if user has used CURVES (reserved for variable speed compressors)
-    # instead of CURVE (should be used for single speed compressors),
+    # Check if user has used CURVE (reserved for single speed compressors)
+    # instead of CURVES (should be used for variable speed compressors),
     # and give clear error message.
     if EcalcYamlKeywords.consumer_chart_curve in model_config:
         raise DataValidationError(


### PR DESCRIPTION
## Why is this pull request needed?

Keyword `CURVE` is reserved for _single_ speed compressors only. _Variable_ speed compressors should use the keyword `CURVES`. Due to the obvious similarity it is a risk that the user mixes the two, e.g. using `CURVE` for variable speed compressors. When this happens the error message is difficult to understand.

## What does this pull request change?

- Improve error message when `CURVE` is used for variable speed compressor models
- Improve error message when the keyword `CURVES` is not found (typo etc.) in general, for variable speed compressor models.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-189?atlOrigin=eyJpIjoiZmMyMzkwNzAxNDAwNDdhMzk1NDM4ZDRmNTAyMmU1NTgiLCJwIjoiaiJ9