### PR TITLE
ECALC-19 - Check for zero efficiency

### DIFF
--- a/src/ecalc_cli/commands/run.py
+++ b/src/ecalc_cli/commands/run.py
@@ -4,6 +4,12 @@ from pathlib import Path
 import libecalc.common.time_utils
 import libecalc.version
 import typer
+from libecalc.common.run_info import RunInfo
+from libecalc.core.ecalc import EnergyCalculator
+from libecalc.core.graph_result import GraphResult
+from libecalc.input.model import YamlModel
+from libecalc.output.utils.file_utils import OutputFormat, get_result_output
+
 from ecalc_cli.errors import EcalcCLIError
 from ecalc_cli.io.cache import Cache
 from ecalc_cli.io.output import (
@@ -15,11 +21,6 @@ from ecalc_cli.io.output import (
 )
 from ecalc_cli.logger import logger
 from ecalc_cli.types import DateFormat, Frequency
-from libecalc.common.run_info import RunInfo
-from libecalc.core.ecalc import EnergyCalculator
-from libecalc.core.graph_result import GraphResult
-from libecalc.input.model import YamlModel
-from libecalc.output.utils.file_utils import OutputFormat, get_result_output
 
 
 def run(

--- a/src/ecalc_cli/commands/selftest.py
+++ b/src/ecalc_cli/commands/selftest.py
@@ -1,6 +1,7 @@
 import libecalc.version
-from ecalc_cli.logger import logger
 from ecalc_neqsim_wrapper import start_server
+
+from ecalc_cli.logger import logger
 
 
 def selftest_java() -> bool:

--- a/src/ecalc_cli/commands/show.py
+++ b/src/ecalc_cli/commands/show.py
@@ -3,10 +3,6 @@ from pathlib import Path
 import libecalc.common.time_utils
 import libecalc.version
 import typer
-from ecalc_cli.io.cache import Cache
-from ecalc_cli.io.output import write_output
-from ecalc_cli.logger import logger
-from ecalc_cli.types import DateFormat, Frequency
 from libecalc.input.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
 from libecalc.input.yaml_entities import ResourceStream
 from libecalc.output.utils.file_utils import (
@@ -14,6 +10,11 @@ from libecalc.output.utils.file_utils import (
     get_component_output,
     get_result_output,
 )
+
+from ecalc_cli.io.cache import Cache
+from ecalc_cli.io.output import write_output
+from ecalc_cli.logger import logger
+from ecalc_cli.types import DateFormat, Frequency
 
 app = typer.Typer()
 

--- a/src/ecalc_cli/io/cache.py
+++ b/src/ecalc_cli/io/cache.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from ecalc_cli.logger import logger
 from libecalc import dto
 from libecalc.common.run_info import RunInfo
 from libecalc.core.graph_result import EnergyCalculatorResult, GraphResult
 from libecalc.dto.base import EcalcBaseModel
 from libecalc.dto.result import EcalcModelResult
+
+from ecalc_cli.logger import logger
 
 
 class CacheData(EcalcBaseModel):

--- a/src/ecalc_cli/io/output.py
+++ b/src/ecalc_cli/io/output.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Dict, List
 
 import libecalc.common.time_utils
-from ecalc_cli.errors import EcalcCLIError
 from libecalc import dto
 from libecalc.common.run_info import RunInfo
 from libecalc.common.time_utils import resample_time_steps
@@ -16,6 +15,8 @@ from libecalc.output.results.exporter import Exporter
 from libecalc.output.results.formatters.formatter import CSVFormatter
 from libecalc.output.results.handlers.handler import MultiFileHandler
 from libecalc.output.utils.file_utils import OutputFormat, get_result_output
+
+from ecalc_cli.errors import EcalcCLIError
 
 
 def write_output(output: str, output_file: Path = None):

--- a/src/ecalc_cli/main.py
+++ b/src/ecalc_cli/main.py
@@ -2,11 +2,12 @@ from pathlib import Path
 
 import libecalc.version
 import typer
+from libecalc.input.validation_errors import DataValidationError
+
 from ecalc_cli.commands import show
 from ecalc_cli.commands.run import run
 from ecalc_cli.commands.selftest import selftest
 from ecalc_cli.logger import CLILogConfigurator, LogLevel, logger
-from libecalc.input.validation_errors import DataValidationError
 
 app = typer.Typer(name="ecalc")
 

--- a/src/libecalc/core/models/compressor/train/stage.py
+++ b/src/libecalc/core/models/compressor/train/stage.py
@@ -139,6 +139,9 @@ class CompressorTrainStage(BaseModel):
         polytropic_efficiency = compressor_chart_head_and_efficiency_result.polytropic_efficiency
         chart_area_flag = compressor_chart_head_and_efficiency_result.chart_area_flag
 
+        if polytropic_efficiency == 0.0:
+            raise ValueError("Division by zero error. Polytropic efficiency from compressor chart is 0.")
+
         # Enthalpy change
         enthalpy_change_J_per_kg = polytropic_head_J_per_kg / polytropic_efficiency
 


### PR DESCRIPTION
Added to give a more informative "division by zero" error when polytropic efficiency is 0.