### PR TITLE
fix: resample method for TimeSeriesBoolean

### DIFF
--- a/src/libecalc/common/time_utils.py
+++ b/src/libecalc/common/time_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -211,7 +211,10 @@ def create_time_steps(
         the requested frequency
 
     """
-    date_range = pd.date_range(start=start, end=end, freq=frequency.value)
+    # If the start date or end date is part of the date_range made by the frequency, the returned date range will
+    # always include the start and end date (no matter what the include_start_date and include_end_date booleans are).
+    # To avoid this add one day to start and subtract one day from end.
+    date_range = pd.date_range(start=start + timedelta(days=1), end=end - timedelta(days=1), freq=frequency.value)
 
     time_steps = [clear_time(time_step) for time_step in date_range]
     if include_start_date:

--- a/src/tests/libecalc/common/utils/test_rates.py
+++ b/src/tests/libecalc/common/utils/test_rates.py
@@ -72,13 +72,16 @@ class TestBooleanTimeSeries:
     @pytest.fixture
     def boolean_series(self):
         return TimeSeriesBoolean(
-            values=[False, True, True, False, True],
+            values=[False, True, True, False, True, True, False, True],
             timesteps=[
                 datetime(2019, 7, 1),
                 datetime(2020, 1, 1),
                 datetime(2020, 7, 1),
                 datetime(2021, 1, 1),
                 datetime(2021, 7, 1),
+                datetime(2022, 1, 1),
+                datetime(2022, 7, 1),
+                datetime(2023, 1, 1),
             ],
             unit=Unit.NONE,
         )
@@ -92,36 +95,43 @@ class TestBooleanTimeSeries:
     def test_resample_boolean(self, boolean_series):
         # resample including start and end date
         yearly_values = boolean_series.resample(freq=Frequency.YEAR)
-        assert yearly_values.values == [False, True, False, True]
+        assert yearly_values.values == [False, True, False, False, True]
         assert yearly_values.timesteps == [
             datetime(2019, 7, 1),
             datetime(2020, 1, 1),
             datetime(2021, 1, 1),
-            datetime(2021, 7, 1),
+            datetime(2022, 1, 1),
+            datetime(2023, 1, 1),
         ]
 
         # resample including start and without end date
         yearly_values = boolean_series.resample(freq=Frequency.YEAR, include_end_date=False)
-        assert yearly_values.values == [False, True, False]
+        assert yearly_values.values == [False, True, False, False]
         assert yearly_values.timesteps == [
             datetime(2019, 7, 1),
             datetime(2020, 1, 1),
             datetime(2021, 1, 1),
+            datetime(2022, 1, 1),
         ]
 
         # resample without start and including end date
         yearly_values = boolean_series.resample(freq=Frequency.YEAR, include_start_date=False)
-        assert yearly_values.values == [True, False, True]
+        assert yearly_values.values == [True, False, False, True]
         assert yearly_values.timesteps == [
             datetime(2020, 1, 1),
             datetime(2021, 1, 1),
-            datetime(2021, 7, 1),
+            datetime(2022, 1, 1),
+            datetime(2023, 1, 1),
         ]
 
         # resample without start and end date
         yearly_values = boolean_series.resample(freq=Frequency.YEAR, include_start_date=False, include_end_date=False)
-        assert yearly_values.values == [True, False]
-        assert yearly_values.timesteps == [datetime(2020, 1, 1), datetime(2021, 1, 1)]
+        assert yearly_values.values == [True, False, False]
+        assert yearly_values.timesteps == [
+            datetime(2020, 1, 1),
+            datetime(2021, 1, 1),
+            datetime(2022, 1, 1),
+        ]
 
     def test_indexing(self, boolean_series):
         first_timestep = TimeSeriesBoolean(


### PR DESCRIPTION
If a period between two timesteps in the resampled boolean variable corresponds to several periods in the original boolean variable, the resampling method should return False if any of the respecitve periods in the original boolean variable are False. Currently the first boolean value is chosen. This PR aims to fix that.

## Have you remembered and considered?

- [x] Update documentation, if relevant
- [x] Update manual changelog, if relevant
- [x] Update migration guide, if relevant
- [x] Tagged commit with `BREAKING:` in footer or `!` in header if breaking
- [x] Considered to add tests
- [x] Used conventional commits syntax
