### PR TITLE
Docs: Wrong_category_for_directly_driven_compressor_in_simple_model_e…

### DIFF
--- a/docs/docs/about/modelling/examples/simple.md
+++ b/docs/docs/about/modelling/examples/simple.md
@@ -421,9 +421,9 @@ INSTALLATIONS:
           TYPE: DIRECT
           FUELRATE: $var.flare_fuel_rate_sm3_day
       - NAME: Gas export compressor
-        CATEGORY: COMPRESSOR
+        CATEGORY: GAS-DRIVEN-COMPRESSOR
         ENERGY_USAGE_MODEL:
-          TYPE: GAS-DRIVEN-COMPRESSOR
+          TYPE: COMPRESSOR
           ENERGYFUNCTION: compressor_with_turbine_sampled
           RATE: $var.gas_export_rate_sm3_per_day
           SUCTION_PRESSURE: 50 #not used but a number is needed for eCalc


### PR DESCRIPTION
In Examples -> Simple model, the category of FUELCONSUMERS, "NAME: Gas export compressor", should be GAS-DRIVEN-COMPRESSOR and not COMPRESSOR.

## Have you remembered and considered?

- [ ] Update documentation, if relevant
- [ ] Update manual changelog, if relevant
- [ ] Update migration guide, if relevant
- [ ] Tagged commit with `BREAKING:` in footer or `!` in header if breaking
- [ ] Considered to add tests
- [ ] Used conventional commits syntax

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
