### PR TITLE
docs: add missing keywords surge control margin

### DIFF
--- a/docs/docs/about/references/keywords/CONTROL_MARGIN.md
+++ b/docs/docs/about/references/keywords/CONTROL_MARGIN.md
@@ -1,0 +1,126 @@
+# CONTROL_MARGIN
+
+[MODELS](/about/references/keywords/MODELS.md) /
+[...] /
+[STAGES](/about/references/keywords/STAGES.md)
+
+## Description
+
+This keyword defines the surge control margin for a variable speed compressor chart.
+
+The `CONTROL_MARGIN` behaves as an alternate to the minimum flow line: The input will be 'cropped' to only include points to the right of the control line - modelling recirculation (ASV) from the correct control line.
+
+The `CONTROL_MARGIN` is given as a percentage or fraction ([CONTROL_MARGIN_UNIT](/about/references/keywords/CONTROL_MARGIN_UNIT.md)) of the rate difference between minimum- and maximum flow, 
+for the given speed. It is used to calculate the increase in minimum flow for each individual speed curve. 
+It is defined when setting up the stages in a [Variable speed compressor train model](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md) or [Variable speed compressor train model with multiple streams and pressures](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md).
+
+It is currently only possible to define a surge control margin for variable speed compressors.
+
+See [Surge control margin for variable speed compressor chart](/about/modelling/setup/models/compressor_modelling/compressor_charts/index.md) for more details.
+
+## Use in [Variable speed compressor train model](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md)
+### Format
+
+~~~~yaml
+MODELS:
+  - NAME: <model name>
+    TYPE: VARIABLE_SPEED_COMPRESSOR_TRAIN
+    FLUID_MODEL: <reference to fluid model, must be defined in MODELS>
+    ...
+    COMPRESSOR_TRAIN:
+      STAGES:
+        - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
+          COMPRESSOR_CHART: <reference to compressor chart model for first stage, must be defined in MODELS or FACILITY_INPUTS>
+          CONTROL_MARGIN: <Default value is zero>
+          CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
+          ....
+~~~~
+
+### Example
+~~~~yaml
+MODELS:
+  - NAME: compressor_model
+    TYPE: VARIABLE_SPEED_COMPRESSOR_TRAIN
+    FLUID_MODEL: fluid_model
+    ...
+    COMPRESSOR_TRAIN:
+      STAGES:
+        - INLET_TEMPERATURE: 20
+          COMPRESSOR_CHART: 1_stage_chart
+          CONTROL_MARGIN: 0.1
+          CONTROL_MARGIN_UNIT: FRACTION
+          ....
+~~~~
+
+## Use in [Variable speed compressor train model with multiple streams and pressures](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md)
+
+### Format
+
+~~~~~~~~yaml
+MODELS:
+  - NAME: <model name>
+    TYPE: VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES
+    ....
+    STREAMS:
+        - NAME: <name of stream 1>
+          TYPE: INGOING
+          FLUID_MODEL: <reference to fluid model, must be defined in MODELS>
+        - NAME: <name of stream 2>
+          TYPE: INGOING
+          FLUID_MODEL: <reference to fluid model, must be defined in MODELS>
+        - ...
+        - NAME: <name of stream N>
+          TYPE: OUTGOING # NB: No fluid definition for outgoing streams!
+    STAGES:
+      - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
+        COMPRESSOR_CHART: <reference to a compressor chart model defined in MODELS>
+        STREAM: <Optional>
+          - <reference stream from STREAMS for one in- or outgoing stream. Optional>
+          - <reference stream from STREAMS for another in- or outgoing stream. Optional>
+        CONTROL_MARGIN: <Default value 0.0>
+        CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
+        PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
+        INTERSTAGE_CONTROL_PRESSURE:
+          UPSTREAM_PRESSURE_CONTROL: <pressure control>
+          DOWNSTREAM_PRESSURE_CONTROL: <pressure control>
+      - ...
+~~~~~~~~
+
+### Example
+
+~~~~~~~~yaml
+MODELS:
+  - NAME: compressor_model
+    TYPE: VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES
+    ....
+    STREAMS:
+      - NAME: 1_stage_inlet
+        TYPE: INGOING
+        FLUID_MODEL: fluid_model_1
+      - NAME: 3_stage_inlet
+        TYPE: INGOING
+        FLUID_MODEL: fluid_model_2
+      - NAME: 2_stage_outlet
+        TYPE: OUTGOING
+    STAGES:
+      - COMPRESSOR_CHART: 1_stage_chart
+        INLET_TEMPERATURE: 20
+        STREAM: 
+          - 1_stage_inlet
+        CONTROL_MARGIN: 10
+        CONTROL_MARGIN_UNIT: PERCENTAGE
+      - COMPRESSOR_CHART: 2_stage_chart 
+        INLET_TEMPERATURE: 30
+        CONTROL_MARGIN: 15
+        CONTROL_MARGIN_UNIT: PERCENTAGE
+      - COMPRESSOR_CHART: 3_stage_chart 
+        INLET_TEMPERATURE: 35
+        STREAM: 
+          - 2_stage_outlet
+          - 3_stage_inlet
+        INTERSTAGE_CONTROL_PRESSURE:
+          UPSTREAM_PRESSURE_CONTROL: INDIVIDUAL_ASV_RATE  #1st and 2nd stage
+          DOWNSTREAM_PRESSURE_CONTROL: INDIVIDUAL_ASV_RATE #3rd and 4th stage
+      - COMPRESSOR_CHART: 4_stage_chart 
+        INLET_TEMPERATURE: 15
+~~~~~~~~

