### PR TITLE
refactor: move crossover to component_conditions for system v2

### DIFF
--- a/src/libecalc/core/ecalc.py
+++ b/src/libecalc/core/ecalc.py
@@ -52,7 +52,11 @@ class EnergyCalculator:
                     sub_components=[],
                 )
             elif isinstance(component_dto, libecalc.dto.components.PumpSystem):
-                pump_system = ConsumerSystem(id=component_dto.id, consumers=component_dto.pumps)
+                pump_system = ConsumerSystem(
+                    id=component_dto.id,
+                    consumers=component_dto.pumps,
+                    component_conditions=component_dto.component_conditions,
+                )
                 evaluated_operational_settings = component_dto.evaluate_operational_settings(
                     variables_map=variables_map,
                 )
@@ -60,7 +64,11 @@ class EnergyCalculator:
                     variables_map=variables_map, temporal_operational_settings=evaluated_operational_settings
                 )
             elif isinstance(component_dto, libecalc.dto.components.CompressorSystem):
-                compressor_system = ConsumerSystem(id=component_dto.id, consumers=component_dto.compressors)
+                compressor_system = ConsumerSystem(
+                    id=component_dto.id,
+                    consumers=component_dto.compressors,
+                    component_conditions=component_dto.component_conditions,
+                )
                 evaluated_operational_settings = component_dto.evaluate_operational_settings(
                     variables_map=variables_map,
                 )

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -181,7 +181,6 @@ class CompressorSystemOperationalSetting(EcalcBaseModel):
     rates: List[Expression]
     inlet_pressures: List[Expression]
     outlet_pressures: List[Expression]
-    crossover: List[int]
 
 
 class PumpSystemOperationalSetting(EcalcBaseModel):
@@ -189,11 +188,15 @@ class PumpSystemOperationalSetting(EcalcBaseModel):
     rates: List[Expression]
     inlet_pressures: List[Expression]
     outlet_pressures: List[Expression]
+
+
+class SystemComponentConditions(EcalcBaseModel):
     crossover: List[int]
 
 
 class CompressorSystem(BaseConsumer):
     component_type: Literal[ComponentType.COMPRESSOR_SYSTEM_V2] = ComponentType.COMPRESSOR_SYSTEM_V2
+    component_conditions: SystemComponentConditions
     operational_settings: Dict[datetime, List[CompressorSystemOperationalSetting]]
     compressors: List[CompressorComponent]
 
@@ -266,7 +269,6 @@ class CompressorSystem(BaseConsumer):
                         rates=rates,
                         inlet_pressures=inlet_pressure,
                         outlet_pressures=outlet_pressure,
-                        crossover=operational_setting.crossover,
                     )
                 )
             evaluated_temporal_operational_settings[period.start] = evaluated_operational_settings
@@ -276,6 +278,7 @@ class CompressorSystem(BaseConsumer):
 
 class PumpSystem(BaseConsumer):
     component_type: Literal[ComponentType.PUMP_SYSTEM_V2] = ComponentType.PUMP_SYSTEM_V2
+    component_conditions: SystemComponentConditions
     operational_settings: Dict[datetime, List[PumpSystemOperationalSetting]]
     pumps: List[PumpComponent]
 
@@ -335,7 +338,6 @@ class PumpSystem(BaseConsumer):
                         inlet_pressures=inlet_pressure,
                         outlet_pressures=outlet_pressure,
                         fluid_density=fluid_density,
-                        crossover=operational_setting.crossover,
                     )
                 )
             evaluated_temporal_operational_settings[period.start] = evaluated_operational_settings

--- a/src/libecalc/dto/core_specs/system/operational_settings.py
+++ b/src/libecalc/dto/core_specs/system/operational_settings.py
@@ -16,7 +16,6 @@ class EvaluatedPumpSystemOperationalSettings(BaseModel):
     rates: List[TimeSeriesRate]
     inlet_pressures: List[TimeSeriesFloat]
     outlet_pressures: List[TimeSeriesFloat]
