### PR TITLE
ECALC-631 chore: improve error messages for mandatory keywords

### DIFF
--- a/docs/docs/about/references/keywords/RATE.md
+++ b/docs/docs/about/references/keywords/RATE.md
@@ -44,6 +44,9 @@ RATE: SIM1:GAS_PROD
 ~~~~~~~~
 
 ## Use in EMISSION for VENTING_EMITTERS (from eCalc v8.8)
+The attribute `VALUE` is required, while `UNIT` and `TYPE` are optional. Allowed values for
+`UNIT` are kg/d and t/d, while STREAM_DAY and CALENDAR_DAY are valid for `TYPE`.
+
 ### Format
 ~~~~~~~~yaml
 VENTING_EMITTERS:

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -9,6 +9,7 @@ from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import Annotated
 
 from libecalc import dto
+from libecalc.common.errors.exceptions import EcalcError
 from libecalc.common.priorities import Priorities
 from libecalc.common.stream_conditions import TimeSeriesStreamConditions
 from libecalc.common.string.string_utils import generate_id, get_duplicates
@@ -43,6 +44,7 @@ from libecalc.dto.utils.validators import (
 )
 from libecalc.dto.variables import VariablesMap
 from libecalc.expression import Expression
+from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingEmitter,
 )
@@ -367,6 +369,17 @@ class Installation(BaseComponent):
                 )
 
         return user_defined_category
+
+    @field_validator("fuel_consumers", mode="before")
+    def check_fuel_consumers_exist(cls, fuel_consumers):
+        if not fuel_consumers:
+            raise EcalcError(
+                title="Keywords are missing",
+                message=f"It is required to specify at least one of the two keywords "
+                f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.generator_sets} "
+                f"in the model.",
+            )
+        return fuel_consumers
 
     def get_graph(self) -> ComponentGraph:
         graph = ComponentGraph()

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -9,7 +9,6 @@ from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import Annotated
 
 from libecalc import dto
-from libecalc.common.errors.exceptions import EcalcError
 from libecalc.common.priorities import Priorities
 from libecalc.common.stream_conditions import TimeSeriesStreamConditions
 from libecalc.common.string.string_utils import generate_id, get_duplicates
@@ -373,11 +372,9 @@ class Installation(BaseComponent):
     @field_validator("fuel_consumers", mode="before")
     def check_fuel_consumers_exist(cls, fuel_consumers):
         if not fuel_consumers:
-            raise EcalcError(
-                title="Keywords are missing",
-                message=f"It is required to specify at least one of the two keywords "
-                f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.generator_sets} "
-                f"in the model.",
+            raise ValueError(
+                f"Keywords are missing:\n It is required to specify at least one of the two keywords "
+                f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.generator_sets} in the model.",
             )
         return fuel_consumers
 

--- a/src/libecalc/fixtures/cases/all_energy_usage_models/all_models_dto.py
+++ b/src/libecalc/fixtures/cases/all_energy_usage_models/all_models_dto.py
@@ -16,7 +16,9 @@ from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import 
     YamlVentingEmission,
     YamlVentingEmitter,
 )
-from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import YamlRate
+from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
+    YamlEmissionRate,
+)
 
 
 @pytest.fixture
@@ -982,7 +984,8 @@ def methane_venting(regularity) -> YamlVentingEmitter:
         name="methane_venting",
         category=ConsumerUserDefinedCategoryType.COLD_VENTING_FUGITIVE,
         emission=YamlVentingEmission(
-            name="CH4", rate=YamlRate(value="FLARE;METHANE_RATE", unit=Unit.KILO_PER_DAY, type=RateType.STREAM_DAY)
+            name="CH4",
+            rate=YamlEmissionRate(value="FLARE;METHANE_RATE", unit=Unit.KILO_PER_DAY, type=RateType.STREAM_DAY),
         ),
     )
 

