### PR TITLE
chore: allow venting emitters without fuelconsumers

### DIFF
--- a/src/libecalc/application/graph_result.py
+++ b/src/libecalc/application/graph_result.py
@@ -145,13 +145,17 @@ class GraphResult:
                 ),  # Initial value, handle no power output from components
             )
 
-            energy_usage = reduce(
-                operator.add,
-                [
-                    TimeSeriesRate.from_timeseries_stream_day_rate(component.energy_usage, regularity=regularity)
-                    for component in sub_components
-                    if component.energy_usage.unit == Unit.STANDARD_CUBIC_METER_PER_DAY
-                ],
+            energy_usage = (
+                reduce(
+                    operator.add,
+                    [
+                        TimeSeriesRate.from_timeseries_stream_day_rate(component.energy_usage, regularity=regularity)
+                        for component in sub_components
+                        if component.energy_usage.unit == Unit.STANDARD_CUBIC_METER_PER_DAY
+                    ],
+                )
+                if sub_components
+                else 0
             )
 
             emission_dto_results = self.convert_to_timeseries(self.emission_results, regularity)
@@ -193,7 +197,7 @@ class GraphResult:
                         unit=Unit.NONE,
                     ),
                 )
-            )
+            ) if sub_components else None
         return installation_results
 
     def get_subgraph(self, node_id: str) -> "GraphResult":
@@ -1203,16 +1207,23 @@ class GraphResult:
 
             sub_components.append(obj)
 
+        regularity_emitters = TimeSeriesFloat(
+            values=[1] * self.variables_map.length,
+            unit=Unit.NONE,
+            timesteps=self.variables_map.time_vector,
+        )
+
+        venting_emitter_zero_rate = TimeSeriesRate(
+            values=[0] * self.variables_map.length,
+            timesteps=self.variables_map.time_vector,
+            unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
+            rate_type=RateType.CALENDAR_DAY,
+            regularity=[1] * self.variables_map.length,
+        )
+
         for installation in asset.installations:
-            regularity = regularities[installation.id]  # Already evaluated regularities
             for venting_emitter in installation.venting_emitters:
-                energy_usage = TimeSeriesRate(
-                    timesteps=self.variables_map.time_vector,
-                    values=[0.0] * self.variables_map.length,
-                    regularity=[1] * self.variables_map.length,  # Dummy. Has no effect since value is 0
-                    unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
-                    rate_type=RateType.CALENDAR_DAY,
-                )
+                energy_usage = venting_emitter_zero_rate
                 sub_components.append(
                     libecalc.dto.result.VentingEmitterResult(
                         id=venting_emitter.id,
@@ -1220,7 +1231,7 @@ class GraphResult:
                         componentType=venting_emitter.component_type,
                         component_level=ComponentLevel.CONSUMER,
                         parent=installation.id,
-                        emissions=self._parse_emissions(self.emission_results[venting_emitter.id], regularity),
+                        emissions=self._parse_emissions(self.emission_results[venting_emitter.id], regularity_emitters),
                         timesteps=self.variables_map.time_vector,
                         is_valid=TimeSeriesBoolean(
                             timesteps=self.variables_map.time_vector,
@@ -1233,27 +1244,41 @@ class GraphResult:
                 )
 
         # dto timeseries
-        asset_hydrocarbon_export_rate_core = reduce(
-            operator.add,
-            [installation.hydrocarbon_export_rate for installation in installation_results],
+        asset_hydrocarbon_export_rate_core = (
+            reduce(
+                operator.add,
+                [installation.hydrocarbon_export_rate for installation in installation_results],
+            )
+            if installation_results
+            else venting_emitter_zero_rate
         )
 
         emission_dto_results = self.convert_to_timeseries(
             self.emission_results,
-            regularities,
+            regularities if regularities else regularity_emitters,
         )
         asset_aggregated_emissions = aggregate_emissions(list(emission_dto_results.values()))
 
-        asset_power_core = reduce(
-            operator.add,
-            [installation.power for installation in installation_results if installation.power is not None],
+        asset_power_core = (
+            reduce(
+                operator.add,
+                [installation.power for installation in installation_results if installation.power is not None],
+            )
+            if installation_results
+            else None
         )
 
-        asset_power_cumulative = asset_power_core.to_volumes().to_unit(Unit.GIGA_WATT_HOURS).cumulative()
+        asset_power_cumulative = (
+            asset_power_core.to_volumes().to_unit(Unit.GIGA_WATT_HOURS).cumulative() if installation_results else None
+        )
 
-        asset_energy_usage_core = reduce(
-            operator.add,
-            [installation.energy_usage for installation in installation_results],
+        asset_energy_usage_core = (
+            reduce(
+                operator.add,
+                [installation.energy_usage for installation in installation_results],
+            )
+            if installation_results
+            else venting_emitter_zero_rate
         )
 
         asset_energy_usage_cumulative = asset_energy_usage_core.to_volumes().cumulative()
@@ -1267,7 +1292,9 @@ class GraphResult:
             timesteps=self.variables_map.time_vector,
             is_valid=TimeSeriesBoolean(
                 timesteps=self.variables_map.time_vector,
-                values=aggregate_is_valid(installation_results),
+                values=aggregate_is_valid(installation_results)
+                if installation_results
+                else [True] * self.variables_map.length,
                 unit=Unit.NONE,
             ),
             power=asset_power_core,
@@ -1279,7 +1306,9 @@ class GraphResult:
             emission_intensities=self._compute_intensity(
                 hydrocarbon_export_rate=asset_hydrocarbon_export_rate_core,
                 emissions=asset_aggregated_emissions,
-            ),
+            )
+            if installation_results
+            else [],
         )
 
         return libecalc.dto.result.EcalcModelResult(

--- a/src/libecalc/application/graph_result.py
+++ b/src/libecalc/application/graph_result.py
@@ -1213,7 +1213,7 @@ class GraphResult:
             timesteps=self.variables_map.time_vector,
         )
 
-        venting_emitter_zero_value = TimeSeriesRate(
+        time_series_zero = TimeSeriesRate(
             values=[0] * self.variables_map.length,
             timesteps=self.variables_map.time_vector,
             unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -1223,7 +1223,7 @@ class GraphResult:
 
         for installation in asset.installations:
             for venting_emitter in installation.venting_emitters:
-                energy_usage = venting_emitter_zero_value
+                energy_usage = time_series_zero
                 sub_components.append(
                     libecalc.dto.result.VentingEmitterResult(
                         id=venting_emitter.id,
@@ -1250,7 +1250,7 @@ class GraphResult:
                 [installation.hydrocarbon_export_rate for installation in installation_results],
             )
             if installation_results
-            else venting_emitter_zero_value
+            else time_series_zero
         )
 
         emission_dto_results = self.convert_to_timeseries(
@@ -1278,7 +1278,7 @@ class GraphResult:
                 [installation.energy_usage for installation in installation_results],
             )
             if installation_results
-            else venting_emitter_zero_value
+            else time_series_zero
         )
 
         asset_energy_usage_cumulative = asset_energy_usage_core.to_volumes().cumulative()

--- a/src/libecalc/application/graph_result.py
+++ b/src/libecalc/application/graph_result.py
@@ -1213,7 +1213,7 @@ class GraphResult:
             timesteps=self.variables_map.time_vector,
         )
 
-        venting_emitter_zero_rate = TimeSeriesRate(
+        venting_emitter_zero_value = TimeSeriesRate(
             values=[0] * self.variables_map.length,
             timesteps=self.variables_map.time_vector,
             unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
@@ -1223,7 +1223,7 @@ class GraphResult:
 
         for installation in asset.installations:
             for venting_emitter in installation.venting_emitters:
-                energy_usage = venting_emitter_zero_rate
+                energy_usage = venting_emitter_zero_value
                 sub_components.append(
                     libecalc.dto.result.VentingEmitterResult(
                         id=venting_emitter.id,
@@ -1250,7 +1250,7 @@ class GraphResult:
                 [installation.hydrocarbon_export_rate for installation in installation_results],
             )
             if installation_results
-            else venting_emitter_zero_rate
+            else venting_emitter_zero_value
         )
 
         emission_dto_results = self.convert_to_timeseries(
@@ -1278,7 +1278,7 @@ class GraphResult:
                 [installation.energy_usage for installation in installation_results],
             )
             if installation_results
-            else venting_emitter_zero_rate
+            else venting_emitter_zero_value
         )
 
         asset_energy_usage_cumulative = asset_energy_usage_core.to_volumes().cumulative()

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -368,8 +368,8 @@ class Installation(BaseComponent):
     def check_fuel_consumers_or_venting_emitters_exist(self):
         if not self.fuel_consumers and not self.venting_emitters and not self.generator_sets:
             raise ValueError(
-                f"Keywords are missing:\n It is required to specify at least one of the two keywords "
-                f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",
+                f"Keywords are missing:\n It is required to specify at least one of the keywords "
+                f"{EcalcYamlKeywords.fuel_consumers}, {EcalcYamlKeywords.generator_sets} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",
             )
         return self
 

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -366,7 +366,7 @@ class Installation(BaseComponent):
 
     @model_validator(mode="after")
     def check_fuel_consumers_or_venting_emitters_exist(self):
-        if not self.fuel_consumers and not self.venting_emitters:
+        if not self.fuel_consumers and not self.venting_emitters and not self.generator_sets:
             raise ValueError(
                 f"Keywords are missing:\n It is required to specify at least one of the two keywords "
                 f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -42,6 +42,7 @@ from libecalc.dto.utils.validators import (
 )
 from libecalc.dto.variables import VariablesMap
 from libecalc.expression import Expression
+from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingEmitter,
 )
@@ -362,6 +363,15 @@ class Installation(BaseComponent):
                 )
 
         return user_defined_category
+
+    @model_validator(mode="after")
+    def check_fuel_consumers_or_venting_emitters_exist(self, info: ValidationInfo):
+        if not self.fuel_consumers and not self.venting_emitters:
+            raise ValueError(
+                f"Keywords are missing:\n It is required to specify at least one of the two keywords "
+                f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",
+            )
+        return self
 
     def get_graph(self) -> ComponentGraph:
         graph = ComponentGraph()

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -373,8 +373,7 @@ class Installation(BaseComponent):
             raise ValueError(
                 f"Keywords are missing:\n It is required to specify at least one of the keywords "
                 f"{EcalcYamlKeywords.fuel_consumers}, {EcalcYamlKeywords.generator_sets} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",
-            )
-        # return self
+            ) from None
 
     def get_graph(self) -> ComponentGraph:
         graph = ComponentGraph()

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -366,12 +366,15 @@ class Installation(BaseComponent):
 
     @model_validator(mode="after")
     def check_fuel_consumers_or_venting_emitters_exist(self):
-        if not self.fuel_consumers and not self.venting_emitters and not self.generator_sets:
+        try:
+            if self.fuel_consumers or self.venting_emitters or self.generator_sets:
+                return self
+        except AttributeError:
             raise ValueError(
                 f"Keywords are missing:\n It is required to specify at least one of the keywords "
                 f"{EcalcYamlKeywords.fuel_consumers}, {EcalcYamlKeywords.generator_sets} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",
             )
-        return self
+        # return self
 
     def get_graph(self) -> ComponentGraph:
         graph = ComponentGraph()

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -365,7 +365,7 @@ class Installation(BaseComponent):
         return user_defined_category
 
     @model_validator(mode="after")
-    def check_fuel_consumers_or_venting_emitters_exist(self, info: ValidationInfo):
+    def check_fuel_consumers_or_venting_emitters_exist(self):
         if not self.fuel_consumers and not self.venting_emitters:
             raise ValueError(
                 f"Keywords are missing:\n It is required to specify at least one of the two keywords "

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -42,7 +42,6 @@ from libecalc.dto.utils.validators import (
 )
 from libecalc.dto.variables import VariablesMap
 from libecalc.expression import Expression
-from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingEmitter,
 )
@@ -363,15 +362,6 @@ class Installation(BaseComponent):
                 )
 
         return user_defined_category
-
-    @field_validator("fuel_consumers", mode="before")
-    def check_fuel_consumers_exist(cls, fuel_consumers):
-        if not fuel_consumers:
-            raise ValueError(
-                f"Keywords are missing:\n It is required to specify at least one of the two keywords "
-                f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.generator_sets} in the model.",
-            )
-        return fuel_consumers
 
     def get_graph(self) -> ComponentGraph:
         graph = ComponentGraph()

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
@@ -1,7 +1,6 @@
 from typing import List, Union
 
 from pydantic import ConfigDict, Field, model_validator
-from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import Annotated
 
 from libecalc.common.discriminator_fallback import DiscriminatorWithFallback
@@ -81,7 +80,7 @@ class YamlInstallation(YamlBase):  # TODO: conditional required, either fuelcons
     )
 
     @model_validator(mode="after")
-    def check_fuel_consumers_or_venting_emitters_exist(self, info: ValidationInfo):
+    def check_fuel_consumers_or_venting_emitters_exist(self):
         if not self.fuel_consumers and not self.venting_emitters:
             raise ValueError(
                 f"Keywords are missing:\n It is required to specify at least one of the two keywords "

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
@@ -81,7 +81,7 @@ class YamlInstallation(YamlBase):  # TODO: conditional required, either fuelcons
 
     @model_validator(mode="after")
     def check_fuel_consumers_or_venting_emitters_exist(self):
-        if not self.fuel_consumers and not self.venting_emitters:
+        if not self.fuel_consumers and not self.venting_emitters and not self.generator_sets:
             raise ValueError(
                 f"Keywords are missing:\n It is required to specify at least one of the two keywords "
                 f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
@@ -88,4 +88,4 @@ class YamlInstallation(YamlBase):  # TODO: conditional required, either fuelcons
             raise ValueError(
                 f"Keywords are missing:\n It is required to specify at least one of the keywords "
                 f"{EcalcYamlKeywords.fuel_consumers}, {EcalcYamlKeywords.generator_sets} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",
-            )
+            ) from None

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
@@ -81,9 +81,11 @@ class YamlInstallation(YamlBase):  # TODO: conditional required, either fuelcons
 
     @model_validator(mode="after")
     def check_fuel_consumers_or_venting_emitters_exist(self):
-        if not self.fuel_consumers and not self.venting_emitters and not self.generator_sets:
+        try:
+            if self.fuel_consumers or self.venting_emitters or self.generator_sets:
+                return self
+        except AttributeError:
             raise ValueError(
                 f"Keywords are missing:\n It is required to specify at least one of the keywords "
                 f"{EcalcYamlKeywords.fuel_consumers}, {EcalcYamlKeywords.generator_sets} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",
             )
-        return self

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_installation.py
@@ -83,7 +83,7 @@ class YamlInstallation(YamlBase):  # TODO: conditional required, either fuelcons
     def check_fuel_consumers_or_venting_emitters_exist(self):
         if not self.fuel_consumers and not self.venting_emitters and not self.generator_sets:
             raise ValueError(
-                f"Keywords are missing:\n It is required to specify at least one of the two keywords "
-                f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",
+                f"Keywords are missing:\n It is required to specify at least one of the keywords "
+                f"{EcalcYamlKeywords.fuel_consumers}, {EcalcYamlKeywords.generator_sets} or {EcalcYamlKeywords.installation_venting_emitters} in the model.",
             )
         return self

--- a/src/tests/libecalc/dto/test_categories.py
+++ b/src/tests/libecalc/dto/test_categories.py
@@ -146,6 +146,21 @@ class TestCategories:
         assert dto.types.FuelType(name="test").user_defined_category is None
 
     def test_installation_categories(self):
+        # Installation-dto requires either fuelconsumers or venting emitters to be set, hence use dummy fuelconsumer:
+        fuel_type = dto.types.FuelType(name="fuel-gas", emissions=[])
+        fuel_consumer = dto.FuelConsumer(
+            name="Fuel consumer 1",
+            user_defined_category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.MISCELLANEOUS},
+            fuel={datetime(1900, 1, 1): fuel_type},
+            energy_usage_model={
+                datetime(1900, 1, 1): dto.models.direct.DirectConsumerFunction(
+                    fuel_rate=Expression.setup_from_expression(0), energy_usage_type=EnergyUsageType.FUEL
+                )
+            },
+            regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
+            component_type=ComponentType.GENERIC,
+        )
+
         # Check that illegal category raises error
         with pytest.raises(ValidationError) as exc_info:
             dto.components.Installation(
@@ -195,6 +210,7 @@ class TestCategories:
                 user_defined_category=InstallationUserDefinedCategoryType.MOBILE,
                 hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression(0)},
                 regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
+                fuel_consumers=[fuel_consumer],
             ).user_defined_category
             == InstallationUserDefinedCategoryType.MOBILE
         )
@@ -206,6 +222,7 @@ class TestCategories:
                 user_defined_category=InstallationUserDefinedCategoryType.FIXED,
                 hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression(0)},
                 regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
+                fuel_consumers=[fuel_consumer],
             ).user_defined_category
             == InstallationUserDefinedCategoryType.FIXED
         )
@@ -216,6 +233,7 @@ class TestCategories:
                 name="test",
                 hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression(0)},
                 regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
+                fuel_consumers=[fuel_consumer],
             ).user_defined_category
             is None
         )

--- a/src/tests/libecalc/dto/test_categories.py
+++ b/src/tests/libecalc/dto/test_categories.py
@@ -145,21 +145,8 @@ class TestCategories:
         # Check that not defining category is ok
         assert dto.types.FuelType(name="test").user_defined_category is None
 
-    def test_installation_categories(self):
+    def test_installation_categories(self, flare):
         # Installation-dto requires either fuelconsumers or venting emitters to be set, hence use dummy fuelconsumer:
-        fuel_type = dto.types.FuelType(name="fuel-gas", emissions=[])
-        fuel_consumer = dto.FuelConsumer(
-            name="Fuel consumer 1",
-            user_defined_category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.MISCELLANEOUS},
-            fuel={datetime(1900, 1, 1): fuel_type},
-            energy_usage_model={
-                datetime(1900, 1, 1): dto.models.direct.DirectConsumerFunction(
-                    fuel_rate=Expression.setup_from_expression(0), energy_usage_type=EnergyUsageType.FUEL
-                )
-            },
-            regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
-            component_type=ComponentType.GENERIC,
-        )
 
         # Check that illegal category raises error
         with pytest.raises(ValidationError) as exc_info:
@@ -210,7 +197,7 @@ class TestCategories:
                 user_defined_category=InstallationUserDefinedCategoryType.MOBILE,
                 hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression(0)},
                 regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
-                fuel_consumers=[fuel_consumer],
+                fuel_consumers=[flare],
             ).user_defined_category
             == InstallationUserDefinedCategoryType.MOBILE
         )
@@ -222,7 +209,7 @@ class TestCategories:
                 user_defined_category=InstallationUserDefinedCategoryType.FIXED,
                 hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression(0)},
                 regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
-                fuel_consumers=[fuel_consumer],
+                fuel_consumers=[flare],
             ).user_defined_category
             == InstallationUserDefinedCategoryType.FIXED
         )
@@ -233,7 +220,7 @@ class TestCategories:
                 name="test",
                 hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression(0)},
                 regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
-                fuel_consumers=[fuel_consumer],
+                fuel_consumers=[flare],
             ).user_defined_category
             is None
         )

--- a/src/tests/libecalc/dto/test_installation.py
+++ b/src/tests/libecalc/dto/test_installation.py
@@ -5,12 +5,12 @@ from libecalc.expression import Expression
 
 
 class TestInstallation:
-    def test_valid(self):
+    def test_valid(self, flare):
         installation_dto = dto.Installation(
             name="test",
             regularity={datetime(1900, 1, 1): Expression.setup_from_expression("sim;var")},
             hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression("sim1;var1")},
