### PR TITLE
fix: wrong handling of values and timesteps in temporal models

### DIFF
--- a/src/libecalc/core/models/compressor/results.py
+++ b/src/libecalc/core/models/compressor/results.py
@@ -316,22 +316,22 @@ class CompressorTrainResultSingleTimeStep(BaseModel):
             compressor_stage_result[i].rate_has_recirculation = [
                 bool(result_list[t].stage_results[i].rate_has_recirculation)
                 for t in range(len(result_list))
-                if result_list[t].stage_results[i].rate_has_recirculation is not None
+                if bool(result_list[t].stage_results[i].rate_has_recirculation) is not None
             ]
             compressor_stage_result[i].rate_exceeds_maximum = [
                 bool(result_list[t].stage_results[i].rate_exceeds_maximum)
                 for t in range(len(result_list))
-                if result_list[t].stage_results[i].rate_exceeds_maximum is not None
+                if bool(result_list[t].stage_results[i].rate_exceeds_maximum) is not None
             ]
             compressor_stage_result[i].pressure_is_choked = [
                 bool(result_list[t].stage_results[i].pressure_is_choked)
                 for t in range(len(result_list))
-                if result_list[t].stage_results[i].pressure_is_choked is not None
+                if bool(result_list[t].stage_results[i].pressure_is_choked) is not None
             ]
             compressor_stage_result[i].head_exceeds_maximum = [
                 bool(result_list[t].stage_results[i].head_exceeds_maximum)
                 for t in range(len(result_list))
-                if result_list[t].stage_results[i].head_exceeds_maximum is not None
+                if bool(result_list[t].stage_results[i].head_exceeds_maximum) is not None
             ]
             compressor_stage_result[i].fluid_composition = {}
             compressor_stage_result[i].chart = compressor_charts[i] if compressor_charts is not None else None

--- a/src/libecalc/core/models/compressor/results.py
+++ b/src/libecalc/core/models/compressor/results.py
@@ -135,181 +135,207 @@ class CompressorTrainResultSingleTimeStep(BaseModel):
         compressor_charts: Optional[List[Union[dto.SingleSpeedChart, dto.VariableSpeedChart]]],
     ) -> List[CompressorStageResult]:
         number_of_stages = max([len(t.stage_results) for t in result_list])
