### PR TITLE
Refactor/component graph

### DIFF
--- a/examples/simple_python_model.ipynb
+++ b/examples/simple_python_model.ipynb
@@ -778,7 +778,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "print(\"Iterating the model components to plot results: \\n\")\n",
-    "for identity, component in model_graph.components.items():\n",
+    "for identity, component in model_graph.nodes.items():\n",
     "    if identity in result.consumer_results:\n",
     "        component_result = result.consumer_results[identity].component_result\n",
     "        ds = pd.Series(component_result.energy_usage.values, index=component_result.energy_usage.timesteps)\n",

--- a/examples/simple_yaml_model.ipynb
+++ b/examples/simple_yaml_model.ipynb
@@ -90,7 +90,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "print(\"Iterating the model components to plot results: \\n\")\n",
-    "for identity, component in yaml_model.graph.components.items():\n",
+    "for identity, component in yaml_model.graph.nodes.items():\n",
     "    if identity in result.consumer_results:\n",
     "        component_result = result.consumer_results[identity].component_result\n",
     "        ds = pd.Series(component_result.energy_usage.values, index=component_result.energy_usage.timesteps)\n",

--- a/src/libecalc/common/graph.py
+++ b/src/libecalc/common/graph.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Dict, Generic, List, Protocol, TypeVar
+
+import networkx as nx
+from typing_extensions import Self
+
+NodeID = str
+
+
+class NodeWithID(Protocol):
+    @property
+    def id(self) -> NodeID:
+        ...
+
+
+TNode = TypeVar("TNode", bound=NodeWithID)
+
+
+class Graph(Generic[TNode]):
+    def __init__(self):
+        self.graph = nx.DiGraph()
+        self.nodes: Dict[NodeID, TNode] = {}
+
+    def add_node(self, node: TNode) -> Self:
+        self.graph.add_node(node.id)
+        self.nodes[node.id] = node
+        return self
+
+    def add_edge(self, from_id: NodeID, to_id: NodeID) -> Self:
+        if from_id not in self.nodes or to_id not in self.nodes:
+            raise ValueError("Add node before adding edges")
+
+        self.graph.add_edge(from_id, to_id)
+        return self
+
+    def add_subgraph(self, subgraph: Graph) -> Self:
+        self.nodes.update(subgraph.nodes)
+        self.graph = nx.compose(self.graph, subgraph.graph)
+        return self
+
+    def get_successors(self, node_id: NodeID, recursively=False) -> List[NodeID]:
+        if recursively:
+            return [
+                successor_id
+                for successor_id in nx.dfs_tree(self.graph, source=node_id).nodes()
+                if successor_id != node_id
+            ]
+        else:
+            return list(self.graph.successors(node_id))
+
+    def get_predecessor(self, node_id: NodeID) -> NodeID:
+        predecessors = list(self.graph.predecessors(node_id))
+        if len(predecessors) > 1:
+            raise ValueError(
+                f"Tried to get a single predecessor of node with several predecessors. NodeID: {node_id}, "
+                f"Predecessors: {', '.join(predecessors)}"
+            )
+        return predecessors[0]
+
+    @property
+    def root(self) -> NodeID:
+        return list(nx.topological_sort(self.graph))[0]
+
+    def get_node(self, node_id: NodeID) -> TNode:
+        return self.nodes[node_id]
+
+    @property
+    def sorted_node_ids(self) -> List[NodeID]:
+        return list(nx.topological_sort(self.graph))
+
+    def __iter__(self):
+        return iter(self.graph)

--- a/src/libecalc/core/ecalc.py
+++ b/src/libecalc/core/ecalc.py
@@ -24,8 +24,8 @@ class EnergyCalculator:
         self._graph = graph
 
     def evaluate_energy_usage(self, variables_map: dto.VariablesMap) -> Dict[str, EcalcModelResult]:
