### PR TITLE
fix: get_max_rate for single/variable speed compressor trains

### DIFF
--- a/docs/docs/changelog/next.md
+++ b/docs/docs/changelog/next.md
@@ -15,6 +15,8 @@ sidebar_position: 1
 
 ## Fixes
 
+* Make sure that maximum standard rate calculations takes a potential maximum power constraint into account for single speed compressor trains and variable speed compressor trains. 
+
 
 ## Breaking changes
 

--- a/src/libecalc/core/models/compressor/train/utils/common.py
+++ b/src/libecalc/core/models/compressor/train/utils/common.py
@@ -10,6 +10,7 @@ from libecalc.core.models.compressor.train.utils.enthalpy_calculations import (
 OUTLET_PRESSURE_CONVERGENCE_TOLERANCE = 1e-2
 PRESSURE_CALCULATION_TOLERANCE = 1e-3
 POWER_CALCULATION_TOLERANCE = 1e-3
+RATE_CALCULATION_TOLERANCE = 1e-3
 
 
 def calculate_asv_corrected_rate(

--- a/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -21,7 +21,9 @@ from libecalc.core.models.compressor.train.types import (
     FluidStreamObjectForMultipleStreams,
 )
 from libecalc.core.models.compressor.train.utils.common import (
+    POWER_CALCULATION_TOLERANCE,
     PRESSURE_CALCULATION_TOLERANCE,
+    RATE_CALCULATION_TOLERANCE,
 )
 from libecalc.core.models.compressor.train.utils.numeric_methods import (
     find_root,
@@ -310,6 +312,19 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         train_result_for_minimum_speed = _calculate_train_result_given_rate_ps_speed(_speed=minimum_speed)
         train_result_for_maximum_speed = _calculate_train_result_given_rate_ps_speed(_speed=maximum_speed)
 
+        if not train_result_for_maximum_speed.is_valid:
+            # will not find valid result - the rate is above maximum rate, return invalid results at maximum speed
+            return train_result_for_maximum_speed
+        if not train_result_for_minimum_speed.is_valid:
+            # rate is above maximum rate for minimum speed. Find the lowest minimum speed which gives a valid result
+            minimum_speed = -maximize_x_given_boolean_condition_function(
+                x_min=-self.maximum_speed,
+                x_max=-self.minimum_speed,
+                bool_func=lambda x: _calculate_train_result_given_rate_ps_speed(_speed=-x).is_valid,
+            )
+            train_result_for_minimum_speed = _calculate_train_result_given_rate_ps_speed(_speed=minimum_speed)
+
+        # Solution 1, iterate on speed until target discharge pressure is found
         if (
             train_result_for_minimum_speed.discharge_pressure
             <= target_discharge_pressure
@@ -324,7 +339,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
 
             return _calculate_train_result_given_rate_ps_speed(_speed=speed)
 
-        # Or target pressure is too low:
+        # Solution 2, try pressure control mechanism or target pressure is too low:
         elif target_discharge_pressure < train_result_for_minimum_speed.discharge_pressure:
             if self.pressure_control:
                 return self.calculate_compressor_train_given_rate_ps_pd_speed(
@@ -338,7 +353,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
                     CompressorTrainCommonShaftFailureStatus.TARGET_DISCHARGE_PRESSURE_TOO_LOW
                 )
                 return train_result_for_minimum_speed
-        # Else target pressure is too high
+        # Solution 3, target discharge pressure is too high
         else:
             train_result_for_maximum_speed.failure_status = (
                 CompressorTrainCommonShaftFailureStatus.TARGET_DISCHARGE_PRESSURE_TOO_HIGH
@@ -597,13 +612,19 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
 
         min_std_rate_for_stream_m3_per_day_at_max_speed = self.streams[
             stream_to_maximize
-        ].fluid.mass_rate_to_standard_rate(mass_rate_kg_per_hour=min_mass_rate_kg_per_hr_at_max_speed)
+        ].fluid.mass_rate_to_standard_rate(mass_rate_kg_per_hour=min_mass_rate_kg_per_hr_at_max_speed) * (
+            1 + RATE_CALCULATION_TOLERANCE
+        )
         max_std_rate_for_stream_m3_per_day_at_max_speed = self.streams[
             stream_to_maximize
-        ].fluid.mass_rate_to_standard_rate(mass_rate_kg_per_hour=max_mass_rate_kg_per_hr_at_max_speed)
+        ].fluid.mass_rate_to_standard_rate(mass_rate_kg_per_hour=max_mass_rate_kg_per_hr_at_max_speed) * (
+            1 - RATE_CALCULATION_TOLERANCE
+        )
         max_std_rate_for_stream_m3_per_day_at_min_speed = self.streams[
             stream_to_maximize
-        ].fluid.mass_rate_to_standard_rate(mass_rate_kg_per_hour=max_mass_rate_kg_per_hr_at_min_speed)
+        ].fluid.mass_rate_to_standard_rate(mass_rate_kg_per_hour=max_mass_rate_kg_per_hr_at_min_speed) * (
+            1 - RATE_CALCULATION_TOLERANCE
+        )
 
         result_min_std_rate_for_stream_at_max_speed = _calculate_train_result_at_max_speed_given_std_rate_for_stream(
             std_rate_for_stream=min_std_rate_for_stream_m3_per_day_at_max_speed
@@ -682,63 +703,117 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
                 ).discharge_pressure
                 - target_discharge_pressure,
             )
-            return result_std_rate
+            rate_to_return = result_std_rate * (1 - RATE_CALCULATION_TOLERANCE)
 
         # Solution 3: If solution not found along max speed curve,
         # run at max_mass_rate, but using the defined pressure control.
-        elif self.data_transfer_object.pressure_control is not None:
-            std_rates_std_m3_per_day_per_stream[stream_to_maximize] = max_std_rate_m3_per_day_at_max_speed
-            if self.calculate_compressor_train_given_rate_ps_pd_speed(
+        elif (
+            self.data_transfer_object.pressure_control is not None
+            and self.calculate_compressor_train_given_rate_ps_pd_speed(
                 speed=self.maximum_speed,
                 inlet_pressure=suction_pressure,
                 outlet_pressure=target_discharge_pressure,
-                std_rates_std_m3_per_day_per_stream=std_rates_std_m3_per_day_per_stream,
-            ).is_valid:
-                return max_std_rate_m3_per_day_at_max_speed
-
-        # Ensuring that the maximum mass rate at min speed is valid for the whole train.
-        if not result_max_std_rate_for_stream_at_min_speed.is_valid:
-            max_std_rate_m3_per_day_at_min_speed = maximize_x_given_boolean_condition_function(
-                x_min=EPSILON,
-                x_max=max_std_rate_for_stream_m3_per_day_at_min_speed,
-                bool_func=lambda x: _calculate_train_result_at_min_speed_given_std_rate_for_stream(
-                    std_rate_for_stream=x
-                ).is_valid,
-            )
-            result_max_std_rate_at_min_speed = _calculate_train_result_at_min_speed_given_std_rate_for_stream(
-                std_rate_for_stream=max_std_rate_m3_per_day_at_min_speed
-            )
-        else:
-            # max_std_rate_m3_per_day_at_min_speed = max_std_rate_for_stream_m3_per_day_at_min_speed
-            result_max_std_rate_at_min_speed = result_max_std_rate_for_stream_at_min_speed
-
-        # Solution scenario 3. Solution at the "Stone wall".
-        if (
-            result_max_std_rate_at_max_speed.discharge_pressure
-            >= target_discharge_pressure
-            >= result_max_std_rate_at_min_speed.discharge_pressure
+                std_rates_std_m3_per_day_per_stream=np.asarray(
+                    [
+                        std_rates_std_m3_per_day_per_stream[i]
+                        if i != stream_to_maximize
+                        else max_std_rate_m3_per_day_at_max_speed
+                        for i, _ in enumerate(self.streams)
+                    ]
+                ),
+            ).is_valid
         ):
-            result_speed = find_root(
-                lower_bound=self.minimum_speed,
-                upper_bound=self.maximum_speed,
-                func=lambda x: _calculate_train_result_given_speed_at_stone_wall(speed=x)[1].discharge_pressure
-                - target_discharge_pressure,
-            )
-            max_valid_std_rate_m3_per_day, compressor_train_result = _calculate_train_result_given_speed_at_stone_wall(
-                speed=result_speed
-            )
+            rate_to_return = max_std_rate_m3_per_day_at_max_speed * (1 - RATE_CALCULATION_TOLERANCE)
 
-            return max_valid_std_rate_m3_per_day
-
-        # Solution scenario 4. Too high pressure even at min speed and max flow rate.
-        elif result_max_std_rate_at_min_speed.discharge_pressure > target_discharge_pressure:
-            # Todo: We could add additional functionality where the user can use to control what happens below
-            #    minimum speed, such as ASV, choke, etc.
-            return 0.0
+        # Solution scenario 4. Solution at the "Stone wall".
         else:
-            msg = "You should not end up here. Please contact eCalc support."
-            logger.exception(msg)
-            raise IllegalStateException(msg)
+            # Ensuring that the maximum mass rate at min speed is valid for the whole train.
+            if not result_max_std_rate_for_stream_at_min_speed.is_valid:
+                max_std_rate_m3_per_day_at_min_speed = maximize_x_given_boolean_condition_function(
+                    x_min=EPSILON,
+                    x_max=max_std_rate_for_stream_m3_per_day_at_min_speed,
+                    bool_func=lambda x: _calculate_train_result_at_min_speed_given_std_rate_for_stream(
+                        std_rate_for_stream=x
+                    ).is_valid,
+                )
+                result_max_std_rate_at_min_speed = _calculate_train_result_at_min_speed_given_std_rate_for_stream(
+                    std_rate_for_stream=max_std_rate_m3_per_day_at_min_speed
+                )
+            else:
+                # max_std_rate_m3_per_day_at_min_speed = max_std_rate_for_stream_m3_per_day_at_min_speed
+                result_max_std_rate_at_min_speed = result_max_std_rate_for_stream_at_min_speed
+
+            if (
+                result_max_std_rate_at_max_speed.discharge_pressure
+                >= target_discharge_pressure
+                >= result_max_std_rate_at_min_speed.discharge_pressure
+            ):
+                result_speed = find_root(
+                    lower_bound=self.minimum_speed,
+                    upper_bound=self.maximum_speed,
+                    func=lambda x: _calculate_train_result_given_speed_at_stone_wall(speed=x)[1].discharge_pressure
+                    - target_discharge_pressure,
+                )
+                (
+                    max_valid_std_rate_m3_per_day,
+                    compressor_train_result,
+                ) = _calculate_train_result_given_speed_at_stone_wall(speed=result_speed)
+
+                rate_to_return = max_valid_std_rate_m3_per_day * (1 - RATE_CALCULATION_TOLERANCE)
+
+            # Solution scenario 5. Too high pressure even at min speed and max flow rate.
+            elif result_max_std_rate_at_min_speed.discharge_pressure > target_discharge_pressure:
+                # Todo: We could add additional functionality where the user can use to control what happens below
+                #    minimum speed, such as ASV, choke, etc.
+                return 0.0
+            else:
+                msg = "You should not end up here. Please contact eCalc support."
+                logger.exception(msg)
+                raise IllegalStateException(msg)
+
+        # Check that rate_to_return, suction_pressure and discharge_pressure does not require too much power.
+        # If so, reduce rate such that power comes below maximum power
+        std_rates_std_m3_per_day_per_stream[stream_to_maximize] = rate_to_return
+        if not self.data_transfer_object.maximum_power:
+            return rate_to_return
+        elif (
+            self.evaluate_rate_ps_pd(
+                rate=np.asarray([std_rates_std_m3_per_day_per_stream]),
+                suction_pressure=np.asarray([suction_pressure]),
+                discharge_pressure=np.asarray([target_discharge_pressure]),
+            ).power_megawatt[0]
+            > self.data_transfer_object.maximum_power
+        ):
+            # check if minimum_rate gives too high power consumption
+            std_rates_std_m3_per_day_per_stream[stream_to_maximize] = EPSILON
+            result_with_minimum_rate = self.evaluate_rate_ps_pd(
+                rate=np.asarray([std_rates_std_m3_per_day_per_stream]),
+                suction_pressure=np.asarray([suction_pressure]),
+                discharge_pressure=np.asarray([target_discharge_pressure]),
+            )
+            if result_with_minimum_rate.power_megawatt[0] > self.data_transfer_object.maximum_power:
+                return 0.0  # can't find solution
+            else:
+                std_rate_with_maximum_power = find_root(
+                    lower_bound=result_with_minimum_rate.rate_sm3_day[stream_to_maximize],
+                    upper_bound=rate_to_return,
+                    func=lambda x: self.evaluate_rate_ps_pd(
+                        rate=np.asarray(
+                            [
+                                std_rates_std_m3_per_day_per_stream[i] if i != stream_to_maximize else x
+                                for i, _ in enumerate(self.streams)
+                            ]
+                        ),
+                        suction_pressure=np.asarray([suction_pressure]),
+                        discharge_pressure=np.asarray([target_discharge_pressure]),
+                    ).power[0]
+                    - self.data_transfer_object.maximum_power * (1 - POWER_CALCULATION_TOLERANCE),
+                    relative_convergence_tolerance=1e-3,
+                    maximum_number_of_iterations=20,
+                )
+                return std_rate_with_maximum_power
+        else:
+            return rate_to_return
 
     def evaluate_rate_ps_pint_pd(
         self,

--- a/src/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
+++ b/src/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
@@ -272,13 +272,13 @@ def test_find_and_calculate_for_compressor_shaft_speed_given_rate_ps_pd_invalid_
     )
     assert result.chart_area_status == ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE
 
-    # Target pressure too large
+    # Target pressure too large, but rate still too high
     result = variable_speed_compressor_train.calculate_shaft_speed_given_rate_ps_pd(
         mass_rate_kg_per_hour=mass_rate_kg_per_hour,
         suction_pressure=20,
         target_discharge_pressure=1000,
     )
-    assert result.failure_status == CompressorTrainCommonShaftFailureStatus.TARGET_DISCHARGE_PRESSURE_TOO_HIGH
+    assert result.failure_status == CompressorTrainCommonShaftFailureStatus.ABOVE_MAXIMUM_FLOW_RATE
 
     # Target pressure too low -> but still possible because of downstream choke. However, the rate is still too high.
     result = variable_speed_compressor_train.calculate_shaft_speed_given_rate_ps_pd(
@@ -287,7 +287,6 @@ def test_find_and_calculate_for_compressor_shaft_speed_given_rate_ps_pd_invalid_
         target_discharge_pressure=1,
     )
     assert result.chart_area_status == ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE
-    assert result.discharge_pressure == 1
     assert not result.is_valid
 
     # Rate is too large, but point is below stonewall, i.e. rate is too large for resulting speed, but not too large


### PR DESCRIPTION
Inside get_max_rate for variable speed compressor trains, we find the results for maximum speed and minimum speed for the shaft. If the target discharge pressure is between the discharge pressure at minimum speed and at maximum speed, we iterate on speed between the minimum and maximum speeds until a solution is found giving the correct target discharge pressure. There has been no check that the results and minimum and maximum speeds are actually valid. The result have ended up in situations where the results at minimum speed is invalid, and hence the final result also potentially end up as invalid (when in fact valid solutions exists). Also there has been no check to make sure that the found maximum standard rate requires less power than the maximum power defined for the compressor train.

This PR adds two things:

1. For variable speed compressor trains (including multiple streams and pressures), we find the minimum and maximum speeds that produce a valid result for the compressor train given rate and suction pressure. 
2. For single/variable speed compressor trains we make sure that the max rate is below maximum power

## Have you remembered and considered?

- [x] Update documentation, if relevant
- [x] Update manual changelog, if relevant
- [x] Update migration guide, if relevant
- [x] Tagged commit with `BREAKING:` in footer or `!` in header if breaking
- [x] Considered to add tests
- [x] Used conventional commits syntax