-        return [
-            CompressorStageResult(
-                energy_usage=[
-                    result_list[t].stage_results[i].power_megawatt
-                    if result_list[t].stage_results[i].power_megawatt is not None
-                    else np.nan
-                    for t in range(len(result_list))
-                ],
-                energy_usage_unit=Unit.MEGA_WATT,
-                power=[
-                    result_list[t].stage_results[i].power_megawatt
-                    if result_list[t].stage_results[i].power_megawatt is not None
-                    else np.nan
-                    for t in range(len(result_list))
-                ],
-                power_unit=Unit.MEGA_WATT,
-                mass_rate_kg_per_hr=[
-                    result_list[t].stage_results[i].mass_rate_asv_corrected_kg_per_hour
-                    if result_list[t].stage_results[i].mass_rate_asv_corrected_kg_per_hour is not None
-                    else np.nan
-                    for t in range(len(result_list))
-                ],
-                mass_rate_before_asv_kg_per_hr=[
-                    result_list[t].stage_results[i].mass_rate_kg_per_hour
-                    if result_list[t].stage_results[i].mass_rate_kg_per_hour is not None
-                    else np.nan
-                    for t in range(len(result_list))
-                ],
-                inlet_stream_condition=CompressorStreamCondition(
-                    pressure=[
-                        result_list[t].stage_results[i].inlet_stream.pressure_bara
-                        if result_list[t].stage_results[i].inlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    pressure_before_choking=[
-                        result_list[t].stage_results[i].inlet_pressure_before_choking
-                        if result_list[t].stage_results[i].inlet_pressure_before_choking is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    # Note: Here we reverse the lingo from "before ASV" to "ASV corrected"
-                    actual_rate_m3_per_hr=[
-                        result_list[t].stage_results[i].inlet_actual_rate_asv_corrected_m3_per_hour
-                        if result_list[t].stage_results[i].inlet_actual_rate_asv_corrected_m3_per_hour is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    actual_rate_before_asv_m3_per_hr=[
-                        result_list[t].stage_results[i].inlet_actual_rate_m3_per_hour
-                        if result_list[t].stage_results[i].inlet_actual_rate_m3_per_hour is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    density_kg_per_m3=[
-                        result_list[t].stage_results[i].inlet_stream.density_kg_per_m3
-                        if result_list[t].stage_results[i].inlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    kappa=[
-                        result_list[t].stage_results[i].inlet_stream.kappa
-                        if result_list[t].stage_results[i].inlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    z=[
-                        result_list[t].stage_results[i].inlet_stream.z
-                        if result_list[t].stage_results[i].inlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    temperature_kelvin=[
-                        result_list[t].stage_results[i].inlet_stream.temperature_kelvin
-                        if result_list[t].stage_results[i].inlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                ),
-                outlet_stream_condition=CompressorStreamCondition(
-                    pressure=[
-                        result_list[t].stage_results[i].outlet_stream.pressure_bara
-                        if result_list[t].stage_results[i].outlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    pressure_before_choking=[
-                        result_list[t].stage_results[i].outlet_pressure_before_choking
-                        if result_list[t].stage_results[i].outlet_pressure_before_choking is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    actual_rate_m3_per_hr=[
-                        result_list[t].stage_results[i].outlet_actual_rate_m3_per_hour
-                        if result_list[t].stage_results[i].outlet_actual_rate_m3_per_hour is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    actual_rate_before_asv_m3_per_hr=[np.nan] * len(result_list),
-                    density_kg_per_m3=[
-                        result_list[t].stage_results[i].outlet_stream.density_kg_per_m3
-                        if result_list[t].stage_results[i].outlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    kappa=[
-                        result_list[t].stage_results[i].outlet_stream.kappa
-                        if result_list[t].stage_results[i].outlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    z=[
-                        result_list[t].stage_results[i].outlet_stream.z
-                        if result_list[t].stage_results[i].outlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                    temperature_kelvin=[
-                        result_list[t].stage_results[i].outlet_stream.temperature_kelvin
-                        if result_list[t].stage_results[i].outlet_stream is not None
-                        else np.nan
-                        for t in range(len(result_list))
-                    ],
-                ),
-                polytropic_enthalpy_change_kJ_per_kg=[
-                    result_list[t].stage_results[i].polytropic_enthalpy_change_kJ_per_kg
-                    if result_list[t].stage_results[i].polytropic_enthalpy_change_kJ_per_kg is not None
-                    else np.nan
-                    for t in range(len(result_list))
-                ],
-                polytropic_head_kJ_per_kg=[
-                    result_list[t].stage_results[i].polytropic_head_kJ_per_kg
-                    if result_list[t].stage_results[i].polytropic_head_kJ_per_kg is not None
-                    else np.nan
-                    for t in range(len(result_list))
-                ],
-                polytropic_efficiency=[
-                    result_list[t].stage_results[i].polytropic_efficiency
-                    if result_list[t].stage_results[i].polytropic_efficiency is not None
-                    else np.nan
-                    for t in range(len(result_list))
-                ],
-                polytropic_enthalpy_change_before_choke_kJ_per_kg=[
-                    result_list[t].stage_results[i].polytropic_enthalpy_change_before_choke_kJ_per_kg
-                    if result_list[t].stage_results[i].polytropic_enthalpy_change_before_choke_kJ_per_kg is not None
-                    else np.nan
-                    for t in range(len(result_list))
-                ],
-                speed=[result.speed for result in result_list],
-                asv_recirculation_loss_mw=[
-                    result_list[t].stage_results[i].asv_recirculation_loss_mw
-                    if result_list[t].stage_results[i].asv_recirculation_loss_mw is not None
-                    else np.nan
-                    for t in range(len(result_list))
-                ],
-                # Validity flags
-                is_valid=[result_list[t].stage_results[i].is_valid for t in range(len(result_list))],
-                chart_area_flags=[result_list[t].stage_results[i].chart_area_flag for t in range(len(result_list))],
-                rate_has_recirculation=[
-                    bool(result_list[t].stage_results[i].rate_has_recirculation) for t in range(len(result_list))
-                ],
-                rate_exceeds_maximum=[
-                    bool(result_list[t].stage_results[i].rate_exceeds_maximum) for t in range(len(result_list))
-                ],
-                pressure_is_choked=[
-                    bool(result_list[t].stage_results[i].pressure_is_choked) for t in range(len(result_list))
-                ],
-                head_exceeds_maximum=[
-                    bool(result_list[t].stage_results[i].head_exceeds_maximum) for t in range(len(result_list))
-                ],
-                fluid_composition={},
-                chart=compressor_charts[i] if compressor_charts is not None else None,
-            )
-            for i in range(number_of_stages)
+
+        # Create empty compressor stage results and inlet/outlet stream conditions. This is to ensure correct
+        # number of values and timesteps in case of None etc.
+        compressor_stage_result = [
+            CompressorStageResult.create_empty(len(result_list)) for i in range(number_of_stages)
         ]
+        inlet_stream_condition = [
+            CompressorStreamCondition.create_empty(len(result_list)) for i in range(number_of_stages)
+        ]
+        outlet_stream_condition = [
+            CompressorStreamCondition.create_empty(len(result_list)) for i in range(number_of_stages)
+        ]
+
+        for i in range(number_of_stages):
+            compressor_stage_result[i].energy_usage = [
+                result_list[t].stage_results[i].power_megawatt
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].power_megawatt is not None
+            ]
+            compressor_stage_result[i].energy_usage_unit = Unit.MEGA_WATT
+            compressor_stage_result[i].power = [
+                result_list[t].stage_results[i].power_megawatt
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].power_megawatt is not None
+            ]
+            compressor_stage_result[i].mass_rate_kg_per_hr = [
+                result_list[t].stage_results[i].mass_rate_asv_corrected_kg_per_hour
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].mass_rate_asv_corrected_kg_per_hour is not None
+            ]
+            compressor_stage_result[i].mass_rate_before_asv_kg_per_hr = [
+                result_list[t].stage_results[i].mass_rate_kg_per_hour
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].mass_rate_kg_per_hour is not None
+            ]
+
+            # For inlet- and outlet stream condition it is necessary to check if inlet- or outlet
+            # streams exist. They may not exist, e.g. in case of zero rate etc. In this case, nan should
+            # be set, to ensure match between timesteps and values.
+            inlet_stream_condition[i].pressure = [
+                result_list[t].stage_results[i].inlet_stream.pressure_bara
+                if result_list[t].stage_results[i].inlet_stream is not None
+                and result_list[t].stage_results[i].inlet_stream.pressure_bara is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+            inlet_stream_condition[i].pressure_before_choking = [
+                result_list[t].stage_results[i].inlet_pressure_before_choking
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].inlet_pressure_before_choking is not None
+            ]
+            # Note: Here we reverse the lingo from "before ASV" to "ASV corrected"
+            inlet_stream_condition[i].actual_rate_m3_per_hr = [
+                result_list[t].stage_results[i].inlet_actual_rate_asv_corrected_m3_per_hour
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].inlet_actual_rate_asv_corrected_m3_per_hour is not None
+            ]
+            inlet_stream_condition[i].actual_rate_before_asv_m3_per_hr = [
+                result_list[t].stage_results[i].inlet_actual_rate_m3_per_hour
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].inlet_actual_rate_m3_per_hour is not None
+            ]
+            inlet_stream_condition[i].density_kg_per_m3 = [
+                result_list[t].stage_results[i].inlet_stream.density_kg_per_m3
+                if result_list[t].stage_results[i].inlet_stream is not None
+                and result_list[t].stage_results[i].inlet_stream.density_kg_per_m3 is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+            inlet_stream_condition[i].kappa = [
+                result_list[t].stage_results[i].inlet_stream.kappa
+                if result_list[t].stage_results[i].inlet_stream is not None
+                and result_list[t].stage_results[i].inlet_stream.kappa is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+            inlet_stream_condition[i].z = [
+                result_list[t].stage_results[i].inlet_stream.z
+                if result_list[t].stage_results[i].inlet_stream is not None
+                and result_list[t].stage_results[i].inlet_stream.z is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+            inlet_stream_condition[i].temperature_kelvin = [
+                result_list[t].stage_results[i].inlet_stream.temperature_kelvin
+                if result_list[t].stage_results[i].inlet_stream is not None
+                and result_list[t].stage_results[i].inlet_stream.temperature_kelvin is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+
+            outlet_stream_condition[i].pressure = [
+                result_list[t].stage_results[i].outlet_stream.pressure_bara
+                if result_list[t].stage_results[i].outlet_stream is not None
+                and result_list[t].stage_results[i].outlet_stream.pressure_bara is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+            outlet_stream_condition[i].pressure_before_choking = [
+                result_list[t].stage_results[i].outlet_pressure_before_choking
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].outlet_pressure_before_choking is not None
+            ]
+            outlet_stream_condition[i].actual_rate_m3_per_hr = [
+                result_list[t].stage_results[i].outlet_actual_rate_m3_per_hour
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].outlet_actual_rate_m3_per_hour is not None
+            ]
+            outlet_stream_condition[i].actual_rate_before_asv_m3_per_hr = [np.nan] * len(result_list)
+            outlet_stream_condition[i].density_kg_per_m3 = [
+                result_list[t].stage_results[i].outlet_stream.density_kg_per_m3
+                if result_list[t].stage_results[i].outlet_stream is not None
+                and result_list[t].stage_results[i].outlet_stream.density_kg_per_m3 is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+            outlet_stream_condition[i].kappa = [
+                result_list[t].stage_results[i].outlet_stream.kappa
+                if result_list[t].stage_results[i].outlet_stream is not None
+                and result_list[t].stage_results[i].outlet_stream.kappa is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+            outlet_stream_condition[i].z = [
+                result_list[t].stage_results[i].outlet_stream.z
+                if result_list[t].stage_results[i].outlet_stream is not None
+                and result_list[t].stage_results[i].outlet_stream.z is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+            outlet_stream_condition[i].temperature_kelvin = [
+                result_list[t].stage_results[i].outlet_stream.temperature_kelvin
+                if result_list[t].stage_results[i].outlet_stream is not None
+                and result_list[t].stage_results[i].outlet_stream.temperature_kelvin is not None
+                else np.nan
+                for t in range(len(result_list))
+            ]
+
+            compressor_stage_result[i].inlet_stream_condition = inlet_stream_condition[i]
+            compressor_stage_result[i].outlet_stream_condition = outlet_stream_condition[i]
+
+            compressor_stage_result[i].polytropic_enthalpy_change_kJ_per_kg = [
+                result_list[t].stage_results[i].polytropic_enthalpy_change_kJ_per_kg
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].polytropic_enthalpy_change_kJ_per_kg is not None
+            ]
+            compressor_stage_result[i].polytropic_head_kJ_per_kg = [
+                result_list[t].stage_results[i].polytropic_head_kJ_per_kg
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].polytropic_head_kJ_per_kg is not None
+            ]
+            compressor_stage_result[i].polytropic_efficiency = [
+                result_list[t].stage_results[i].polytropic_efficiency
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].polytropic_efficiency is not None
+            ]
+            compressor_stage_result[i].polytropic_enthalpy_change_before_choke_kJ_per_kg = [
+                result_list[t].stage_results[i].polytropic_enthalpy_change_before_choke_kJ_per_kg
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].polytropic_enthalpy_change_before_choke_kJ_per_kg is not None
+            ]
+            compressor_stage_result[i].speed = [result.speed for result in result_list if result.speed is not None]
+            compressor_stage_result[i].asv_recirculation_loss_mw = [
+                result_list[t].stage_results[i].asv_recirculation_loss_mw
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].asv_recirculation_loss_mw is not None
+            ]
+            # Validity flags
+            compressor_stage_result[i].is_valid = [
+                result_list[t].stage_results[i].is_valid
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].is_valid is not None
+            ]
+            compressor_stage_result[i].chart_area_flags = [
+                result_list[t].stage_results[i].chart_area_flag
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].chart_area_flag is not None
+            ]
+            compressor_stage_result[i].rate_has_recirculation = [
+                bool(result_list[t].stage_results[i].rate_has_recirculation)
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].rate_has_recirculation is not None
+            ]
+            compressor_stage_result[i].rate_exceeds_maximum = [
+                bool(result_list[t].stage_results[i].rate_exceeds_maximum)
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].rate_exceeds_maximum is not None
+            ]
+            compressor_stage_result[i].pressure_is_choked = [
+                bool(result_list[t].stage_results[i].pressure_is_choked)
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].pressure_is_choked is not None
+            ]
+            compressor_stage_result[i].head_exceeds_maximum = [
+                bool(result_list[t].stage_results[i].head_exceeds_maximum)
+                for t in range(len(result_list))
+                if result_list[t].stage_results[i].head_exceeds_maximum is not None
+            ]
+            compressor_stage_result[i].fluid_composition = {}
+            compressor_stage_result[i].chart = compressor_charts[i] if compressor_charts is not None else None
+        return compressor_stage_result
 
     class Config:
         extra = Extra.forbid

--- a/src/libecalc/core/models/compressor/results.py
+++ b/src/libecalc/core/models/compressor/results.py
@@ -137,15 +137,31 @@ class CompressorTrainResultSingleTimeStep(BaseModel):
         number_of_stages = max([len(t.stage_results) for t in result_list])
         return [
             CompressorStageResult(
-                energy_usage=[result_list[t].stage_results[i].power_megawatt for t in range(len(result_list))],
+                energy_usage=[
+                    result_list[t].stage_results[i].power_megawatt
+                    if result_list[t].stage_results[i].power_megawatt is not None
+                    else np.nan
+                    for t in range(len(result_list))
+                ],
                 energy_usage_unit=Unit.MEGA_WATT,
-                power=[result_list[t].stage_results[i].power_megawatt for t in range(len(result_list))],
+                power=[
+                    result_list[t].stage_results[i].power_megawatt
+                    if result_list[t].stage_results[i].power_megawatt is not None
+                    else np.nan
+                    for t in range(len(result_list))
+                ],
                 power_unit=Unit.MEGA_WATT,
                 mass_rate_kg_per_hr=[
-                    result_list[t].stage_results[i].mass_rate_asv_corrected_kg_per_hour for t in range(len(result_list))
+                    result_list[t].stage_results[i].mass_rate_asv_corrected_kg_per_hour
+                    if result_list[t].stage_results[i].mass_rate_asv_corrected_kg_per_hour is not None
+                    else np.nan
+                    for t in range(len(result_list))
                 ],
                 mass_rate_before_asv_kg_per_hr=[
-                    result_list[t].stage_results[i].mass_rate_kg_per_hour for t in range(len(result_list))
+                    result_list[t].stage_results[i].mass_rate_kg_per_hour
+                    if result_list[t].stage_results[i].mass_rate_kg_per_hour is not None
+                    else np.nan
+                    for t in range(len(result_list))
                 ],
                 inlet_stream_condition=CompressorStreamCondition(
                     pressure=[
@@ -155,15 +171,23 @@ class CompressorTrainResultSingleTimeStep(BaseModel):
                         for t in range(len(result_list))
                     ],
                     pressure_before_choking=[
-                        result_list[t].stage_results[i].inlet_pressure_before_choking for t in range(len(result_list))
+                        result_list[t].stage_results[i].inlet_pressure_before_choking
+                        if result_list[t].stage_results[i].inlet_pressure_before_choking is not None
+                        else np.nan
+                        for t in range(len(result_list))
                     ],
                     # Note: Here we reverse the lingo from "before ASV" to "ASV corrected"
                     actual_rate_m3_per_hr=[
                         result_list[t].stage_results[i].inlet_actual_rate_asv_corrected_m3_per_hour
+                        if result_list[t].stage_results[i].inlet_actual_rate_asv_corrected_m3_per_hour is not None
+                        else np.nan
                         for t in range(len(result_list))
                     ],
                     actual_rate_before_asv_m3_per_hr=[
-                        result_list[t].stage_results[i].inlet_actual_rate_m3_per_hour for t in range(len(result_list))
+                        result_list[t].stage_results[i].inlet_actual_rate_m3_per_hour
+                        if result_list[t].stage_results[i].inlet_actual_rate_m3_per_hour is not None
+                        else np.nan
+                        for t in range(len(result_list))
                     ],
                     density_kg_per_m3=[
                         result_list[t].stage_results[i].inlet_stream.density_kg_per_m3
@@ -198,12 +222,18 @@ class CompressorTrainResultSingleTimeStep(BaseModel):
                         for t in range(len(result_list))
                     ],
                     pressure_before_choking=[
-                        result_list[t].stage_results[i].outlet_pressure_before_choking for t in range(len(result_list))
+                        result_list[t].stage_results[i].outlet_pressure_before_choking
+                        if result_list[t].stage_results[i].outlet_pressure_before_choking is not None
+                        else np.nan
+                        for t in range(len(result_list))
                     ],
                     actual_rate_m3_per_hr=[
-                        result_list[t].stage_results[i].outlet_actual_rate_m3_per_hour for t in range(len(result_list))
+                        result_list[t].stage_results[i].outlet_actual_rate_m3_per_hour
+                        if result_list[t].stage_results[i].outlet_actual_rate_m3_per_hour is not None
+                        else np.nan
+                        for t in range(len(result_list))
                     ],
-                    actual_rate_before_asv_m3_per_hr=None,  # Todo: Add me
+                    actual_rate_before_asv_m3_per_hr=[np.nan] * len(result_list),
                     density_kg_per_m3=[
                         result_list[t].stage_results[i].outlet_stream.density_kg_per_m3
                         if result_list[t].stage_results[i].outlet_stream is not None
@@ -231,21 +261,34 @@ class CompressorTrainResultSingleTimeStep(BaseModel):
                 ),
                 polytropic_enthalpy_change_kJ_per_kg=[
                     result_list[t].stage_results[i].polytropic_enthalpy_change_kJ_per_kg
+                    if result_list[t].stage_results[i].polytropic_enthalpy_change_kJ_per_kg is not None
+                    else np.nan
                     for t in range(len(result_list))
                 ],
                 polytropic_head_kJ_per_kg=[
-                    result_list[t].stage_results[i].polytropic_head_kJ_per_kg for t in range(len(result_list))
+                    result_list[t].stage_results[i].polytropic_head_kJ_per_kg
+                    if result_list[t].stage_results[i].polytropic_head_kJ_per_kg is not None
+                    else np.nan
+                    for t in range(len(result_list))
                 ],
                 polytropic_efficiency=[
-                    result_list[t].stage_results[i].polytropic_efficiency for t in range(len(result_list))
+                    result_list[t].stage_results[i].polytropic_efficiency
+                    if result_list[t].stage_results[i].polytropic_efficiency is not None
+                    else np.nan
+                    for t in range(len(result_list))
                 ],
                 polytropic_enthalpy_change_before_choke_kJ_per_kg=[
                     result_list[t].stage_results[i].polytropic_enthalpy_change_before_choke_kJ_per_kg
+                    if result_list[t].stage_results[i].polytropic_enthalpy_change_before_choke_kJ_per_kg is not None
+                    else np.nan
                     for t in range(len(result_list))
                 ],
                 speed=[result.speed for result in result_list],
                 asv_recirculation_loss_mw=[
-                    result_list[t].stage_results[i].asv_recirculation_loss_mw for t in range(len(result_list))
+                    result_list[t].stage_results[i].asv_recirculation_loss_mw
+                    if result_list[t].stage_results[i].asv_recirculation_loss_mw is not None
+                    else np.nan
+                    for t in range(len(result_list))
                 ],
                 # Validity flags
                 is_valid=[result_list[t].stage_results[i].is_valid for t in range(len(result_list))],

--- a/src/libecalc/core/models/compressor/sampled/compressor_model_sampled.py
+++ b/src/libecalc/core/models/compressor/sampled/compressor_model_sampled.py
@@ -208,7 +208,7 @@ class CompressorModelSampled(CompressorModel):
 
         turbine = self.Turbine(self.fuel_values_adjusted, self.power_interpolation_values_adjusted)
         turbine_result = turbine.calculate_turbine_power_usage(interpolated_consumer_values)
-        turbine_power = turbine_result.load if turbine_result is not None else [np.nan] * number_of_data_points
+        turbine_power = turbine_result.load if turbine_result is not None else None
 
         energy_usage = turbine_result.energy_usage if turbine_result is not None else list(interpolated_consumer_values)
 

--- a/src/libecalc/core/models/compressor/sampled/compressor_model_sampled.py
+++ b/src/libecalc/core/models/compressor/sampled/compressor_model_sampled.py
@@ -212,6 +212,16 @@ class CompressorModelSampled(CompressorModel):
 
         energy_usage = turbine_result.energy_usage if turbine_result is not None else list(interpolated_consumer_values)
 
+        inlet_stream_condition = CompressorStreamCondition.create_empty(number_of_timesteps=number_of_data_points)
+        inlet_stream_condition.pressure = (
+            list(suction_pressure) if suction_pressure is not None else [np.nan] * number_of_data_points
+        )
+
+        outlet_stream_condition = CompressorStreamCondition.create_empty(number_of_timesteps=number_of_data_points)
+        outlet_stream_condition.pressure = (
+            list(discharge_pressure) if discharge_pressure is not None else [np.nan] * number_of_data_points
+        )
+
         # Returning a result as if the sampled compressor is a train with a single stage.
         # Note that actual rates are not available since it is not possible to convert from standard rates to
         # actual rates when information about fluid composition (density in particular) is not available
@@ -228,12 +238,8 @@ class CompressorModelSampled(CompressorModel):
                     else Unit.STANDARD_CUBIC_METER_PER_DAY,
                     power=list(interpolated_consumer_values) if self.function_values_are_power else turbine_power,
                     power_unit=Unit.MEGA_WATT,
-                    inlet_stream_condition=CompressorStreamCondition(
-                        pressure=list(suction_pressure) if suction_pressure is not None else None,
-                    ),
-                    outlet_stream_condition=CompressorStreamCondition(
-                        pressure=list(discharge_pressure) if discharge_pressure is not None else None
-                    ),
+                    inlet_stream_condition=inlet_stream_condition,
+                    outlet_stream_condition=outlet_stream_condition,
                     fluid_composition={},
                     chart=None,
                     is_valid=list(

--- a/src/tests/libecalc/core/models/test_energy_function_results.py
+++ b/src/tests/libecalc/core/models/test_energy_function_results.py
@@ -143,7 +143,7 @@ def test_extend_compressor_train_results_over_temporal_models_with_none_variable
         variables={"SIM1;v1": [1, 1], "SIM1;v2": [1, 1]},
     )
 
-    # Results 1: first temporal model - 2 timesteps. Compressor 1 has no power values.
+    # Results 1: first temporal model - 2 timesteps.
     # Initially, before evaluate, mass_rate_kg_per_hr is None.
     result_1 = (
         CompressorConsumerFunction(
@@ -161,7 +161,7 @@ def test_extend_compressor_train_results_over_temporal_models_with_none_variable
     stage_result_3 = CompressorStageResult.create_empty(number_of_timesteps=3)
     stage_result_3.mass_rate_kg_per_hr = [1, 1, 1]
 
-    # Results 2: third temporal model - 3 timesteps. Has real values for mass_rate_kg_per_hr.
+    # Results 2: second temporal model - 3 timesteps. Has real values for mass_rate_kg_per_hr.
     result_2 = CompressorTrainResult(
         energy_usage=[0, 1.0, 1.0],
         energy_usage_unit=Unit.MEGA_WATT,

--- a/src/tests/libecalc/core/models/test_energy_function_results.py
+++ b/src/tests/libecalc/core/models/test_energy_function_results.py
@@ -1,10 +1,18 @@
+from datetime import datetime
+
+import libecalc.dto as dto
 import numpy as np
 from libecalc.common.units import Unit
+from libecalc.core.consumers.legacy_consumer.consumer_function.compressor_consumer_function import (
+    CompressorConsumerFunction,
+)
+from libecalc.core.models.compressor.sampled import CompressorModelSampled
 from libecalc.core.models.results import (
     CompressorStageResult,
     CompressorTrainResult,
     EnergyFunctionGenericResult,
 )
+from libecalc.expression import Expression
 
 
 def test_energy_function_result_append_generic_result():
@@ -108,6 +116,112 @@ def test_extend_mismatching_compressor_stage_results():
     assert len(result.stage_results) == 2
     for stage_result in result.stage_results:
         assert len(stage_result.energy_usage) == 9
+
+
+def test_extend_compressor_train_results_over_temporal_models_with_none_variables():
+    """Check if extending variables over several temporal models are ok.
+    E.g. if first temporal model has None for a give variable, while the
+    second model has values. Then, the extended results should contain correct
+    number of values/timesteps, and include the real values of the second
+    temporal model.
+    :return:
+    """
+
+    compressor1 = CompressorModelSampled(
+        data_transfer_object=dto.CompressorSampled(
+            energy_usage_type=dto.types.EnergyUsageType.FUEL,
+            energy_usage_values=[0, 1],
+            power_interpolation_values=[0.0, 1],
+            rate_values=[0, 1],
+            energy_usage_adjustment_constant=0.0,
+            energy_usage_adjustment_factor=1.0,
+        )
+    )
+
+    compressor2 = CompressorModelSampled(
+        data_transfer_object=dto.CompressorSampled(
+            energy_usage_type=dto.types.EnergyUsageType.FUEL,
+            energy_usage_values=[0, 1],
+            power_interpolation_values=None,
+            rate_values=[0, 1],
+            energy_usage_adjustment_constant=0.0,
+            energy_usage_adjustment_factor=1.0,
+        )
+    )
+
+    variables_map1 = dto.VariablesMap(
+        time_vector=[datetime(2023, 1, 1), datetime(2024, 1, 1)],
+        variables={"SIM1;v1": [1, 1], "SIM1;v2": [1, 1]},
+    )
+    variables_map2 = dto.VariablesMap(
+        time_vector=[datetime(2023, 1, 1), datetime(2024, 1, 1), datetime(2025, 1, 1)],
+        variables={"SIM1;v1": [1, 1], "SIM1;v2": [1, 1], "SIM1;v3": [1, 1]},
+    )
+
+    # Results 1: first temporal model - 2 timesteps. Compressor 1 has no power values.
+    # Initially, before evaluate, mass_rate_kg_per_hr is None.
+    result_1 = (
+        CompressorConsumerFunction(
+            compressor_function=compressor1,
+            rate_expression=Expression.setup_from_expression(1),
+            suction_pressure_expression=Expression.setup_from_expression(20),
+            discharge_pressure_expression=Expression.setup_from_expression(200),
+            condition_expression=None,
+            power_loss_factor_expression=None,
+        )
+        .evaluate(variables_map=variables_map1, regularity=[1] * len(variables_map1.time_vector))
+        .energy_function_result
+    )
+
+    # Results 2: second temporal model - 3 timesteps. Compressor 2 has power values.
+    # Initially, before evaluate, mass_rate_kg_per_hr is None.
+    result_2 = (
+        CompressorConsumerFunction(
+            compressor_function=compressor2,
+            rate_expression=Expression.setup_from_expression(1),
+            suction_pressure_expression=Expression.setup_from_expression(20),
+            discharge_pressure_expression=Expression.setup_from_expression(200),
+            condition_expression=None,
+            power_loss_factor_expression=None,
+        )
+        .evaluate(variables_map=variables_map2, regularity=[1] * len(variables_map2.time_vector))
+        .energy_function_result
+    )
+
+    stage_result_3 = CompressorStageResult.create_empty(number_of_timesteps=3)
+    stage_result_3.mass_rate_kg_per_hr = [1, 1, 1]
+
+    # Results 3: third temporal model - 3 timesteps. Has real values for mass_rate_kg_per_hr.
+    result_3 = CompressorTrainResult(
+        energy_usage=[0, 1.0, 1.0],
+        energy_usage_unit=Unit.MEGA_WATT,
+        power=[np.nan] * 3,
+        power_unit=Unit.MEGA_WATT,
+        stage_results=[stage_result_3],
+        rate_sm3_day=[np.nan] * 3,
+        failure_status=[None] * 3,
+    )
+
+    result = result_1.copy(deep=True)
+    result.extend(result_2)
+    result.extend(result_3)
+
+    # Ensure no data loss when first temporal model contains None for a variable:
+    # Check that extended stage results for mass_rate_kg_per_hr not based only on first
+    # temporal model, i.e. that the variable is not None
+    assert result.stage_results[0].mass_rate_kg_per_hr is not None  # noqa
+
+    # Ensure no data loss when first temporal model contains None for a variable:
+    # Check that extended stage results for mass_rate_kg_per_hr contains correct number
+    # of timestep values, and the real values of the third model - for mass_rate_kg_per_hr
+    assert result.stage_results[0].mass_rate_kg_per_hr == [np.nan, np.nan, np.nan, np.nan, np.nan, 1, 1, 1]  # noqa
+
+    # Ensure no mismatch in timesteps and values when one succeeding temporal model contains None
+    # for a given variable (here: power). Only the first temporal model contains power-values.
+    # Second temporal model has a compressor with None for power interpolation values. Ensure that the
+    # vector still contains 8 values (sum of all timesteps in the three temporal models), a combination
+    # of real values and NaN.:
+    np.testing.assert_allclose(result.power, [1.0, 1.0, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan])
 
 
 def test_extend_compressor_train_result_from_multiple_streams() -> None:

--- a/src/tests/libecalc/integration/snapshots/test_all_consumer_with_time_slots_models/test_all_consumer_with_time_slots_models_results/all_consumer_with_time_slots_models_v3.json
+++ b/src/tests/libecalc/integration/snapshots/test_all_consumer_with_time_slots_models/test_all_consumer_with_time_slots_models_results/all_consumer_with_time_slots_models_v3.json
@@ -746,7 +746,17 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             4.92003682,
@@ -1016,9 +1026,39 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -1107,7 +1147,17 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.01041917,
@@ -1377,9 +1427,39 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -2548,7 +2628,19 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             4.92003682,
@@ -2866,9 +2958,45 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -2965,7 +3093,19 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.01041917,
@@ -3283,9 +3423,45 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -4584,7 +4760,17 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.46001841,
@@ -4854,9 +5040,39 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -4945,7 +5161,17 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1.00520958,
@@ -5215,9 +5441,39 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -5433,7 +5689,17 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.46001841,
@@ -5703,9 +5969,39 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -5794,7 +6090,17 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1.00520958,
@@ -6064,9 +6370,39 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -6306,7 +6642,19 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.46001841,
@@ -6624,9 +6972,45 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -6723,7 +7107,19 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1.00520958,
@@ -7041,9 +7437,45 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -7287,7 +7719,19 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.46001841,
@@ -7605,9 +8049,45 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -7704,7 +8184,19 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1.00520958,
@@ -8022,9 +8514,45 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false,
+                                        false
+                                    ],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -8364,7 +8892,17 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     4.92003682,
@@ -8634,9 +9172,39 @@
                                 0.9703303
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -8725,7 +9293,17 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     2.01041917,
@@ -8995,9 +9573,39 @@
                                 2.37465941
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -10166,7 +10774,19 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     4.92003682,
@@ -10484,9 +11104,45 @@
                                 0.9703303
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -10583,7 +11239,19 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     2.01041917,
@@ -10901,9 +11569,45 @@
                                 2.37465941
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -13311,7 +14015,21 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     10.6131436,
@@ -13677,9 +14395,51 @@
                                 0.44982533
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -13784,7 +14544,21 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     4.73114341,
@@ -14150,9 +14924,51 @@
                                 1.00907125
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -14761,7 +15577,14 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     10.6131436,
@@ -14959,9 +15782,30 @@
                                 0.44982533
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -15038,7 +15882,14 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     4.73114341,
@@ -15236,9 +16087,30 @@
                                 1.00907125
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
+                                false,
+                                false,
+                                false
+                            ],
                             "speed": [
                                 NaN,
                                 NaN,

--- a/src/tests/libecalc/integration/snapshots/test_all_consumer_with_time_slots_models/test_all_consumer_with_time_slots_models_results/all_consumer_with_time_slots_models_v3.json
+++ b/src/tests/libecalc/integration/snapshots/test_all_consumer_with_time_slots_models/test_all_consumer_with_time_slots_models_results/all_consumer_with_time_slots_models_v3.json
@@ -746,17 +746,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             4.92003682,
@@ -881,7 +871,17 @@
                                         34931.8908
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             2.70498586,
                                             2.70498586,
@@ -1016,39 +1016,9 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -1137,17 +1107,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.01041917,
@@ -1272,7 +1232,17 @@
                                         85487.7389
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1.18928647,
                                             1.18928647,
@@ -1407,39 +1377,9 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -1790,7 +1730,17 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             0.0,
                                             0.0,
@@ -2181,7 +2131,17 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             0.0,
                                             0.0,
@@ -2588,19 +2548,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             4.92003682,
@@ -2747,7 +2695,19 @@
                                         34931.8908
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             2.70498586,
                                             2.70498586,
@@ -2906,45 +2866,9 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -3041,19 +2965,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.01041917,
@@ -3200,7 +3112,19 @@
                                         85487.7389
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1.18928647,
                                             1.18928647,
@@ -3359,45 +3283,9 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -3800,7 +3688,19 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             0.0,
                                             0.0,
@@ -4253,7 +4153,19 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             0.0,
                                             0.0,
@@ -4672,17 +4584,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.46001841,
@@ -4807,7 +4709,17 @@
                                         34931.8908
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1.35249293,
                                             1.35249293,
@@ -4942,39 +4854,9 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -5063,17 +4945,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1.00520958,
@@ -5198,7 +5070,17 @@
                                         85487.7389
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             0.59464323,
                                             0.59464323,
@@ -5333,39 +5215,9 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -5581,17 +5433,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.46001841,
@@ -5716,7 +5558,17 @@
                                         34931.8908
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1.35249293,
                                             1.35249293,
@@ -5851,39 +5703,9 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -5972,17 +5794,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1.00520958,
@@ -6107,7 +5919,17 @@
                                         85487.7389
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             0.59464323,
                                             0.59464323,
@@ -6242,39 +6064,9 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -6514,19 +6306,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.46001841,
@@ -6673,7 +6453,19 @@
                                         34931.8908
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1.35249293,
                                             1.35249293,
@@ -6832,45 +6624,9 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -6967,19 +6723,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1.00520958,
@@ -7126,7 +6870,19 @@
                                         85487.7389
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             0.59464323,
                                             0.59464323,
@@ -7285,45 +7041,9 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -7567,19 +7287,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             2.46001841,
@@ -7726,7 +7434,19 @@
                                         34931.8908
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1.35249293,
                                             1.35249293,
@@ -7885,45 +7605,9 @@
                                         0.9703303
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -8020,19 +7704,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1.00520958,
@@ -8179,7 +7851,19 @@
                                         85487.7389
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             0.59464323,
                                             0.59464323,
@@ -8338,45 +8022,9 @@
                                         2.37465941
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false,
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         NaN,
                                         NaN,
@@ -8716,17 +8364,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     4.92003682,
@@ -8851,7 +8489,17 @@
                                 34931.8908
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2.70498586,
                                     2.70498586,
@@ -8986,39 +8634,9 @@
                                 0.9703303
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -9107,17 +8725,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     2.01041917,
@@ -9242,7 +8850,17 @@
                                 85487.7389
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1.18928647,
                                     1.18928647,
@@ -9377,39 +8995,9 @@
                                 2.37465941
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -9760,7 +9348,17 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     0.0,
                                     0.0,
@@ -10151,7 +9749,17 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     0.0,
                                     0.0,
@@ -10558,19 +10166,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     4.92003682,
@@ -10717,7 +10313,19 @@
                                 34931.8908
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2.70498586,
                                     2.70498586,
@@ -10876,45 +10484,9 @@
                                 0.9703303
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -11011,19 +10583,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     2.01041917,
@@ -11170,7 +10730,19 @@
                                 85487.7389
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1.18928647,
                                     1.18928647,
@@ -11329,45 +10901,9 @@
                                 2.37465941
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -11770,7 +11306,19 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     0.0,
                                     0.0,
@@ -12223,7 +11771,19 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     0.0,
                                     0.0,
@@ -13751,21 +13311,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     10.6131436,
@@ -13934,7 +13480,21 @@
                                 16193.7117
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     5.86391331,
                                     5.86391331,
@@ -14117,51 +13677,9 @@
                                 0.44982533
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -14266,21 +13784,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     4.73114341,
@@ -14449,7 +13953,21 @@
                                 36326.565
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2.60244818,
                                     2.60244818,
@@ -14632,51 +14150,9 @@
                                 1.00907125
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -15285,14 +14761,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     10.6131436,
@@ -15384,7 +14853,14 @@
                                 16193.7117
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     5.86391331,
                                     5.86391331,
@@ -15483,30 +14959,9 @@
                                 0.44982533
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 NaN,
                                 NaN,
@@ -15583,14 +15038,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     4.73114341,
@@ -15682,7 +15130,14 @@
                                 36326.565
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2.60244818,
                                     2.60244818,
@@ -15781,30 +15236,9 @@
                                 1.00907125
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
-                                false,
-                                false,
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 NaN,
                                 NaN,

--- a/src/tests/libecalc/integration/snapshots/test_all_energy_usage_models/test_all_results/all_energy_usage_models_v3.json
+++ b/src/tests/libecalc/integration/snapshots/test_all_energy_usage_models/test_all_results/all_energy_usage_models_v3.json
@@ -445,7 +445,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2273.19945,
                                     2273.19945,
@@ -820,7 +825,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1018.66935,
                                     1018.66935,
@@ -1240,9 +1250,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -1314,7 +1321,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1952.49442,
                                     1952.49442,
@@ -1390,21 +1402,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -1479,9 +1482,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -1553,7 +1553,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1029.23822,
                                     1029.23822,
@@ -1629,21 +1634,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -2110,7 +2106,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2304.73524,
                                     2304.73524,
@@ -2485,7 +2486,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1046.25843,
                                     1046.25843,
@@ -2968,9 +2974,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -3042,7 +3045,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2358.4753,
                                     2358.4753,
@@ -3118,21 +3126,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -3343,9 +3342,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -3417,7 +3413,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1062.073,
                                     1062.073,
@@ -3493,21 +3494,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -3907,7 +3899,12 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             4831.22062,
                                             3497.58438,
@@ -4282,7 +4279,12 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             2538.79861,
                                             1987.00433,
@@ -4734,7 +4736,12 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             4831.22062,
                                             3497.58438,
@@ -5109,7 +5116,12 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             2538.79861,
                                             1987.00433,
@@ -5601,7 +5613,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     4831.22062,
                                     3497.58438,
@@ -5976,7 +5993,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2538.79861,
                                     1987.00433,
@@ -6428,7 +6450,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     4831.22062,
                                     3497.58438,
@@ -6803,7 +6830,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2538.79861,
                                     1987.00433,
@@ -7255,7 +7287,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2299.69522,
                                     2299.69522,
@@ -7525,7 +7562,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1038.89912,
                                     1038.89912,
@@ -8029,19 +8071,54 @@
                                 false
                             ],
                             "inlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     200.0,
                                     200.0,
                                     200.0,
                                     200.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
                             "is_valid": [
                                 true,
@@ -8049,27 +8126,92 @@
                                 true,
                                 true
                             ],
-                            "mass_rate_before_asv_kg_per_hr": null,
-                            "mass_rate_kg_per_hr": null,
+                            "mass_rate_before_asv_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "mass_rate_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     400.0,
                                     400.0,
                                     400.0,
                                     400.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
-                            "polytropic_efficiency": null,
-                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                            "polytropic_enthalpy_change_kJ_per_kg": null,
-                            "polytropic_head_kJ_per_kg": null,
+                            "polytropic_efficiency": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_head_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "power": [
                                 3.0352425,
                                 2.372352,
@@ -8095,7 +8237,12 @@
                                 false,
                                 false
                             ],
-                            "speed": null
+                            "speed": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ]
                         }
                     ],
                     "timesteps": [
@@ -8761,9 +8908,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -8835,7 +8979,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1928.90205,
                                     1928.90205,
@@ -8911,21 +9060,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -9000,9 +9140,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -9074,7 +9211,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1015.26913,
                                     1015.26913,
@@ -9150,21 +9292,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -9538,9 +9671,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1873.49819
@@ -9577,7 +9708,9 @@
                                         139780.823
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1113.49205
                                         ],
@@ -9616,15 +9749,9 @@
                                         5.45263395
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -9820,9 +9947,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             760.508945
@@ -9859,7 +9984,9 @@
                                         344347.191
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             500.279242
                                         ],
@@ -9898,15 +10025,9 @@
                                         13.4324519
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -10170,9 +10291,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1873.49819
@@ -10209,7 +10328,9 @@
                                         139780.823
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1113.49205
                                         ],
@@ -10248,15 +10369,9 @@
                                         5.45263395
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -10452,9 +10567,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             760.508945
@@ -10491,7 +10604,9 @@
                                         344347.191
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             500.279242
                                         ],
@@ -10530,15 +10645,9 @@
                                         13.4324519
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -10802,9 +10911,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1873.49819
@@ -10841,7 +10948,9 @@
                                         139780.823
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1113.49205
                                         ],
@@ -10880,15 +10989,9 @@
                                         5.45263395
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -11084,9 +11187,7 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [
-                                        false
-                                    ],
+                                    "head_exceeds_maximum": [],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             760.508945
@@ -11123,7 +11224,9 @@
                                         344347.191
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             500.279242
                                         ],
@@ -11162,15 +11265,9 @@
                                         13.4324519
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [
-                                        false
-                                    ],
-                                    "rate_exceeds_maximum": [
-                                        false
-                                    ],
-                                    "rate_has_recirculation": [
-                                        false
-                                    ],
+                                    "pressure_is_choked": [],
+                                    "rate_exceeds_maximum": [],
+                                    "rate_has_recirculation": [],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -11447,7 +11544,6 @@
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
                                     "head_exceeds_maximum": [
-                                        false,
                                         false
                                     ],
                                     "inlet_stream_condition": {
@@ -11497,7 +11593,10 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1251.95268,
                                             0.0
@@ -11549,15 +11648,12 @@
                                     ],
                                     "power_unit": "MW",
                                     "pressure_is_choked": [
-                                        false,
                                         false
                                     ],
                                     "rate_exceeds_maximum": [
-                                        false,
                                         false
                                     ],
                                     "rate_has_recirculation": [
-                                        false,
                                         false
                                     ],
                                     "speed": [
@@ -11760,7 +11856,6 @@
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
                                     "head_exceeds_maximum": [
-                                        false,
                                         false
                                     ],
                                     "inlet_stream_condition": {
@@ -11810,7 +11905,10 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             562.488023,
                                             0.0
@@ -11862,15 +11960,12 @@
                                     ],
                                     "power_unit": "MW",
                                     "pressure_is_choked": [
-                                        false,
                                         false
                                     ],
                                     "rate_exceeds_maximum": [
-                                        false,
                                         false
                                     ],
                                     "rate_has_recirculation": [
-                                        false,
                                         false
                                     ],
                                     "speed": [
@@ -12157,7 +12252,6 @@
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
                                     "head_exceeds_maximum": [
-                                        false,
                                         false
                                     ],
                                     "inlet_stream_condition": {
@@ -12207,7 +12301,10 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             1251.95268,
                                             0.0
@@ -12259,15 +12356,12 @@
                                     ],
                                     "power_unit": "MW",
                                     "pressure_is_choked": [
-                                        false,
                                         false
                                     ],
                                     "rate_exceeds_maximum": [
-                                        false,
                                         false
                                     ],
                                     "rate_has_recirculation": [
-                                        false,
                                         false
                                     ],
                                     "speed": [
@@ -12470,7 +12564,6 @@
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
                                     "head_exceeds_maximum": [
-                                        false,
                                         false
                                     ],
                                     "inlet_stream_condition": {
@@ -12520,7 +12613,10 @@
                                         0.0
                                     ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN
+                                        ],
                                         "actual_rate_m3_per_hr": [
                                             562.488023,
                                             0.0
@@ -12572,15 +12668,12 @@
                                     ],
                                     "power_unit": "MW",
                                     "pressure_is_choked": [
-                                        false,
                                         false
                                     ],
                                     "rate_exceeds_maximum": [
-                                        false,
                                         false
                                     ],
                                     "rate_has_recirculation": [
-                                        false,
                                         false
                                     ],
                                     "speed": [
@@ -12894,9 +12987,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     1873.49819
@@ -12933,7 +13024,9 @@
                                 139780.823
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1113.49205
                                 ],
@@ -12972,15 +13065,9 @@
                                 5.45263395
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 8532.14529
                             ]
@@ -13176,9 +13263,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     760.508945
@@ -13215,7 +13300,9 @@
                                 344347.191
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     500.279242
                                 ],
@@ -13254,15 +13341,9 @@
                                 13.4324519
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 8532.14529
                             ]
@@ -13526,9 +13607,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     1873.49819
@@ -13565,7 +13644,9 @@
                                 139780.823
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1113.49205
                                 ],