-        component_ids = list(reversed(self._graph.sorted_component_ids))
-        component_dtos = [self._graph.get_component(component_id) for component_id in component_ids]
+        component_ids = list(reversed(self._graph.sorted_node_ids))
+        component_dtos = [self._graph.get_node(component_id) for component_id in component_ids]
 
         consumer_results: Dict[str, EcalcModelResult] = {}
 
@@ -87,7 +87,7 @@ class EnergyCalculator:
         Returns: a mapping from consumer_id to emissions
         """
         emission_results: Dict[str, Dict[str, EmissionResult]] = {}
-        for consumer_dto in self._graph.components.values():
+        for consumer_dto in self._graph.nodes.values():
             if isinstance(consumer_dto, (dto.FuelConsumer, dto.GeneratorSet)):
                 fuel_model = FuelModel(consumer_dto.fuel)
                 energy_usage = consumer_results[consumer_dto.id].component_result.energy_usage

--- a/src/libecalc/core/ecalc.py
+++ b/src/libecalc/core/ecalc.py
@@ -12,14 +12,14 @@ from libecalc.core.consumers.legacy_consumer.component import Consumer
 from libecalc.core.models.fuel import FuelModel
 from libecalc.core.result import EcalcModelResult
 from libecalc.core.result.emission import EmissionResult
-from libecalc.dto.graph import Graph
+from libecalc.dto.component_graph import ComponentGraph
 from libecalc.dto.types import ConsumptionType
 
 
 class EnergyCalculator:
     def __init__(
         self,
-        graph: Graph,
+        graph: ComponentGraph,
     ):
         self._graph = graph
 

--- a/src/libecalc/core/graph_result.py
+++ b/src/libecalc/core/graph_result.py
@@ -29,7 +29,7 @@ from libecalc.common.utils.rates import (
 from libecalc.core.result import ComponentResult, EcalcModelResult
 from libecalc.core.result.emission import EmissionResult
 from libecalc.dto.base import ComponentType
-from libecalc.dto.graph import Graph
+from libecalc.dto.component_graph import ComponentGraph
 from libecalc.dto.models.consumer_system import CompressorSystemConsumerFunction
 from libecalc.dto.result.emission import EmissionIntensityResult, PartialEmissionResult
 from libecalc.dto.result.results import (
@@ -52,7 +52,7 @@ class EnergyCalculatorResult(BaseModel):
 class GraphResult:
     def __init__(
         self,
-        graph: Graph,
+        graph: ComponentGraph,
         consumer_results: Dict[str, EcalcModelResult],
         emission_results: Dict[str, Dict[str, EmissionResult]],
         variables_map: dto.VariablesMap,

--- a/src/libecalc/core/graph_result.py
+++ b/src/libecalc/core/graph_result.py
@@ -99,7 +99,7 @@ class GraphResult:
 
         """
         asset_id = self.graph.root
-        asset = self.graph.get_component(asset_id)
+        asset = self.graph.get_node(asset_id)
         installation_results = []
         for installation in asset.installations:
             regularity = TimeSeriesFloat(
@@ -197,7 +197,7 @@ class GraphResult:
         return installation_results
 
     def get_subgraph(self, node_id: str) -> "GraphResult":
-        subgraph = self.graph.get_component(node_id).get_graph()
+        subgraph = self.graph.get_node(node_id).get_graph()
 
         return GraphResult(
             graph=subgraph,
@@ -374,7 +374,7 @@ class GraphResult:
 
     def get_asset_result(self) -> libecalc.dto.result.EcalcModelResult:
         asset_id = self.graph.root
-        asset = self.graph.get_component(asset_id)
+        asset = self.graph.get_node(asset_id)
 
         if not isinstance(asset, dto.Asset):
             raise ProgrammingError("Need an asset graph to get asset result")
@@ -395,7 +395,7 @@ class GraphResult:
             regularity: TimeSeriesFloat = regularities[parent_installation_id]
 
             if consumer_node_info.component_type in [ComponentType.COMPRESSOR, ComponentType.COMPRESSOR_SYSTEM]:
-                component = self.graph.get_component(consumer_id)
+                component = self.graph.get_node(consumer_id)
 
                 for model in consumer_result.models:
                     period = Period(model.timesteps[0], model.timesteps[-1])
@@ -817,7 +817,7 @@ class GraphResult:
                         ]
                     )
             elif consumer_node_info.component_type in [ComponentType.PUMP, ComponentType.PUMP_SYSTEM]:
-                component = self.graph.get_component(consumer_id)
+                component = self.graph.get_node(consumer_id)
                 for model in consumer_result.models:
                     models.extend(
                         [

--- a/src/libecalc/dto/component_graph.py
+++ b/src/libecalc/dto/component_graph.py
@@ -1,55 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List
-
-import networkx as nx
+from typing import List
 
 from libecalc import dto
 from libecalc.common.component_info.component_level import ComponentLevel
+from libecalc.common.graph import Graph, NodeID
 from libecalc.dto.base import ComponentType
 from libecalc.dto.node_info import NodeInfo
 
-if TYPE_CHECKING:
-    from libecalc.dto.components import ComponentDTO
 
-NodeID = str
-
-
-class ComponentGraph:
-    def __init__(self):
-        self.graph = nx.DiGraph()
-        self.nodes: Dict[NodeID, ComponentDTO] = {}
-
-    def add_node(self, node: ComponentDTO):
-        self.graph.add_node(node.id)
-        self.nodes[node.id] = node
-
-    def add_edge(self, from_id: NodeID, to_id: NodeID):
-        if from_id not in self.nodes or to_id not in self.nodes:
-            raise ValueError("Add node before adding edges")
-
-        self.graph.add_edge(from_id, to_id)
-
-    def add_subgraph(self, subgraph: ComponentGraph):
-        self.nodes.update(subgraph.nodes)
-        self.graph = nx.compose(self.graph, subgraph.graph)
-
-    def get_successors(self, node_id: NodeID, recursively=False) -> List[NodeID]:
-        if recursively:
-            return [
-                successor_id
-                for successor_id in nx.dfs_tree(self.graph, source=node_id).nodes()
-                if successor_id != node_id
-            ]
-        else:
-            return list(self.graph.successors(node_id))
-
-    def get_predecessor(self, node_id: NodeID) -> NodeID:
-        predecessors = list(self.graph.predecessors(node_id))
-        if len(predecessors) > 1:
-            raise ValueError("Component with several parents encountered.")
-        return predecessors[0]
-
+class ComponentGraph(Graph):
     def get_parent_installation_id(self, node_id: NodeID) -> NodeID:
         """
         Simple helper function to get the installation of any component with id
@@ -68,10 +28,6 @@ class ComponentGraph:
 
         parent_id = self.get_predecessor(node_id)
         return self.get_parent_installation_id(parent_id)
-
-    @property
-    def root(self) -> NodeID:
-        return list(nx.topological_sort(self.graph))[0]
 
     def get_node_info(self, node_id: NodeID) -> NodeInfo:
         component_dto = self.nodes[node_id]
@@ -97,9 +53,6 @@ class ComponentGraph:
             component_level=component_level,
         )
 
-    def get_node(self, node_id: NodeID) -> ComponentDTO:
-        return self.nodes[node_id]
-
     def get_node_id_by_name(self, name: str) -> NodeID:
         for node in self.nodes.values():
             if node.name == name:
@@ -109,10 +62,3 @@ class ComponentGraph:
 
     def get_nodes_of_type(self, component_type: ComponentType) -> List[NodeID]:
         return [node.id for node in self.nodes.values() if node.component_type == component_type]
-
-    @property
-    def sorted_node_ids(self) -> List[NodeID]:
-        return list(nx.topological_sort(self.graph))
-
-    def __iter__(self):
-        return iter(self.graph)

--- a/src/libecalc/dto/component_graph.py
+++ b/src/libecalc/dto/component_graph.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 NodeID = str
 
 
-class Graph:
+class ComponentGraph:
     def __init__(self):
         self.graph = nx.DiGraph()
         self.nodes: Dict[NodeID, ComponentDTO] = {}
@@ -30,7 +30,7 @@ class Graph:
 
         self.graph.add_edge(from_id, to_id)
 
-    def add_subgraph(self, subgraph: Graph):
+    def add_subgraph(self, subgraph: ComponentGraph):
         self.nodes.update(subgraph.nodes)
         self.graph = nx.compose(self.graph, subgraph.graph)
 

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -23,7 +23,7 @@ from libecalc.dto.base import (
     EcalcBaseModel,
     InstallationUserDefinedCategoryType,
 )
-from libecalc.dto.graph import Graph
+from libecalc.dto.component_graph import ComponentGraph
 from libecalc.dto.models import (
     ConsumerFunction,
     ElectricEnergyUsageModel,
@@ -222,8 +222,8 @@ class ConsumerSystem(BaseConsumer):
     stream_conditions_priorities: Priorities[SystemStreamConditions]
     consumers: List[Union[CompressorComponent, PumpComponent]]
 
-    def get_graph(self) -> Graph:
-        graph = Graph()
+    def get_graph(self) -> ComponentGraph:
+        graph = ComponentGraph()
         graph.add_node(self)
         for consumer in self.consumers:
             graph.add_node(consumer)
@@ -295,8 +295,8 @@ class GeneratorSet(BaseEquipment):
 
         return user_defined_category
 
-    def get_graph(self) -> Graph:
-        graph = Graph()
+    def get_graph(self) -> ComponentGraph:
+        graph = ComponentGraph()
         graph.add_node(self)
         for electricity_consumer in self.consumers:
             if hasattr(electricity_consumer, "get_graph"):
@@ -341,8 +341,8 @@ class Installation(BaseComponent):
 
         return user_defined_category
 
-    def get_graph(self) -> Graph:
-        graph = Graph()
+    def get_graph(self) -> ComponentGraph:
+        graph = ComponentGraph()
         graph.add_node(self)
         for component in [*self.fuel_consumers, *self.direct_emitters]:
             if hasattr(component, "get_graph"):
@@ -431,8 +431,8 @@ class Asset(Component):
             )
         return values
 
-    def get_graph(self) -> Graph:
-        graph = Graph()
+    def get_graph(self) -> ComponentGraph:
+        graph = ComponentGraph()
         graph.add_node(self)
         for installation in self.installations:
             graph.add_subgraph(installation.get_graph())

--- a/src/libecalc/presentation/exporter/aggregators.py
+++ b/src/libecalc/presentation/exporter/aggregators.py
@@ -71,7 +71,7 @@ class InstallationAggregator(Aggregator):
         :return:
         """
         aggregated_installation_results: List[GroupedQueryResult] = []
-        for installation_id in energy_calculator_result.graph.get_nodes(ComponentType.INSTALLATION):
+        for installation_id in energy_calculator_result.graph.get_nodes_of_type(ComponentType.INSTALLATION):
             installation_graph = energy_calculator_result.get_subgraph(installation_id)
             installation_name = installation_graph.graph.get_node_info(installation_graph.graph.root).name
             single_results: List[QueryResult] = []

--- a/src/libecalc/presentation/exporter/queries.py
+++ b/src/libecalc/presentation/exporter/queries.py
@@ -66,7 +66,7 @@ class FuelQuery(Query):
         unit: Unit,
         frequency: Frequency,
     ) -> Optional[Dict[datetime, float]]:
-        installation_dto = installation_graph.graph.get_component(installation_graph.graph.root)
+        installation_dto = installation_graph.graph.get_node(installation_graph.graph.root)
 
         installation_time_steps = installation_graph.timesteps
         time_steps = resample_time_steps(
@@ -146,7 +146,7 @@ class EmissionQuery(Query):
         unit: Unit,
         frequency: Frequency,
     ) -> Optional[Dict[datetime, float]]:
-        installation_dto = installation_graph.graph.get_component(installation_graph.graph.root)
+        installation_dto = installation_graph.graph.get_node(installation_graph.graph.root)
 
         installation_time_steps = installation_graph.timesteps
         time_steps = resample_time_steps(
@@ -224,7 +224,7 @@ class ElectricityGeneratedQuery(Query):
         unit: Unit,
         frequency: Frequency,
     ) -> Optional[Dict[datetime, float]]:
-        installation_dto = installation_graph.graph.get_component(installation_graph.graph.root)
+        installation_dto = installation_graph.graph.get_node(installation_graph.graph.root)
 
         installation_time_steps = installation_graph.timesteps
         time_steps = resample_time_steps(
@@ -297,7 +297,7 @@ class FuelConsumerPowerConsumptionQuery(Query):
         unit: Unit,
         frequency: Frequency,
     ) -> Optional[Dict[datetime, float]]:
-        installation_dto = installation_graph.graph.get_component(installation_graph.graph.root)
+        installation_dto = installation_graph.graph.get_node(installation_graph.graph.root)
 
         installation_time_steps = installation_graph.timesteps
         time_steps = resample_time_steps(
@@ -388,7 +388,7 @@ class ElConsumerPowerConsumptionQuery(Query):
         unit: Unit,
         frequency: Frequency,
     ) -> Optional[Dict[datetime, float]]:
-        installation_dto = installation_graph.graph.get_component(installation_graph.graph.root)
+        installation_dto = installation_graph.graph.get_node(installation_graph.graph.root)
 
         installation_time_steps = installation_graph.timesteps
         time_steps = resample_time_steps(

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -6,7 +6,7 @@ from libecalc.common.exceptions import EcalcError
 from libecalc.common.logger import logger
 from libecalc.common.time_utils import Frequency
 from libecalc.dto import ResultOptions, VariablesMap
-from libecalc.dto.graph import Graph
+from libecalc.dto.component_graph import ComponentGraph
 from libecalc.infrastructure.file_io import (
     read_facility_resource,
     read_timeseries_resource,
@@ -51,7 +51,7 @@ class YamlModel:
         )
 
     @property
-    def graph(self) -> Graph:
+    def graph(self) -> ComponentGraph:
         return self.dto.get_graph()
 
     @staticmethod

--- a/src/tests/libecalc/common/test_graph.py
+++ b/src/tests/libecalc/common/test_graph.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+from libecalc.common.graph import Graph, NodeID
+
+
+@dataclass
+class Node:
+    node_id: NodeID
+    some_data: Optional[str] = None
+
+    @property
+    def id(self):
+        return self.node_id
+
+
+@pytest.fixture
+def graph_with_subgraph():
+    subgraph = (
+        Graph()
+        .add_node(Node(node_id="3"))
+        .add_node(Node(node_id="4", some_data="test"))
+        .add_edge(from_id="3", to_id="4")
+    )
+
+    graph = (
+        Graph()
+        .add_subgraph(subgraph)
+        .add_node(Node(node_id="2"))
+        .add_node(Node(node_id="1"))
+        .add_edge(from_id="1", to_id="2")
+        .add_edge("2", "3")
+    )
+
+    return graph
+
+
+class TestGraph:
+    def test_get_successors(self):
+        graph = (
+            Graph()
+            .add_node(Node(node_id="1"))
+            .add_node(Node(node_id="2"))
+            .add_node(Node(node_id="3"))
+            .add_edge(from_id="1", to_id="2")
+            .add_edge(from_id="2", to_id="3")
+        )
+        assert graph.get_successors("1") == ["2"]
+        assert graph.get_successors("1", recursively=True) == ["2", "3"]
+        assert graph.get_successors("2", recursively=True) == ["3"]
+        assert graph.get_successors("3", recursively=True) == []
+
+    def test_get_predecessors(self):
+        graph = (
+            Graph()
+            .add_node(Node(node_id="1"))
+            .add_node(Node(node_id="2"))
+            .add_node(Node(node_id="3"))
+            .add_edge(from_id="1", to_id="2")
+            .add_edge(from_id="2", to_id="3")
+        )
+
+        assert graph.get_predecessor("3") == "2"
+        assert graph.get_predecessor("2") == "1"
+
+        graph.add_edge("1", "3")
+        with pytest.raises(ValueError) as exc_info:
+            graph.get_predecessor("3")
+
+        assert str(exc_info.value) == (
+            "Tried to get a single predecessor of node with several predecessors. NodeID: " "3, Predecessors: 2, 1"
+        )
+
+    def test_subgraph(self, graph_with_subgraph):
+        assert len(graph_with_subgraph.nodes) == 4
+        assert set(graph_with_subgraph.nodes.keys()) == {"1", "2", "3", "4"}
+        assert graph_with_subgraph.get_predecessor("3") == "2"
+
+    def test_topological_sort(self, graph_with_subgraph):
+        assert graph_with_subgraph.sorted_node_ids == ["1", "2", "3", "4"]
+
+    def test_root(self, graph_with_subgraph):
+        assert graph_with_subgraph.root == "1"
+
+    def test_get_node_with_data(self, graph_with_subgraph):
+        """
+        Assert returned node is the same node that we passed in.
+
+        Args:
+            graph_with_subgraph:
+
+        Returns:
+
+        """
+        node = graph_with_subgraph.get_node("4")
+        #  TODO: fix typing
+        #   Uncomment line below to see the type, no import needed, install mypy in poetry venv, run poetry shell, then
+        #    run mypy on the file 'mypy <path to file>'.
+        # reveal_type(node)
+        assert isinstance(node, Node)
+        assert node.some_data == "test"

--- a/src/tests/libecalc/integration/test_consumer_system_v2.py
+++ b/src/tests/libecalc/integration/test_consumer_system_v2.py
@@ -74,10 +74,10 @@ def test_compressor_system_v2_results(name: str, consumer_system_v2: DTOCase, re
     ecalc_result = result(consumer_system_v2)
 
     asset_graph = consumer_system_v2.ecalc_model.get_graph()
-    pump_system_id = asset_graph.get_component_id_by_name("pump_system")
-    pump_system_v2_id = asset_graph.get_component_id_by_name("pump_system_v2")
-    compressor_system_id = asset_graph.get_component_id_by_name("compressor_system")
-    compressor_system_v2_id = asset_graph.get_component_id_by_name("compressor_system_v2")
+    pump_system_id = asset_graph.get_node_id_by_name("pump_system")
+    pump_system_v2_id = asset_graph.get_node_id_by_name("pump_system_v2")
+    compressor_system_id = asset_graph.get_node_id_by_name("compressor_system")
+    compressor_system_v2_id = asset_graph.get_node_id_by_name("compressor_system_v2")
 
     pump_system_result = ecalc_result.consumer_results[pump_system_id]
     pump_system_component_result = pump_system_result.component_result.copy(


### PR DESCRIPTION
## Why is this pull request needed?

Reusable generic Graph class

ComponentGraph is used to represent the "is part of" connections. We
also need to represent the stream connections between consumers in
a graph (as seen in system v2). Renaming graph to be able to create
a more generic Graph class that can be reused for StreamGraph.

## What does this pull request change?

Move common graph methods to Graph, while keeping Component specific methods in renamed ComponentGraph

## Issues related to this change:
