### PR TITLE
fix: wrong data for boilers and heaters in ltp-results

### DIFF
--- a/docs/docs/changelog/next.md
+++ b/docs/docs/changelog/next.md
@@ -17,7 +17,7 @@ sidebar_position: 1
 
 
 ## Fixes
-
+- `nmvoc` emissions were incorrectly reported for the ltp categories `HEATER` and `BOILER`: The emission query filters included `nox`, and are now corrected to `nmvoc`.
 
 ## Breaking changes
 

--- a/src/libecalc/fixtures/cases/ltp_export/installation_setup.py
+++ b/src/libecalc/fixtures/cases/ltp_export/installation_setup.py
@@ -24,14 +24,20 @@ ch4_factor = 0.1
 nox_factor = 0.5
 nmvoc_factor = 0
 
+date1 = datetime(2027, 1, 1)
+date2 = datetime(2027, 4, 10)
+date3 = datetime(2028, 1, 1)
+date4 = datetime(2028, 4, 10)
+date5 = datetime(2029, 1, 1)
+
 regularity_temporal_installation = {datetime(1900, 1, 1): Expression.setup_from_expression(regularity_installation)}
 regularity_temporal_consumer = {datetime(1900, 1, 1): Expression.setup_from_expression(regularity_consumer)}
 
-days1_first_half = calculate_delta_days(np.array([datetime(2027, 1, 1), datetime(2027, 4, 10)]))
-days2_first_half = calculate_delta_days(np.array([datetime(2028, 1, 1), datetime(2028, 4, 10)]))
+days_year1_first_half = calculate_delta_days(np.array([date1, date2]))
+days_year2_first_half = calculate_delta_days(np.array([date3, date4]))
 
-days1_second_half = calculate_delta_days(np.array([datetime(2027, 4, 10), datetime(2028, 1, 1)]))
-days2_second_half = calculate_delta_days(np.array([datetime(2028, 4, 10), datetime(2029, 1, 1)]))
+days_year1_second_half = calculate_delta_days(np.array([date2, date3]))
+days_year2_second_half = calculate_delta_days(np.array([date4, date5]))
 
 
 def fuel_turbine() -> dto.types.FuelType:
@@ -114,49 +120,49 @@ def generator_set_diesel() -> dto.GeneratorSetSampled:
 
 def fuel_dict() -> Dict[datetime, dto.types.FuelType]:
     return {
-        datetime(2027, 1, 1): diesel_turbine(),
-        datetime(2027, 4, 10): fuel_turbine(),
-        datetime(2028, 1, 1): diesel_turbine(),
-        datetime(2028, 4, 10): fuel_turbine(),
-        datetime(2029, 1, 1): diesel_turbine(),
+        date1: diesel_turbine(),
+        date2: fuel_turbine(),
+        date3: diesel_turbine(),
+        date4: fuel_turbine(),
+        date5: diesel_turbine(),
     }
 
 
 def fuel_dict_multi() -> Dict[datetime, dto.types.FuelType]:
     return {
-        datetime(2027, 1, 1): diesel_turbine_multi(),
-        datetime(2027, 4, 10): fuel_turbine(),
-        datetime(2028, 1, 1): diesel_turbine_multi(),
-        datetime(2028, 4, 10): fuel_turbine(),
-        datetime(2029, 1, 1): diesel_turbine_multi(),
+        date1: diesel_turbine_multi(),
+        date2: fuel_turbine(),
+        date3: diesel_turbine_multi(),
+        date4: fuel_turbine(),
+        date5: diesel_turbine_multi(),
     }
 
 
 def generator_set_dict() -> Dict[datetime, dto.GeneratorSetSampled]:
     return {
-        datetime(2027, 1, 1): generator_set_diesel(),
-        datetime(2027, 4, 10): generator_set_fuel(),
-        datetime(2028, 1, 1): generator_set_diesel(),
-        datetime(2028, 4, 10): generator_set_fuel(),
-        datetime(2029, 1, 1): generator_set_diesel(),
+        date1: generator_set_diesel(),
+        date2: generator_set_fuel(),
+        date3: generator_set_diesel(),
+        date4: generator_set_fuel(),
+        date5: generator_set_diesel(),
     }
 
 
 def category_dict() -> Dict[datetime, ConsumerUserDefinedCategoryType]:
     return {
-        datetime(2027, 1, 1): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
-        datetime(2027, 4, 10): ConsumerUserDefinedCategoryType.POWER_FROM_SHORE,
-        datetime(2028, 1, 1): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
-        datetime(2028, 4, 10): ConsumerUserDefinedCategoryType.POWER_FROM_SHORE,
-        datetime(2029, 1, 1): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
+        date1: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
+        date2: ConsumerUserDefinedCategoryType.POWER_FROM_SHORE,
+        date3: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
+        date4: ConsumerUserDefinedCategoryType.POWER_FROM_SHORE,
+        date5: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
     }
 
 
 def category_dict_coarse() -> Dict[datetime, ConsumerUserDefinedCategoryType]:
     return {
-        datetime(2027, 1, 1): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
-        datetime(2027, 4, 10): ConsumerUserDefinedCategoryType.POWER_FROM_SHORE,
-        datetime(2028, 1, 1): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
+        date1: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
+        date2: ConsumerUserDefinedCategoryType.POWER_FROM_SHORE,
+        date3: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
     }
 
 