@@ -13604,15 +13685,9 @@
                                 5.45263395
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 8532.14529
                             ]
@@ -13808,9 +13883,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     760.508945
@@ -13847,7 +13920,9 @@
                                 344347.191
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     500.279242
                                 ],
@@ -13886,15 +13961,9 @@
                                 13.4324519
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 8532.14529
                             ]
@@ -14158,9 +14227,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     1873.49819
@@ -14197,7 +14264,9 @@
                                 139780.823
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1113.49205
                                 ],
@@ -14236,15 +14305,9 @@
                                 5.45263395
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 8532.14529
                             ]
@@ -14440,9 +14503,7 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [
-                                false
-                            ],
+                            "head_exceeds_maximum": [],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     760.508945
@@ -14479,7 +14540,9 @@
                                 344347.191
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     500.279242
                                 ],
@@ -14518,15 +14581,9 @@
                                 13.4324519
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [
-                                false
-                            ],
-                            "rate_exceeds_maximum": [
-                                false
-                            ],
-                            "rate_has_recirculation": [
-                                false
-                            ],
+                            "pressure_is_choked": [],
+                            "rate_exceeds_maximum": [],
+                            "rate_has_recirculation": [],
                             "speed": [
                                 8532.14529
                             ]
@@ -14803,7 +14860,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -14853,7 +14909,10 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1251.95268,
                                     0.0
@@ -14905,15 +14964,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
                                 false
                             ],
                             "speed": [
@@ -15116,7 +15172,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -15166,7 +15221,10 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     562.488023,
                                     0.0
@@ -15218,15 +15276,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
                                 false
                             ],
                             "speed": [
@@ -15513,7 +15568,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -15563,7 +15617,10 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1251.95268,
                                     0.0
@@ -15615,15 +15672,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
                                 false
                             ],
                             "speed": [
@@ -15826,7 +15880,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -15876,7 +15929,10 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     562.488023,
                                     0.0
@@ -15928,15 +15984,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
                                 false
                             ],
                             "speed": [
@@ -16216,9 +16269,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -16290,7 +16340,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     310.226436,
                                     310.226436,
@@ -16366,21 +16421,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -16455,9 +16501,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -16529,7 +16572,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     156.641844,
                                     156.641844,
@@ -16605,21 +16653,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -17027,9 +17066,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -17101,7 +17137,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     3266.79404,
                                     3343.08867,
@@ -17177,21 +17218,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -17402,9 +17434,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -17476,7 +17505,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2174.74202,
                                     2207.42425,
@@ -17552,21 +17586,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -17777,9 +17802,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -17851,7 +17873,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     841.568005,
                                     848.845492,
@@ -17927,21 +17954,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -18152,9 +18170,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -18226,7 +18241,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     87.7997353,
                                     89.1719489,
@@ -18302,21 +18322,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -18527,9 +18538,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -18601,7 +18609,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     46.271731,
                                     46.4273668,
@@ -18677,21 +18690,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -18840,19 +18844,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             200.0,
                                             200.0,
                                             200.0,
                                             200.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -18860,27 +18899,92 @@
                                         true,
                                         true
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             400.0,
                                             400.0,
                                             400.0,
                                             400.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         3.0352425,
                                         2.372352,
@@ -18906,7 +19010,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -19009,19 +19118,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             200.0,
                                             200.0,
                                             200.0,
                                             200.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -19029,27 +19173,92 @@
                                         true,
                                         true
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             400.0,
                                             400.0,
                                             400.0,
                                             400.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         3.0352425,
                                         2.372352,
@@ -19075,7 +19284,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -19218,19 +19432,54 @@
                                 false
                             ],
                             "inlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     200.0,
                                     200.0,
                                     200.0,
                                     200.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
                             "is_valid": [
                                 true,
@@ -19238,27 +19487,92 @@
                                 true,
                                 true
                             ],