-    crossover: List[int]
 
     def get_consumer_operational_settings(
         self, consumer_index: int, timesteps: List[datetime]
@@ -38,21 +37,18 @@ class EvaluatedPumpSystemOperationalSettings(BaseModel):
         new_rates = []
         new_inlet_pressures = []
         new_outlet_pressures = []
-        new_crossover = []
         new_fluid_density = []
         for consumer_index, _ in enumerate(self.rates):
             new_rates.append(self.rates[consumer_index].for_timestep(timestep))
             new_inlet_pressures.append(self.inlet_pressures[consumer_index].for_timestep(timestep))
             new_outlet_pressures.append(self.outlet_pressures[consumer_index].for_timestep(timestep))
             new_fluid_density.append(self.fluid_density[consumer_index].for_timestep(timestep))
-            new_crossover.append(self.crossover[consumer_index])
 
         return EvaluatedPumpSystemOperationalSettings(
             rates=new_rates,
             inlet_pressures=new_inlet_pressures,
             outlet_pressures=new_outlet_pressures,
             fluid_density=new_fluid_density,
-            crossover=new_crossover,
         )
 
 
@@ -60,7 +56,6 @@ class EvaluatedCompressorSystemOperationalSettings(BaseModel):
     rates: List[TimeSeriesRate]
     inlet_pressures: List[TimeSeriesFloat]
     outlet_pressures: List[TimeSeriesFloat]
-    crossover: List[int]
 
     def get_consumer_operational_settings(
         self, consumer_index: int, timesteps: List[datetime]
@@ -81,16 +76,13 @@ class EvaluatedCompressorSystemOperationalSettings(BaseModel):
         new_rates = []
         new_inlet_pressures = []
         new_outlet_pressures = []
-        new_crossover = []
         for consumer_index, _ in enumerate(self.rates):
             new_rates.append(self.rates[consumer_index].for_timestep(timestep))
             new_inlet_pressures.append(self.inlet_pressures[consumer_index].for_timestep(timestep))
             new_outlet_pressures.append(self.outlet_pressures[consumer_index].for_timestep(timestep))
-            new_crossover.append(self.crossover[consumer_index])
 
         return EvaluatedCompressorSystemOperationalSettings(
             rates=new_rates,
             inlet_pressures=new_inlet_pressures,
             outlet_pressures=new_outlet_pressures,
-            crossover=new_crossover,
         )

--- a/src/libecalc/fixtures/cases/consumer_system_v2/consumer_system_v2_dto.py
+++ b/src/libecalc/fixtures/cases/consumer_system_v2/consumer_system_v2_dto.py
@@ -17,6 +17,7 @@ from libecalc.dto.base import (
     FuelTypeUserDefinedCategoryType,
     InstallationUserDefinedCategoryType,
 )
+from libecalc.dto.components import SystemComponentConditions
 from libecalc.dto.types import ConsumptionType, EnergyUsageType
 from libecalc.expression import Expression
 from libecalc.fixtures.case_types import DTOCase
@@ -194,26 +195,26 @@ compressor_system_v2 = dto.components.CompressorSystem(
     regularity=regularity,
     consumes=ConsumptionType.FUEL,
     fuel=fuel,
+    component_conditions=SystemComponentConditions(
+        crossover=[0, 1, 1],
+    ),
     operational_settings={
         datetime(2022, 1, 1, 0, 0): [
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 6000000, 6000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("250")] * 3,
-                crossover=[0, 1, 1],
             ),  # Invalid operational setting, should not be valid for any timesteps
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in ["$var.compressor1", 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],
             ),  # Valid for first timestep
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
-            ),
+            ),  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
         ]
     },
     compressors=[
@@ -229,46 +230,43 @@ compressor_system_v2_with_temporal_model = dto.components.CompressorSystem(
     regularity=regularity,
     consumes=ConsumptionType.FUEL,
     fuel=fuel,
+    component_conditions=SystemComponentConditions(
+        crossover=[0, 1, 1],
+    ),
     operational_settings={
         datetime(2022, 1, 1, 0, 0): [
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 6000000, 6000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("250")] * 3,
-                crossover=[0, 1, 1],
             ),  # Invalid operational setting, should not be valid for any timesteps
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in ["$var.compressor1", 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],
             ),  # Valid for first timestep
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
-            ),
+            ),  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
         ],
         datetime(2024, 1, 1, 0, 0): [
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 6000000, 6000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("250")] * 3,
-                crossover=[0, 1, 1],
             ),  # Invalid operational setting, should not be valid for any timesteps
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in ["$var.compressor1", 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],
             ),  # Valid for first timestep
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
-            ),
+            ),  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
         ],
     },
     compressors=[
@@ -284,46 +282,43 @@ compressor_system_v2_with_overlapping_temporal_models = dto.components.Compresso
     regularity=regularity,
     consumes=ConsumptionType.FUEL,
     fuel=fuel,
+    component_conditions=SystemComponentConditions(
+        crossover=[0, 1, 1],
+    ),
     operational_settings={
         datetime(2022, 1, 1, 0, 0): [
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 6000000, 6000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("250")] * 3,
-                crossover=[0, 1, 1],
             ),  # Invalid operational setting, should not be valid for any timesteps
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in ["$var.compressor1", 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],
             ),  # Valid for first timestep
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
-            ),
+            ),  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
         ],
         datetime(2025, 1, 1, 0, 0): [
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 6000000, 6000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("250")] * 3,
-                crossover=[0, 1, 1],
             ),  # Invalid operational setting, should not be valid for any timesteps
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in ["$var.compressor1", 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],
             ),  # Valid for first timestep
             dto.components.CompressorSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [1000000, 5000000, 5000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
-            ),
+            ),  # Crossover makes this valid. 1 mill from consumer 2 and 3 sent to 1.
         ],
     },
     compressors=[
@@ -382,20 +377,21 @@ pump_system_v2 = dto.components.PumpSystem(
     user_defined_category={datetime(2022, 1, 1): ConsumerUserDefinedCategoryType.PUMP},
     regularity=regularity,
     consumes=dto.types.ConsumptionType.ELECTRICITY,
+    component_conditions=SystemComponentConditions(
+        crossover=[0, 1, 1],
+    ),
     operational_settings={
         datetime(2022, 1, 1, 0, 0): [
             dto.components.PumpSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [4000000, 5000000, 6000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("250")] * 3,
-                crossover=[0, 1, 1],
                 fluid_density=[Expression.setup_from_expression("2")] * 3,
             ),
             dto.components.PumpSystemOperationalSetting(
                 rates=[Expression.setup_from_expression(x) for x in [2000000, 2500000, 3000000]],
                 inlet_pressures=[Expression.setup_from_expression("50")] * 3,
                 outlet_pressures=[Expression.setup_from_expression("125")] * 3,
-                crossover=[0, 1, 1],
                 fluid_density=[Expression.setup_from_expression("2")] * 3,
             ),
         ]

--- a/src/libecalc/fixtures/cases/consumer_system_v2/data/consumer_system_v2.yaml
+++ b/src/libecalc/fixtures/cases/consumer_system_v2/data/consumer_system_v2.yaml
@@ -79,17 +79,17 @@ INSTALLATIONS:
                 ENERGY_USAGE_MODEL: pump_single_speed
               - NAME: pump3
                 ENERGY_USAGE_MODEL: pump_single_speed
+            COMPONENT_CONDITIONS:
+              CROSSOVER: [ 0, 1, 1 ]
             OPERATIONAL_SETTINGS:
               - RATES: [ 4000000, 5000000, 6000000 ]
                 INLET_PRESSURE: 50
                 OUTLET_PRESSURE: 250
                 FLUID_DENSITY: 2
-                CROSSOVER: [0, 1, 1]
-              - RATES: [2000000, 2500000, 3000000]
+              - RATES: [ 2000000, 2500000, 3000000 ]
                 INLET_PRESSURE: 50
                 OUTLET_PRESSURE: 125
                 FLUID_DENSITY: 2
-                CROSSOVER: [0, 1, 1]
     FUELCONSUMERS:
       - NAME: compressor_system
         CATEGORY: COMPRESSOR
@@ -125,16 +125,15 @@ INSTALLATIONS:
             ENERGY_USAGE_MODEL: compressor_sampled_1d
           - NAME: compressor3
             ENERGY_USAGE_MODEL: compressor_sampled_1d
+        COMPONENT_CONDITIONS:
+          CROSSOVER: [ 0, 1, 1 ]
         OPERATIONAL_SETTINGS:
           - RATES: [ 1000000, 6000000, 6000000 ]
             INLET_PRESSURE: 50
             OUTLET_PRESSURE: 250
-            CROSSOVER: [ 0, 1, 1 ]
           - RATES: [ "$var.compressor1", 5000000, 5000000 ]
             INLET_PRESSURE: 50
             OUTLET_PRESSURE: 125
-            CROSSOVER: [ 0, 1, 1 ]
           - RATES: [ 1000000, 5000000, 5000000 ]
             INLET_PRESSURE: 50
             OUTLET_PRESSURE: 125
-            CROSSOVER: [ 0, 1, 1 ]

--- a/src/libecalc/input/yaml_types/components/system/yaml_compressor_system.py
+++ b/src/libecalc/input/yaml_types/components/system/yaml_compressor_system.py
@@ -4,11 +4,15 @@ from typing import Any, Dict, List, Literal, Optional
 from libecalc import dto
 from libecalc.common.time_utils import Period, define_time_model_for_period
 from libecalc.dto.base import ComponentType
+from libecalc.dto.components import SystemComponentConditions
 from libecalc.dto.types import ConsumptionType
 from libecalc.expression import Expression
 from libecalc.expression.expression import ExpressionType
 from libecalc.input.mappers.utils import resolve_and_validate_reference
 from libecalc.input.yaml_entities import References
+from libecalc.input.yaml_types.components.system.yaml_system_component_conditions import (
+    YamlSystemComponentConditions,
+)
 from libecalc.input.yaml_types.components.yaml_base import (
     YamlConsumerBase,
     YamlConsumerSystemOperationalConditionBase,
@@ -34,6 +38,12 @@ class YamlCompressorSystem(YamlConsumerBase):
         title="Type",
         description="The type of the component",
         alias="TYPE",
+    )
+
+    component_conditions: YamlSystemComponentConditions = Field(
+        None,
+        title="System component conditions",
+        description="Contains conditions for the component, in this case the system.",
     )
 
     operational_settings: YamlTemporalModel[List[YamlCompressorSystemOperationalSettings]]
@@ -105,7 +115,6 @@ class YamlCompressorSystem(YamlConsumerBase):
                         rates=rates,
                         inlet_pressures=[Expression.setup_from_expression(pressure) for pressure in inlet_pressures],
                         outlet_pressures=[Expression.setup_from_expression(pressure) for pressure in outlet_pressures],
-                        crossover=operational_setting.crossover or [0] * number_of_compressors,
                     )
                 )
 
