### PR TITLE
fix: make ecalc installable again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ classifiers=[
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 
+packages = [
+    { include = "cli", from = "src" },
+    { include = "neqsim_ecalc_wrapper", from = "src" },
+    { include = "libecalc", from = "src" },
+]
+
 [tool.poetry.scripts]
 ecalc = 'cli.main:main'
 


### PR DESCRIPTION
When restructuring libecalc the previous mappings
for which packages was removed for simplicity. We
need to include those in order to make poetry/pip
include the required packages in src/ directory, since it will only include libecalc by default (it will look for src dir and package name). It is nevertheless better to be explicit.

The current functionality is the same way as it worked before it failed.