--- a/docs/docs/about/references/keywords/CONTROL_MARGIN_UNIT.md
+++ b/docs/docs/about/references/keywords/CONTROL_MARGIN_UNIT.md
@@ -1,0 +1,50 @@
+# CONTROL_MARGIN_UNIT
+
+[MODELS](/about/references/keywords/MODELS.md) /
+[...] /
+[STAGES](/about/references/keywords/STAGES.md)
+
+## Description
+
+This keyword defines the unit of the [surge control margin](/about/references/keywords/CONTROL_MARGIN.md) for a variable speed compressor chart.
+
+The `CONTROL_MARGIN_UNIT` is given as a percentage or fraction of the rate difference between minimum- and maximum flow.
+
+It is defined when setting up the stages in a [Variable speed compressor train model](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md) or [Variable speed compressor train model with multiple streams and pressures](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md).
+
+It is currently only possible to define a surge control margin for variable speed compressors.
+
+See [Surge control margin for variable speed compressor chart](/about/modelling/setup/models/compressor_modelling/compressor_charts/index.md) for more details.
+
+### Format
+
+~~~~yaml
+MODELS:
+  - NAME: <model name>
+    TYPE: VARIABLE_SPEED_COMPRESSOR_TRAIN
+    FLUID_MODEL: <reference to fluid model, must be defined in MODELS>
+    ...
+    COMPRESSOR_TRAIN:
+      STAGES:
+        - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
+          COMPRESSOR_CHART: <reference to compressor chart model for first stage, must be defined in MODELS or FACILITY_INPUTS>
+          CONTROL_MARGIN: <Default value is zero>
+          CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
+          ....
+~~~~
+
+### Example
+~~~~yaml
+MODELS:
+  - NAME: compressor_model
+    TYPE: VARIABLE_SPEED_COMPRESSOR_TRAIN
+    FLUID_MODEL: fluid_model
+    ...
+    COMPRESSOR_TRAIN:
+      STAGES:
+        - INLET_TEMPERATURE: 20
+          COMPRESSOR_CHART: 1_stage_chart
+          CONTROL_MARGIN: 0.1
+          CONTROL_MARGIN_UNIT: FRACTION
+          ....
+~~~~

--- a/docs/docs/changelog/next.md
+++ b/docs/docs/changelog/next.md
@@ -15,9 +15,10 @@ sidebar_position: 1
 - Added chart area flag NO_FLOW_RATE to the possible statuses for an operational point in a variable speed compressor chart. The chart area flags can currently only be found in the json result file, but we will also try to find a way of displaying this information in the WebApp as well.
 - Whenever there is a variable speed compressor only recirculation fluid (can happen in a multiple streams and pressures compressor train) a warning will be logged.
 
-
 ## Fixes
 - `nmvoc` emissions were incorrectly reported for the ltp categories `HEATER` and `BOILER`: The emission query filters included `nox`, and are now corrected to `nmvoc`.
+- Instead of applying the surge control margin to the average of the minimum flow rate for all speed curves in the compressor chart, a more robust calculation is implemented for variable speed compressors: The updated minimum flow is calculated individually for each speed, using the control margin as the increase in minimum flow, in percentage or fraction of the rate difference between minimum- and maximum flow, for the given speed. This solves the problem of eCalc failing when the new calculated minimum rate was outside the compressor chart for a given speed.
+
 
 ## Breaking changes
 


### PR DESCRIPTION
## Why is this pull request needed?

Description of the keywords `CONTROL_MARGIN` and `CONTROL_MARGIN_UNIT` is missing the the YAML keywords section in eCalc Docs.

## What does this pull request change?

- [ ] Add description of keyword CONTROL_MARGIN
- [ ] Add description of keyword CONTROL_MARGIN_UNIT
- [ ] Update changelog with description of new control margin calculation

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-318?atlOrigin=eyJpIjoiZmVmNDM3NzRkZDU3NDk3ZTllYmFhYjgxYzY5NTA5Y2EiLCJwIjoiaiJ9