### PR TITLE
chore: only calculate max standard rate for time steps with valid inp…

### DIFF
--- a/src/libecalc/core/models/__init__.py
+++ b/src/libecalc/core/models/__init__.py
@@ -1,1 +1,5 @@
-from .model_input_validation import ModelInputFailureStatus, validate_model_input
+from .model_input_validation import (
+    INVALID_INPUT,
+    ModelInputFailureStatus,
+    validate_model_input,
+)

--- a/src/libecalc/core/models/compressor/train/simplified_train.py
+++ b/src/libecalc/core/models/compressor/train/simplified_train.py
@@ -368,10 +368,6 @@ class CompressorTrainSimplifiedKnownStages(CompressorTrainSimplified):
         if self.stages is None:
             raise ValueError("Can't calculate max pressure when compressor stages are not defined.")
 
-        valid_idx = np.where(np.logical_and(suction_pressures > 0, discharge_pressures > 0), 1, 0)
-        suction_pressures = np.where(valid_idx, suction_pressures, 1)
-        discharge_pressures = np.where(valid_idx, discharge_pressures, 1)
-
         use_stage_for_maximum_rate_calculation = np.asarray([stage.compressor_chart for stage in self.stages])
         if not use_stage_for_maximum_rate_calculation.any():
             msg = "Calculating maximum rate is not possible for when all compressor charts are generic from data"
@@ -421,7 +417,7 @@ class CompressorTrainSimplifiedKnownStages(CompressorTrainSimplified):
             axis=0,
         )
 
-        return np.where(valid_idx, maximum_rates, np.nan)
+        return maximum_rates
 
     @staticmethod
     def _calulate_inlet_pressure_stages(

--- a/src/libecalc/core/models/compressor/train/single_speed_compressor_train_common_shaft.py
+++ b/src/libecalc/core/models/compressor/train/single_speed_compressor_train_common_shaft.py
@@ -806,9 +806,6 @@ class SingleSpeedCompressorTrainCommonShaft(CompressorTrainModel):
         discharge_pressures: NDArray[np.float64],
     ) -> NDArray[np.float64]:
         """Calculate the max standard rate [Sm3/day] that the compressor train can operate at."""
-        valid_idx = np.where(suction_pressures > 0, 1, 0)
-        suction_pressures = np.where(valid_idx, suction_pressures, 1)
-
         inlet_streams = self.fluid.get_fluid_streams(
             pressure_bara=suction_pressures,
             temperature_kelvin=np.full_like(suction_pressures, fill_value=self.stages[0].inlet_temperature_kelvin),
@@ -827,11 +824,7 @@ class SingleSpeedCompressorTrainCommonShaft(CompressorTrainModel):
 
             max_mass_rates.append(max_mass_rate)
 
-        return np.array(
-            self.fluid.mass_rate_to_standard_rate(
-                mass_rate_kg_per_hour=np.where(valid_idx, np.array(max_mass_rates), np.nan)
-            )
-        )
+        return np.array(self.fluid.mass_rate_to_standard_rate(mass_rate_kg_per_hour=np.array(max_mass_rates)))
 
     def _get_max_mass_rate_single_timestep(
         self,

--- a/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft.py
+++ b/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft.py
@@ -237,10 +237,6 @@ class VariableSpeedCompressorTrainCommonShaft(CompressorTrainModel):
             List of maximum standard rates corresponding to given inlet and outlet pressures [Sm3/day]
 
         """
-
-        valid_idx = np.where(suction_pressures > 0, 1, 0)
-        suction_pressures = np.where(valid_idx, suction_pressures, 1)
-
         inlet_streams = self.fluid.get_fluid_streams(
             pressure_bara=suction_pressures,
             temperature_kelvin=np.full_like(suction_pressures, fill_value=self.stages[0].inlet_temperature_kelvin),
@@ -262,11 +258,7 @@ class VariableSpeedCompressorTrainCommonShaft(CompressorTrainModel):
 
             max_mass_rates.append(max_mass_rate)
 
-        return np.array(
-            self.fluid.mass_rate_to_standard_rate(
-                mass_rate_kg_per_hour=np.where(valid_idx, np.array(max_mass_rates), np.nan)
-            )
-        )
+        return np.array(self.fluid.mass_rate_to_standard_rate(mass_rate_kg_per_hour=np.array(max_mass_rates)))
 
     def _get_max_mass_rate_single_timestep(
         self,

--- a/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -364,9 +364,6 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         given in rates_per_stream. This means that changing the rates for more than one stream to the max available
         rate will not be meaningful.
         """
-        valid_idx = np.where(suction_pressures > 0, 1, 0)
-        suction_pressures = np.where(valid_idx, suction_pressures, 1)
-
         max_std_rate_per_stream = []
         for stream_index, _ in enumerate(self.streams):
             max_std_rates = []

--- a/src/libecalc/core/models/model_input_validation.py
+++ b/src/libecalc/core/models/model_input_validation.py
@@ -5,6 +5,8 @@ import numpy as np
 from libecalc.common.logger import logger
 from numpy.typing import NDArray
 
+INVALID_INPUT = np.nan
+
 
 class ModelInputFailureStatus(str, Enum):
     INVALID_RATE_INPUT = "INVALID_RATE_INPUT"

--- a/src/tests/libecalc/core/models/compressor_modelling/conftest.py
+++ b/src/tests/libecalc/core/models/compressor_modelling/conftest.py
@@ -123,6 +123,7 @@ def single_speed_compressor_train(medium_fluid_dto, single_speed_chart_dto) -> d
         maximum_discharge_pressure=None,
         energy_usage_adjustment_constant=0,
         energy_usage_adjustment_factor=1,
+        calculate_max_rate=True,
     )
 
 

--- a/src/tests/libecalc/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
+++ b/src/tests/libecalc/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
@@ -348,6 +348,24 @@ def test_calculate_single_speed_train(single_speed_compressor_train):
     assert result.stage_results[1].chart_area_flag == ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE
 
 
+def test_calculate_evaluate_rate_ps_pd_single_speed_train_with_max_rate(single_speed_compressor_train):
+    rate = [300000, 300000]
+    suction_pressure = [10, 0]
+    discharge_pressure = [40, 40]
+
+    compressor_train = SingleSpeedCompressorTrainCommonShaft(
+        data_transfer_object=single_speed_compressor_train,
+    )
+    result = compressor_train.evaluate_rate_ps_pd(
+        rate=np.asarray(rate),
+        suction_pressure=np.asarray(suction_pressure),
+        discharge_pressure=np.asarray(discharge_pressure),
+    )
+
+    assert np.isnan(result.max_standard_rate[1])
+    assert result.max_standard_rate[0] == pytest.approx(407354, rel=0.001)
+
+
 def test_calculate_single_speed_train_zero_mass_rate(medium_fluid, single_speed_compressor_train):
     """We want to get a result object when rate is zero regardless of invalid/zero pressures. To ensure
     this we set pressure -> 1 when both rate and pressure is zero. This may happen when pressure is a function


### PR DESCRIPTION
…ut operational conditions

The operating conditions (rate, suction/intermediate/discharge pressures) are validated. Invalid suction pressure input is flagged and the rate is set to zero such that no calculations are performed. The pressure input is not changed so the current code will try to calculate the max standard rate also in situations where i.e. the discharge pressure is less than the suction pressure. 

## What does this pull request change?

Instead of calculating valid indexes inside get_max_standard_rate for each type of compressor train, the max standard rate is calculated only for the time steps that are already validated to be valid (that does not have a input_failure_status).

## Issues related to this change:

[ECALC 302](https://equinor-ecalc.atlassian.net/browse/ECALC-302)