-            # fuel_consumers=[],
+            fuel_consumers=[flare],
         )
         assert installation_dto.hydrocarbon_export == {
             datetime(1900, 1, 1): Expression.setup_from_expression(value="sim1;var1"),

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -332,8 +332,8 @@ def test_no_emitters_or_fuelconsumers():
         )
 
     assert (
-        f"Keywords are missing:\n It is required to specify at least one of the two keywords "
-        f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.installation_venting_emitters} "
+        f"\nminimal_installation:\nValue error, Keywords are missing:\n It is required to specify at least one of the keywords "
+        f"{EcalcYamlKeywords.fuel_consumers}, {EcalcYamlKeywords.generator_sets} or {EcalcYamlKeywords.installation_venting_emitters} "
         f"in the model."
     ) in str(ee.value)
 

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -39,6 +39,8 @@ from libecalc.fixtures.cases.venting_emitters.venting_emitter_yaml import (
     venting_emitter_yaml_factory,
 )
 from libecalc.presentation.exporter.configs.configs import LTPConfig
+from libecalc.presentation.yaml.validation_errors import DtoValidationError
+from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 
 time_vector_installation = [
     datetime(2027, 1, 1),
@@ -231,27 +233,27 @@ def test_venting_emitters():
     variables = dto.VariablesMap(time_vector=time_vector, variables={})
 
     installation_sd_kg_per_day = venting_emitter_yaml_factory(
-        emission_rate=emission_rate,
+        emission_rates=[emission_rate],
         regularity=regularity,
-        unit=Unit.KILO_PER_DAY,
-        emission_name="ch4",
-        rate_type=RateType.STREAM_DAY,
+        units=[Unit.KILO_PER_DAY],
+        emission_names=["ch4"],
+        rate_types=[RateType.STREAM_DAY],
     )
 
     installation_sd_tons_per_day = venting_emitter_yaml_factory(
-        emission_rate=emission_rate,
+        emission_rates=[emission_rate],
         regularity=regularity,
-        rate_type=RateType.STREAM_DAY,
-        unit=Unit.TONS_PER_DAY,
-        emission_name="ch4",
+        rate_types=[RateType.STREAM_DAY],
+        units=[Unit.TONS_PER_DAY],
+        emission_names=["ch4"],
     )
 
     installation_cd_kg_per_day = venting_emitter_yaml_factory(
-        emission_rate=emission_rate,
+        emission_rates=[emission_rate],
         regularity=regularity,
-        rate_type=RateType.CALENDAR_DAY,
-        unit=Unit.KILO_PER_DAY,
-        emission_name="ch4",
+        rate_types=[RateType.CALENDAR_DAY],
+        units=[Unit.KILO_PER_DAY],
+        emission_names=["ch4"],
     )
 
     ltp_result_input_sd_kg_per_day = get_consumption(model=installation_sd_kg_per_day, variables=variables)
@@ -281,6 +283,59 @@ def test_venting_emitters():
 
     # Verify that results is independent of regularity, when input rate is in calendar days
     assert emission_input_cd_kg_per_day == (emission_rate / 1000) * 365
+
+
+def test_only_venting_emitters_no_fuelconsumers():
+    """
+    Test that it is possible with only venting emitters, without fuelconsumers.
+    """
+    time_vector = [
+        datetime(2027, 1, 1),
+        datetime(2028, 1, 1),
+    ]
+    regularity = 0.2
+    emission_rate = 10
+
+    variables = dto.VariablesMap(time_vector=time_vector, variables={})
+
+    installation_venting_emitters = venting_emitter_yaml_factory(
+        emission_rates=[emission_rate],
+        regularity=regularity,
+        units=[Unit.KILO_PER_DAY],
+        emission_names=["ch4"],
+        rate_types=[RateType.STREAM_DAY],
+        include_emitters=True,
+        include_fuel_consumers=False,
+    )
+    venting_emitter_results = get_consumption(model=installation_venting_emitters, variables=variables)
+    emissions_ch4 = get_sum_ltp_column(venting_emitter_results, installation_nr=0, ltp_column_nr=0)
+    assert emissions_ch4 == (emission_rate / 1000) * 365 * regularity
+
+
+def test_no_emitters_or_fuelconsumers():
+    """
+    Test that eCalc returns error when neither fuelconsumers or venting emitters are specified.
+    """
+
+    regularity = 0.2
+    emission_rate = 10
+
+    with pytest.raises(DtoValidationError) as ee:
+        venting_emitter_yaml_factory(
+            emission_rates=[emission_rate],
+            regularity=regularity,
+            units=[Unit.KILO_PER_DAY],
+            emission_names=["ch4"],
+            rate_types=[RateType.STREAM_DAY],
+            include_emitters=False,
+            include_fuel_consumers=False,
+        )
+
+    assert (
+        f"Keywords are missing:\n It is required to specify at least one of the two keywords "
+        f"{EcalcYamlKeywords.fuel_consumers} or {EcalcYamlKeywords.installation_venting_emitters} "
+        f"in the model."
+    ) in str(ee.value)
 
 
 def test_total_oil_loaded():

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter_validation_errors.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter_validation_errors.py
@@ -15,13 +15,13 @@ def test_wrong_keyword_name_emitters():
 
     with pytest.raises(DtoValidationError) as exc:
         venting_emitter_yaml_factory(
-            emission_rate=emission_rate,
+            emission_rates=[emission_rate],
             regularity=regularity,
-            unit=Unit.KILO_PER_DAY,
-            emission_name="ch4",
-            rate_type=RateType.STREAM_DAY,
+            units=[Unit.KILO_PER_DAY],
+            emission_names=["ch4"],
+            rate_types=[RateType.STREAM_DAY],
             emission_keyword_name="EMISSION2",
-            name="Venting emitter 1",
+            names=["Venting emitter 1"],
         )
 
     assert "Venting emitter 1:\nEMISSION:\tThis keyword is missing, it is required" in str(exc.value)
@@ -36,13 +36,13 @@ def test_wrong_unit_emitters():
 
     with pytest.raises(DtoValidationError) as exc:
         venting_emitter_yaml_factory(
-            emission_rate=emission_rate,
+            emission_rates=[emission_rate],
             regularity=regularity,
-            unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
-            emission_name="ch4",
-            rate_type=RateType.STREAM_DAY,
+            units=[Unit.STANDARD_CUBIC_METER_PER_DAY],
+            emission_names=["ch4"],
+            rate_types=[RateType.STREAM_DAY],
             emission_keyword_name="EMISSION",
-            name="Venting emitter 1",
+            names=["Venting emitter 1"],
         )
 
     assert "Venting emitter 1:\nInput should be <Unit.KILO_PER_DAY: 'kg/d'> or <Unit.TONS_PER_DAY: 't/d'>" in str(


### PR DESCRIPTION
## Why is this pull request needed?

eCalc will fail if one of the keywords `GENERATORSETS` or `FUELCONSUMERS` is missing. Hence, it is not possible to have a model with only `VENTING_EMITTERS`.

## What does this pull request change?

Modify graph_result to accept a model with `VENTING_EMITTERS` only. 

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-772?atlOrigin=eyJpIjoiNjkyMjQ1YmZmMjI4NDAyZjhjMGRlZjc2YmJlY2NlMTAiLCJwIjoiaiJ9