@@ -131,11 +140,23 @@ class YamlCompressorSystem(YamlConsumerBase):
             for compressor in self.consumers
         ]
 
+        if self.component_conditions is not None:
+            component_conditions = SystemComponentConditions(
+                crossover=self.component_conditions.crossover
+                if self.component_conditions.crossover is not None
+                else [0] * number_of_compressors,
+            )
+        else:
+            component_conditions = SystemComponentConditions(
+                crossover=[0] * number_of_compressors,
+            )
+
         return dto.components.CompressorSystem(
             name=self.name,
             user_defined_category=define_time_model_for_period(self.category, target_period=target_period),
             regularity=regularity,
             consumes=consumes,
+            component_conditions=component_conditions,
             operational_settings=parsed_operational_settings,
             compressors=compressors,
             fuel=fuel,

--- a/src/libecalc/input/yaml_types/components/system/yaml_system_component_conditions.py
+++ b/src/libecalc/input/yaml_types/components/system/yaml_system_component_conditions.py
@@ -1,0 +1,31 @@
+from typing import List, Optional
+
+from libecalc.input.yaml_types import YamlBase
+from pydantic import Field
+
+
+class YamlSystemComponentConditions(YamlBase):
+    crossover: Optional[List[int]] = Field(
+        None,
+        title="Crossover",
+        description=(
+            "CROSSOVER specifies if rates are to be crossed over to another consumer if rate capacity is exceeded. If the energy"
+            " consumption calculation is not successful for a consumer, and the consumer has a valid cross-over defined, the"
+            " consumer will be allocated its maximum rate and the exceeding rate will be added to the cross-over consumer.\n"
+            "To avoid loops, a consumer can only be either receiving or giving away rate. For a cross-over to be valid, the"
+            ' discharge pressure at the consumer "receiving" overshooting rate must be higher than or equal to the discharge'
+            ' pressure of the "sending" consumer. This is because it is possible to choke pressure down to meet the outlet pressure'
+            ' in a flow line with lower pressure, but not possible to "pressure up" in the crossover flow line.\n'
+            "Some examples show how the crossover logic works:\n"
+            "Crossover is given as and list of integer values for the first position is the first consumer, second position is"
+            " the second consumer, etc. The number specifies which consumer to send cross-over flow to, and 0 signifies no"
+            " cross-over possible. Note that we use 1-index here.\n"
+            "Example 1:\n"
+            "Two consumers where there is a cross-over such that if the rate for the first consumer exceeds its capacity,"
+            " the excess rate will be processed by the second consumer. The second consumer can not cross-over to anyone.\n"
+            "CROSSOVER: [2, 0]\n"
+            "Example 2:\n"
+            "The first and second consumers may both send exceeding rate to the third consumer if their capacity is exceeded.\n"
+            "CROSSOVER: [3,3,0]"
+        ),
+    )

--- a/src/libecalc/input/yaml_types/components/yaml_base.py
+++ b/src/libecalc/input/yaml_types/components/yaml_base.py
@@ -70,30 +70,6 @@ class YamlConsumerSystemOperationalConditionBase(YamlBase):
     outlet_pressures: opt_expr_list = Field(
         None, title="Outlet pressures", description="Outlet pressures [bara] as a list of expressions."
     )
-    crossover: Optional[List[int]] = Field(
-        None,
-        title="Crossover",
-        description=(
-            "CROSSOVER specifies if rates are to be crossed over to another consumer if rate capacity is exceeded. If the energy"
-            " consumption calculation is not successful for a consumer, and the consumer has a valid cross-over defined, the"
-            " consumer will be allocated its maximum rate and the exceeding rate will be added to the cross-over consumer.\n"
-            "To avoid loops, a consumer can only be either receiving or giving away rate. For a cross-over to be valid, the"
-            ' discharge pressure at the consumer "receiving" overshooting rate must be higher than or equal to the discharge'
-            ' pressure of the "sending" consumer. This is because it is possible to choke pressure down to meet the outlet pressure'
-            ' in a flow line with lower pressure, but not possible to "pressure up" in the crossover flow line.\n'
-            "Some examples show how the crossover logic works:\n"
-            "Crossover is given as and list of integer values for the first position is the first consumer, second position is"
-            " the second consumer, etc. The number specifies which consumer to send cross-over flow to, and 0 signifies no"
-            " cross-over possible. Note that we use 1-index here.\n"
-            "Example 1:\n"
-            "Two consumers where there is a cross-over such that if the rate for the first consumer exceeds its capacity,"
-            " the excess rate will be processed by the second consumer. The second consumer can not cross-over to anyone.\n"
-            "CROSSOVER: [2, 0]\n"
-            "Example 2:\n"
-            "The first and second consumers may both send exceeding rate to the third consumer if their capacity is exceeded.\n"
-            "CROSSOVER: [3,3,0]"
-        ),
-    )
 
     @validator("inlet_pressure", always=True)
     def mutually_exclusive_inlet_pressure(cls, v, values):

--- a/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
+++ b/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
@@ -90,6 +90,15 @@
                             "title": "CATEGORY",
                             "type": "string"
                         },
