### PR TITLE
Revert "refactor: allow str in resource stream (#371)"

### DIFF
--- a/src/libecalc/presentation/yaml/yaml_entities.py
+++ b/src/libecalc/presentation/yaml/yaml_entities.py
@@ -34,12 +34,10 @@ class YamlTimeseriesResource:
 @dataclass
 class ResourceStream:
     name: str
-    stream: Union[TextIO, str]
+    stream: TextIO
 
     # Implement read to make resource behave as a stream.
     def read(self, *args, **kwargs):
-        if isinstance(self.stream, str):
-            return self.stream
         return self.stream.read(*args, **kwargs)
 
 

--- a/src/tests/ecalc_cli/test_app.py
+++ b/src/tests/ecalc_cli/test_app.py
@@ -710,7 +710,8 @@ class TestYamlFile:
 
         yaml_wrong_name = (Path("test.name.yaml")).absolute()
         yaml_reader = PyYamlYamlModel.YamlReader(loader=yaml.SafeLoader)
-        yaml_stream = ResourceStream(name=yaml_wrong_name.name, stream="")
+        stream = StringIO("")
+        yaml_stream = ResourceStream(name=yaml_wrong_name.name, stream=stream)
 
         with pytest.raises(EcalcError) as ee:
             yaml_reader.load(yaml_file=yaml_stream)

--- a/src/tests/libecalc/input/test_file_io.py
+++ b/src/tests/libecalc/input/test_file_io.py
@@ -269,7 +269,7 @@ class TestReadYaml:
         )
 
         dump_yaml = PyYamlYamlModel.dump_and_load_yaml(main_yaml=main_yaml, resources=resources)
-        assert dump_yaml == yaml_resource.read()
+        assert dump_yaml == yaml_resource.stream.getvalue()
 
 
 def valid_ecalc_file(


### PR DESCRIPTION
This reverts commit fe9f3f2008ee32f2a9614d4c88966e4c5e4831f6.

Overlooked the parameters given to read, i.e. size is passed to read but ignored for str type.