### PR TITLE
chore: make sure no mismatch between timestemps and time series values

### DIFF
--- a/src/libecalc/common/utils/rates.py
+++ b/src/libecalc/common/utils/rates.py
@@ -580,6 +580,18 @@ class TimeSeriesVolumesCumulative(TimeSeries[float]):
 
 
 class TimeSeriesVolumes(TimeSeries[float]):
+    @validator("values", pre=True)
+    def check_length_timestep_values(cls, v: list, values, field: ModelField):
+        # Initially timesteps for volumes contains one more item than values
+        # After reindex number of timesteps equals number of values
+        # TODO: Ensure periodical volumes are handled in a consistent way. Why different after reindex?
+        if len(v) not in [len(values["timesteps"]), len(values["timesteps"]) - 1]:
+            raise ProgrammingError(
+                "Time series: number of timesteps do not match number "
+                "of values. Most likely a bug, report to eCalc Dev Team."
+            )
+        return v
+
     def resample(self, freq: Frequency):
         msg = (
             f"{self.__repr_name__()} does not have an resample method."

--- a/src/libecalc/common/utils/rates.py
+++ b/src/libecalc/common/utils/rates.py
@@ -9,6 +9,7 @@ from enum import Enum
 from typing import (
     Any,
     DefaultDict,
+    Dict,
     Generic,
     Iterable,
     Iterator,
@@ -162,7 +163,7 @@ class TimeSeries(GenericModel, Generic[TimeSeriesValue], ABC):
         return v
 
     @validator("values", pre=True)
-    def timesteps_values_one_to_one(cls, v: list, values, field: ModelField):
+    def timesteps_values_one_to_one(cls, v: List[Any], values: Dict[str, Any]):
         nr_timesteps = len(values["timesteps"])
         nr_values = len(v)
 
@@ -581,7 +582,7 @@ class TimeSeriesVolumesCumulative(TimeSeries[float]):
 
 class TimeSeriesVolumes(TimeSeries[float]):
     @validator("values", pre=True)
-    def check_length_timestep_values(cls, v: list, values, field: ModelField):
+    def check_length_timestep_values(cls, v: List[Any], values: Dict[str, Any]):
         # Initially timesteps for volumes contains one more item than values
         # After reindex number of timesteps equals number of values
         # TODO: Ensure periodical volumes are handled in a consistent way. Why different after reindex?

--- a/src/libecalc/common/utils/rates.py
+++ b/src/libecalc/common/utils/rates.py
@@ -161,6 +161,23 @@ class TimeSeries(GenericModel, Generic[TimeSeriesValue], ABC):
             return math.nan
         return v
 
+    @validator("values", pre=True)
+    def timesteps_values_one_to_one(cls, v: list, values, field: ModelField):
+        nr_timesteps = len(values["timesteps"])
+        nr_values = len(v)
+
+        if not cls.__name__ == TimeSeriesVolumes.__name__:
+            if nr_timesteps != nr_values:
+                if all(math.isnan(i) for i in v):
+                    # TODO: This should probably be solved another place. Temporary solution to make things run
+                    return [math.nan] * len(values["timesteps"])
+                else:
+                    raise ProgrammingError(
+                        "Time series: number of timesteps do not match number "
+                        "of values. Most likely a bug, report to eCalc Dev Team."
+                    )
+        return v
+
     def __len__(self) -> int:
         return len(self.values)
 

--- a/src/tests/libecalc/common/utils/test_rates.py
+++ b/src/tests/libecalc/common/utils/test_rates.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import numpy as np
 import pytest
+from libecalc.common.exceptions import ProgrammingError
 from libecalc.common.time_utils import Frequency
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
@@ -292,6 +293,27 @@ class TestTimeSeriesRate:
 
         assert sum_of_rates.values == expected_values
         assert sum_of_rates.regularity == expected_regularity
+
+    def test_mismatch_timesteps_values(self):
+        with pytest.raises(ProgrammingError) as exc_info:
+            TimeSeriesRate(
+                timesteps=[
+                    datetime(2023, 1, 1),
+                    datetime(2023, 1, 4),
+                    datetime(2023, 1, 7),
+                    datetime(2023, 1, 9),
+                ],
+                values=[10] * 3,
+                regularity=[1, 1, 1, 1],
+                unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
+                rate_type=RateType.STREAM_DAY,
+            )
+
+        assert str(exc_info.value) == (
+            "Violation of programming rules: Time series: "
+            "number of timesteps do not match number of values. "
+            "Most likely a bug, report to eCalc Dev Team."
+        )
 
 
 class TestTimeseriesRateToVolumes:


### PR DESCRIPTION
## Why is this pull request needed?

When there is a mismatch between number timesteps and number of time series values, this may be silently ignored. The danger is that a single value or few values are extrapolated, or mapped incorrectly, and therefore getting wrong results.
 
We should make sure that we always have a 1:1 relationshop between timesteps and values when working with timeseries to make sure that this cannot be a problem.


## What does this pull request change?
- [x] Add a regular validator in `TimeSeries` to ensure there is no mismatch between timesteps and values.
- [x] Add test.

## Issues related to this change:
