### PR TITLE
Docs: added keyword MAXIMUM_POWER in eCalc YAML keyword list.

### DIFF
--- a/docs/docs/about/references/keywords/MAXIMUM_POWER.md
+++ b/docs/docs/about/references/keywords/MAXIMUM_POWER.md
@@ -1,0 +1,25 @@
+# MAXIMUM_POWER
+
+[MODELS](/about/references/keywords/MODELS.md) / 
+[MAXIMUM_POWER](/about/references/keywords/MAXIMUM_POWER.md)
+
+## Description
+
+`MAXIMUM_POWER` is an optional constand maximum power (MW) that the compressor train can provide.
+## Functionality
+
+ It is an optional setting and supported for compressor train models [SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN](/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md), [VARIABLE_SPEED_COMPRESSOR_TRAIN](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md), [VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md).
+
+## Format
+
+~~~~~~~~yaml
+MODELS:
+  - NAME: <model name>
+    TYPE: SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN
+    FLUID_MODEL: <reference to fluid model, must be defined in [MODELS]>
+    COMPRESSOR_TRAIN:
+    POWER_ADJUSTMENT_CONSTANT: <Optional constant MW adjustment added to the model>
+    MAXIMUM_POWER: <Optional constant MW maximum power the compressor train can require>
+    CALCULATE_MAX_RATE: <Optional. compressor train max standard rate [Sm3/day] in result if set to true. Default false. Use with caution. This will increase runtime significantly. >
+        ...
+~~~~~~~~

--- a/docs/docs/about/references/keywords/MAXIMUM_POWER.md
+++ b/docs/docs/about/references/keywords/MAXIMUM_POWER.md
@@ -8,7 +8,7 @@
 `MAXIMUM_POWER` is an optional constant giving the maximum power (MW) that the compressor train can use.
 ## Functionality
 
- It is an optional setting and supported for compressor train models [SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN](/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md), [VARIABLE_SPEED_COMPRESSOR_TRAIN](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md), [VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md).
+ It is an optional setting and supported for compressor train models [SINGLE_SPEED_COMPRESSOR_TRAIN](/about/modelling/setup/models/compressor_modelling/compressor_models_types/single_speed_compressor_train_model.md), [SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN](/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md), [VARIABLE_SPEED_COMPRESSOR_TRAIN](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md), [VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md).
 
 ## Format
 

--- a/docs/docs/about/references/keywords/MAXIMUM_POWER.md
+++ b/docs/docs/about/references/keywords/MAXIMUM_POWER.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-`MAXIMUM_POWER` is an optional constand maximum power (MW) that the compressor train can provide.
+`MAXIMUM_POWER` is an optional constant giving the maximum power (MW) that the compressor train can use.
 ## Functionality
 
  It is an optional setting and supported for compressor train models [SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN](/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md), [VARIABLE_SPEED_COMPRESSOR_TRAIN](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md), [VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md).


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed because a new keyword MAXIMUM_POWER was added in eCalc YAML keywords.

