### PR TITLE
chore: show correct version

### DIFF
--- a/src/libecalc/version.py
+++ b/src/libecalc/version.py
@@ -1,7 +1,7 @@
 from libecalc.common.version import Version
 
 # DO NOT EDIT - replaced in CI with release please
-__version__ = "8.3.0"  # x-release-please-version
+__version__ = "8.4.0"  # x-release-please-version
 # END DO NOT EDIT
 
 


### PR DESCRIPTION
To avoid confusion, set version to 8.4 here to have it aligned with pyproject.toml. Was not updated due to CICD/release-please bug
