### PR TITLE
refactor: allow str in resource stream

### DIFF
--- a/src/libecalc/presentation/yaml/yaml_entities.py
+++ b/src/libecalc/presentation/yaml/yaml_entities.py
@@ -34,10 +34,12 @@ class YamlTimeseriesResource:
 @dataclass
 class ResourceStream:
     name: str
-    stream: TextIO
+    stream: Union[TextIO, str]
 
     # Implement read to make resource behave as a stream.
     def read(self, *args, **kwargs):
+        if isinstance(self.stream, str):
+            return self.stream
         return self.stream.read(*args, **kwargs)
 
 

--- a/src/tests/ecalc_cli/test_app.py
+++ b/src/tests/ecalc_cli/test_app.py
@@ -710,8 +710,7 @@ class TestYamlFile:
 
         yaml_wrong_name = (Path("test.name.yaml")).absolute()
         yaml_reader = PyYamlYamlModel.YamlReader(loader=yaml.SafeLoader)
-        stream = StringIO("")
-        yaml_stream = ResourceStream(name=yaml_wrong_name.name, stream=stream)
+        yaml_stream = ResourceStream(name=yaml_wrong_name.name, stream="")
 
         with pytest.raises(EcalcError) as ee:
             yaml_reader.load(yaml_file=yaml_stream)

--- a/src/tests/libecalc/input/test_file_io.py
+++ b/src/tests/libecalc/input/test_file_io.py
@@ -269,7 +269,7 @@ class TestReadYaml:
         )
 
         dump_yaml = PyYamlYamlModel.dump_and_load_yaml(main_yaml=main_yaml, resources=resources)
-        assert dump_yaml == yaml_resource.stream.getvalue()
+        assert dump_yaml == yaml_resource.read()
 
 
 def valid_ecalc_file(


### PR DESCRIPTION
Allowing str in resource stream allows for a simpler interface for a resource with a name and read function.