### PR TITLE
refactor: use common consumer system dto class

### DIFF
--- a/src/libecalc/core/ecalc.py
+++ b/src/libecalc/core/ecalc.py
@@ -51,35 +51,16 @@ class EnergyCalculator:
                     models=[],
                     sub_components=[],
                 )
-            elif isinstance(component_dto, libecalc.dto.components.PumpSystem):
-                pump_system = ConsumerSystem(
+            elif isinstance(component_dto, libecalc.dto.components.ConsumerSystem):
+                consumer_system = ConsumerSystem(
                     id=component_dto.id,
-                    consumers=component_dto.pumps,
+                    consumers=component_dto.consumers,
                     component_conditions=component_dto.component_conditions,
                 )
                 evaluated_stream_conditions = component_dto.evaluate_stream_conditions(
                     variables_map=variables_map,
                 )
-                system_result = pump_system.evaluate(
-                    variables_map=variables_map, system_stream_conditions_priorities=evaluated_stream_conditions
-                )
-                consumer_results[component_dto.id] = system_result
-                for consumer_result in system_result.sub_components:
-                    consumer_results[consumer_result.id] = EcalcModelResult(
-                        component_result=consumer_result,
-                        sub_components=[],
-                        models=[],
-                    )
-            elif isinstance(component_dto, libecalc.dto.components.CompressorSystem):
-                compressor_system = ConsumerSystem(
-                    id=component_dto.id,
-                    consumers=component_dto.compressors,
-                    component_conditions=component_dto.component_conditions,
-                )
-                evaluated_stream_conditions = component_dto.evaluate_stream_conditions(
-                    variables_map=variables_map,
-                )
-                system_result = compressor_system.evaluate(
+                system_result = consumer_system.evaluate(
                     variables_map=variables_map, system_stream_conditions_priorities=evaluated_stream_conditions
                 )
                 consumer_results[component_dto.id] = system_result
@@ -113,7 +94,7 @@ class EnergyCalculator:
                     variables_map=variables_map,
                     fuel_rate=np.asarray(energy_usage.values),
                 )
-            elif isinstance(consumer_dto, (dto.components.CompressorSystem, dto.components.PumpSystem)):
+            elif isinstance(consumer_dto, dto.components.ConsumerSystem):
                 if consumer_dto.consumes == ConsumptionType.FUEL:
                     fuel_model = FuelModel(consumer_dto.fuel)
                     energy_usage = consumer_results[consumer_dto.id].component_result.energy_usage

--- a/src/libecalc/fixtures/cases/consumer_system_v2/consumer_system_v2_dto.py
+++ b/src/libecalc/fixtures/cases/consumer_system_v2/consumer_system_v2_dto.py
@@ -195,7 +195,8 @@ compressor_system = dto.FuelConsumer(
     user_defined_category={datetime(2022, 1, 1): ConsumerUserDefinedCategoryType.COMPRESSOR},
 )
 
-compressor_system_v2 = dto.components.CompressorSystem(
+compressor_system_v2 = dto.components.ConsumerSystem(
+    component_type=ComponentType.COMPRESSOR_SYSTEM_V2,
     name="compressor_system_v2",
     user_defined_category={datetime(2022, 1, 1): ConsumerUserDefinedCategoryType.COMPRESSOR},
     regularity=regularity,
@@ -377,7 +378,7 @@ compressor_system_v2 = dto.components.CompressorSystem(
             },
         },
     },
-    compressors=[
+    consumers=[
         compressor1,  # Max rate of 4000000
         compressor2,  # Max rate of 4000000
         compressor3,  # Max rate of 4000000
@@ -428,8 +429,9 @@ pump_system = dto.ElectricityConsumer(
     user_defined_category={datetime(2022, 1, 1): ConsumerUserDefinedCategoryType.PUMP},
 )
 
-pump_system_v2 = dto.components.PumpSystem(
+pump_system_v2 = dto.components.ConsumerSystem(
     name="pump_system_v2",
+    component_type=ComponentType.PUMP_SYSTEM_V2,
     user_defined_category={datetime(2022, 1, 1): ConsumerUserDefinedCategoryType.PUMP},
     regularity=regularity,
     consumes=dto.types.ConsumptionType.ELECTRICITY,
@@ -577,7 +579,7 @@ pump_system_v2 = dto.components.PumpSystem(
             },
         },
     },
-    pumps=[pump1, pump2, pump3],
+    consumers=[pump1, pump2, pump3],
 )
 
 

--- a/src/libecalc/input/yaml_types/components/system/yaml_compressor_system.py
+++ b/src/libecalc/input/yaml_types/components/system/yaml_compressor_system.py
@@ -64,7 +64,7 @@ class YamlCompressorSystem(YamlConsumerBase):
         references: References,
         target_period: Period,
         fuel: Optional[Dict[datetime, dto.types.FuelType]] = None,
-    ) -> dto.components.CompressorSystem:
+    ) -> dto.components.ConsumerSystem:
         compressors: List[dto.components.CompressorComponent] = [
             dto.components.CompressorComponent(
                 consumes=consumes,
@@ -107,13 +107,14 @@ class YamlCompressorSystem(YamlConsumerBase):
                 crossover=[],
             )
 
-        return dto.components.CompressorSystem(
+        return dto.components.ConsumerSystem(
+            component_type=ComponentType.COMPRESSOR_SYSTEM_V2,
             name=self.name,
             user_defined_category=define_time_model_for_period(self.category, target_period=target_period),
             regularity=regularity,
             consumes=consumes,
             component_conditions=component_conditions,
             stream_conditions_priorities=self.stream_conditions_priorities,
-            compressors=compressors,
+            consumers=compressors,
             fuel=fuel,
         )

--- a/src/libecalc/input/yaml_types/components/system/yaml_pump_system.py
+++ b/src/libecalc/input/yaml_types/components/system/yaml_pump_system.py
@@ -57,7 +57,7 @@ class YamlPumpSystem(YamlConsumerBase):
         references: References,
         target_period: Period,
         fuel: Optional[Dict[datetime, dto.types.FuelType]] = None,
-    ) -> dto.components.PumpSystem:
+    ) -> dto.components.ConsumerSystem:
         pumps: List[dto.components.PumpComponent] = [
             dto.components.PumpComponent(
                 consumes=consumes,
@@ -100,13 +100,14 @@ class YamlPumpSystem(YamlConsumerBase):
                 crossover=[],
             )
 
-        return dto.components.PumpSystem(
+        return dto.components.ConsumerSystem(
+            component_type=ComponentType.PUMP_SYSTEM_V2,
             name=self.name,
             user_defined_category=define_time_model_for_period(self.category, target_period=target_period),
             regularity=regularity,
             consumes=consumes,
             component_conditions=component_conditions,
             stream_conditions_priorities=self.stream_conditions_priorities,
-            pumps=pumps,
+            consumers=pumps,
             fuel=fuel,
         )


### PR DESCRIPTION
## Why is this pull request needed?

No need to have separate systems for pump and compressor

## What does this pull request change?

Creates ConsumerSystem instead of Pump- and CompressorSystem in dto.

## Issues related to this change:
