### PR TITLE
refactor: rename Stream to StreamConditions

### DIFF
--- a/src/libecalc/common/stream_conditions.py
+++ b/src/libecalc/common/stream_conditions.py
@@ -10,7 +10,7 @@ from libecalc.common.string_utils import to_camel_case
 from libecalc.common.utils.rates import TimeSeriesFloat, TimeSeriesStreamDayRate
 
 
-class Stream(BaseModel):
+class StreamConditions(BaseModel):
     class Config:
         extra = Extra.forbid
         alias_generator = to_camel_case
@@ -21,7 +21,7 @@ class Stream(BaseModel):
     pressure: Optional[TimeSeriesFloat]
     fluid_density: Optional[TimeSeriesFloat] = None
 
-    def mix(self, *other_streams: "Stream") -> "Stream":
+    def mix(self, *other_streams: "StreamConditions") -> "StreamConditions":
         """
         Mix two streams. This needs to be expanded to handle fluids (density, composition, etc.).
 
@@ -50,7 +50,7 @@ class Stream(BaseModel):
             # TODO: return a warning object with the specific timesteps?
             raise ValueError("Increasing pressure when mixing streams. That should not happen.")
 
-        return Stream(
+        return StreamConditions(
             name=f"Mixed-{'-'.join(stream.name for stream in streams)}",
             rate=reduce(operator.add, [stream.rate for stream in streams]),
             pressure=target_pressure,
@@ -67,7 +67,7 @@ class Stream(BaseModel):
         Returns: the stream that is relevant for the given timestep.
 
         """
