### PR TITLE
fix: make iteration loops for simplified train consistent

### DIFF
--- a/src/libecalc/core/models/compressor/train/simplified_train.py
+++ b/src/libecalc/core/models/compressor/train/simplified_train.py
@@ -560,11 +560,6 @@ class CompressorTrainSimplifiedKnownStages(CompressorTrainSimplified):
                     " This should normally not happen. Please contact eCalc support."
                 )
 
-        maximum_actual_volume_rate = maximum_rate_function(
-            heads=polytropic_head,
-            extrapolate_heads_below_minimum=False,
-        )
-
         return maximum_actual_volume_rate
 
 

--- a/src/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
+++ b/src/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
@@ -194,7 +194,7 @@ def test_calculate_maximum_rate_given_outlet_pressure_all_calculation_points(
     pressure_ratios = [1, 2, 3, 4, 5, 10, 100, 1000]
 
     # These expected max rates are here just to assure stability in the results. They are not assured to be correct!
-    approx_expected_max_rates = [1116990, 1359255, 1536130, 1052085, 1052085, 1052085, 1052085, 1052085]
+    approx_expected_max_rates = [1116990, 1359022, 1536130, 1052085, 1052085, 1052085, 1052085, 1052085]
     for pressure_ratio, approx_expected_max_rate in zip(pressure_ratios, approx_expected_max_rates):
         calculated_max_rate = (
             CompressorTrainSimplifiedKnownStages.calculate_maximum_rate_given_outlet_pressure_all_calculation_points(


### PR DESCRIPTION
## Why is this pull request needed?

https://github.com/equinor/ecalc/blob/883b7e6888d5ff4ddca41cbeac0f7c7dd96e60a6/src/libecalc/core/models/compressor/train/simplified_train.py#L481 and https://github.com/equinor/ecalc/blob/883b7e6888d5ff4ddca41cbeac0f7c7dd96e60a6/src/libecalc/core/models/compressor/train/utils/enthalpy_calculations.py#L20 both have the same iterative loop changing z and kappa, but the algorithm for finding the max rate has an extra update in the end (https://github.com/equinor/ecalc/blob/883b7e6888d5ff4ddca41cbeac0f7c7dd96e60a6/src/libecalc/core/models/compressor/train/simplified_train.py#L563). Removing this extra update solves the numerical problems reported in this issue.


## Issues related to this change:
ECALC 381