### PR TITLE
docs: update changelog for upcoming release v8.4

### DIFF
--- a/docs/docs/about/migration_guides/v7_to_v8.md
+++ b/docs/docs/about/migration_guides/v7_to_v8.md
@@ -1,7 +1,7 @@
 ---
 title: v7 to v8
 description: v7 to v8 migration
-sidebar_position: 2
+sidebar_position: 0
 ---
 
 # v7 to v8

--- a/docs/docs/about/migration_guides/v8-1_to_v8-2.md
+++ b/docs/docs/about/migration_guides/v8-1_to_v8-2.md
@@ -1,7 +1,7 @@
 ---
 title: v8.1 to v8.2
 description: v8.1 to v8.2 migration
-sidebar_position: 0
+sidebar_position: 2
 ---
 
 # v8.1 to v8.2

--- a/docs/docs/about/migration_guides/v8-2_to_v8-3.md
+++ b/docs/docs/about/migration_guides/v8-2_to_v8-3.md
@@ -1,0 +1,9 @@
+---
+title: v8.2 to v8.3
+description: v8.2 to v8.3 migration
+sidebar_position: 3
+---
+
+# v8.2 to v8.3
+
+It is no longer accepted to change `ENERGY_USAGE_MODEL TYPE` over time, within one consumer. In case `TYPE` evolution is needed, the model can be split in two consumers.

--- a/docs/docs/about/migration_guides/v8-3_to_v8-4.md
+++ b/docs/docs/about/migration_guides/v8-3_to_v8-4.md
@@ -1,0 +1,9 @@
+---
+title: v8.3 to v8.4
+description: v8.3 to v8.4 migration
+sidebar_position: 4
+---
+
+# v8.3 to v8.4
+
+No migration is needed.

--- a/docs/docs/changelog/next.md
+++ b/docs/docs/changelog/next.md
@@ -1,0 +1,21 @@
+---
+slug: latest
+title: Next
+authors: ecalc-team
+tags: [release, eCalc]
+sidebar_position: 1
+---
+
+# eCalc
+
+
+
+## New Features
+
+
+## Fixes
+
+
+## Breaking changes
+
+

--- a/docs/docs/changelog/separator.md
+++ b/docs/docs/changelog/separator.md
@@ -1,0 +1,7 @@
+---
+slug: separator
+title: ---
+authors: ecalc-team
+tags: [release, eCalc]
+sidebar_position: 2
+---

--- a/docs/docs/changelog/v7-0.md
+++ b/docs/docs/changelog/v7-0.md
@@ -3,7 +3,7 @@ slug: v7-0-release
 title: v7.0
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 10
+sidebar_position: 3
 ---
 
 # eCalc v7.0

--- a/docs/docs/changelog/v7-1.md
+++ b/docs/docs/changelog/v7-1.md
@@ -3,7 +3,7 @@ slug: v7-1-release
 title: v7.1
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 9
+sidebar_position: 4
 ---
 
 # eCalc v7.1

--- a/docs/docs/changelog/v7-2.md
+++ b/docs/docs/changelog/v7-2.md
@@ -3,7 +3,7 @@ slug: v7-2-release
 title: v7.2
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 8
+sidebar_position: 5
 ---
 
 # eCalc v7.2

--- a/docs/docs/changelog/v7-3.md
+++ b/docs/docs/changelog/v7-3.md
@@ -3,7 +3,7 @@ slug: v7-3-release
 title: v7.3
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 7
+sidebar_position: 6
 ---
 
 # eCalc v7.3

--- a/docs/docs/changelog/v7-4.md
+++ b/docs/docs/changelog/v7-4.md
@@ -3,7 +3,7 @@ slug: v7-4-release
 title: v7.4
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # eCalc v7.4

--- a/docs/docs/changelog/v7-5.md
+++ b/docs/docs/changelog/v7-5.md
@@ -3,7 +3,7 @@ slug: v7-5-release
 title: v7.5
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 5
+sidebar_position: 8
 ---
 
 # eCalc v7.5

--- a/docs/docs/changelog/v7-6.md
+++ b/docs/docs/changelog/v7-6.md
@@ -3,7 +3,7 @@ slug: v7-6-release
 title: v7.6
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 4
+sidebar_position: 9
 ---
 
 # eCalc v7.6

--- a/docs/docs/changelog/v8-0.md
+++ b/docs/docs/changelog/v8-0.md
@@ -3,7 +3,7 @@ slug: v8.0-release
 title: v8.0
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 3
+sidebar_position: 10
 ---
 
 # eCalc v8.0

--- a/docs/docs/changelog/v8-1.md
+++ b/docs/docs/changelog/v8-1.md
@@ -3,7 +3,7 @@ slug: v8.1-release
 title: v8.1
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 2
+sidebar_position: 11
 ---
 
 # eCalc v8.1

--- a/docs/docs/changelog/v8-2.md
+++ b/docs/docs/changelog/v8-2.md
@@ -3,7 +3,7 @@ slug: v8.2-release
 title: v8.2
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 1
+sidebar_position: 12
 ---
 
 # eCalc v8.2

--- a/docs/docs/changelog/v8-3.md
+++ b/docs/docs/changelog/v8-3.md
@@ -3,7 +3,7 @@ slug: v8.3-release
 title: v8.3
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 0
+sidebar_position: 13
 ---
 
 # eCalc v8.3

--- a/docs/docs/changelog/v8-4.md
+++ b/docs/docs/changelog/v8-4.md
@@ -1,6 +1,6 @@
 ---
-slug: latest
-title: Next
+slug: v8.4-release
+title: v8.4 (Latest)
 authors: ecalc-team
 tags: [release, eCalc]
 sidebar_position: 0
@@ -8,14 +8,17 @@ sidebar_position: 0
 
 # eCalc
 
-
-
 ## New Features
-- Add requested inlet- and outlet compressor pressures from input data to results. In cases where active pressure control mechanisms are active, requested inlet- and outlet pressures may differ from pressures calculated by eCalc. It is now possible to analyse both requested- and calculated pressures.
+
+- Add `requested inlet- and outlet compressor pressures` from input data to results. In cases where active pressure control mechanisms are active, requested inlet- and outlet pressures may differ from `calculated pressures`. It is now possible to analyse both requested- and calculated pressures.
+- Specify `rate type` for majority of output `rate` results as either `stream day` or `calendar day`.
+- Improved error messages
 
 ## Fixes
 
+- `Actual rate` was incorrectly returned for `compressor sampled`. Actual rate cannot be known for `compressor sampled` since we need to know `fluid properties` in order to do that. `Actual rate` has therefore been removed from `compressor sampled`.
+- Handle bug in `Variable Speed Compressor Train With Multiple Streams And Pressures` when no rate is entering a compressor stage wrt. recirculation. 
+- Other minor fixes
 
 ## Breaking changes
-
 


### PR DESCRIPTION
changed structure a bit to make it easier to update changelog and index for upcoming releases.

![smakelig](https://github.com/equinor/ecalc/assets/1592894/31ef5c7f-07b2-4b22-8753-c1cc62407eff)

when entering changelog, one would by default look at the current release (that is out), and next release would be just under. below those, the releases are listed chronologically.

When should we delete old changelogs? We have changelogs back to v7...

Or perhaps a separate section to archive for previous major releases?