-        return Stream(
+        return StreamConditions(
             name=self.name,
             rate=self.rate.for_timestep(current_timestep) if self.rate is not None else None,
             pressure=self.pressure.for_timestep(current_timestep) if self.pressure is not None else None,
@@ -75,7 +75,7 @@ class Stream(BaseModel):
         )
 
     @classmethod
-    def mix_all(cls, streams: List["Stream"]) -> "Stream":
+    def mix_all(cls, streams: List["StreamConditions"]) -> "StreamConditions":
         if len(streams) == 0:
             raise ValueError("No streams to mix")
         if len(streams) == 1:
@@ -92,4 +92,4 @@ class Stage(BaseModel):
         allow_population_by_field_name = True
 
     name: Literal["inlet", "before_choke", "outlet"]
-    stream: Stream
+    stream: StreamConditions

--- a/src/libecalc/core/consumers/base/component.py
+++ b/src/libecalc/core/consumers/base/component.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.common.utils.rates import TimeSeriesFloat
 from libecalc.core.result import EcalcModelResult
 from libecalc.dto import VariablesMap
@@ -21,7 +21,7 @@ class BaseConsumerWithoutOperationalSettings(ABC):
     id: str
 
     @abstractmethod
-    def get_max_rate(self, inlet_stream: Stream, target_pressure: TimeSeriesFloat) -> List[float]:
+    def get_max_rate(self, inlet_stream: StreamConditions, target_pressure: TimeSeriesFloat) -> List[float]:
         ...
 
     @abstractmethod

--- a/src/libecalc/core/consumers/compressor/component.py
+++ b/src/libecalc/core/consumers/compressor/component.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from libecalc import dto
-from libecalc.common.stream import Stage, Stream
+from libecalc.common.stream_conditions import Stage, StreamConditions
 from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
@@ -33,7 +33,7 @@ class Compressor(BaseConsumerWithoutOperationalSettings):
 
         self._operational_settings: Optional[CompressorOperationalSettings] = None
 
-    def get_max_rate(self, inlet_stream: Stream, target_pressure: TimeSeriesFloat) -> List[float]:
+    def get_max_rate(self, inlet_stream: StreamConditions, target_pressure: TimeSeriesFloat) -> List[float]:
         """
         For each timestep, get the maximum rate that this compressor can handle, given in -and outlet pressures.
 
@@ -54,7 +54,7 @@ class Compressor(BaseConsumerWithoutOperationalSettings):
 
     def evaluate(
         self,
-        streams: List[Stream],
+        streams: List[StreamConditions],
     ) -> EcalcModelResult:
         model_results = []
         evaluated_timesteps = []
@@ -85,7 +85,7 @@ class Compressor(BaseConsumerWithoutOperationalSettings):
                 aggregated_result.extend(model_result)
 
         # Mixing all input rates to get total rate passed through compressor. Used when reporting streams.
-        total_requested_inlet_stream = Stream.mix_all(inlet_streams)
+        total_requested_inlet_stream = StreamConditions.mix_all(inlet_streams)
 
         energy_usage = TimeSeriesStreamDayRate(
             values=aggregated_result.energy_usage,
@@ -128,7 +128,7 @@ class Compressor(BaseConsumerWithoutOperationalSettings):
                 Stage(name="inlet", stream=total_requested_inlet_stream),
                 Stage(
                     name="before_choke",
-                    stream=Stream(
+                    stream=StreamConditions(
                         name="before_choke",
                         rate=total_requested_inlet_stream.rate,
                         pressure=outlet_pressure_before_choke,
@@ -136,7 +136,7 @@ class Compressor(BaseConsumerWithoutOperationalSettings):
                 ),
                 Stage(
                     name="outlet",
-                    stream=Stream(
+                    stream=StreamConditions(
                         name="outlet",
                         rate=total_requested_inlet_stream.rate,  # Actual, not requested, different because of crossover
                         pressure=outlet_stream.pressure,

--- a/src/libecalc/core/consumers/pump/component.py
+++ b/src/libecalc/core/consumers/pump/component.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from libecalc import dto
-from libecalc.common.stream import Stage, Stream
+from libecalc.common.stream_conditions import Stage, StreamConditions
 from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
@@ -31,7 +31,7 @@ class Pump(BaseConsumerWithoutOperationalSettings):
 
         self._operational_settings: Optional[PumpOperationalSettings] = None
 
-    def get_max_rate(self, inlet_stream: Stream, target_pressure: TimeSeriesFloat) -> List[float]:
+    def get_max_rate(self, inlet_stream: StreamConditions, target_pressure: TimeSeriesFloat) -> List[float]:
         """
         For each timestep, get the maximum rate that this pump can handle, given
         the operational settings given, such as in -and outlet pressures and fluid density (current conditions)
@@ -54,7 +54,7 @@ class Pump(BaseConsumerWithoutOperationalSettings):
 
     def evaluate(
         self,
-        streams: List[Stream],
+        streams: List[StreamConditions],
     ) -> EcalcModelResult:
         model_results = []
         evaluated_timesteps = []
@@ -85,7 +85,7 @@ class Pump(BaseConsumerWithoutOperationalSettings):
                 aggregated_result.extend(model_result)
 
         # Mixing all input rates to get total rate passed through compressor. Used when reporting streams.
-        total_requested_inlet_stream = Stream.mix_all(inlet_streams)
+        total_requested_inlet_stream = StreamConditions.mix_all(inlet_streams)
 
         component_result = core_results.PumpResult(
             timesteps=evaluated_timesteps,
@@ -130,7 +130,7 @@ class Pump(BaseConsumerWithoutOperationalSettings):
                 ),
                 Stage(
                     name="outlet",
-                    stream=Stream(
+                    stream=StreamConditions(
                         name="outlet",
                         rate=total_requested_inlet_stream.rate,  # Actual, not requested, different because of crossover
                         pressure=outlet_stream.pressure,

--- a/src/libecalc/core/models/compressor/base.py
+++ b/src/libecalc/core/models/compressor/base.py
@@ -9,7 +9,7 @@ from numpy.typing import NDArray
 
 from libecalc import dto
 from libecalc.common.logger import logger
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.common.units import Unit
 from libecalc.core.models.base import BaseModel
 from libecalc.core.models.compressor.train.utils.common import (
@@ -41,8 +41,8 @@ class CompressorModel(BaseModel):
     @abstractmethod
     def get_max_standard_rate_from_streams(
         self,
-        inlet_streams: List[Stream],
-        outlet_stream: Stream,
+        inlet_streams: List[StreamConditions],
+        outlet_stream: StreamConditions,
     ):
         raise NotImplementedError
 
@@ -64,8 +64,8 @@ class CompressorModel(BaseModel):
     @abstractmethod
     def evaluate_streams(
         self,
-        inlet_streams: List[Stream],
-        outlet_stream: Stream,
+        inlet_streams: List[StreamConditions],
+        outlet_stream: StreamConditions,
     ):
         raise NotImplementedError
 
@@ -97,8 +97,8 @@ class CompressorWithTurbineModel(CompressorModel):
 
     def evaluate_streams(
         self,
-        inlet_streams: List[Stream],
-        outlet_stream: Stream,
+        inlet_streams: List[StreamConditions],
+        outlet_stream: StreamConditions,
     ) -> CompressorTrainResult:
         return self.evaluate_turbine_based_on_compressor_model_result(
             compressor_energy_function_result=self.compressor_model.evaluate_streams(

--- a/src/libecalc/core/models/compressor/sampled/compressor_model_sampled.py
+++ b/src/libecalc/core/models/compressor/sampled/compressor_model_sampled.py
@@ -9,7 +9,7 @@ from scipy.interpolate import interp1d
 from libecalc import dto
 from libecalc.common.feature_flags import Feature
 from libecalc.common.logger import logger
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.common.units import Unit
 from libecalc.common.utils.adjustment import transform_linear
 from libecalc.core.models.compressor.base import CompressorModel
@@ -257,10 +257,10 @@ class CompressorModelSampled(CompressorModel):
 
     def evaluate_streams(
         self,
-        inlet_streams: List[Stream],
-        outlet_stream: Stream,
+        inlet_streams: List[StreamConditions],
+        outlet_stream: StreamConditions,
     ) -> CompressorTrainResult:
-        mixed_input_streams = Stream.mix_all(streams=inlet_streams)
+        mixed_input_streams = StreamConditions.mix_all(streams=inlet_streams)
         return self.evaluate_rate_ps_pd(
             rate=np.asarray(mixed_input_streams.rate.values),
             suction_pressure=np.asarray(mixed_input_streams.pressure.values),

--- a/src/libecalc/core/models/compressor/train/base.py
+++ b/src/libecalc/core/models/compressor/train/base.py
@@ -7,7 +7,7 @@ from numpy.typing import NDArray
 from libecalc import dto
 from libecalc.common.feature_flags import Feature
 from libecalc.common.logger import logger
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.common.units import Unit
 from libecalc.core.models import (
     INVALID_INPUT,
@@ -155,8 +155,8 @@ class CompressorTrainModel(CompressorModel, ABC, Generic[TModel]):
 
     def evaluate_streams(
         self,
-        inlet_streams: List[Stream],
-        outlet_stream: Stream,
+        inlet_streams: List[StreamConditions],
+        outlet_stream: StreamConditions,
     ) -> CompressorTrainResult:
         """
         Evaluate model based on inlet streams and the expected outlet stream.
@@ -167,7 +167,7 @@ class CompressorTrainModel(CompressorModel, ABC, Generic[TModel]):
         Returns:
 
         """
-        mixed_inlet_stream = Stream.mix_all(inlet_streams)
+        mixed_inlet_stream = StreamConditions.mix_all(inlet_streams)
         return self.evaluate_rate_ps_pd(
             rate=np.asarray(mixed_inlet_stream.rate.values),
             suction_pressure=np.asarray(mixed_inlet_stream.pressure.values),

--- a/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -8,7 +8,7 @@ from numpy.typing import NDArray
 from libecalc import dto
 from libecalc.common.exceptions import EcalcError, IllegalStateException
 from libecalc.common.logger import logger
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.common.units import Unit, UnitConstants
 from libecalc.core.models import ModelInputFailureStatus, validate_model_input
 from libecalc.core.models.compressor.results import CompressorTrainResultSingleTimeStep
@@ -100,8 +100,8 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
 
     def evaluate_streams(
         self,
-        inlet_streams: List[Stream],
-        outlet_stream: Stream,
+        inlet_streams: List[StreamConditions],
+        outlet_stream: StreamConditions,
     ) -> CompressorTrainResult:
         """
         Evaluate model based on inlet streams and the expected outlet stream.
@@ -125,7 +125,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
 
         # Order streams either based on name or use index
         stream_index_counter = 0
-        ordered_streams: List[Stream] = []
+        ordered_streams: List[StreamConditions] = []
         for stream_definition in self.streams:
             try:
                 inlet_stream = next(

--- a/src/libecalc/core/models/pump/pump.py
+++ b/src/libecalc/core/models/pump/pump.py
@@ -8,7 +8,7 @@ from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 
 from libecalc.common.logger import logger
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.common.units import Unit, UnitConstants
 from libecalc.common.utils.adjustment import transform_linear
 from libecalc.core.models.base import BaseModel
@@ -56,8 +56,8 @@ class PumpModel(BaseModel):
     @abstractmethod
     def evaluate_streams(
         self,
-        inlet_streams: List[Stream],
-        outlet_stream: Stream,
+        inlet_streams: List[StreamConditions],
+        outlet_stream: StreamConditions,
     ) -> PumpModelResult:
         pass
 
@@ -222,8 +222,8 @@ class PumpVariableSpeed(PumpModel):
         return pump_result
 
 
-def evaluate_streams(self, inlet_streams: List[Stream], outlet_stream: Stream) -> PumpModelResult:
-    total_requested_stream = Stream.mix_all(inlet_streams)
+def evaluate_streams(self, inlet_streams: List[StreamConditions], outlet_stream: StreamConditions) -> PumpModelResult:
+    total_requested_stream = StreamConditions.mix_all(inlet_streams)
     return self.evaluate_rate_ps_pd_density(
         rate=np.asarray(total_requested_stream.rate.values),
         suction_pressures=np.asarray(total_requested_stream.pressure.values),
@@ -339,8 +339,10 @@ class PumpSingleSpeed(PumpModel):
 
         return pump_result
 
-    def evaluate_streams(self, inlet_streams: List[Stream], outlet_stream: Stream) -> PumpModelResult:
-        total_requested_stream = Stream.mix_all(inlet_streams)
+    def evaluate_streams(
+        self, inlet_streams: List[StreamConditions], outlet_stream: StreamConditions
+    ) -> PumpModelResult:
+        total_requested_stream = StreamConditions.mix_all(inlet_streams)
         return self.evaluate_rate_ps_pd_density(
             rate=np.asarray(total_requested_stream.rate.values),
             suction_pressures=np.asarray(total_requested_stream.pressure.values),

--- a/src/libecalc/core/result/results.py
+++ b/src/libecalc/core/result/results.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from typing_extensions import Self
 
-from libecalc.common.stream import Stage
+from libecalc.common.stream_conditions import Stage
 from libecalc.common.tabular_time_series import TabularTimeSeriesUtils
 from libecalc.common.utils.rates import (
     TimeSeriesBoolean,

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -9,7 +9,7 @@ from typing_extensions import Annotated
 
 from libecalc import dto
 from libecalc.common.priorities import Priorities
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.common.string_utils import generate_id, get_duplicates
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
@@ -184,7 +184,7 @@ class ExpressionTimeSeries(EcalcBaseModel):
     unit: Unit
 
 
-class ExpressionStream(EcalcBaseModel):
+class ExpressionStreamConditions(EcalcBaseModel):
     rate: Optional[ExpressionTimeSeries] = None
     pressure: Optional[ExpressionTimeSeries] = None
     temperature: Optional[ExpressionTimeSeries] = None
@@ -195,7 +195,7 @@ ConsumerID = str
 PriorityID = str
 StreamID = str
 
-SystemStreamConditions = Dict[ConsumerID, Dict[StreamID, ExpressionStream]]
+SystemStreamConditions = Dict[ConsumerID, Dict[StreamID, ExpressionStreamConditions]]
 
 
 class Crossover(EcalcBaseModel):
@@ -230,12 +230,14 @@ class ConsumerSystem(BaseConsumer):
             graph.add_edge(self.id, consumer.id)
         return graph
 
-    def evaluate_stream_conditions(self, variables_map: VariablesMap) -> Priorities[Dict[ConsumerID, List[Stream]]]:
-        parsed_priorities: Priorities[Dict[ConsumerID, List[Stream]]] = defaultdict(dict)
+    def evaluate_stream_conditions(
+        self, variables_map: VariablesMap
+    ) -> Priorities[Dict[ConsumerID, List[StreamConditions]]]:
+        parsed_priorities: Priorities[Dict[ConsumerID, List[StreamConditions]]] = defaultdict(dict)
         for priority_name, priority in self.stream_conditions_priorities.items():
             for consumer_name, streams_conditions in priority.items():
                 parsed_priorities[priority_name][generate_id(consumer_name)] = [
-                    Stream(
+                    StreamConditions(
                         name=stream_name,
                         rate=TimeSeriesStreamDayRate(
                             timesteps=variables_map.time_vector,

--- a/src/libecalc/dto/core_specs/compressor/operational_settings.py
+++ b/src/libecalc/dto/core_specs/compressor/operational_settings.py
@@ -5,13 +5,13 @@ from typing import List
 
 from typing_extensions import Self
 
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.dto.core_specs.base.operational_settings import OperationalSettings
 
 
 class CompressorOperationalSettings(OperationalSettings):
-    inlet_streams: List[Stream]
-    outlet_stream: Stream
+    inlet_streams: List[StreamConditions]
+    outlet_stream: StreamConditions
 
     timesteps: List[datetime]
 

--- a/src/libecalc/dto/core_specs/pump/operational_settings.py
+++ b/src/libecalc/dto/core_specs/pump/operational_settings.py
@@ -5,13 +5,13 @@ from typing import List
 
 from typing_extensions import Self
 
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.dto.core_specs.base.operational_settings import OperationalSettings
 
 
 class PumpOperationalSettings(OperationalSettings):
-    inlet_streams: List[Stream]
-    outlet_stream: Stream
+    inlet_streams: List[StreamConditions]
+    outlet_stream: StreamConditions
 
     timesteps: List[datetime]
 

--- a/src/libecalc/dto/result/results.py
+++ b/src/libecalc/dto/result/results.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated
 
 from libecalc.common.component_info.component_level import ComponentLevel
 from libecalc.common.logger import logger
-from libecalc.common.stream import Stage
+from libecalc.common.stream_conditions import Stage
 from libecalc.common.time_utils import Frequency
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (

--- a/src/libecalc/fixtures/cases/consumer_system_v2/consumer_system_v2_dto.py
+++ b/src/libecalc/fixtures/cases/consumer_system_v2/consumer_system_v2_dto.py
@@ -21,7 +21,7 @@ from libecalc.dto.base import (
 )
 from libecalc.dto.components import (
     Crossover,
-    ExpressionStream,
+    ExpressionStreamConditions,
     ExpressionTimeSeries,
     SystemComponentConditions,
 )
@@ -211,7 +211,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
     stream_conditions_priorities={
         "pri1": {
             "compressor1": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=1000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -221,7 +221,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.BARA,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=250,
                         unit=Unit.BARA,
@@ -229,7 +229,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "compressor2": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=6000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -239,7 +239,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.BARA,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=250,
                         unit=Unit.BARA,
@@ -247,7 +247,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "compressor3": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=6000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -257,7 +257,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.BARA,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=250,
                         unit=Unit.BARA,
@@ -267,7 +267,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
         },
         "pri2": {
             "compressor1": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value="$var.compressor1",
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -277,7 +277,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.BARA,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=125,
                         unit=Unit.BARA,
@@ -285,7 +285,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "compressor2": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=5000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -295,7 +295,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.BARA,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=125,
                         unit=Unit.BARA,
@@ -303,7 +303,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "compressor3": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=5000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -313,7 +313,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.BARA,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=125,
                         unit=Unit.BARA,
@@ -323,7 +323,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
         },
         "pri3": {
             "compressor1": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=1000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -333,7 +333,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.BARA,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=125,
                         unit=Unit.BARA,
@@ -341,7 +341,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "compressor2": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=5000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -351,7 +351,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.BARA,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=125,
                         unit=Unit.BARA,
@@ -359,7 +359,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "compressor3": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=5000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -369,7 +369,7 @@ compressor_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.BARA,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=125,
                         unit=Unit.BARA,
@@ -443,7 +443,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
     stream_conditions_priorities={
         "pri1": {
             "pump1": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=4000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -457,7 +457,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.KG_SM3,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=250,
                         unit=Unit.BARA,
@@ -465,7 +465,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "pump2": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=5000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -479,7 +479,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.KG_SM3,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=250,
                         unit=Unit.BARA,
@@ -487,7 +487,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "pump3": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=6000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -501,7 +501,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.KG_SM3,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=250,
                         unit=Unit.BARA,
@@ -511,7 +511,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
         },
         "pri2": {
             "pump1": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=2000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -525,7 +525,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.KG_SM3,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=125,
                         unit=Unit.BARA,
@@ -533,7 +533,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "pump2": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=2500000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -547,7 +547,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.KG_SM3,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=125,
                         unit=Unit.BARA,
@@ -555,7 +555,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                 ),
             },
             "pump3": {
-                "inlet": ExpressionStream(
+                "inlet": ExpressionStreamConditions(
                     rate=ExpressionTimeSeries(
                         value=3000000,
                         unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -569,7 +569,7 @@ pump_system_v2 = dto.components.ConsumerSystem(
                         unit=Unit.KG_SM3,
                     ),
                 ),
-                "outlet": ExpressionStream(
+                "outlet": ExpressionStreamConditions(
                     pressure=ExpressionTimeSeries(
                         value=125,
                         unit=Unit.BARA,

--- a/src/libecalc/presentation/yaml/yaml_types/components/system/yaml_consumer_system.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/system/yaml_consumer_system.py
@@ -23,7 +23,9 @@ from libecalc.presentation.yaml.yaml_types.components.yaml_compressor import (
     YamlCompressor,
 )
 from libecalc.presentation.yaml.yaml_types.components.yaml_pump import YamlPump
-from libecalc.presentation.yaml.yaml_types.yaml_stream import YamlStream
+from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
+    YamlStreamConditions,
+)
 
 opt_expr_list = Optional[List[ExpressionType]]
 
@@ -31,7 +33,7 @@ PriorityID = str
 StreamID = str
 ConsumerID = str
 
-YamlConsumerStreamConditions = Dict[StreamID, YamlStream]
+YamlConsumerStreamConditions = Dict[StreamID, YamlStreamConditions]
 YamlConsumerStreamConditionsMap = Dict[ConsumerID, YamlConsumerStreamConditions]
 YamlPriorities = Dict[PriorityID, YamlConsumerStreamConditionsMap]
 

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
@@ -40,7 +40,7 @@ class YamlDensity(YamlTimeSeries):
     unit: Unit = Unit.KG_SM3
 
 
-class YamlStream(YamlBase):
+class YamlStreamConditions(YamlBase):
     class Config:
         title = "Stream"
 

--- a/src/tests/libecalc/common/test_tabular_time_series.py
+++ b/src/tests/libecalc/common/test_tabular_time_series.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List
 
 import pytest
-from libecalc.common.stream import Stage, Stream
+from libecalc.common.stream_conditions import Stage, StreamConditions
 from libecalc.common.tabular_time_series import TabularTimeSeriesUtils
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
@@ -69,7 +69,7 @@ class TestMerge:
             stage_list=[
                 Stage(
                     name="inlet",
-                    stream=Stream(
+                    stream=StreamConditions(
                         name="inlet",
                         rate=TimeSeriesStreamDayRate(
                             timesteps=first_timesteps,
@@ -85,7 +85,7 @@ class TestMerge:
                 ),
                 Stage(
                     name="outlet",
-                    stream=Stream(
+                    stream=StreamConditions(
                         name="outlet",
                         rate=TimeSeriesStreamDayRate(
                             timesteps=first_timesteps,
@@ -145,7 +145,7 @@ class TestMerge:
             stage_list=[
                 Stage(
                     name="inlet",
-                    stream=Stream(
+                    stream=StreamConditions(
                         name="inlet",
                         rate=TimeSeriesStreamDayRate(
                             timesteps=second_timesteps,
@@ -161,7 +161,7 @@ class TestMerge:
                 ),
                 Stage(
                     name="outlet",
-                    stream=Stream(
+                    stream=StreamConditions(
                         name="outlet",
                         rate=TimeSeriesStreamDayRate(
                             timesteps=second_timesteps,
@@ -226,7 +226,7 @@ class TestMerge:
                 stage_list=[
                     Stage(
                         name="inlet",
-                        stream=Stream(
+                        stream=StreamConditions(
                             name="inlet",
                             rate=TimeSeriesStreamDayRate(
                                 timesteps=expected_timesteps,
@@ -242,7 +242,7 @@ class TestMerge:
                     ),
                     Stage(
                         name="outlet",
-                        stream=Stream(
+                        stream=StreamConditions(
                             name="outlet",
                             rate=TimeSeriesStreamDayRate(
                                 timesteps=expected_timesteps,

--- a/src/tests/libecalc/core/consumers/test_crossover.py
+++ b/src/tests/libecalc/core/consumers/test_crossover.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List
 
 import pytest
-from libecalc.common.stream import Stream
+from libecalc.common.stream_conditions import StreamConditions
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
     TimeSeriesFloat,
@@ -11,9 +11,9 @@ from libecalc.common.utils.rates import (
 from libecalc.core.consumers.consumer_system import ConsumerSystem
 
 
-def create_stream_from_rate(rate: List[float], name: str = "inlet") -> Stream:
+def create_stream_from_rate(rate: List[float], name: str = "inlet") -> StreamConditions:
     timesteps = [datetime(2020, 1, i + 1) for i in range(len(rate))]
-    return Stream(
+    return StreamConditions(
         name=name,
         rate=TimeSeriesStreamDayRate(
             timesteps=timesteps,

--- a/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
+++ b/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
@@ -202,7 +202,7 @@
                             "additionalProperties": {
                                 "additionalProperties": {
                                     "additionalProperties": {
-                                        "$ref": "#/definitions/YamlStream"
+                                        "$ref": "#/definitions/YamlStreamConditions"
                                     },
                                     "type": "object"
                                 },
@@ -264,7 +264,7 @@
                             "additionalProperties": {
                                 "additionalProperties": {
                                     "additionalProperties": {
-                                        "$ref": "#/definitions/YamlStream"
+                                        "$ref": "#/definitions/YamlStreamConditions"
                                     },
                                     "type": "object"
                                 },
@@ -1344,7 +1344,7 @@
                     "title": "YamlSingleVariable",
                     "type": "object"
                 },
-                "YamlStream": {
+                "YamlStreamConditions": {
                     "additionalProperties": false,
                     "properties": {
                         "FLUID_DENSITY": {


### PR DESCRIPTION
We should use StreamConditions because the Stream is defined as the from, to definition of a stream.