### PR TITLE
docs: remove costs mentioned in docs

### DIFF
--- a/docs/docs/about/references/keywords/EMITTER_MODEL.md
+++ b/docs/docs/about/references/keywords/EMITTER_MODEL.md
@@ -15,8 +15,7 @@
 
 ## Description
 The emitter model specifies the data to calculate the direct emissions on an installation. This data is used to set up
-a function that may be evaluated for a set of time series and return a result including the emissions emitted and
-the related cost of the emissions.
+a function that may be evaluated for a set of time series and return an emission result.
 
 The [EMISSION_RATE](/about/references/keywords/EMISSION_RATE.md) describes the rate [kg/day] of emissions, and is required.
 


### PR DESCRIPTION
## Why is this pull request needed?

Previously eCalc has done simplified economical calculations. These have been removed. Some remains are still in the documentation, e.g. a description of emission costs.

## What does this pull request change?

Remove costs mentioned in the docs describing the emitter model.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-515