--- a/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
+++ b/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
@@ -27,6 +27,14 @@ def venting_emitter_yaml_factory(
       CATEGORY: FIXED
       REGULARITY: {regularity}
 
+      FUELCONSUMERS:
+        - NAME: testings
+          CATEGORY: MISCELLANEOUS
+          FUEL: fuel
+          ENERGY_USAGE_MODEL:
+            TYPE: DIRECT
+            FUELRATE: 10
+
       VENTING_EMITTERS:
       - NAME: Venting emitter 1
         CATEGORY: COLD-VENTING-FUGITIVE

--- a/src/libecalc/presentation/yaml/mappers/component_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/component_mapper.py
@@ -4,7 +4,6 @@ from typing import Dict, Optional, Union
 from pydantic import ValidationError
 
 from libecalc import dto
-from libecalc.common.errors.exceptions import EcalcError
 from libecalc.common.logger import logger
 from libecalc.common.time_utils import Period, define_time_model_for_period
 from libecalc.dto.base import ComponentType
@@ -266,21 +265,12 @@ class InstallationMapper:
             for fuel_consumer in data.get(EcalcYamlKeywords.fuel_consumers, [])
         ]
 
-        if not fuel_consumers and not generator_sets:
-            raise EcalcError(
-                title="Keywords are missing",
-                message=f"It is required to specify at least one of the two keywords "
-                f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.generator_sets} "
-                f"in the model.",
-            )
         venting_emitters = []
         for venting_emitter in data.get(EcalcYamlKeywords.installation_venting_emitters, []):
             try:
                 venting_emitters.append(YamlVentingEmitter(**venting_emitter))
             except ValidationError as e:
-                raise DtoValidationError(
-                    data=data, component_name=venting_emitter[EcalcYamlKeywords.name], validation_error=e
-                ) from e
+                raise DtoValidationError(data=venting_emitter, validation_error=e) from e
 
         hydrocarbon_export = define_time_model_for_period(
             data.get(

--- a/src/libecalc/presentation/yaml/mappers/component_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/component_mapper.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Union
 from pydantic import ValidationError
 
 from libecalc import dto
+from libecalc.common.errors.exceptions import EcalcError
 from libecalc.common.logger import logger
 from libecalc.common.time_utils import Period, define_time_model_for_period
 from libecalc.dto.base import ComponentType
@@ -265,6 +266,13 @@ class InstallationMapper:
             for fuel_consumer in data.get(EcalcYamlKeywords.fuel_consumers, [])
         ]
 
+        if not fuel_consumers and not generator_sets:
+            raise EcalcError(
+                title="Keywords are missing",
+                message=f"It is required to specify at least one of the two keywords "
+                f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.generator_sets} "
+                f"in the model.",
+            )
         venting_emitters = []
         for venting_emitter in data.get(EcalcYamlKeywords.installation_venting_emitters, []):
             try:

--- a/src/libecalc/presentation/yaml/mappers/component_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/component_mapper.py
@@ -4,7 +4,6 @@ from typing import Dict, Optional, Union
 from pydantic import ValidationError
 
 from libecalc import dto
-from libecalc.common.errors.exceptions import EcalcError
 from libecalc.common.logger import logger
 from libecalc.common.time_utils import Period, define_time_model_for_period
 from libecalc.dto.base import ComponentType
@@ -271,19 +270,9 @@ class InstallationMapper:
             try:
                 venting_emitters.append(YamlVentingEmitter(**venting_emitter))
             except ValidationError as e:
-                error_names = [err["loc"][0] for err in e.errors()]
-                error_messages = [err["msg"] for err in e.errors()]
-                to_user = []
-                for name, message in zip(error_names, error_messages):
-                    if message == "Extra inputs are not permitted":
-                        message_to_user = "This is not a valid keyword"
-                    else:
-                        message_to_user = message
-                    to_user.append(f"\n {name}: {message_to_user}")
-
-                raise EcalcError(
-                    title=f"Error in Yaml-input for venting emitter {venting_emitter['NAME']}", message="".join(to_user)
-                )
+                raise DtoValidationError(
+                    data=data, component_name=venting_emitter[EcalcYamlKeywords.name], validation_error=e
+                ) from e
 
         hydrocarbon_export = define_time_model_for_period(
             data.get(

--- a/src/libecalc/presentation/yaml/validation_errors.py
+++ b/src/libecalc/presentation/yaml/validation_errors.py
@@ -13,9 +13,6 @@ from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 
 Loc = Tuple[Union[int, str], ...]
 
-expected_schemes = ["test scheme"]
-field = ["EMISSION", "RATE"]
-
 CUSTOM_MESSAGES = {
     "missing": "This keyword is missing, it is required",
     "extra_forbidden": "This is not a valid keyword",

--- a/src/libecalc/presentation/yaml/validation_errors.py
+++ b/src/libecalc/presentation/yaml/validation_errors.py
@@ -124,10 +124,9 @@ class DtoValidationError(DataValidationError):
         self,
         data: Optional[Union[Dict[str, Any], YamlDict]],
         validation_error: PydanticValidationError,
-        component_name: Optional[str] = None,
         **kwargs,
     ):
-        name = component_name if component_name is not None else data.get(EcalcYamlKeywords.name)
+        name = data.get(EcalcYamlKeywords.name)
         message_title = f"\n{name}:"
         messages = [message_title]
 

--- a/src/libecalc/presentation/yaml/validation_errors.py
+++ b/src/libecalc/presentation/yaml/validation_errors.py
@@ -118,7 +118,7 @@ class DtoValidationError(DataValidationError):
         self,
         data: Optional[Union[Dict[str, Any], YamlDict]],
         validation_error: PydanticValidationError,
-        component_name: Optional[str],
+        component_name: Optional[str] = None,
         **kwargs,
     ):
         name = component_name if component_name is not None else data.get(EcalcYamlKeywords.name)

--- a/src/libecalc/presentation/yaml/validation_errors.py
+++ b/src/libecalc/presentation/yaml/validation_errors.py
@@ -130,15 +130,12 @@ class DtoValidationError(DataValidationError):
         error_names = []
         error_locs = []
         try:
-            # error_names = [err["loc"][0] for err in errors]
-            # error_messages = [err["msg"] for err in errors]
-
             for error in errors:
                 error_name = error["loc"][0]
                 error_names.append(error_name)
                 error_locs.append(error["loc"])
 
-                if error["msg"] == "Extra inputs are not permitted":
+                if error["type"] == "extra_forbidden":
                     error_message = "This is not a valid keyword"
                 else:
                     error_message = error["msg"]

--- a/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
+++ b/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
@@ -20,7 +20,9 @@ from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_category_field import (
     CategoryField,
 )
-from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import YamlRate
+from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
+    YamlEmissionRate,
+)
 
 
 class YamlVentingEmission(YamlBase):
@@ -30,7 +32,7 @@ class YamlVentingEmission(YamlBase):
         description="Name of emission",
     )
 
-    rate: YamlRate = Field(..., title="RATE", description="The emission rate")
+    rate: YamlEmissionRate = Field(..., title="RATE", description="The emission rate")
 
 
 class YamlVentingEmitter(YamlBase):

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import Literal, Optional
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field
 
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
@@ -17,34 +17,14 @@ class YamlRate(YamlTimeSeries):
     model_config = ConfigDict(title="Rate")
 
     unit: Unit = Unit.STANDARD_CUBIC_METER_PER_DAY
-    type: RateType = RateType.STREAM_DAY
-
-    @field_validator("type", mode="before")
-    @classmethod
-    def rate_type_validator(cls, value):
-        return RateType.STREAM_DAY if value is None else value
+    type: Literal[RateType.STREAM_DAY, RateType.CALENDAR_DAY] = RateType.STREAM_DAY
 
 
 class YamlEmissionRate(YamlTimeSeries):
     model_config = ConfigDict(title="Rate")
 
-    unit: Unit = Unit.KILO_PER_DAY
-    type: RateType = RateType.STREAM_DAY
-
-    @field_validator("type", mode="before")
-    @classmethod
-    def rate_type_validator(cls, value):
-        return RateType.STREAM_DAY if value is None else value
-
-    @field_validator("unit", mode="before")
-    @classmethod
-    def unit_validator(cls, value):
-        valid_units = [Unit.KILO_PER_DAY, Unit.TONS_PER_DAY]
-        if value not in valid_units:
-            raise ValueError(
-                f"{value} is not a valid input unit for emissions. Valid units are [{', '.join(valid_units)}]."
-            )
-        return RateType.STREAM_DAY if value is None else value
+    unit: Literal[Unit.KILO_PER_DAY, Unit.TONS_PER_DAY] = Unit.KILO_PER_DAY
+    type: Literal[RateType.STREAM_DAY, RateType.CALENDAR_DAY] = RateType.STREAM_DAY
 
 
 class YamlPressure(YamlTimeSeries):

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
@@ -25,6 +25,18 @@ class YamlRate(YamlTimeSeries):
         return RateType.STREAM_DAY if value is None else value
 
 
+class YamlEmissionRate(YamlTimeSeries):
+    model_config = ConfigDict(title="Rate")
+
+    unit: Unit = Unit.KILO_PER_DAY
+    type: RateType = RateType.STREAM_DAY
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def rate_type_validator(cls, value):
+        return RateType.STREAM_DAY if value is None else value
+
+
 class YamlPressure(YamlTimeSeries):
     model_config = ConfigDict(title="Pressure")
 

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
@@ -36,6 +36,16 @@ class YamlEmissionRate(YamlTimeSeries):
     def rate_type_validator(cls, value):
         return RateType.STREAM_DAY if value is None else value
 
+    @field_validator("unit", mode="before")
+    @classmethod
+    def unit_validator(cls, value):
+        valid_units = [Unit.KILO_PER_DAY, Unit.TONS_PER_DAY]
+        if value not in valid_units:
+            raise ValueError(
+                f"{value} is not a valid input unit for emissions. Valid units are [{', '.join(valid_units)}]."
+            )
+        return RateType.STREAM_DAY if value is None else value
+
 
 class YamlPressure(YamlTimeSeries):
     model_config = ConfigDict(title="Pressure")

--- a/src/tests/libecalc/dto/test_categories.py
+++ b/src/tests/libecalc/dto/test_categories.py
@@ -16,14 +16,16 @@ from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import 
     YamlVentingEmission,
     YamlVentingEmitter,
 )
-from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import YamlRate
+from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
+    YamlEmissionRate,
+)
 from pydantic import ValidationError
 
 
 class TestCategories:
     def test_venting_emitter_categories(self):
         emission = YamlVentingEmission(
-            name="CH4", rate=YamlRate(value=4, type=RateType.STREAM_DAY, unit=Unit.KILO_PER_DAY)
+            name="CH4", rate=YamlEmissionRate(value=4, type=RateType.STREAM_DAY, unit=Unit.KILO_PER_DAY)
         )
 
         # Check that illegal category raises error

--- a/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
+++ b/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
@@ -53,14 +53,6 @@
                     "title": "InstallationUserDefinedCategoryType",
                     "type": "string"
                 },
-                "RateType": {
-                    "enum": [
-                        "STREAM_DAY",
-                        "CALENDAR_DAY"
-                    ],
-                    "title": "RateType",
-                    "type": "string"
-                },
                 "Unit": {
                     "description": "A very simple unit registry to convert between common eCalc units.",
                     "enum": [
@@ -482,10 +474,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -501,10 +493,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -520,10 +512,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -555,10 +547,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -1134,20 +1126,22 @@
                     "additionalProperties": false,
                     "properties": {
                         "TYPE": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/$defs/RateType"
-                                }
+                            "default": "STREAM_DAY",
+                            "enum": [
+                                "STREAM_DAY",
+                                "CALENDAR_DAY"
                             ],
-                            "default": "STREAM_DAY"
+                            "title": "Type",
+                            "type": "string"
                         },
                         "UNIT": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/$defs/Unit"
-                                }
+                            "default": "kg/d",
+                            "enum": [
+                                "kg/d",
+                                "t/d"
                             ],
-                            "default": "kg/d"
+                            "title": "Unit",
+                            "type": "string"
                         },
                         "VALUE": {
                             "anyOf": [
@@ -1198,10 +1192,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -1326,10 +1320,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -1369,10 +1363,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -1426,10 +1420,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -1491,10 +1485,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -1566,10 +1560,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -1674,10 +1668,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -1810,10 +1804,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -1926,10 +1920,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -2931,10 +2925,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -2950,10 +2944,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -2969,10 +2963,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -2988,10 +2982,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -3023,10 +3017,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     }
                                 ]
                             },