@@ -172,18 +178,18 @@ def offshore_wind() -> dto.ElectricityConsumer:
         name="direct_consumer",
         component_type=dto.base.ComponentType.GENERIC,
         user_defined_category={
-            datetime(2027, 1, 1): ConsumerUserDefinedCategoryType.MISCELLANEOUS,
-            datetime(2027, 4, 10): ConsumerUserDefinedCategoryType.OFFSHORE_WIND,
-            datetime(2028, 1, 1): ConsumerUserDefinedCategoryType.MISCELLANEOUS,
-            datetime(2028, 4, 10): ConsumerUserDefinedCategoryType.OFFSHORE_WIND,
-            datetime(2029, 1, 1): ConsumerUserDefinedCategoryType.MISCELLANEOUS,
+            date1: ConsumerUserDefinedCategoryType.MISCELLANEOUS,
+            date2: ConsumerUserDefinedCategoryType.OFFSHORE_WIND,
+            date3: ConsumerUserDefinedCategoryType.MISCELLANEOUS,
+            date4: ConsumerUserDefinedCategoryType.OFFSHORE_WIND,
+            date5: ConsumerUserDefinedCategoryType.MISCELLANEOUS,
         },
         energy_usage_model={
-            datetime(2027, 1, 1): direct_consumer(power=0),
-            datetime(2027, 4, 10): direct_consumer(power=power_offshore_wind_mw),
-            datetime(2028, 1, 1): direct_consumer(power=0),
-            datetime(2028, 4, 10): direct_consumer(power=power_offshore_wind_mw),
-            datetime(2029, 1, 1): direct_consumer(power=0),
+            date1: direct_consumer(power=0),
+            date2: direct_consumer(power=power_offshore_wind_mw),
+            date3: direct_consumer(power=0),
+            date4: direct_consumer(power=power_offshore_wind_mw),
+            date5: direct_consumer(power=0),
         },
         regularity=regularity_temporal_consumer,
     )
@@ -194,7 +200,7 @@ def no_el_consumption() -> dto.ElectricityConsumer:
         name="no_el_consumption",
         component_type=dto.base.ComponentType.GENERIC,
         user_defined_category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.FIXED_PRODUCTION_LOAD},
-        energy_usage_model={datetime(2027, 1, 1): direct_consumer(power=0)},
+        energy_usage_model={date1: direct_consumer(power=0)},
         regularity=regularity_temporal_consumer,
     )
 
