### PR TITLE
chore: revert nan to num in expressions

### DIFF
--- a/src/libecalc/expression/expression_evaluator.py
+++ b/src/libecalc/expression/expression_evaluator.py
@@ -45,7 +45,11 @@ def eval_tokens(tokens: List[Token], array_length: int) -> NDArray[np.float64]:
     token_values = [token.value for token in tokens]
     check_tokens(token_values)
 
-    evaluated_values = eval_parentheses(tokens=token_values)
+    evaluated_values = np.nan_to_num(
+        x=eval_parentheses(
+            tokens=token_values,
+        )  # type: ignore[arg-type]
+    )
 
     if isinstance(evaluated_values, (Number, int, float)):
         evaluated_values = np.full(fill_value=evaluated_values, shape=array_length)
@@ -206,7 +210,7 @@ def eval_mults(tokens):
         for factor in values:
             value = value * factor
         np.seterr(**current_numpy_error)
-    return value
+    return np.nan_to_num(value)
 
 
 def eval_powers(tokens):
@@ -224,7 +228,7 @@ def eval_powers(tokens):
         else:
             value = eval_value(tokens)
 
-    return value
+    return np.nan_to_num(value)
 
 
 def eval_value(tokens):
@@ -262,7 +266,7 @@ def eval_value(tokens):
             raise ValueError("Should not enter here - no time series in expression evaluator")
         else:
             var = tokens[0]
-    var = var
+    var = np.nan_to_num(var)
     return var
 
 

--- a/src/tests/ecalc_cli/snapshots/test_app/test_json_true/test_v3.json
+++ b/src/tests/ecalc_cli/snapshots/test_app/test_json_true/test_v3.json
@@ -836,18 +836,18 @@
         ],
         "unit": "bara",
         "values": [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
         ]
       },
       "requested_outlet_pressure": {
@@ -867,18 +867,18 @@
         ],
         "unit": "bara",
         "values": [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
         ]
       },
       "stage_results": [
@@ -2316,18 +2316,18 @@
         ],
         "unit": "bara",
         "values": [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
         ]
       },
       "requested_outlet_pressure": {
@@ -2347,18 +2347,18 @@
         ],
         "unit": "bara",
         "values": [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
         ]
       },
       "stage_results": [

--- a/src/tests/ecalc_cli/snapshots/test_app/test_json_true_detailed_output/test_full_json_v3.json
+++ b/src/tests/ecalc_cli/snapshots/test_app/test_json_true_detailed_output/test_full_json_v3.json
@@ -836,18 +836,18 @@
         ],
         "unit": "bara",
         "values": [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
         ]
       },
       "requested_outlet_pressure": {
@@ -867,18 +867,18 @@
         ],
         "unit": "bara",
         "values": [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
         ]
       },
       "stage_results": [
@@ -2316,18 +2316,18 @@
         ],
         "unit": "bara",
         "values": [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
         ]
       },
       "requested_outlet_pressure": {
@@ -2347,18 +2347,18 @@
         ],
         "unit": "bara",
         "values": [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0,
+          0.0
         ]
       },
       "stage_results": [

--- a/src/tests/libecalc/expression/test_expression.py
+++ b/src/tests/libecalc/expression/test_expression.py
@@ -1,6 +1,5 @@
 import datetime
 
-import numpy as np
 import pytest
 from libecalc.expression import Expression
 from pydantic import parse_obj_as
@@ -121,8 +120,8 @@ class TestExpression:
 
         # Check that nan is handled correctly when division by zero occur, but
         # values are later disregarded by conditions
-        assert np.isnan(
-            Expression.setup_from_expression("0{/}0").evaluate(variables=variables, fill_length=len(time_vector))[0]
+        assert (
+            Expression.setup_from_expression("0{/}0").evaluate(variables=variables, fill_length=len(time_vector)) == 0
         )
 
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Why is this pull request needed?

Removing conversion of NaN to numeric value (0) in expressions introduces challenges with several existing asset models, especially related to zero-division (rates). This will make many models fail. Hence, the conversion of NaN to numeric (0) is added back. This is a short term solution. On the long term a more robust way of handling NaN should be used.

## What does this pull request change?

- [x] Include np.nan_to_num in expression evaluator.
- [x] Update snapshots

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-234?atlOrigin=eyJpIjoiMjVkOTgzOTlkNDc3NDVmNDhjMmQ0NmVkZTc1NTU1YjEiLCJwIjoiaiJ9