@@ -3062,12 +3056,13 @@
                     "additionalProperties": false,
                     "properties": {
                         "TYPE": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/$defs/RateType"
-                                }
+                            "default": "STREAM_DAY",
+                            "enum": [
+                                "STREAM_DAY",
+                                "CALENDAR_DAY"
                             ],
-                            "default": "STREAM_DAY"
+                            "title": "Type",
+                            "type": "string"
                         },
                         "UNIT": {
                             "allOf": [

--- a/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
+++ b/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
@@ -1130,6 +1130,46 @@
                     "title": "Emission",
                     "type": "object"
                 },
+                "YamlEmissionRate": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "TYPE": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/$defs/RateType"
+                                }
+                            ],
+                            "default": "STREAM_DAY"
+                        },
+                        "UNIT": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/$defs/Unit"
+                                }
+                            ],
+                            "default": "kg/d"
+                        },
+                        "VALUE": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ],
+                            "title": "Value"
+                        }
+                    },
+                    "required": [
+                        "VALUE"
+                    ],
+                    "title": "Rate",
+                    "type": "object"
+                },
                 "YamlEnergyUsageModelCompressor": {
                     "additionalProperties": false,
                     "properties": {
@@ -4003,7 +4043,7 @@
                         "RATE": {
                             "allOf": [
                                 {
-                                    "$ref": "#/$defs/YamlRate"
+                                    "$ref": "#/$defs/YamlEmissionRate"
                                 }
                             ],
                             "description": "The emission rate",

--- a/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
+++ b/src/tests/libecalc/input/validation/snapshots/test_validation_json_schemas/test_json_schema_changed/schemas.json
@@ -474,10 +474,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -493,10 +493,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -512,10 +512,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -547,10 +547,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -1192,10 +1192,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -1320,10 +1320,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -1363,10 +1363,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -1420,10 +1420,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -1485,10 +1485,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -1560,10 +1560,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -1668,10 +1668,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -1804,10 +1804,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -1920,10 +1920,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -2925,10 +2925,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -2944,10 +2944,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -2963,10 +2963,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -2982,10 +2982,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },
@@ -3017,10 +3017,10 @@
                                         "type": "string"
                                     },
                                     {
-                                        "type": "integer"
+                                        "type": "number"
                                     },
                                     {
-                                        "type": "number"
+                                        "type": "integer"
                                     }
                                 ]
                             },

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -11,7 +11,9 @@ from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import 
     YamlVentingEmission,
     YamlVentingEmitter,
 )
-from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import YamlRate
+from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
+    YamlEmissionRate,
+)
 
 
 @pytest.fixture
@@ -35,7 +37,7 @@ def test_venting_emitter(variables_map):
         category=ConsumerUserDefinedCategoryType.COLD_VENTING_FUGITIVE,
         emission=YamlVentingEmission(
             name="ch4",
-            rate=YamlRate(
+            rate=YamlEmissionRate(
                 value="TSC1;Methane_rate {*} 1.02",
                 unit=Unit.KILO_PER_DAY,
                 type=RateType.STREAM_DAY,


### PR DESCRIPTION
## Why is this pull request needed?

Difficult for user to understand error message, and where things go wrong, when problems with mandatory keywords in yaml.

## What does this pull request change?

- [x] Improve yaml error messages for DtoValidationError: More precise feedback to user.
- [x] Use customized pydantic error messages.
- [x] At least one of the keywords FUELCONSUMERS and GENERATORSETS is required. Improve error message if both are missing. This is how it works today. Will allow for only VENTING_EMITTERS later, separate task.
- [x] Update tests
- [x] Update snapshots
- [x] Update docs for `RATE`

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-631?atlOrigin=eyJpIjoiYmM0Y2M5YjFkNGQxNDg5NTg4ZDA5NGFmYTFkZDFjMDQiLCJwIjoiaiJ9