-                            "mass_rate_before_asv_kg_per_hr": null,
-                            "mass_rate_kg_per_hr": null,
+                            "mass_rate_before_asv_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "mass_rate_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     400.0,
                                     400.0,
                                     400.0,
                                     400.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
-                            "polytropic_efficiency": null,
-                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                            "polytropic_enthalpy_change_kJ_per_kg": null,
-                            "polytropic_head_kJ_per_kg": null,
+                            "polytropic_efficiency": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_head_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "power": [
                                 3.0352425,
                                 2.372352,
@@ -19284,7 +19598,12 @@
                                 false,
                                 false
                             ],
-                            "speed": null
+                            "speed": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ]
                         }
                     ],
                     "timesteps": [
@@ -19387,19 +19706,54 @@
                                 false
                             ],
                             "inlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     200.0,
                                     200.0,
                                     200.0,
                                     200.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
                             "is_valid": [
                                 true,
@@ -19407,27 +19761,92 @@
                                 true,
                                 true
                             ],
-                            "mass_rate_before_asv_kg_per_hr": null,
-                            "mass_rate_kg_per_hr": null,
+                            "mass_rate_before_asv_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "mass_rate_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     400.0,
                                     400.0,
                                     400.0,
                                     400.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
-                            "polytropic_efficiency": null,
-                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                            "polytropic_enthalpy_change_kJ_per_kg": null,
-                            "polytropic_head_kJ_per_kg": null,
+                            "polytropic_efficiency": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_head_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "power": [
                                 3.0352425,
                                 2.372352,
@@ -19453,7 +19872,12 @@
                                 false,
                                 false
                             ],