+                        "COMPONENT_CONDITIONS": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/YamlSystemComponentConditions"
+                                }
+                            ],
+                            "description": "Contains conditions for the component, in this case the system.",
+                            "title": "System component conditions"
+                        },
                         "CONSUMERS": {
                             "items": {
                                 "$ref": "#/definitions/YamlCompressor"
@@ -144,14 +153,6 @@
                 "YamlCompressorSystemOperationalSettings": {
                     "additionalProperties": false,
                     "properties": {
-                        "CROSSOVER": {
-                            "description": "CROSSOVER specifies if rates are to be crossed over to another consumer if rate capacity is exceeded. If the energy consumption calculation is not successful for a consumer, and the consumer has a valid cross-over defined, the consumer will be allocated its maximum rate and the exceeding rate will be added to the cross-over consumer.\nTo avoid loops, a consumer can only be either receiving or giving away rate. For a cross-over to be valid, the discharge pressure at the consumer \"receiving\" overshooting rate must be higher than or equal to the discharge pressure of the \"sending\" consumer. This is because it is possible to choke pressure down to meet the outlet pressure in a flow line with lower pressure, but not possible to \"pressure up\" in the crossover flow line.\nSome examples show how the crossover logic works:\nCrossover is given as and list of integer values for the first position is the first consumer, second position is the second consumer, etc. The number specifies which consumer to send cross-over flow to, and 0 signifies no cross-over possible. Note that we use 1-index here.\nExample 1:\nTwo consumers where there is a cross-over such that if the rate for the first consumer exceeds its capacity, the excess rate will be processed by the second consumer. The second consumer can not cross-over to anyone.\nCROSSOVER: [2, 0]\nExample 2:\nThe first and second consumers may both send exceeding rate to the third consumer if their capacity is exceeded.\nCROSSOVER: [3,3,0]",
-                            "items": {
-                                "type": "integer"
-                            },
-                            "title": "Crossover",
-                            "type": "array"
-                        },
                         "INLET_PRESSURE": {
                             "anyOf": [
                                 {
@@ -1172,6 +1173,15 @@
                             "title": "CATEGORY",
                             "type": "string"
                         },
+                        "COMPONENT_CONDITIONS": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/YamlSystemComponentConditions"
+                                }
+                            ],
+                            "description": "Contains conditions for the component, in this case the system.",
+                            "title": "System component conditions"
+                        },
                         "CONSUMERS": {
                             "items": {
                                 "$ref": "#/definitions/YamlPump"
@@ -1226,14 +1236,6 @@
                 "YamlPumpSystemOperationalSettings": {
                     "additionalProperties": false,
                     "properties": {
-                        "CROSSOVER": {
-                            "description": "CROSSOVER specifies if rates are to be crossed over to another consumer if rate capacity is exceeded. If the energy consumption calculation is not successful for a consumer, and the consumer has a valid cross-over defined, the consumer will be allocated its maximum rate and the exceeding rate will be added to the cross-over consumer.\nTo avoid loops, a consumer can only be either receiving or giving away rate. For a cross-over to be valid, the discharge pressure at the consumer \"receiving\" overshooting rate must be higher than or equal to the discharge pressure of the \"sending\" consumer. This is because it is possible to choke pressure down to meet the outlet pressure in a flow line with lower pressure, but not possible to \"pressure up\" in the crossover flow line.\nSome examples show how the crossover logic works:\nCrossover is given as and list of integer values for the first position is the first consumer, second position is the second consumer, etc. The number specifies which consumer to send cross-over flow to, and 0 signifies no cross-over possible. Note that we use 1-index here.\nExample 1:\nTwo consumers where there is a cross-over such that if the rate for the first consumer exceeds its capacity, the excess rate will be processed by the second consumer. The second consumer can not cross-over to anyone.\nCROSSOVER: [2, 0]\nExample 2:\nThe first and second consumers may both send exceeding rate to the third consumer if their capacity is exceeded.\nCROSSOVER: [3,3,0]",
-                            "items": {
-                                "type": "integer"
-                            },
-                            "title": "Crossover",
-                            "type": "array"
-                        },
                         "FLUID_DENSITIES": {
                             "description": "The fluid density [kg/m3] as a list of expressions.",
                             "items": {
@@ -1383,6 +1385,21 @@
                         "VALUE"
                     ],
                     "title": "YamlSingleVariable",
+                    "type": "object"
+                },
+                "YamlSystemComponentConditions": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "CROSSOVER": {
+                            "description": "CROSSOVER specifies if rates are to be crossed over to another consumer if rate capacity is exceeded. If the energy consumption calculation is not successful for a consumer, and the consumer has a valid cross-over defined, the consumer will be allocated its maximum rate and the exceeding rate will be added to the cross-over consumer.\nTo avoid loops, a consumer can only be either receiving or giving away rate. For a cross-over to be valid, the discharge pressure at the consumer \"receiving\" overshooting rate must be higher than or equal to the discharge pressure of the \"sending\" consumer. This is because it is possible to choke pressure down to meet the outlet pressure in a flow line with lower pressure, but not possible to \"pressure up\" in the crossover flow line.\nSome examples show how the crossover logic works:\nCrossover is given as and list of integer values for the first position is the first consumer, second position is the second consumer, etc. The number specifies which consumer to send cross-over flow to, and 0 signifies no cross-over possible. Note that we use 1-index here.\nExample 1:\nTwo consumers where there is a cross-over such that if the rate for the first consumer exceeds its capacity, the excess rate will be processed by the second consumer. The second consumer can not cross-over to anyone.\nCROSSOVER: [2, 0]\nExample 2:\nThe first and second consumers may both send exceeding rate to the third consumer if their capacity is exceeded.\nCROSSOVER: [3,3,0]",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "title": "Crossover",
+                            "type": "array"
+                        }
+                    },
+                    "title": "YamlSystemComponentConditions",
                     "type": "object"
                 },
                 "YamlTabularModel": {


### PR DESCRIPTION
Only allow a single crossover, not change it over time.

Make it more clear that operational settings only contain stream conditions for consumers. Rename coming.