### PR TITLE
fix: correct fallback to pydantic v1

### DIFF
--- a/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
+++ b/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
@@ -7,7 +7,11 @@ try:
     from pydantic.v1 import Field
 except ImportError:
     from pydantic import Field
-from pydantic.class_validators import validator
+
+try:
+    from pydantic.v1.class_validators import validator
+except ImportError:
+    from pydantic.class_validators import validator
 
 from libecalc.common.string.string_utils import generate_id
 from libecalc.common.temporal_model import TemporalExpression, TemporalModel

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
@@ -4,7 +4,11 @@ try:
     from pydantic.v1 import Field
 except ImportError:
     from pydantic import Field
-from pydantic.class_validators import validator
+
+try:
+    from pydantic.v1.class_validators import validator
+except ImportError:
+    from pydantic.class_validators import validator
 
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType


### PR DESCRIPTION
merge issues caused us to continue to use
pydantic v1, while we want to use v2. v2 and
v1 cannot be used at the same time and causes
problems.

## Have you remembered and considered?

- [x] Update documentation, if relevant
- [x] Update manual changelog, if relevant
- [x] Update migration guide, if relevant
- [x] Tagged commit with `BREAKING:` in footer or `!` in header if breaking
- [x] Considered to add tests
- [x] Used conventional commits syntax

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