-                            "speed": null
+                            "speed": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ]
                         }
                     ],
                     "timesteps": [
@@ -19912,7 +20336,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     3608.52723,
                                     3608.52723,
@@ -20287,7 +20716,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1368.10868,
                                     1368.10868,
@@ -20863,7 +21297,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     2299.69522,
                                     2299.69522,
@@ -21133,7 +21572,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1038.89912,
                                     1038.89912,
@@ -22247,9 +22691,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -22321,7 +22762,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1958.12678,
                                     1958.12678,
@@ -22397,21 +22843,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [
@@ -22486,9 +22923,6 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -22560,7 +22994,12 @@
                                 0.0
                             ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "actual_rate_m3_per_hr": [
                                     1029.23775,
                                     1029.23775,
@@ -22636,21 +23075,12 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
-                                false,
-                                false,
-                                false,
                                 false
                             ],
                             "speed": [

--- a/src/tests/libecalc/integration/snapshots/test_all_energy_usage_models/test_all_results/all_energy_usage_models_v3.json
+++ b/src/tests/libecalc/integration/snapshots/test_all_energy_usage_models/test_all_results/all_energy_usage_models_v3.json
@@ -1250,6 +1250,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -1402,12 +1405,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -1482,6 +1494,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -1634,12 +1649,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -2974,6 +2998,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -3126,12 +3153,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -3342,6 +3378,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -3494,12 +3533,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -8908,6 +8956,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -9060,12 +9111,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -9140,6 +9200,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -9292,12 +9355,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -9671,7 +9743,9 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1873.49819
@@ -9749,9 +9823,15 @@
                                         5.45263395
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false
+                                    ],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -9947,7 +10027,9 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             760.508945
@@ -10025,9 +10107,15 @@
                                         13.4324519
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false
+                                    ],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -10291,7 +10379,9 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1873.49819
@@ -10369,9 +10459,15 @@
                                         5.45263395
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false
+                                    ],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -10567,7 +10663,9 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             760.508945
@@ -10645,9 +10743,15 @@
                                         13.4324519
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false
+                                    ],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -10911,7 +11015,9 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             1873.49819
@@ -10989,9 +11095,15 @@
                                         5.45263395
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false
+                                    ],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -11187,7 +11299,9 @@
                                     ],
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
-                                    "head_exceeds_maximum": [],
+                                    "head_exceeds_maximum": [
+                                        false
+                                    ],
                                     "inlet_stream_condition": {
                                         "actual_rate_before_asv_m3_per_hr": [
                                             760.508945
@@ -11265,9 +11379,15 @@
                                         13.4324519
                                     ],
                                     "power_unit": "MW",
-                                    "pressure_is_choked": [],
-                                    "rate_exceeds_maximum": [],
-                                    "rate_has_recirculation": [],
+                                    "pressure_is_choked": [
+                                        false
+                                    ],
+                                    "rate_exceeds_maximum": [
+                                        false
+                                    ],
+                                    "rate_has_recirculation": [
+                                        false
+                                    ],
                                     "speed": [
                                         8532.14529
                                     ]
@@ -11544,6 +11664,7 @@
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
                                     "head_exceeds_maximum": [
+                                        false,
                                         false
                                     ],
                                     "inlet_stream_condition": {
@@ -11648,12 +11769,15 @@
                                     ],
                                     "power_unit": "MW",
                                     "pressure_is_choked": [
+                                        false,
                                         false
                                     ],
                                     "rate_exceeds_maximum": [
+                                        false,
                                         false
                                     ],
                                     "rate_has_recirculation": [
+                                        false,
                                         false
                                     ],
                                     "speed": [
@@ -11856,6 +11980,7 @@
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
                                     "head_exceeds_maximum": [
+                                        false,
                                         false
                                     ],
                                     "inlet_stream_condition": {
@@ -11960,12 +12085,15 @@
                                     ],
                                     "power_unit": "MW",
                                     "pressure_is_choked": [
+                                        false,
                                         false
                                     ],
                                     "rate_exceeds_maximum": [
+                                        false,
                                         false
                                     ],
                                     "rate_has_recirculation": [
+                                        false,
                                         false
                                     ],
                                     "speed": [
@@ -12252,6 +12380,7 @@
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
                                     "head_exceeds_maximum": [
+                                        false,
                                         false
                                     ],
                                     "inlet_stream_condition": {
@@ -12356,12 +12485,15 @@
                                     ],
                                     "power_unit": "MW",
                                     "pressure_is_choked": [
+                                        false,
                                         false
                                     ],
                                     "rate_exceeds_maximum": [
+                                        false,
                                         false
                                     ],
                                     "rate_has_recirculation": [
+                                        false,
                                         false
                                     ],
                                     "speed": [
@@ -12564,6 +12696,7 @@
                                     "energy_usage_unit": "MW",
                                     "fluid_composition": {},
                                     "head_exceeds_maximum": [
+                                        false,
                                         false
                                     ],
                                     "inlet_stream_condition": {
@@ -12668,12 +12801,15 @@
                                     ],
                                     "power_unit": "MW",
                                     "pressure_is_choked": [
+                                        false,
                                         false
                                     ],
                                     "rate_exceeds_maximum": [
+                                        false,
                                         false
                                     ],
                                     "rate_has_recirculation": [
+                                        false,
                                         false
                                     ],
                                     "speed": [
@@ -12987,7 +13123,9 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     1873.49819
@@ -13065,9 +13203,15 @@
                                 5.45263395
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false
+                            ],
                             "speed": [
                                 8532.14529
                             ]
@@ -13263,7 +13407,9 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     760.508945
@@ -13341,9 +13487,15 @@
                                 13.4324519
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false
+                            ],
                             "speed": [
                                 8532.14529
                             ]
@@ -13607,7 +13759,9 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     1873.49819
@@ -13685,9 +13839,15 @@
                                 5.45263395
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false
+                            ],
                             "speed": [
                                 8532.14529
                             ]
@@ -13883,7 +14043,9 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     760.508945
@@ -13961,9 +14123,15 @@
                                 13.4324519
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false
+                            ],
                             "speed": [
                                 8532.14529
                             ]
@@ -14227,7 +14395,9 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     1873.49819
@@ -14305,9 +14475,15 @@
                                 5.45263395
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false
+                            ],
                             "speed": [
                                 8532.14529
                             ]
