### PR TITLE
ECALC-201 - chore: add validation for missing headers in csv resource file

### DIFF
--- a/src/ecalc/libraries/libecalc/common/libecalc/input/file_io.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/file_io.py
@@ -388,12 +388,14 @@ def unpack_zip(file: IO) -> Tuple[List[ValidEcalcFile], List[InvalidEcalcFile]]:
 
 def _validate_headers(headers: List[str]):
     for header in headers:
-        if not re.match(r"^[A-Za-z][A-Za-z0-9_.,\-\s#+:\/]*$", header) or re.match(r"^Unnamed: \d+$", header):
+        if not re.match(r"^[A-Za-z][A-Za-z0-9_.,\-\s#+:\/]*$", header):
             raise ValueError(
-                "Csv input file must include header, each header value must start with a letter in the english "
+                "Each header value must start with a letter in the english "
                 "alphabet (a-zA-Z). And may only contain letters, spaces, numbers or any of the following characters "
                 "[ _ - # + : . , /] "
             )
+        elif re.match(r"^Unnamed: \d+$", header):
+            raise ValueError("CSV input file must include header")
 
 
 def _validate_not_nan(columns: List[List]):

--- a/src/ecalc/libraries/libecalc/common/libecalc/input/file_io.py
+++ b/src/ecalc/libraries/libecalc/common/libecalc/input/file_io.py
@@ -388,7 +388,7 @@ def unpack_zip(file: IO) -> Tuple[List[ValidEcalcFile], List[InvalidEcalcFile]]:
 
 def _validate_headers(headers: List[str]):
     for header in headers:
-        if not re.match(r"^[A-Za-z][A-Za-z0-9_.,\-\s#+:\/]*$", header):
+        if not re.match(r"^[A-Za-z][A-Za-z0-9_.,\-\s#+:\/]*$", header) or re.match(r"^Unnamed: \d+$", header):
             raise ValueError(
                 "Csv input file must include header, each header value must start with a letter in the english "
                 "alphabet (a-zA-Z). And may only contain letters, spaces, numbers or any of the following characters "

--- a/src/ecalc/libraries/libecalc/common/tests/input/test_file_io.py
+++ b/src/ecalc/libraries/libecalc/common/tests/input/test_file_io.py
@@ -107,7 +107,7 @@ def create_csv_from_line(tmp_path: Path, csv_line: str) -> Path:
 
 
 @pytest.fixture
-def get_tmp_path(tmp_path: Path) -> Path:
+def tmp_path_fixture(tmp_path: Path) -> Path:
     return tmp_path
 
 
@@ -143,21 +143,21 @@ class TestReadFacilityResource:
             ("aa ><, bb", False),
         ],
     )  # This is not meant to be extensive, just to test that we have some validation
-    def test_valid_characters(self, get_tmp_path, csv_line: str, is_valid_characters: bool):
+    def test_valid_characters(self, tmp_path_fixture, csv_line: str, is_valid_characters: bool):
         if is_valid_characters:
-            file_io.read_facility_resource(create_csv_from_line(get_tmp_path, csv_line))
+            file_io.read_facility_resource(create_csv_from_line(tmp_path_fixture, csv_line))
         else:
             with pytest.raises(ValueError) as e:
-                file_io.read_facility_resource(create_csv_from_line(get_tmp_path, csv_line))
+                file_io.read_facility_resource(create_csv_from_line(tmp_path_fixture, csv_line))
             assert (
                 str(e.value) == "Each header value must start with a letter in the "
                 "english alphabet (a-zA-Z). And may only contain letters, spaces, numbers or any of the following "
                 "characters [ _ - # + : . , /] "
             )
 
-    def test_missing_headers(self, get_tmp_path):
+    def test_missing_headers(self, tmp_path_fixture):
         with pytest.raises(ValueError) as e:
-            file_io.read_facility_resource(create_csv_from_line(get_tmp_path, "HEADER1        ,,HEADER3"))
+            file_io.read_facility_resource(create_csv_from_line(tmp_path_fixture, "HEADER1        ,,HEADER3"))
         assert str(e.value) == "CSV input file must include header"
 
 

--- a/src/ecalc/libraries/libecalc/common/tests/input/test_file_io.py
+++ b/src/ecalc/libraries/libecalc/common/tests/input/test_file_io.py
@@ -150,7 +150,7 @@ class TestReadFacilityResource:
             with pytest.raises(ValueError) as e:
                 file_io.read_facility_resource(create_csv_from_line(get_tmp_path, csv_line))
             assert (
-                str(e.value) == "Csv input file must include header, each header value must start with a letter in the "
+                str(e.value) == "Each header value must start with a letter in the "
                 "english alphabet (a-zA-Z). And may only contain letters, spaces, numbers or any of the following "
                 "characters [ _ - # + : . , /] "
             )
@@ -158,11 +158,7 @@ class TestReadFacilityResource:
     def test_missing_headers(self, get_tmp_path):
         with pytest.raises(ValueError) as e:
             file_io.read_facility_resource(create_csv_from_line(get_tmp_path, "HEADER1        ,,HEADER3"))
-        assert (
-            str(e.value) == "Csv input file must include header, each header value must start with a letter in the "
-            "english alphabet (a-zA-Z). And may only contain letters, spaces, numbers or any of the following "
-            "characters [ _ - # + : . , /] "
-        )
+        assert str(e.value) == "CSV input file must include header"
 
 
 @pytest.fixture

--- a/src/ecalc/libraries/libecalc/common/tests/input/test_file_io.py
+++ b/src/ecalc/libraries/libecalc/common/tests/input/test_file_io.py
@@ -100,14 +100,14 @@ def facility_resource_missing_value_file(tmp_path):
     return facility_file
 
 
-def create_csv_from_line(tmp_path, csv_line: str):
+def create_csv_from_line(tmp_path: Path, csv_line: str) -> Path:
     csv_file = tmp_path / "csv_file.csv"
     csv_file.write_text(csv_line)
     return csv_file
 
 
 @pytest.fixture
-def get_tmp_path(tmp_path):
+def get_tmp_path(tmp_path: Path) -> Path:
     return tmp_path
 
 
@@ -143,7 +143,7 @@ class TestReadFacilityResource:
             ("aa ><, bb", False),
         ],
     )  # This is not meant to be extensive, just to test that we have some validation
-    def test_valid_characters(self, get_tmp_path, csv_line, is_valid_characters):
+    def test_valid_characters(self, get_tmp_path, csv_line: str, is_valid_characters: bool):
         if is_valid_characters:
             file_io.read_facility_resource(create_csv_from_line(get_tmp_path, csv_line))
         else:


### PR DESCRIPTION
Add check for missing headers in resource CSV files, and more validation tests .

Missing headers will be named "Unnamed: 1" etc by pandas. 