### PR TITLE
chore: handle requested pressures for compressor systems

### DIFF
--- a/src/libecalc/common/feature_flags.py
+++ b/src/libecalc/common/feature_flags.py
@@ -19,13 +19,13 @@ class Feature:
 
         def decorate(experimental_feature: Callable):
             @wraps(experimental_feature)
-            def with_experimental(self, *args, **kwargs):
+            def with_experimental(*args, **kwargs):
                 logger.warning(
                     f"!EXPERIMENTAL! {feature_description}."
-                    f" It has not thoroughly tested and Quality Assured yet. Use at own risk. !EXPERIMENTAL!"
+                    f" It has not been thoroughly tested and Quality Assured yet. Use at own risk. !EXPERIMENTAL!"
                 )
                 try:
-                    return experimental_feature(self, *args, **kwargs)
+                    return experimental_feature(*args, **kwargs)
                 except Exception as e:
                     logger.error(
                         f"Error in {feature_description}: {e}."

--- a/src/libecalc/core/graph_result.py
+++ b/src/libecalc/core/graph_result.py
@@ -227,24 +227,41 @@ class GraphResult:
         :param energy_usage_model: Temporal energy model
         :param pressure_type: Compressor pressure type, inlet- or outlet
         :param name: name of compressor
+        :param operational_setting_index: if multiple operational settings for one model
         :return: Temporal model with pressures as expressions
         """
+
         evaluated_temporal_energy_usage_models = {}
+        operational_setting_index = 0
+
         for period, model in TemporalModel(energy_usage_model).items():
             if isinstance(model, CompressorSystemConsumerFunction):
-                for compressor, operational_setting in zip(model.compressors, model.operational_settings):
+                for compressor in model.compressors:
                     if compressor.name == name:
-                        pressures = operational_setting.suction_pressure
+                        # Challenge: do not handle variation in operational settings, just select first priority.
+                        # Possible to vary inlet- and outlet pressures between different operational settings
+                        # priorities, within one temporal model,
+                        operational_setting = model.operational_settings[operational_setting_index]
+                        compressor_nr = int(
+                            [i for i, compressor in enumerate(model.compressors) if compressor.name == name][0]
+                        )
 
-                        if pressure_type.value == CompressorPressureType.OUTLET_PRESSURE:
-                            pressures = operational_setting.discharge_pressure
+                        if pressure_type.value == CompressorPressureType.INLET_PRESSURE:
+                            if operational_setting.suction_pressures is not None:
+                                pressures = operational_setting.suction_pressures[compressor_nr]
+                            else:
+                                pressures = operational_setting.suction_pressure
+                        else:
+                            if operational_setting.discharge_pressures is not None:
+                                pressures = operational_setting.discharge_pressures[compressor_nr]
+                            else:
+                                pressures = operational_setting.discharge_pressure
 
                         if pressures is None:
                             pressures = math.nan
 
                         if not isinstance(pressures, Expression):
                             pressures = Expression.setup_from_expression(value=pressures)
-
                         evaluated_temporal_energy_usage_models[period.start] = pressures
             else:
                 pressures = model.suction_pressure

--- a/src/libecalc/core/graph_result.py
+++ b/src/libecalc/core/graph_result.py
@@ -217,12 +217,12 @@ class GraphResult:
         }
 
     @staticmethod
-    def get_operational_setting_index(timestep: datetime, operational_settings_used: TimeSeriesInt):
+    def operational_setting_used_id(timestep: datetime, operational_settings_used: TimeSeriesInt) -> int:
         timestep_index = operational_settings_used.timesteps.index(timestep)
 
-        operational_setting_index = operational_settings_used.values[timestep_index]
+        operational_setting_id = operational_settings_used.values[timestep_index]
 
-        return operational_setting_index - 1
+        return operational_setting_id - 1
 
     @staticmethod
     def get_requested_compressor_pressures(
@@ -259,11 +259,11 @@ class GraphResult:
             for timestep in model_timesteps:
                 for compressor in model_subset.compressors:
                     if compressor.name == name:
-                        operational_setting_index = GraphResult.get_operational_setting_index(
+                        operational_setting_used_id = GraphResult.operational_setting_used_id(
                             timestep=timestep, operational_settings_used=operational_settings_used
                         )
 
-                        operational_setting = model_subset.operational_settings[operational_setting_index]
+                        operational_setting = model_subset.operational_settings[operational_setting_used_id]
 
                         # Find correct compressor in case of different pressures for different components in system:
                         compressor_nr = int(

--- a/src/libecalc/core/graph_result.py
+++ b/src/libecalc/core/graph_result.py
@@ -9,6 +9,7 @@ from libecalc import dto
 from libecalc.common.component_info.component_level import ComponentLevel
 from libecalc.common.component_info.compressor import CompressorPressureType
 from libecalc.common.exceptions import ProgrammingError
+from libecalc.common.feature_flags import Feature
 from libecalc.common.temporal_model import TemporalExpression, TemporalModel
 from libecalc.common.time_utils import Period
 from libecalc.common.units import Unit
@@ -217,6 +218,9 @@ class GraphResult:
         }
 
     @staticmethod
+    @Feature.experimental(
+        feature_description="Reporting requested pressures from compressor systems is an experimental feature."
+    )
     def operational_setting_used_id(timestep: datetime, operational_settings_used: TimeSeriesInt) -> int:
         timestep_index = operational_settings_used.timesteps.index(timestep)
 

--- a/src/libecalc/dto/result/results.py
+++ b/src/libecalc/dto/result/results.py
@@ -195,8 +195,8 @@ class CompressorModelStageResult(EcalcResultBaseModel):
 class CompressorModelResult(ConsumerModelResultBase):
     componentType: Literal[ComponentType.COMPRESSOR]
     failure_status: List[Optional[CompressorTrainCommonShaftFailureStatus]]
-    requested_inlet_pressure: TimeSeriesFloat
-    requested_outlet_pressure: TimeSeriesFloat
+    requested_inlet_pressure: Union[TimeSeriesFloat, List[TimeSeriesFloat]]
+    requested_outlet_pressure: Union[TimeSeriesFloat, List[TimeSeriesFloat]]
     rate: TimeSeriesRate
     stage_results: List[CompressorModelStageResult]
     turbine_result: Optional[TurbineModelResult] = None

--- a/src/libecalc/dto/result/results.py
+++ b/src/libecalc/dto/result/results.py
@@ -195,8 +195,8 @@ class CompressorModelStageResult(EcalcResultBaseModel):
 class CompressorModelResult(ConsumerModelResultBase):
     componentType: Literal[ComponentType.COMPRESSOR]
     failure_status: List[Optional[CompressorTrainCommonShaftFailureStatus]]
-    requested_inlet_pressure: Union[TimeSeriesFloat, List[TimeSeriesFloat]]
-    requested_outlet_pressure: Union[TimeSeriesFloat, List[TimeSeriesFloat]]
+    requested_inlet_pressure: TimeSeriesFloat
+    requested_outlet_pressure: TimeSeriesFloat
     rate: TimeSeriesRate
     stage_results: List[CompressorModelStageResult]
     turbine_result: Optional[TurbineModelResult] = None


### PR DESCRIPTION
## Why is this pull request needed?

Extracting requested inlet- and outlet pressure does not work correctly for compressor systems:
When using `SUCTION_PRESSURES` or `DISCHARGE_PRESSURES` there are one pressure per component in the system. This list of pressures is not captured and the pressures are set to nan, and then nan to num (0).

## What does this pull request change?

- Update `get_requested_compressor_pressures` in `graph_result`, to select correct pressures for compressors in system
- Ensure correct operational setting is used for the compressors in the system

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-252?atlOrigin=eyJpIjoiYTJiZGUwNmY5MjlhNGMwMjg5YTc1Y2FiNTY0ZTkxNDQiLCJwIjoiaiJ9