@@ -205,7 +211,7 @@ def simple_direct_el_consumer() -> dto.ElectricityConsumer:
         component_type=dto.base.ComponentType.GENERIC,
         user_defined_category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.FIXED_PRODUCTION_LOAD},
         energy_usage_model={
-            datetime(2027, 1, 1): dto.DirectConsumerFunction(
+            date1: dto.DirectConsumerFunction(
                 load=Expression.setup_from_expression(value=power_usage_mw),
                 energy_usage_type=dto.types.EnergyUsageType.POWER,
                 consumption_rate_type=dto.types.RateType.STREAM_DAY,
@@ -221,7 +227,7 @@ def simple_direct_el_consumer_mobile() -> dto.ElectricityConsumer:
         component_type=dto.base.ComponentType.GENERIC,
         user_defined_category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.FIXED_PRODUCTION_LOAD},
         energy_usage_model={
-            datetime(2027, 1, 1): dto.DirectConsumerFunction(
+            date1: dto.DirectConsumerFunction(
                 load=Expression.setup_from_expression(value=power_usage_mw),
                 energy_usage_type=dto.types.EnergyUsageType.POWER,
                 consumption_rate_type=dto.types.RateType.STREAM_DAY,
@@ -246,10 +252,10 @@ def boiler_heater() -> dto.FuelConsumer:
     return dto.FuelConsumer(
         name="boiler",
         component_type=dto.base.ComponentType.DIRECT_EMITTER,
-        fuel={datetime(2027, 1, 1): fuel_turbine()},
+        fuel={date1: fuel_turbine()},
         user_defined_category={
-            datetime(2027, 1, 1): ConsumerUserDefinedCategoryType.BOILER,
-            datetime(2028, 4, 10): ConsumerUserDefinedCategoryType.HEATER,
+            date1: ConsumerUserDefinedCategoryType.BOILER,
+            date4: ConsumerUserDefinedCategoryType.HEATER,
         },
         regularity=regularity_temporal_consumer,
         energy_usage_model={
@@ -267,11 +273,11 @@ def compressor() -> dto.FuelConsumer:
         component_type=dto.base.ComponentType.COMPRESSOR,
         fuel={datetime(2027, 1, 1): fuel_turbine()},
         user_defined_category={
-            datetime(2027, 1, 1): ConsumerUserDefinedCategoryType.MISCELLANEOUS,
-            datetime(2027, 4, 10): ConsumerUserDefinedCategoryType.GAS_DRIVEN_COMPRESSOR,
-            datetime(2028, 1, 1): ConsumerUserDefinedCategoryType.MISCELLANEOUS,
-            datetime(2028, 4, 10): ConsumerUserDefinedCategoryType.GAS_DRIVEN_COMPRESSOR,
-            datetime(2029, 1, 1): ConsumerUserDefinedCategoryType.MISCELLANEOUS,
+            date1: ConsumerUserDefinedCategoryType.MISCELLANEOUS,
+            date2: ConsumerUserDefinedCategoryType.GAS_DRIVEN_COMPRESSOR,
+            date3: ConsumerUserDefinedCategoryType.MISCELLANEOUS,
+            date4: ConsumerUserDefinedCategoryType.GAS_DRIVEN_COMPRESSOR,
+            date5: ConsumerUserDefinedCategoryType.MISCELLANEOUS,
         },
         regularity=regularity_temporal_consumer,
         energy_usage_model={
@@ -300,9 +306,9 @@ def generator_set_direct_consumer_temporal_model() -> dto.GeneratorSet:
 def generator_set_offshore_wind_temporal_model() -> dto.GeneratorSet:
     return dto.GeneratorSet(
         name="genset",
-        user_defined_category={datetime(2027, 1, 1): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR},
-        fuel={datetime(2027, 1, 1): fuel_turbine()},
-        generator_set_model={datetime(2027, 1, 1): generator_set_fuel()},
+        user_defined_category={date1: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR},
+        fuel={date1: fuel_turbine()},
+        generator_set_model={date1: generator_set_fuel()},
         consumers=[offshore_wind()],
         regularity=regularity_temporal_consumer,
     )
@@ -311,9 +317,9 @@ def generator_set_offshore_wind_temporal_model() -> dto.GeneratorSet:
 def generator_set_compressor_temporal_model() -> dto.GeneratorSet:
     return dto.GeneratorSet(
         name="genset",
-        user_defined_category={datetime(2027, 1, 1): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR},
-        fuel={datetime(2027, 1, 1): fuel_turbine()},
-        generator_set_model={datetime(2027, 1, 1): generator_set_fuel()},
+        user_defined_category={date1: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR},
+        fuel={date1: fuel_turbine()},
+        generator_set_model={date1: generator_set_fuel()},
         consumers=[no_el_consumption()],
         regularity=regularity_temporal_consumer,
     )
@@ -342,24 +348,24 @@ def generator_set_mobile_diesel() -> dto.GeneratorSet:
 
 
 def expected_fuel_consumption():
-    consumption = float(fuel_rate * days2_second_half * regularity_consumer)
+    consumption = float(fuel_rate * days_year2_second_half * regularity_consumer)
     return consumption
 
 
 def expected_diesel_consumption():
-    consumption = float(diesel_rate * (days1_first_half + days2_first_half) * regularity_consumer)
+    consumption = float(diesel_rate * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
     return consumption
 
 
 def expected_pfs_el_consumption():
-    consumption_mw_per_day = power_usage_mw * days1_second_half * regularity_consumer
+    consumption_mw_per_day = power_usage_mw * days_year1_second_half * regularity_consumer
     consumption = float(Unit.MEGA_WATT_DAYS.to(Unit.GIGA_WATT_HOURS)(consumption_mw_per_day))
     return consumption
 
 
 def expected_gas_turbine_el_generated():
     consumption_mw_per_day = (
-        power_usage_mw * (days1_first_half + days2_first_half + days2_second_half) * regularity_consumer
+        power_usage_mw * (days_year1_first_half + days_year2_first_half + days_year2_second_half) * regularity_consumer
     )
     consumption = float(Unit.MEGA_WATT_DAYS.to(Unit.GIGA_WATT_HOURS)(consumption_mw_per_day))
     return consumption
@@ -368,58 +374,62 @@ def expected_gas_turbine_el_generated():
 def expected_co2_from_fuel():
     emission_kg_per_day = float(fuel_rate * co2_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * days2_second_half * regularity_consumer)
+    emission_tons = float(emission_tons_per_day * days_year2_second_half * regularity_consumer)
     return emission_tons
 
 
 def expected_co2_from_diesel():
     emission_kg_per_day = float(diesel_rate * co2_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * (days1_first_half + days2_first_half) * regularity_consumer)
+    emission_tons = float(emission_tons_per_day * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
     return emission_tons
 
 
 def expected_ch4_from_diesel():
     emission_kg_per_day = float(diesel_rate * ch4_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * (days1_first_half + days2_first_half) * regularity_consumer)
+    emission_tons = float(emission_tons_per_day * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
     return emission_tons
 
 
 def expected_nox_from_diesel():
     emission_kg_per_day = float(diesel_rate * nox_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * (days1_first_half + days2_first_half) * regularity_consumer)
+    emission_tons = float(emission_tons_per_day * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
     return emission_tons
 
 
 def expected_nmvoc_from_diesel():
     emission_kg_per_day = float(diesel_rate * nmvoc_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * (days1_first_half + days2_first_half) * regularity_consumer)
+    emission_tons = float(emission_tons_per_day * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
     return emission_tons
 
 
 def expected_offshore_wind_el_consumption():
-    consumption_mw_per_day = power_offshore_wind_mw * (days1_second_half + days2_second_half) * regularity_consumer
+    consumption_mw_per_day = (
+        power_offshore_wind_mw * (days_year1_second_half + days_year2_second_half) * regularity_consumer
+    )
     consumption = -float(Unit.MEGA_WATT_DAYS.to(Unit.GIGA_WATT_HOURS)(consumption_mw_per_day))
     return consumption
 
 
 # Why is this the only one without regularity?
 def expected_gas_turbine_compressor_el_consumption():
-    consumption_mw_per_day = power_compressor_mw * (days1_second_half + days2_second_half)
+    consumption_mw_per_day = power_compressor_mw * (days_year1_second_half + days_year2_second_half)
     consumption = float(Unit.MEGA_WATT_DAYS.to(Unit.GIGA_WATT_HOURS)(consumption_mw_per_day))
     return consumption
 
 
 def expected_boiler_fuel_consumption():
-    consumption = float(fuel_rate * (days1_first_half + days1_second_half + days2_first_half) * regularity_consumer)
+    consumption = float(
+        fuel_rate * (days_year1_first_half + days_year1_second_half + days_year2_first_half) * regularity_consumer
+    )
     return consumption
 
 
 def expected_heater_fuel_consumption():
-    consumption = float(fuel_rate * days2_second_half * regularity_consumer)
+    consumption = float(fuel_rate * days_year2_second_half * regularity_consumer)
     return consumption
 
 
@@ -427,7 +437,9 @@ def expected_co2_from_boiler():
     emission_kg_per_day = float(fuel_rate * co2_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
     emission_tons = float(
-        emission_tons_per_day * (days1_first_half + days1_second_half + days2_first_half) * regularity_consumer
+        emission_tons_per_day
+        * (days_year1_first_half + days_year1_second_half + days_year2_first_half)
+        * regularity_consumer
     )
     return emission_tons
 
@@ -435,7 +447,7 @@ def expected_co2_from_boiler():
 def expected_co2_from_heater():
     emission_kg_per_day = float(fuel_rate * co2_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * days2_second_half * regularity_consumer)
+    emission_tons = float(emission_tons_per_day * days_year2_second_half * regularity_consumer)
     return emission_tons
 
 

--- a/src/libecalc/output/results/configs/configs.py
+++ b/src/libecalc/output/results/configs/configs.py
@@ -385,7 +385,7 @@ class LTPConfig(ResultConfig):
                         installation_category="FIXED",
                         fuel_type_category="FUEL-GAS",
                         consumer_categories=["BOILER"],
-                        emission_type="nox",
+                        emission_type="nmvoc",
                     ),
                 ),
                 Applier(
@@ -396,7 +396,7 @@ class LTPConfig(ResultConfig):
                         installation_category="FIXED",
                         fuel_type_category="DIESEL",
                         consumer_categories=["BOILER"],
-                        emission_type="nox",
+                        emission_type="nmvoc",
                     ),
                 ),
                 Applier(
@@ -407,7 +407,7 @@ class LTPConfig(ResultConfig):
                         installation_category="FIXED",
                         fuel_type_category="FUEL-GAS",
                         consumer_categories=["HEATER"],
-                        emission_type="nox",
+                        emission_type="nmvoc",
                     ),
                 ),
                 Applier(
@@ -418,7 +418,7 @@ class LTPConfig(ResultConfig):
                         installation_category="FIXED",
                         fuel_type_category="DIESEL",
                         consumer_categories=["HEATER"],
-                        emission_type="nox",
+                        emission_type="nmvoc",
                     ),
                 ),
                 Applier(

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -19,6 +19,8 @@ from libecalc.fixtures.cases.ltp_export.installation_setup import (
     expected_gas_turbine_compressor_el_consumption,
     expected_gas_turbine_el_generated,
     expected_heater_fuel_consumption,
+    expected_nmvoc_from_diesel,
+    expected_nox_from_diesel,
     expected_offshore_wind_el_consumption,
     expected_pfs_el_consumption,
     installation_boiler_heater_dto,
@@ -69,7 +71,7 @@ def get_sum_ltp_column(ltp_result, installation_nr, ltp_column_nr) -> float:
     return ltp_sum
 
 
-def test_ch4_diesel_fixed_and_mobile():
+def test_emissions_diesel_fixed_and_mobile():
     """Test reporting of CH4 from diesel in LTP."""
     installation_fixed = installation_diesel_fixed_dto()
     installation_mobile = installation_diesel_mobile_dto()
@@ -86,9 +88,24 @@ def test_ch4_diesel_fixed_and_mobile():
 
     ltp_result = get_consumption(installation=asset, variables=variables)
 
-    ch4_from_diesel_fixed = get_sum_ltp_column(ltp_result, installation_nr=0, ltp_column_nr=2)
-    ch4_from_diesel_mobile = get_sum_ltp_column(ltp_result, installation_nr=1, ltp_column_nr=2)
+    co2_from_diesel_fixed = get_sum_ltp_column(ltp_result, installation_nr=0, ltp_column_nr=1)
+    co2_from_diesel_mobile = get_sum_ltp_column(ltp_result, installation_nr=1, ltp_column_nr=1)
 
+    nox_from_diesel_fixed = get_sum_ltp_column(ltp_result, installation_nr=0, ltp_column_nr=2)
+    nox_from_diesel_mobile = get_sum_ltp_column(ltp_result, installation_nr=1, ltp_column_nr=2)
+
+    nmvoc_from_diesel_fixed = get_sum_ltp_column(ltp_result, installation_nr=0, ltp_column_nr=3)
+    nmvoc_from_diesel_mobile = get_sum_ltp_column(ltp_result, installation_nr=1, ltp_column_nr=3)
+
+    ch4_from_diesel_fixed = get_sum_ltp_column(ltp_result, installation_nr=0, ltp_column_nr=4)
+    ch4_from_diesel_mobile = get_sum_ltp_column(ltp_result, installation_nr=1, ltp_column_nr=4)
+
+    assert co2_from_diesel_fixed == expected_co2_from_diesel()
+    assert co2_from_diesel_mobile == expected_co2_from_diesel()
+    assert nox_from_diesel_fixed == expected_nox_from_diesel()
+    assert nox_from_diesel_mobile == expected_nox_from_diesel()
+    assert nmvoc_from_diesel_fixed == expected_nmvoc_from_diesel()
+    assert nmvoc_from_diesel_mobile == expected_nmvoc_from_diesel()
     assert ch4_from_diesel_fixed == expected_ch4_from_diesel()
     assert ch4_from_diesel_mobile == expected_ch4_from_diesel()
 


### PR DESCRIPTION
## Why is this pull request needed?

Calculation of nmvoc-emissions for the `BOILER`- and `HEATER` ltp-categories are wrong. The emission query asks for nox instead of nmvoc.

## What does this pull request change?

Update emission query to ask for correct emission type.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-313?atlOrigin=eyJpIjoiM2EwY2MwYzQ4ZTRiNGY5ZGEzZmMyMTgyNjAwYTJiYWMiLCJwIjoiaiJ9