### PR TITLE
chore: version must be updated in version.py

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,7 @@ jobs:
           changelog-types: '[{ "type": "feat", "section": "Features", "hidden": false },{ "type": "feature", "section": "Features", "hidden": false },{ "type": "fix", "section": "Bug Fixes", "hidden": false },{ "type": "perf", "section": "Performance Improvements", "hidden": false },{ "type": "revert", "section": "Reverts", "hidden": false },{ "type": "docs", "section": "Documentation", "hidden": false },{ "type": "style", "section": "Styles", "hidden": false },{ "type": "chore", "section": "Miscellaneous Chores", "hidden": false },{ "type": "refactor", "section": "Code Refactoring", "hidden": false },{ "type": "test", "section": "Tests", "hidden": false },{ "type": "build", "section": "Build System", "hidden": false },{ "type": "ci", "section": "Continuous Integration", "hidden": false }]'
           extra-files: |
             pyproject.toml
-            src/libecalc/common/version.py
+            src/libecalc/version.py
       - uses: actions/checkout@v2
       - name: Create vX.Y release branch (for simpler patching) - if normal release (not patching)
         if: ${{ steps.release.outputs.release_created && env.VERSIONING_STRATEGY != 'always-bump-patch' }}

--- a/src/libecalc/version.py
+++ b/src/libecalc/version.py
@@ -1,13 +1,13 @@
 from libecalc.common.version import Version
 
-# DO NOT EDIT - replaced in CI
+# DO NOT EDIT - replaced in CI with release please
 __version__ = "8.3.0"  # x-release-please-version
 # END DO NOT EDIT
 
 
 def current_version() -> Version:
     """Get the current version of eCalc. This is set and
-    built in in CICD pipeline. Locally it will always be 0.0.0
+    built in the CICD pipeline.
     :return:
     """
     return Version.from_string(__version__)


### PR DESCRIPTION
Incorrect version.py file was referred to in
release-please, and hence the version within libecalc was not updated. showing v8.3.0 even though it was v8.4.0.

