### PR TITLE
chore: change ltp-filter for oil loaded/stored

### DIFF
--- a/src/libecalc/fixtures/cases/ltp_export/loading_storage_ltp_yaml.py
+++ b/src/libecalc/fixtures/cases/ltp_export/loading_storage_ltp_yaml.py
@@ -1,0 +1,64 @@
+from typing import List
+
+import yaml
+
+from libecalc.common.utils.rates import RateType
+from libecalc.dto import Asset
+from libecalc.presentation.yaml.model import PyYamlYamlModel
+from libecalc.presentation.yaml.parse_input import map_yaml_to_dto
+
+
+def ltp_oil_loaded_yaml_factory(
+    emission_factor: float,
+    rate_types: List[RateType],
+    fuel_rates: [float],
+    emission_name: str,
+    regularity: float,
+    categories: List[str],
+    consumer_names: List[str],
+) -> Asset:
+    input_text = f"""
+    FUEL_TYPES:
+    - NAME: fuel
+      EMISSIONS:
+      - NAME: {emission_name}
+        FACTOR: {emission_factor}
+
+    INSTALLATIONS:
+    - NAME: minimal_installation
+      HCEXPORT: 0
+      FUEL: fuel
+      CATEGORY: FIXED
+      REGULARITY: {regularity}
+
+      FUELCONSUMERS:
+      {create_direct_consumers_yaml(categories, fuel_rates, rate_types, consumer_names)}
+
+    """
+
+    create_direct_consumers_yaml(categories, fuel_rates, rate_types, consumer_names)
+    yaml_text = yaml.safe_load(input_text)
+    configuration = PyYamlYamlModel(
+        internal_datamodel=yaml_text,
+        instantiated_through_read=True,
+    )
+    yaml_model = map_yaml_to_dto(configuration=configuration, resources={}, name="test")
+    return yaml_model
+
+
+def create_direct_consumers_yaml(
+    categories: List[str], fuel_rates: List[float], rate_types: List[RateType], consumer_names: List[str]
+) -> str:
+    consumers = ""
+    for category, fuel_rate, rate_type, consumer_name in zip(categories, fuel_rates, rate_types, consumer_names):
+        consumer = f"""
+        - NAME: {consumer_name}
+          CATEGORY: {category}
+          FUEL: fuel
+          ENERGY_USAGE_MODEL:
+            TYPE: DIRECT
+            FUELRATE: {fuel_rate}
+            CONSUMPTION_RATE_TYPE: {rate_type}
+        """
+        consumers = consumers + consumer
+    return consumers

--- a/src/libecalc/presentation/exporter/configs/configs.py
+++ b/src/libecalc/presentation/exporter/configs/configs.py
@@ -595,7 +595,7 @@ class LTPConfig(ResultConfig):
                     unit=Unit.STANDARD_CUBIC_METER,
                     query=FuelQuery(
                         installation_category="FIXED",
-                        consumer_categories=["STORAGE"],
+                        consumer_categories=["LOADING"],
                     ),
                 ),
                 Applier(

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
@@ -26,7 +26,7 @@ class YamlRate(YamlTimeSeries):
         title = "Rate"
 
     unit: Unit = Unit.STANDARD_CUBIC_METER_PER_DAY
-    type: RateType = RateType.STREAM_DAY
+    type: Optional[RateType]
 
     @validator("type", pre=True)
     def rate_type_validator(cls, value):

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
@@ -26,7 +26,7 @@ class YamlRate(YamlTimeSeries):
         title = "Rate"
 
     unit: Unit = Unit.STANDARD_CUBIC_METER_PER_DAY
-    type: Optional[RateType]
+    type: RateType = RateType.STREAM_DAY
 
     @validator("type", pre=True)
     def rate_type_validator(cls, value):


### PR DESCRIPTION

## Why is this pull request needed?

Currently, `Total Oil Loaded/Stored` is filtered by the category `STORAGE`. There's not always storage related emissions for loaded oil. But all known use cases with storage emissions also have loading emissions, so the category should be changed to `LOADING` to avoid post-processing/workarounds.

## What does this pull request change?

- [x] Change ltp filter for `Total Oil Loaded/Stored` to `LOADING`
- [x] Add test to verify correct volumes for oil loaded/stored

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-124?atlOrigin=eyJpIjoiN2IzYzZiNmMxNTczNGUxMjkwOWY2NmU1MTY5ODQ4YTYiLCJwIjoiaiJ9