### PR TITLE
fix: do not allow for negative recirculation if rate is above max flo…

### DIFF
--- a/src/libecalc/core/models/compressor/train/single_speed_compressor_train_common_shaft.py
+++ b/src/libecalc/core/models/compressor/train/single_speed_compressor_train_common_shaft.py
@@ -486,9 +486,10 @@ class SingleSpeedCompressorTrainCommonShaft(CompressorTrainModel):
             train_result_for_minimum_asv_rate_fraction = _calculate_train_result_given_asv_rate_margin(
                 asv_rate_fraction=minimum_asv_fraction
             )
-            if outlet_pressure_train_bara > train_result_for_minimum_asv_rate_fraction.discharge_pressure:
+            if (
+                train_result_for_minimum_asv_rate_fraction.chart_area_status == ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE
+            ) or (outlet_pressure_train_bara > train_result_for_minimum_asv_rate_fraction.discharge_pressure):
                 return train_result_for_minimum_asv_rate_fraction
-
             train_result_for_maximum_asv_rate_fraction = _calculate_train_result_given_asv_rate_margin(
                 asv_rate_fraction=maximum_asv_fraction
             )

--- a/src/libecalc/core/models/compressor/train/stage.py
+++ b/src/libecalc/core/models/compressor/train/stage.py
@@ -127,13 +127,14 @@ class CompressorTrainStage(BaseModel):
             if isinstance(self.compressor_chart, VariableSpeedCompressorChart)
             else self.compressor_chart.maximum_rate
         )
+        available_capacity_for_actual_rate_m3_per_hour = max(
+            0, compressor_maximum_actual_rate_m3_per_hour - actual_rate_m3_per_hour
+        )  #  if the actual_rate_m3_per_hour is above capacity, the available capacity should be zero, not negative
 
         additional_rate_m3_per_hour = 0.0
         # Add contribution from asv_rate_fraction (potentially used for pressure control)
         if asv_rate_fraction:
-            additional_rate_m3_per_hour = asv_rate_fraction * (
-                compressor_maximum_actual_rate_m3_per_hour - actual_rate_m3_per_hour
-            )
+            additional_rate_m3_per_hour = asv_rate_fraction * available_capacity_for_actual_rate_m3_per_hour
         # Add contribution from asv_additional_mass_rate (potentially used for pressure control)
         if asv_additional_mass_rate:
             additional_rate_m3_per_hour = asv_additional_mass_rate / inlet_density_kg_per_m3

--- a/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft.py
+++ b/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft.py
@@ -664,7 +664,15 @@ class VariableSpeedCompressorTrainCommonShaft(CompressorTrainModel):
                 train_results.stage_results[-1] = choked_stage_results
 
         elif self.pressure_control == FixedSpeedPressureControl.INDIVIDUAL_ASV_RATE:
-            # first check if full recirculation gives low enough discharge pressure
+            # first check if there is room for recirculation
+            train_result_no_recirculation = self.calculate_compressor_train_given_rate_ps_speed(
+                mass_rate_kg_per_hour=mass_rate_kg_per_hour,
+                inlet_pressure_bara=inlet_pressure,
+                speed=speed,
+            )
+            if not train_result_no_recirculation.within_capacity:
+                return train_result_no_recirculation
+            # then check if full recirculation gives low enough discharge pressure
             train_result_max_recirculation = self.calculate_compressor_train_given_rate_ps_speed(
                 mass_rate_kg_per_hour=mass_rate_kg_per_hour,
                 inlet_pressure_bara=inlet_pressure,

--- a/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -1131,7 +1131,15 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
                 train_results.stage_results[-1] = choked_stage_results
 
         elif self.pressure_control == FixedSpeedPressureControl.INDIVIDUAL_ASV_RATE:
-            # first check if full recirculation gives low enough discharge pressure
+            # first check if there is room for recirculation
+            train_result_no_recirculation = self.calculate_compressor_train_given_rate_ps_speed(
+                std_rates_std_m3_per_day_per_stream=std_rates_std_m3_per_day_per_stream,
+                inlet_pressure_bara=inlet_pressure,
+                speed=speed,
+            )
+            if not train_result_no_recirculation.within_capacity:
+                return train_result_no_recirculation
+            # then check if full recirculation gives low enough discharge pressure
             train_result_max_recirculation = self.calculate_compressor_train_given_rate_ps_speed(
                 std_rates_std_m3_per_day_per_stream=std_rates_std_m3_per_day_per_stream,
                 inlet_pressure_bara=inlet_pressure,


### PR DESCRIPTION
…w rate for a compressor chart

## Why is this pull request needed?

The code currently allows for negative available capacity when checking how much room there is for recirculation in evaluation of a compressor stage. If the compressor stage is out of capacity already, the available capacity should of course be zero.
