### PR TITLE
Ecalc 125 resampling when first date in resampling frequency is different from first date in global time vector

### DIFF
--- a/src/ecalc_cli/io/output.py
+++ b/src/ecalc_cli/io/output.py
@@ -146,11 +146,9 @@ def export_tsv(
     Returns:
 
     """
-    resampled_timevector = resample_time_steps(
-        results.timesteps,
-        frequency,
-        remove_last=True,  # last step is always added as a STOP, and does infer the end of the time vector
-    )
+    resampled_timevector = resample_time_steps(results.timesteps, frequency)[
+        :-1
+    ]  # last step is always added as a STOP, and does infer the end of the time vector
 
     prognosis_filter = config.filter(frequency=frequency)
     result = prognosis_filter.filter(results, resampled_timevector)

--- a/src/libecalc/dto/result/tabular_time_series.py
+++ b/src/libecalc/dto/result/tabular_time_series.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import pandas as pd
 from typing_extensions import Self
 
-from libecalc.common.time_utils import Frequency
+from libecalc.common.time_utils import Frequency, resample_time_steps
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
     RateType,
@@ -102,7 +102,5 @@ class TabularTimeSeries(ABC, EcalcResultBaseModel):
                 # NOTE: turbine_result is not resampled. Should add support?
                 pass
 
-        resampled.timesteps = (
-            pd.date_range(start=self.timesteps[0], end=self.timesteps[-1], freq=freq.value).to_pydatetime().tolist()
-        )
+        resampled.timesteps = resample_time_steps(self.timesteps, frequency=freq)
         return resampled


### PR DESCRIPTION
## Why is this pull request needed?

Currently, if a reporting frequency other than data defined is chosen, the global time vector is forced to start and end at dates which is part of the requested reporting frequency (e.g. 1st of January for YEARLY). If the start date is in e.g. August 2023, the resampled time series will start 1st of January 2023, and we will start extrapolating the results, before resampling - which is not straightforward. What should be set to nan, what should be set to zero.


## What does this pull request change?

This PR adds the start date and the end date from the initial global time vector to the resampled time vector of any frequency. This means that cumulative volumes are kept intact, no volumes are lost. The start and end of the data defined global time vector and the resampled time vector will be the same, but the dates in between will be different.

In a LTP reporting context the volumes from the start date to the end of that year will be reported (e.g. from 1st of Aug to 31st of December), also the volumes from 1st of January the last year until the end date (e.g. 31st of July).

## Issues related to this change:
ECALC-125