@@ -14503,7 +14679,9 @@
                             ],
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
-                            "head_exceeds_maximum": [],
+                            "head_exceeds_maximum": [
+                                false
+                            ],
                             "inlet_stream_condition": {
                                 "actual_rate_before_asv_m3_per_hr": [
                                     760.508945
@@ -14581,9 +14759,15 @@
                                 13.4324519
                             ],
                             "power_unit": "MW",
-                            "pressure_is_choked": [],
-                            "rate_exceeds_maximum": [],
-                            "rate_has_recirculation": [],
+                            "pressure_is_choked": [
+                                false
+                            ],
+                            "rate_exceeds_maximum": [
+                                false
+                            ],
+                            "rate_has_recirculation": [
+                                false
+                            ],
                             "speed": [
                                 8532.14529
                             ]
@@ -14860,6 +15044,7 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -14964,12 +15149,15 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
                                 false
                             ],
                             "speed": [
@@ -15172,6 +15360,7 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -15276,12 +15465,15 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
                                 false
                             ],
                             "speed": [
@@ -15568,6 +15760,7 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -15672,12 +15865,15 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
                                 false
                             ],
                             "speed": [
@@ -15880,6 +16076,7 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -15984,12 +16181,15 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
                                 false
                             ],
                             "speed": [
@@ -16269,6 +16469,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -16421,12 +16624,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -16501,6 +16713,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -16653,12 +16868,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -17066,6 +17290,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -17218,12 +17445,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -17434,6 +17670,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -17586,12 +17825,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -17802,6 +18050,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -17954,12 +18205,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -18170,6 +18430,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -18322,12 +18585,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -18538,6 +18810,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -18690,12 +18965,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -22691,6 +22975,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -22843,12 +23130,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [
@@ -22923,6 +23219,9 @@
                             "energy_usage_unit": "MW",
                             "fluid_composition": {},
                             "head_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "inlet_stream_condition": {
@@ -23075,12 +23374,21 @@
                             ],
                             "power_unit": "MW",
                             "pressure_is_choked": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_exceeds_maximum": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "rate_has_recirculation": [
+                                false,
+                                false,
+                                false,
                                 false
                             ],
                             "speed": [

--- a/src/tests/libecalc/integration/snapshots/test_consumer_system_v2/test_compressor_system_v2_results/consumer_system_v2-consumer_system_v20/consumer_system_v2.json
+++ b/src/tests/libecalc/integration/snapshots/test_consumer_system_v2/test_compressor_system_v2_results/consumer_system_v2-consumer_system_v20/consumer_system_v2.json
@@ -2781,19 +2781,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             50.0,
                                             50.0,
                                             50.0,
                                             50.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         false,
@@ -2801,27 +2836,92 @@
                                         false,
                                         false
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             250.0,
                                             250.0,
                                             250.0,
                                             250.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         NaN,
                                         NaN,
@@ -2847,7 +2947,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -2950,19 +3055,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             50.0,
                                             50.0,
                                             50.0,
                                             50.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -2970,27 +3110,92 @@
                                         true,
                                         true
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             250.0,
                                             250.0,
                                             250.0,
                                             250.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         4.0,
                                         4.0,
@@ -3016,7 +3221,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -3119,19 +3329,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             50.0,
                                             50.0,
                                             50.0,
                                             50.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -3139,27 +3384,92 @@
                                         true,
                                         true
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             250.0,
                                             250.0,
                                             250.0,
                                             250.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         4.0,
                                         4.0,
@@ -3185,7 +3495,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -3290,19 +3605,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             50.0,
                                             50.0,
                                             50.0,
                                             50.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -3310,27 +3660,92 @@
                                         true,
                                         false
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             125.0,
                                             125.0,
                                             125.0,
                                             125.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         2.0,
                                         2.0,
@@ -3356,7 +3771,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -3459,19 +3879,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             50.0,
                                             50.0,
                                             50.0,
                                             50.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -3479,27 +3934,92 @@
                                         true,
                                         true
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             125.0,
                                             125.0,
                                             125.0,
                                             125.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         4.0,
                                         4.0,
@@ -3525,7 +4045,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -3628,19 +4153,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             50.0,
                                             50.0,
                                             50.0,
                                             50.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -3648,27 +4208,92 @@
                                         true,
                                         true
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             125.0,
                                             125.0,
                                             125.0,
                                             125.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         4.0,
                                         4.0,
@@ -3694,7 +4319,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -3799,19 +4429,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             50.0,
                                             50.0,
                                             50.0,
                                             50.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -3819,27 +4484,92 @@
                                         true,
                                         true
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             125.0,
                                             125.0,
                                             125.0,
                                             125.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         3.0,
                                         3.0,
@@ -3865,7 +4595,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -3968,19 +4703,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             50.0,
                                             50.0,
                                             50.0,
                                             50.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -3988,27 +4758,92 @@
                                         true,
                                         true
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             125.0,
                                             125.0,
                                             125.0,
                                             125.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         4.0,
                                         4.0,
@@ -4034,7 +4869,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -4137,19 +4977,54 @@
                                         false
                                     ],
                                     "inlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             50.0,
                                             50.0,
                                             50.0,
                                             50.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
                                     "is_valid": [
                                         true,
@@ -4157,27 +5032,92 @@
                                         true,
                                         true
                                     ],
