### PR TITLE
fix: issue with crossover rate calculation in system v2

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/core/consumers/consumer_system.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/core/consumers/consumer_system.py
@@ -308,6 +308,6 @@ class ConsumerSystem(BaseConsumer):
             # We handle the rates per stream backwards in order to forward inbound cross-overs first
             # if the compressor/pump in question (with inbound cross-over) is above capacity itself.
             diff = np.subtract(rate, left_over_crossover_rate)
-            left_over_crossover_rate = np.where(diff < 0, diff, 0)
+            left_over_crossover_rate = np.where(diff < 0, np.absolute(diff), 0)
             rates_within_capacity.append(list(np.where(diff >= 0, diff, 0)))
         return crossover_rate, list(reversed(rates_within_capacity))

--- a/src/ecalc/libraries/libecalc/common/tests/core/consumers/test_crossover.py
+++ b/src/ecalc/libraries/libecalc/common/tests/core/consumers/test_crossover.py
@@ -20,18 +20,24 @@ class TestCrossover:
             [1, 1],  # 1 exceeding
             [[4, 4]],
         ),
-        # (  # FAILS: Exceeds capacity, cross over required - fails as well..correct? leads to expected_rates_within_capacity = [[6, 6], [0, 0]]
-        # max_rate = [4, 4]  # 4 for both timesteps
-        # rates = [[5, 5], [2, 2]]  # 4 in rate
-        # expected_crossover_rate = [3, 3]  # 1 exceeding
-        # expected_rates_within_capacity = [[4, 4], [0, 0]]
-        # ),
-        # (  # FAILS: Exceeds capacity, cross over required - bug? leads to expected_rates_within_capacity = [[6, 6], [0, 0]]
-        # max_rate = [4, 4]  # 4 for both timesteps
-        # rates = [[5, 5], [0, 0]]  # 4 in rate
-        # expected_crossover_rate = [1, 1]  # 1 exceeding
-        # expected_rates_within_capacity = [[4, 4], [0, 0]]
-        # ),
+        (  # Exceeds capacity two times, cross over required
+            [4, 4],  # 4 for both timesteps
+            [[5, 5], [2, 2]],  # 4 in rate
+            [3, 3],  # 1 exceeding
+            [[4, 4], [0, 0]],
+        ),
+        (  # Exceeds capacity two times, cross over required
+            [4, 4],  # 4 for both timesteps
+            [[5, 5], [0, 0]],  # 4 in rate
+            [1, 1],  # 1 exceeding
+            [[4, 4], [0, 0]],
+        ),
+        (  # Exceeds capacity three times, cross over required
+            [2, 2],  # 4 for both timesteps
+            [[3, 3], [1, 1], [1, 1]],
+            [3, 3],  # 1 exceeding
+            [[2, 2], [0, 0], [0, 0]],
+        ),
         (  # Under capacity
             [4, 4],  # 4 for both timesteps
             [[2, 2], [1, 1]],  # 3 in rate, below 4


### PR DESCRIPTION
When we had to reduce several rates to get within capacity we set the remaining crossover to a negative value, which then caused issues as we subtracted the remaining crossover from the next rate.