### PR TITLE
docs: update migration guide economics

### DIFF
--- a/docs/docs/about/migration_guides/v8-5_to_v8-6.md
+++ b/docs/docs/about/migration_guides/v8-5_to_v8-6.md
@@ -1,0 +1,16 @@
+---
+title: v8.5 to v8.6
+description: v8.5 to v8.6 migration
+sidebar_position: 5
+---
+
+# v8.5 to v8.6
+
+## Economics
+
+Economic details have been deprecated from eCalc. 
+If you have used input data such as `TAX`, `QUOTA` and `PRICE` for fuel and emissions in your model, 
+they will be ignored and hence not reported. It will be treated as an error in a future version of eCalc.
+
+
+

--- a/docs/docs/about/migration_guides/v8-6_to_v8-7.md
+++ b/docs/docs/about/migration_guides/v8-6_to_v8-7.md
@@ -1,7 +1,7 @@
 ---
 title: v8.6 to v8.7
 description: v8.6 to v8.7 migration
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # v8.6 to v8.7


### PR DESCRIPTION

## Why is this pull request needed?

Economic details are removed from eCalc v8.5 to v8.6. This is not reflected in the migration guide.

## What does this pull request change?

Add migration guide for v8.5 to v8.6.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-594?atlOrigin=eyJpIjoiMDAwNWFiZWFjMjhiNGQ0NWIwZTY3ODg3NWZjNDIyOWYiLCJwIjoiaiJ9