### PR TITLE
refactor: collect results in priority optimizer

### DIFF
--- a/src/libecalc/common/priority_optimizer.py
+++ b/src/libecalc/common/priority_optimizer.py
@@ -92,14 +92,16 @@ class PriorityOptimizer(Generic[TResult, TPriority]):
 
         We process each timestep separately.
 
+        It will default to the last priority if all settings fails
+
         Args:
             timesteps: The timesteps that we want to figure out which priority to use for.
             priorities: Dict of priorities, key is used to identify the priority in the results.
             evaluator: The evaluator function gives a list of results back, each result with its own unique id.
 
         Returns:
-            PriorityOptimizerResult: result containing priorities used and a map of the calculated results. The keys of
-                the results map are the timestep used, the priority index and the id of the result.
+            PriorityOptimizerResult: result containing priorities used and a list of the results merged on priorities
+            used,
 
         """
         is_valid = TimeSeriesBoolean(timesteps=timesteps, values=[False] * len(timesteps), unit=Unit.NONE)

--- a/src/libecalc/common/priority_optimizer.py
+++ b/src/libecalc/common/priority_optimizer.py
@@ -18,21 +18,68 @@ from libecalc.common.utils.rates import (
 TResult = TypeVar("TResult")
 TPriority = TypeVar("TPriority")
 
+ComponentID = str
+
 
 @dataclass
 class PriorityOptimizerResult(Generic[TResult]):
     priorities_used: TimeSeriesString
-    priority_results: Dict[datetime, Dict[PriorityID, Dict[str, TResult]]]
+    priority_results: List[typing.Any]  # TODO: typing. This is the consumer results merged based on priorities used
 
 
 @dataclass
 class EvaluatorResult(Generic[TResult]):
-    id: str
+    id: ComponentID
     result: TResult
     is_valid: TimeSeriesBoolean
 
 
 class PriorityOptimizer(Generic[TResult, TPriority]):
+    @staticmethod
+    def get_component_ids(
+        priority_results: Dict[datetime, Dict[PriorityID, Dict[ComponentID, TResult]]]
+    ) -> List[ComponentID]:
+        component_ids = []
+        for timestep in priority_results:
+            for priority in priority_results[timestep]:
+                for component_id in priority_results[timestep][priority].keys():
+                    if component_id not in component_ids:
+                        component_ids.append(component_id)
+        return component_ids
+
+    def collect_consumer_results(
+        self,
+        priorities_used: TimeSeriesString,
+        priority_results: Dict[datetime, Dict[PriorityID, Dict[ComponentID, TResult]]],
+    ) -> List[typing.Any]:  # TODO: Any type since we don't have access to component_result within TResult
+        """
+        Merge consumer results into a single result per consumer based on the operational settings used. I.e. pick results
+        from the correct operational setting result and merge into a single result per consumer.
+        Args:
+            priorities_used:
+            priority_results:
+
+        Returns: List of merged consumer results
+
+        """
+        component_ids = self.get_component_ids(priority_results)
+
+        consumer_results: Dict[ComponentID, typing.Any] = {}
+        for component_id in component_ids:
+            for timestep_index, timestep in enumerate(priorities_used.timesteps):
+                priority_used = priorities_used.values[timestep_index]
+                prev_result = consumer_results.get(component_id)
+                consumer_result_subset = priority_results[timestep][priority_used][
+                    component_id
+                ].component_result  # TODO: Accessing something the type does not make clear exists
+
+                if prev_result is None:
+                    consumer_results[component_id] = consumer_result_subset
+                else:
+                    consumer_results[component_id] = prev_result.merge(consumer_result_subset)
+
+        return list(consumer_results.values())
+
     def optimize(
         self,
         timesteps: List[datetime],
@@ -93,5 +140,7 @@ class PriorityOptimizer(Generic[TResult, TPriority]):
                     break
         return PriorityOptimizerResult(
             priorities_used=priorities_used,
-            priority_results=dict(priority_results),
+            priority_results=self.collect_consumer_results(
+                priorities_used=priorities_used, priority_results=priority_results
+            ),
         )

--- a/src/libecalc/core/ecalc.py
+++ b/src/libecalc/core/ecalc.py
@@ -62,7 +62,7 @@ class EnergyCalculator:
                     variables_map=variables_map,
                 )
                 system_result = consumer_system.evaluate(
-                    variables_map=variables_map, system_stream_conditions_priorities=evaluated_stream_conditions
+                    timesteps=variables_map.time_vector, system_stream_conditions_priorities=evaluated_stream_conditions
                 )
                 consumer_results[component_dto.id] = system_result
                 for consumer_result in system_result.sub_components:


### PR DESCRIPTION
## Why is this pull request needed?

Don't want to deal with priority results outside PriorityOptimizer. 

This only works if we can merge results from core in a generic way. I'm thinking we should introduce ids for all objects to make sure we don't merge objects that should not be merged (i.e. merging on index, but the objects are not the same)

## What does this pull request change?

Collect results based on priority used before returning from optimize in PriorityOptimizer

## Issues related to this change:
