### PR TITLE
docs: update documentation with info about direct emitters name change

### DIFF
--- a/docs/docs/about/migration_guides/v8-6_to_v8-7.md
+++ b/docs/docs/about/migration_guides/v8-6_to_v8-7.md
@@ -6,4 +6,4 @@ sidebar_position: 4
 
 # v8.6 to v8.7
 
-DIRECT_EMITTERS are renamed to VENTING_EMITTERS in the Yaml input-file.
+Change name from DIRECT_EMITTERS to VENTING_EMITTERS in the Yaml input-file.

--- a/docs/docs/about/migration_guides/v8-6_to_v8-7.md
+++ b/docs/docs/about/migration_guides/v8-6_to_v8-7.md
@@ -1,0 +1,9 @@
+---
+title: v8.6 to v8.7
+description: v8.6 to v8.7 migration
+sidebar_position: 4
+---
+
+# v8.6 to v8.7
+
+DIRECT_EMITTERS are renamed to VENTING_EMITTERS in the Yaml input-file.

--- a/docs/docs/about/migration_guides/v8-6_to_v8-7.md
+++ b/docs/docs/about/migration_guides/v8-6_to_v8-7.md
@@ -1,7 +1,7 @@
 ---
 title: v8.6 to v8.7
 description: v8.6 to v8.7 migration
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # v8.6 to v8.7

--- a/docs/docs/about/migration_guides/v8-6_to_v8-7.md
+++ b/docs/docs/about/migration_guides/v8-6_to_v8-7.md
@@ -6,4 +6,4 @@ sidebar_position: 4
 
 # v8.6 to v8.7
 
-Change name from DIRECT_EMITTERS to VENTING_EMITTERS in the Yaml input-file.
+Change name from `DIRECT_EMITTERS` to `VENTING_EMITTERS` in the Yaml input-file.

--- a/docs/docs/about/references/keywords/DIRECT_EMITTERS.md
+++ b/docs/docs/about/references/keywords/DIRECT_EMITTERS.md
@@ -1,5 +1,7 @@
 # DIRECT_EMITTERS
 
+> Deprecated since eCalc v8.7 (changed name to `VENTING_EMITTERS`)
+
 [INSTALLATIONS](/about/references/keywords/INSTALLATIONS.md) / 
 [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md)
 

--- a/docs/docs/about/references/keywords/DIRECT_EMITTERS.md
+++ b/docs/docs/about/references/keywords/DIRECT_EMITTERS.md
@@ -1,7 +1,7 @@
-# VENTING_EMITTERS
+# DIRECT_EMITTERS
 
 [INSTALLATIONS](/about/references/keywords/INSTALLATIONS.md) / 
-[VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md)
+[DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md)
 
 
 | Required   | Child of                  | Children/Options                   |
@@ -9,19 +9,19 @@
 | Yes        | `INSTALLATIONS`      | `NAME` <br /> `EMISSION_NAME`  <br />  `CATEGORY`  <br />  `EMITTER_MODEL`    |
 
 :::important
-eCalc version 8.7: VENTING_EMITTERS keyword is introduced as a replacement for [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md).
+eCalc version 8.7: DIRECT_EMITTERS are renamed to [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md).
 eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
 :::
 
 ## Description
-The [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword covers the direct emissions on the installation
+The [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword covers the direct emissions on the installation
 that are not consuming energy. The attributes [NAME](/about/references/keywords/NAME.md),
 [EMISSION_NAME](/about/references/keywords/EMISSION_NAME.md), [CATEGORY](/about/references/keywords/CATEGORY.md) and
 [EMITTER_MODEL](/about/references/keywords/EMITTER_MODEL.md) are required.
 
 ## Format
 ~~~~~~~~yaml
-VENTING_EMITTERS:
+DIRECT_EMITTERS:
   - NAME: <emitter name>
     EMISSION_NAME: <emission name>
     CATEGORY: <category>
@@ -30,14 +30,14 @@ VENTING_EMITTERS:
 
 ## Example
 ~~~~~~~~yaml
-VENTING_EMITTERS:
-  - NAME: SomeVentingEmitter
+DIRECT_EMITTERS:
+  - NAME: SomeDirectEmitter
     EMISSION_NAME: CH4
     CATEGORY: COLD-VENTING-FUGITIVE
     EMITTER_MODEL:
       <emitter model data>
   ...
-  - NAME: SomeOtherVentingEmitter
+  - NAME: SomeOtherDirectEmitter
     EMISSION_NAME: C2H6
     CATEGORY: COLD-VENTING-FUGITIVE
     EMITTER_MODEL:

--- a/docs/docs/about/references/keywords/DIRECT_EMITTERS.md
+++ b/docs/docs/about/references/keywords/DIRECT_EMITTERS.md
@@ -1,6 +1,9 @@
 # DIRECT_EMITTERS
+<span className="major-change-deprecation"> Deprecated from eCalc v8.7 (changed name to <strong>VENTING_EMITTERS</strong>).
+</span>
+&nbsp;
 
-> Deprecated since eCalc v8.7 (changed name to `VENTING_EMITTERS`)
+
 
 [INSTALLATIONS](/about/references/keywords/INSTALLATIONS.md) / 
 [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md)
@@ -11,8 +14,8 @@
 | Yes        | `INSTALLATIONS`      | `NAME` <br /> `EMISSION_NAME`  <br />  `CATEGORY`  <br />  `EMITTER_MODEL`    |
 
 :::important
-eCalc version 8.7: DIRECT_EMITTERS are renamed to [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md).
-eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
+- eCalc version 8.7: DIRECT_EMITTERS are renamed to [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md).
+- eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
 :::
 
 ## Description

--- a/docs/docs/about/references/keywords/EMISSION_NAME.md
+++ b/docs/docs/about/references/keywords/EMISSION_NAME.md
@@ -8,8 +8,8 @@
 | Yes         | `VENTING_EMITTERS` | None                               |
 
 :::important
-eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is replacing the [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword.
-eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
+- eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is replacing the [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword.
+- eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
 :::
 
 ## Description

--- a/docs/docs/about/references/keywords/EMISSION_NAME.md
+++ b/docs/docs/about/references/keywords/EMISSION_NAME.md
@@ -3,9 +3,14 @@
 [...] /
 [EMISSION_NAME](/about/references/keywords/EMISSION_NAME.md)
 
-| Required   | Child of                  | Children/Options                   |
-|------------|---------------------------|------------------------------------|
-| Yes         | `VENTING_EMITTERS`      | None                               |
+| Required   | Child of                                            | Children/Options                   |
+|------------|-----------------------------------------------------|------------------------------------|
+| Yes         | `VENTING_EMITTERS` | None                               |
+
+:::important
+eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is introduced as a replacement for [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md).
+eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
+:::
 
 ## Description
 Name of an entity.

--- a/docs/docs/about/references/keywords/EMISSION_NAME.md
+++ b/docs/docs/about/references/keywords/EMISSION_NAME.md
@@ -8,7 +8,7 @@
 | Yes         | `VENTING_EMITTERS` | None                               |
 
 :::important
-eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is introduced as a replacement for [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md).
+eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is replacing the [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword.
 eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
 :::
 

--- a/docs/docs/about/references/keywords/EMITTER_MODEL.md
+++ b/docs/docs/about/references/keywords/EMITTER_MODEL.md
@@ -9,7 +9,7 @@
 | No         | `VENTING_EMITTERS`         | `EMISSION_RATE`   |
 
 :::important
-eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is introduced as a replacement for [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md).
+eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is replacing the [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword.
 eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
 :::
 

--- a/docs/docs/about/references/keywords/EMITTER_MODEL.md
+++ b/docs/docs/about/references/keywords/EMITTER_MODEL.md
@@ -9,8 +9,8 @@
 | No         | `VENTING_EMITTERS`         | `EMISSION_RATE`   |
 
 :::important
-eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is replacing the [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword.
-eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
+- eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is replacing the [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword.
+- eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
 :::
 
 ## Description

--- a/docs/docs/about/references/keywords/EMITTER_MODEL.md
+++ b/docs/docs/about/references/keywords/EMITTER_MODEL.md
@@ -8,6 +8,11 @@
 |------------|---------------------------|-------------------|
 | No         | `VENTING_EMITTERS`         | `EMISSION_RATE`   |
 
+:::important
+eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is introduced as a replacement for [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md).
+eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
+:::
+
 ## Description
 The emitter model specifies the data to calculate the direct emissions on an installation. This data is used to set up
 a function that may be evaluated for a set of time series and return a result including the emissions emitted and

--- a/docs/docs/about/references/keywords/VENTING_EMITTERS.md
+++ b/docs/docs/about/references/keywords/VENTING_EMITTERS.md
@@ -9,7 +9,7 @@
 | Yes        | `INSTALLATIONS`      | `NAME` <br /> `EMISSION_NAME`  <br />  `CATEGORY`  <br />  `EMITTER_MODEL`    |
 
 :::important
-eCalc version 8.7: VENTING_EMITTERS keyword is introduced as a replacement for [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md).
+eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is replacing the [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword.
 eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
 :::
 

--- a/docs/docs/about/references/keywords/VENTING_EMITTERS.md
+++ b/docs/docs/about/references/keywords/VENTING_EMITTERS.md
@@ -9,8 +9,8 @@
 | Yes        | `INSTALLATIONS`      | `NAME` <br /> `EMISSION_NAME`  <br />  `CATEGORY`  <br />  `EMITTER_MODEL`    |
 
 :::important
-eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is replacing the [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword.
-eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
+- eCalc version 8.7: [VENTING_EMITTERS](/about/references/keywords/VENTING_EMITTERS.md) keyword is replacing the [DIRECT_EMITTERS](/about/references/keywords/DIRECT_EMITTERS.md) keyword.
+- eCalc version 8.6 and earlier: Use DIRECT_EMITTERS as before.
 :::
 
 ## Description

--- a/docs/docs/changelog/changelog.md
+++ b/docs/docs/changelog/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [8.7.0](https://github.com/equinor/ecalc/compare/v8.6.0...v8.7.0)
+
+
+### ⚠ BREAKING CHANGES
+
+* change name from DIRECT_EMITTERS to VENTING_EMITTERS in input Yaml-file ([#303](https://github.com/equinor/ecalc/pull/303))
+
 ## [8.6.0](https://github.com/equinor/ecalc/compare/v8.5.0...v8.6.0) (2023-11-21)
 
 

--- a/docs/docs/changelog/changelog.md
+++ b/docs/docs/changelog/changelog.md
@@ -5,7 +5,7 @@
 
 ### ⚠ BREAKING CHANGES
 
-* Change name from DIRECT_EMITTERS to VENTING_EMITTERS in input Yaml-file ([#303](https://github.com/equinor/ecalc/pull/303))
+* Change name from `DIRECT_EMITTERS` to `VENTING_EMITTERS` in input Yaml-file ([#303](https://github.com/equinor/ecalc/pull/303))
 
 ## [8.6.0](https://github.com/equinor/ecalc/compare/v8.5.0...v8.6.0) (2023-11-21)
 

--- a/docs/docs/changelog/changelog.md
+++ b/docs/docs/changelog/changelog.md
@@ -5,7 +5,7 @@
 
 ### ⚠ BREAKING CHANGES
 
-* change name from DIRECT_EMITTERS to VENTING_EMITTERS in input Yaml-file ([#303](https://github.com/equinor/ecalc/pull/303))
+* Change name from DIRECT_EMITTERS to VENTING_EMITTERS in input Yaml-file ([#303](https://github.com/equinor/ecalc/pull/303))
 
 ## [8.6.0](https://github.com/equinor/ecalc/compare/v8.5.0...v8.6.0) (2023-11-21)
 

--- a/docs/docs/changelog/v8-7.md
+++ b/docs/docs/changelog/v8-7.md
@@ -3,7 +3,7 @@ slug: v8.7-release
 title: v8.7 (Next)
 authors: ecalc-team
 tags: [release, eCalc]
-sidebar_position: 0
+sidebar_position: 1
 ---
 
 # eCalc

--- a/docs/docs/changelog/v8-7.md
+++ b/docs/docs/changelog/v8-7.md
@@ -10,4 +10,4 @@ sidebar_position: 0
 
 ## Breaking changes
 
-- Change name from DIRECT_EMITTERS to VENTING_EMITTERS in input Yaml-file.
+- Change name from `DIRECT_EMITTERS` to `VENTING_EMITTERS` in input Yaml-file.

--- a/docs/docs/changelog/v8-7.md
+++ b/docs/docs/changelog/v8-7.md
@@ -1,0 +1,13 @@
+---
+slug: v8.7-release
+title: v8.7 (Next)
+authors: ecalc-team
+tags: [release, eCalc]
+sidebar_position: 0
+---
+
+# eCalc
+
+## Breaking changes
+
+- Change name from DIRECT_EMITTERS to VENTING_EMITTERS in input Yaml-file.

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -44,3 +44,10 @@
   padding: 0 var(--ifm-pre-padding);
   border-left: 3px solid rgba(14, 201, 41, 0.88);
 }
+.major-change-deprecation {
+  background-color: #ff000020;
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+  border-left: 3px solid #ff000080;
+}


### PR DESCRIPTION
## Why is this pull request needed?

We have changed from direct to venting emitters, they both have to coexist for a while, since some users are on older versions, and the latest official in Komodo still has direct emitters. It should be quite visible on the page for keyword at which version it was removed, and/or removed, or significantly changed (e.g parameters).

## What does this pull request change?

- [x] Add information in docs to make it clear which eCalc version is using `DIRECT_EMITTERS` and from which version `VENTING_EMITTERS` is used.
- [x] Keyword description for `DIRECT_EMITTERS` added back to documentation, with description of version changes.
- [x] Update migration guide
- [x] Update changelog

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-525?atlOrigin=eyJpIjoiNWE3ODY5MmJjOWVhNDAxZGJjN2U5MTZlMDJjN2VjZGIiLCJwIjoiaiJ9