-                                    "mass_rate_before_asv_kg_per_hr": null,
-                                    "mass_rate_kg_per_hr": null,
+                                    "mass_rate_before_asv_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "mass_rate_kg_per_hr": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "outlet_stream_condition": {
-                                        "actual_rate_before_asv_m3_per_hr": null,
-                                        "actual_rate_m3_per_hr": null,
-                                        "density_kg_per_m3": null,
-                                        "kappa": null,
+                                        "actual_rate_before_asv_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "actual_rate_m3_per_hr": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "density_kg_per_m3": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "kappa": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
                                         "pressure": [
                                             125.0,
                                             125.0,
                                             125.0,
                                             125.0
                                         ],
-                                        "pressure_before_choking": null,
-                                        "temperature_kelvin": null,
-                                        "z": null
+                                        "pressure_before_choking": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "temperature_kelvin": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ],
+                                        "z": [
+                                            NaN,
+                                            NaN,
+                                            NaN,
+                                            NaN
+                                        ]
                                     },
-                                    "polytropic_efficiency": null,
-                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                                    "polytropic_enthalpy_change_kJ_per_kg": null,
-                                    "polytropic_head_kJ_per_kg": null,
+                                    "polytropic_efficiency": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_enthalpy_change_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
+                                    "polytropic_head_kJ_per_kg": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ],
                                     "power": [
                                         4.0,
                                         4.0,
@@ -4203,7 +5143,12 @@
                                         false,
                                         false
                                     ],
-                                    "speed": null
+                                    "speed": [
+                                        NaN,
+                                        NaN,
+                                        NaN,
+                                        NaN
+                                    ]
                                 }
                             ],
                             "timesteps": [
@@ -4346,19 +5291,54 @@
                                 false
                             ],
                             "inlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     50.0,
                                     50.0,
                                     50.0,
                                     50.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
                             "is_valid": [
                                 true,
@@ -4366,27 +5346,92 @@
                                 true,
                                 true
                             ],
-                            "mass_rate_before_asv_kg_per_hr": null,
-                            "mass_rate_kg_per_hr": null,
+                            "mass_rate_before_asv_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "mass_rate_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     125.0,
                                     125.0,
                                     125.0,
                                     125.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
-                            "polytropic_efficiency": null,
-                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                            "polytropic_enthalpy_change_kJ_per_kg": null,
-                            "polytropic_head_kJ_per_kg": null,
+                            "polytropic_efficiency": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_head_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "power": [
                                 2.0,
                                 2.0,
@@ -4412,7 +5457,12 @@
                                 false,
                                 false
                             ],
-                            "speed": null
+                            "speed": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ]
                         }
                     ],
                     "timesteps": [
@@ -4515,19 +5565,54 @@
                                 false
                             ],
                             "inlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     50.0,
                                     50.0,
                                     50.0,
                                     50.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
                             "is_valid": [
                                 true,
@@ -4535,27 +5620,92 @@
                                 true,
                                 true
                             ],
-                            "mass_rate_before_asv_kg_per_hr": null,
-                            "mass_rate_kg_per_hr": null,
+                            "mass_rate_before_asv_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "mass_rate_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     125.0,
                                     125.0,
                                     125.0,
                                     125.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
-                            "polytropic_efficiency": null,
-                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                            "polytropic_enthalpy_change_kJ_per_kg": null,
-                            "polytropic_head_kJ_per_kg": null,
+                            "polytropic_efficiency": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_head_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "power": [
                                 4.0,
                                 4.0,
@@ -4581,7 +5731,12 @@
                                 false,
                                 false
                             ],
-                            "speed": null
+                            "speed": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ]
                         }
                     ],
                     "timesteps": [
@@ -4684,19 +5839,54 @@
                                 false
                             ],
                             "inlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     50.0,
                                     50.0,
                                     50.0,
                                     50.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
                             "is_valid": [
                                 true,
@@ -4704,27 +5894,92 @@
                                 true,
                                 true
                             ],
-                            "mass_rate_before_asv_kg_per_hr": null,
-                            "mass_rate_kg_per_hr": null,
+                            "mass_rate_before_asv_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "mass_rate_kg_per_hr": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "outlet_stream_condition": {
-                                "actual_rate_before_asv_m3_per_hr": null,
-                                "actual_rate_m3_per_hr": null,
-                                "density_kg_per_m3": null,
-                                "kappa": null,
+                                "actual_rate_before_asv_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "actual_rate_m3_per_hr": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "density_kg_per_m3": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "kappa": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
                                 "pressure": [
                                     125.0,
                                     125.0,
                                     125.0,
                                     125.0
                                 ],
-                                "pressure_before_choking": null,
-                                "temperature_kelvin": null,
-                                "z": null
+                                "pressure_before_choking": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "temperature_kelvin": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ],
+                                "z": [
+                                    NaN,
+                                    NaN,
+                                    NaN,
+                                    NaN
+                                ]
                             },
-                            "polytropic_efficiency": null,
-                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": null,
-                            "polytropic_enthalpy_change_kJ_per_kg": null,
-                            "polytropic_head_kJ_per_kg": null,
+                            "polytropic_efficiency": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_before_choke_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_enthalpy_change_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
+                            "polytropic_head_kJ_per_kg": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ],
                             "power": [
                                 4.0,
                                 4.0,
@@ -4750,7 +6005,12 @@
                                 false,
                                 false
                             ],
-                            "speed": null
+                            "speed": [
+                                NaN,
+                                NaN,
+                                NaN,
+                                NaN
+                            ]
                         }
                     ],
                     "timesteps": [


### PR DESCRIPTION
## Why is this pull request needed?

Problem when extending time series for compressors across temporal models in `EnergyModelBaseResult.extend()`. This is basically related to how None-values are treated. Two bugs:

- Loss of data: When first temporal model contains `None` and next temporal model contains real values, the merge/extend function evaluates to `None` - ignoring data from second temporal model.
- Mismatch between timesteps and values: When first temporal model contains real values, and next temporal model contains `None`, the merge/extend function evaluates to the values of the first temporal model. The timesteps in the second model are ignored, hence a mismatch between number of timesteps and number of values are introduced for the actual time series.

## What does this pull request change?

- [x] `CompressorTrainResultSingleStep`: Ensure that all time series have values or NaN for all valid timesteps, even if input is `None`
- [x] `CompressorModelSampled`: Ensure that all time series have values or NaN for all valid timesteps, even if input is `None`
- [x] Update snapshots
- [x] Add test

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-376?atlOrigin=eyJpIjoiNzY4MzVlMWU2ZjEzNDMwNzhiYzNhMDZkMmExYzljOTQiLCJwIjoiaiJ9