### PR TITLE
chore!: add TYPE and multiple emissions for venting emitters

### DIFF
--- a/src/libecalc/application/energy_calculator.py
+++ b/src/libecalc/application/energy_calculator.py
@@ -186,7 +186,6 @@ class EnergyCalculator:
                         name=consumer_dto.name,
                         timesteps=variables_map.time_vector,
                         rate=emission_rate[1],
-                        emission_rate_to_volume_factor=consumer_dto.emission.emission_rate_to_volume_factor,
                     )
                     venting_emitter_results[emission_rate[0]] = emission_result
                 emission_results[consumer_dto.id] = venting_emitter_results

--- a/src/libecalc/application/energy_calculator.py
+++ b/src/libecalc/application/energy_calculator.py
@@ -177,16 +177,16 @@ class EnergyCalculator:
                 installation = self._graph.get_node(installation_id)
 
                 venting_emitter_results = {}
-                emission_rates = consumer_dto.get_emission_rate(
+                emission_rates = consumer_dto.get_emission_rates(
                     variables_map=variables_map, regularity=installation.regularity
                 )
 
-                for emission_rate in emission_rates.items():
+                for emission_name, emission_rate in emission_rates.items():
                     emission_result = EmissionResult(
-                        name=consumer_dto.name,
+                        name=emission_name,
                         timesteps=variables_map.time_vector,
-                        rate=emission_rate[1],
+                        rate=emission_rate,
                     )
-                    venting_emitter_results[emission_rate[0]] = emission_result
+                    venting_emitter_results[emission_name] = emission_result
                 emission_results[consumer_dto.id] = venting_emitter_results
         return Numbers.format_results_to_precision(emission_results, precision=6)

--- a/src/libecalc/application/energy_calculator.py
+++ b/src/libecalc/application/energy_calculator.py
@@ -176,17 +176,18 @@ class EnergyCalculator:
                 installation_id = self._graph.get_parent_installation_id(consumer_dto.id)
                 installation = self._graph.get_node(installation_id)
 
-                emission_rate = consumer_dto.get_emission_rate(
+                venting_emitter_results = {}
+                emission_rates = consumer_dto.get_emission_rate(
                     variables_map=variables_map, regularity=installation.regularity
                 )
 
-                emission_result = {
-                    consumer_dto.emission.name: EmissionResult(
+                for emission_rate in emission_rates.items():
+                    emission_result = EmissionResult(
                         name=consumer_dto.name,
                         timesteps=variables_map.time_vector,
-                        rate=emission_rate,
+                        rate=emission_rate[1],
                         emission_rate_to_volume_factor=consumer_dto.emission.emission_rate_to_volume_factor,
                     )
-                }
-                emission_results[consumer_dto.id] = emission_result
+                    venting_emitter_results[emission_rate[0]] = emission_result
+                emission_results[consumer_dto.id] = venting_emitter_results
         return Numbers.format_results_to_precision(emission_results, precision=6)

--- a/src/libecalc/core/result/emission.py
+++ b/src/libecalc/core/result/emission.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional
+from typing import List
 
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import TimeSeriesStreamDayRate
@@ -14,7 +14,6 @@ class EmissionResult(EcalcResultBaseModel):
     name: str
     timesteps: List[datetime]
     rate: TimeSeriesStreamDayRate  # ton/day
-    emission_rate_to_volume_factor: Optional[float] = None
 
     @classmethod
     def create_empty(cls, name: str, timesteps: List[datetime]):

--- a/src/libecalc/fixtures/cases/all_energy_usage_models/all_models_dto.py
+++ b/src/libecalc/fixtures/cases/all_energy_usage_models/all_models_dto.py
@@ -15,6 +15,7 @@ from libecalc.fixtures.case_types import DTOCase
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingEmission,
     YamlVentingEmitter,
+    YamlVentingType,
 )
 from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
     YamlEmissionRate,
@@ -983,10 +984,13 @@ def methane_venting(regularity) -> YamlVentingEmitter:
     return YamlVentingEmitter(
         name="methane_venting",
         category=ConsumerUserDefinedCategoryType.COLD_VENTING_FUGITIVE,
-        emission=YamlVentingEmission(
-            name="CH4",
-            rate=YamlEmissionRate(value="FLARE;METHANE_RATE", unit=Unit.KILO_PER_DAY, type=RateType.STREAM_DAY),
-        ),
+        type=YamlVentingType.DIRECT_EMISSION,
+        emissions=[
+            YamlVentingEmission(
+                name="CH4",
+                rate=YamlEmissionRate(value="FLARE;METHANE_RATE", unit=Unit.KILO_PER_DAY, type=RateType.STREAM_DAY),
+            )
+        ],
     )
 
 

--- a/src/libecalc/fixtures/cases/all_energy_usage_models/data/all_energy_usage_models.yaml
+++ b/src/libecalc/fixtures/cases/all_energy_usage_models/data/all_energy_usage_models.yaml
@@ -616,9 +616,10 @@ INSTALLATIONS:
     VENTING_EMITTERS:
       - NAME: methane_venting
         CATEGORY: COLD-VENTING-FUGITIVE
-        EMISSION:
-          NAME: CH4
-          RATE:
-            VALUE: FLARE;METHANE_RATE
-            UNIT: kg/d
-            TYPE: STREAM_DAY
+        TYPE: DIRECT_EMISSION
+        EMISSIONS:
+          - NAME: CH4
+            RATE:
+              VALUE: FLARE;METHANE_RATE
+              UNIT: kg/d
+              TYPE: STREAM_DAY

--- a/src/libecalc/fixtures/cases/ltp_export/utilities.py
+++ b/src/libecalc/fixtures/cases/ltp_export/utilities.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from typing import List, Union
+
+from libecalc import dto
+from libecalc.application.energy_calculator import EnergyCalculator
+from libecalc.application.graph_result import GraphResult
+from libecalc.common.time_utils import Frequency
+from libecalc.presentation.exporter.configs.configs import LTPConfig
+
+
+def get_consumption(
+    model: Union[dto.Installation, dto.Asset], variables: dto.VariablesMap, time_vector: List[datetime]
+):
+    model = model
+    graph = model.get_graph()
+    energy_calculator = EnergyCalculator(graph=graph)
+
+    consumer_results = energy_calculator.evaluate_energy_usage(variables)
+    emission_results = energy_calculator.evaluate_emissions(variables, consumer_results)
+
+    graph_result = GraphResult(
+        graph=graph,
+        variables_map=variables,
+        consumer_results=consumer_results,
+        emission_results=emission_results,
+    )
+
+    ltp_filter = LTPConfig.filter(frequency=Frequency.YEAR)
+    ltp_result = ltp_filter.filter(graph_result, time_vector)
+
+    return ltp_result
+
+
+def get_sum_ltp_column(ltp_result, installation_nr, ltp_column_nr) -> float:
+    ltp_sum = sum(
+        float(v) for (k, v) in ltp_result.query_results[installation_nr].query_results[ltp_column_nr].values.items()
+    )
+    return ltp_sum

--- a/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
+++ b/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
@@ -7,27 +7,47 @@ from libecalc.common.utils.rates import RateType
 from libecalc.dto import Asset
 from libecalc.presentation.yaml.model import PyYamlYamlModel
 from libecalc.presentation.yaml.parse_input import map_yaml_to_dto
+from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
+    YamlVentingType,
+)
 
 
 def venting_emitter_yaml_factory(
-    emission_rates: List[float],
     rate_types: List[RateType],
     units: List[Unit],
     emission_names: List[str],
     regularity: float,
+    names: List[str],
+    emission_rates: List[float] = None,
     emitter_types: List[str] = None,
     categories: List[str] = None,
     emission_keyword_name: str = "EMISSIONS",
-    names: List[str] = None,
+    emission_factors: List[float] = None,
+    oil_rates: List[float] = None,
+    units_oil_rates: List[Unit] = None,
     include_emitters: bool = True,
     include_fuel_consumers: bool = True,
 ) -> Asset:
     if categories is None:
-        categories = ["STORAGE"]
-    if names is None:
-        names = ["Venting emitter 1"]
+        categories = ["STORAGE"] * len(names)
     if emitter_types is None:
-        emitter_types = ["DIRECT_EMISSION"]
+        emitter_types = ["DIRECT_EMISSION"] * len(names)
+    if emission_factors is None:
+        emission_factors = [0.1] * len(emission_names)
+    if oil_rates is None:
+        oil_rates = [10] * len(names)
+    if units_oil_rates is None:
+        units_oil_rates = [Unit.KILO_PER_DAY] * len(names)
+    if emission_rates is None:
+        emission_rates = [10] * len(names)
+
+    f"""
+        {create_venting_emitters_yaml(
+        categories=categories, rate_types=rate_types, emitter_names=names, emission_names=emission_names,
+        emission_rates=emission_rates, units=units, emission_keyword_name=emission_keyword_name, include_emitters=include_emitters,
+        emitter_types=emitter_types, oil_rates=oil_rates, emission_factors=emission_factors, units_oil_rates=units_oil_rates,
+    )}
+    """
 
     input_text = f"""
         FUEL_TYPES:
@@ -51,7 +71,7 @@ def venting_emitter_yaml_factory(
           {create_venting_emitters_yaml(
         categories=categories, rate_types=rate_types, emitter_names=names, emission_names=emission_names,
         emission_rates=emission_rates, units=units, emission_keyword_name=emission_keyword_name, include_emitters=include_emitters,
-        emitter_types=emitter_types,
+        emitter_types=emitter_types, oil_rates=oil_rates, emission_factors=emission_factors, units_oil_rates=units_oil_rates,
     )}
 
         """
@@ -88,7 +108,10 @@ def create_venting_emitters_yaml(
     emission_names: List[str],
     emission_rates: List[float],
     units: List[Unit],
+    units_oil_rates: List[Unit],
     emission_keyword_name: str,
+    emission_factors: List[float],
+    oil_rates: List[float],
     include_emitters: bool,
     emitter_types: List[str],
 ) -> str:
@@ -96,25 +119,48 @@ def create_venting_emitters_yaml(
         return ""
     else:
         emitters = "VENTING_EMITTERS:"
-        for category, rate_type, emitter_name, emission_name, emission_rate, unit, emitter_type in zip(
+        for category, rate_type, emitter_name, emitter_type, oil_rate, unit_oil_rate in zip(
             categories,
             rate_types,
             emitter_names,
-            emission_names,
-            emission_rates,
-            units,
             emitter_types,
+            oil_rates,
+            units_oil_rates,
         ):
+            emissions = ""
+            if emitter_type == YamlVentingType.DIRECT_EMISSION.name:
+                emission_keyword = emission_keyword_name
+                for emission_name, emission_rate, unit in zip(emission_names, emission_rates, units):
+                    emission = f"""
+                    - NAME: {emission_name}
+                      RATE:
+                        VALUE: {emission_rate}
+                        UNIT:  {unit}
+                        TYPE: {rate_type}
+                    """
+                    emissions = emissions + emission
+            else:
+                emission_keyword = "VOLUME"
+                emissions = f"""
+                RATE:
+                  VALUE: {oil_rate}
+                  UNIT: {unit_oil_rate}
+                  TYPE: {rate_type}
+                EMISSIONS:
+                """
+                for emission_name, emission_factor in zip(emission_names, emission_factors):
+                    emission = f"""
+                    - NAME: {emission_name}
+                      EMISSION_FACTOR: {emission_factor}
+                    """
+                    emissions = emissions + emission
+
             emitter = f"""
             - NAME: {emitter_name}
               CATEGORY: {category}
               TYPE: {emitter_type}
-              {emission_keyword_name}:
-                - NAME: {emission_name}
-                  RATE:
-                    VALUE: {emission_rate}
-                    UNIT:  {unit}
-                    TYPE: {rate_type}
+              {emission_keyword}:
+                {emissions}
             """
             emitters = emitters + emitter
     return emitters

--- a/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
+++ b/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
@@ -108,9 +108,9 @@ def create_venting_emitters_yaml(
             emitter = f"""
             - NAME: {emitter_name}
               CATEGORY: {category}
+              TYPE: {emitter_type}
               {emission_keyword_name}:
                 - NAME: {emission_name}
-                  TYPE: {emitter_type}
                   RATE:
                     VALUE: {emission_rate}
                     UNIT:  {unit}

--- a/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
+++ b/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
@@ -15,9 +15,9 @@ def venting_emitter_yaml_factory(
     units: List[Unit],
     emission_names: List[str],
     regularity: float,
-    volume_factors: List[float] = None,
+    emitter_types: List[str] = None,
     categories: List[str] = None,
-    emission_keyword_name: str = "EMISSION",
+    emission_keyword_name: str = "EMISSIONS",
     names: List[str] = None,
     include_emitters: bool = True,
     include_fuel_consumers: bool = True,
@@ -26,8 +26,8 @@ def venting_emitter_yaml_factory(
         categories = ["STORAGE"]
     if names is None:
         names = ["Venting emitter 1"]
-    if volume_factors is None:
-        volume_factors = [None]
+    if emitter_types is None:
+        emitter_types = ["DIRECT_EMISSION"]
 
     input_text = f"""
         FUEL_TYPES:
@@ -51,24 +51,11 @@ def venting_emitter_yaml_factory(
           {create_venting_emitters_yaml(
         categories=categories, rate_types=rate_types, emitter_names=names, emission_names=emission_names,
         emission_rates=emission_rates, units=units, emission_keyword_name=emission_keyword_name, include_emitters=include_emitters,
-        volume_factors=volume_factors,
+        emitter_types=emitter_types,
     )}
 
         """
 
-    create_fuel_consumers(include_fuel_consumers=include_fuel_consumers)
-
-    create_venting_emitters_yaml(
-        categories=categories,
-        rate_types=rate_types,
-        emitter_names=names,
-        emission_names=emission_names,
-        emission_rates=emission_rates,
-        units=units,
-        volume_factors=volume_factors,
-        emission_keyword_name=emission_keyword_name,
-        include_emitters=include_emitters,
-    )
     yaml_text = yaml.safe_load(input_text)
     configuration = PyYamlYamlModel(
         internal_datamodel=yaml_text,
@@ -101,36 +88,33 @@ def create_venting_emitters_yaml(
     emission_names: List[str],
     emission_rates: List[float],
     units: List[Unit],
-    volume_factors: List[float],
     emission_keyword_name: str,
     include_emitters: bool,
+    emitter_types: List[str],
 ) -> str:
     if not include_emitters:
         return ""
     else:
         emitters = "VENTING_EMITTERS:"
-        for category, rate_type, emitter_name, emission_name, emission_rate, unit, volume_factor in zip(
+        for category, rate_type, emitter_name, emission_name, emission_rate, unit, emitter_type in zip(
             categories,
             rate_types,
             emitter_names,
             emission_names,
             emission_rates,
             units,
-            volume_factors,
+            emitter_types,
         ):
-            volume_factor_string = (
-                f"EMISSION_RATE_TO_VOLUME_FACTOR: {volume_factor}" if volume_factor is not None else ""
-            )
             emitter = f"""
             - NAME: {emitter_name}
               CATEGORY: {category}
               {emission_keyword_name}:
-                NAME: {emission_name}
-                {volume_factor_string}
-                RATE:
-                  VALUE: {emission_rate}
-                  UNIT:  {unit}
-                  TYPE: {rate_type}
+                - NAME: {emission_name}
+                  TYPE: {emitter_type}
+                  RATE:
+                    VALUE: {emission_rate}
+                    UNIT:  {unit}
+                    TYPE: {rate_type}
             """
             emitters = emitters + emitter
     return emitters

--- a/src/libecalc/presentation/exporter/configs/configs.py
+++ b/src/libecalc/presentation/exporter/configs/configs.py
@@ -20,7 +20,6 @@ from libecalc.presentation.exporter.queries import (
     EmissionQuery,
     FuelConsumerPowerConsumptionQuery,
     FuelQuery,
-    VolumeQuery,
 )
 
 """
@@ -588,15 +587,6 @@ class LTPConfig(ResultConfig):
                         installation_category="FIXED",
                         consumer_categories=["LOADING"],
                         emission_type="ch4",
-                    ),
-                ),
-                Applier(
-                    name="loadedAndStoredOil",  # TODO: Get correct Centuries name here
-                    title="Total Oil Loaded/Stored new",
-                    unit=Unit.TONS,
-                    query=VolumeQuery(
-                        installation_category="FIXED",
-                        consumer_categories=["LOADING"],
                     ),
                 ),
                 Applier(

--- a/src/libecalc/presentation/exporter/queries.py
+++ b/src/libecalc/presentation/exporter/queries.py
@@ -12,7 +12,6 @@ from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
     TimeSeriesFloat,
     TimeSeriesRate,
-    TimeSeriesStreamDayRate,
     TimeSeriesVolumes,
 )
 from libecalc.core.result import GeneratorSetResult
@@ -231,101 +230,6 @@ class EmissionQuery(Query):
                 }
 
             return aggregated_result_volume if aggregated_result_volume else None
-        return None
-
-
-class VolumeQuery(Query):
-    def __init__(
-        self,
-        installation_category: Optional[str] = None,
-        consumer_categories: Optional[List[str]] = None,
-        fuel_type_category: Optional[str] = None,
-        emission_type: Optional[str] = None,
-    ):
-        self.installation_category = installation_category
-        self.consumer_categories = consumer_categories
-        self.fuel_type_category = fuel_type_category
-        self.emission_type = emission_type
-
-    def query(
-        self,
-        installation_graph: GraphResult,
-        unit: Unit,
-        frequency: Frequency,
-    ) -> Optional[Dict[datetime, float]]:
-        installation_dto = installation_graph.graph.get_node(installation_graph.graph.root)
-
-        installation_time_steps = installation_graph.timesteps
-        time_steps = resample_time_steps(
-            frequency=frequency,
-            time_steps=installation_time_steps,
-        )
-
-        regularity = TimeSeriesFloat(
-            timesteps=installation_time_steps,
-            values=TemporalExpression.evaluate(
-                temporal_expression=TemporalModel(installation_dto.regularity),
-                variables_map=installation_graph.variables_map,
-            ),
-            unit=Unit.NONE,
-        )
-
-        aggregated_emission_volume_output_unit = {}
-        aggregated_emission_volume: Dict[datetime, float] = defaultdict(float)
-        unit_in = None
-
-        if self.installation_category is None or installation_dto.user_defined_category == self.installation_category:
-            # Add loading and storage volumes related to venting emissions, but ensure that emissions are not counted twice.
-            # Venting emissions have no fuel, and should not count when asking for emissions for a given fuel
-            if self.fuel_type_category is None:
-                for venting_emitter in installation_dto.venting_emitters:
-                    if (
-                        self.consumer_categories is None
-                        or venting_emitter.user_defined_category in self.consumer_categories
-                    ):
-                        emissions = installation_graph.get_emissions(venting_emitter.id)
-
-                        for emission_name, emission in emissions.items():
-                            if emission.emission_rate_to_volume_factor is None:
-                                return None
-                            else:
-                                rate = TimeSeriesStreamDayRate(
-                                    timesteps=emission.rate.timesteps,
-                                    unit=emission.rate.unit,
-                                    values=[
-                                        rate_value / emission.emission_rate_to_volume_factor
-                                        for rate_value in emission.rate.values
-                                    ],
-                                )
-
-                            emission_volumes = TimeSeriesRate.from_timeseries_stream_day_rate(
-                                rate, regularity=regularity
-                            ).to_volumes()
-                            unit_in = emission_volumes.unit
-                            for timestep, emission_volume in emission_volumes.datapoints():
-                                if self.emission_type is None or emission_name == self.emission_type:
-                                    aggregated_emission_volume[timestep] += emission_volume
-
-            if aggregated_emission_volume:
-                sorted_result = dict(
-                    dict(sorted(zip(aggregated_emission_volume.keys(), aggregated_emission_volume.values()))).items()
-                )
-                sorted_result = {**dict.fromkeys(installation_time_steps, 0.0), **sorted_result}
-                date_keys = list(sorted_result.keys())
-
-                reindexed_result = (
-                    TimeSeriesVolumes(timesteps=date_keys, values=list(sorted_result.values())[:-1], unit=unit_in)
-                    .to_unit(Unit.KILO)
-                    .to_unit(unit)
-                    .reindex(time_steps)
-                    .fill_nan(0)
-                )
-
-                aggregated_emission_volume_output_unit = {
-                    reindexed_result.timesteps[i]: reindexed_result.values[i] for i in range(len(reindexed_result))
-                }
-
-            return aggregated_emission_volume_output_unit if aggregated_emission_volume_output_unit else None
         return None
 
 

--- a/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
+++ b/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 import numpy as np
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from libecalc.common.string.string_utils import generate_id
@@ -142,6 +142,19 @@ class YamlVentingEmitter(YamlBase):
     #                 f"{ConsumerUserDefinedCategoryType.LOADING} and {ConsumerUserDefinedCategoryType.STORAGE}."
     #             )
     #     return emission
+
+    @model_validator(mode="after")
+    def check_types(self):
+        if self.emissions is None and self.oil_volume is None:
+            if self.type == YamlVentingType.DIRECT_EMISSION:
+                raise ValueError(
+                    f"The keyword EMISSIONS is required for VENTING_EMITTERS of TYPE {YamlVentingType.DIRECT_EMISSION.name}"
+                )
+            if self.type == YamlVentingType.OIL_VOLUME:
+                raise ValueError(
+                    f"The keyword VOLUME is required for VENTING_EMITTERS of TYPE {YamlVentingType.OIL_VOLUME.name}"
+                )
+        return self
 
     def get_emission_rate(
         self, variables_map: VariablesMap, regularity: Dict[datetime, Expression]

--- a/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
+++ b/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
@@ -87,14 +87,20 @@ class YamlVentingEmitter(YamlBase):
         validate_default=True,
     )
 
-    emissions: Optional[YamlVentingEmission] = Field(
+    type: YamlVentingType = Field(
+        ...,
+        title="TYPE",
+        description="Type of venting emitter",
+    )
+
+    emissions: Optional[List[YamlVentingEmission]] = Field(
         None,
         title="EMISSIONS",
         description="The emission",
     )
 
     oil_volume: Optional[YamlVentingVolumeEmission] = Field(
-        ...,
+        None,
         title="VOLUME",
         description="The emissions",
     )

--- a/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
+++ b/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
@@ -125,24 +125,6 @@ class YamlVentingEmitter(YamlBase):
                 )
         return category
 
-    # @field_validator("emissions", mode="after")
-    # def check_volume_emission_factor(cls, emission, info: ValidationInfo):
-    #     """Provide which value and context to make it easier for user to correct wrt mandatory changes."""
-    #     category = info.data.get("category")
-    #     name = ""
-    #
-    #     if info.data.get("name") is not None:
-    #         name = f"with the name {info.data.get('name')}"
-    #
-    #     if emission.emission_rate_to_volume_factor is not None:
-    #         if category not in [ConsumerUserDefinedCategoryType.LOADING, ConsumerUserDefinedCategoryType.STORAGE]:
-    #             raise ValueError(
-    #                 f"{cls.model_config['title']} {name}: It is not possible to specify FACTOR for CATEGORY {category}. "
-    #                 f"The volume/emission factor in EMISSION is only allowed for the categories "
-    #                 f"{ConsumerUserDefinedCategoryType.LOADING} and {ConsumerUserDefinedCategoryType.STORAGE}."
-    #             )
-    #     return emission
-
     @model_validator(mode="after")
     def check_types(self):
         if self.emissions is None and self.volume is None:
@@ -156,7 +138,7 @@ class YamlVentingEmitter(YamlBase):
                 )
         return self
 
-    def get_emission_rate(
+    def get_emission_rates(
         self, variables_map: VariablesMap, regularity: Dict[datetime, Expression]
     ) -> Dict[str, TimeSeriesStreamDayRate]:
         regularity_evaluated = TemporalExpression.evaluate(
@@ -213,8 +195,6 @@ class YamlVentingEmitter(YamlBase):
                 .evaluate(variables=variables_map.variables, fill_length=len(variables_map.time_vector))
                 .tolist()
             )
-
-            # emission_rate = Unit.to(self.emission.rate.unit, Unit.KILO_PER_DAY)(emission_rate).tolist()
 
             if emission.rate.type == RateType.CALENDAR_DAY:
                 emission_rate = Rates.to_stream_day(

--- a/src/tests/libecalc/dto/test_categories.py
+++ b/src/tests/libecalc/dto/test_categories.py
@@ -15,6 +15,7 @@ from libecalc.expression import Expression
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingEmission,
     YamlVentingEmitter,
+    YamlVentingType,
 )
 from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
     YamlEmissionRate,
@@ -32,8 +33,9 @@ class TestCategories:
         with pytest.raises(ValidationError) as exc_info:
             YamlVentingEmitter(
                 name="test",
-                emission=emission,
+                emissions=[emission],
                 category="VENTING-EMISSIONS",
+                type=YamlVentingType.DIRECT_EMISSION,
             )
 
         assert (
@@ -45,8 +47,9 @@ class TestCategories:
         with pytest.raises(ValidationError) as exc_info:
             YamlVentingEmitter(
                 name="test",
-                emission=emission,
+                emissions=[emission],
                 category="fuel-gas",
+                type=YamlVentingType.DIRECT_EMISSION,
             )
 
         assert (
@@ -58,8 +61,9 @@ class TestCategories:
         with pytest.raises(ValidationError) as exc_info:
             YamlVentingEmitter(
                 name="test",
-                emission=emission,
+                emissions=[emission],
                 category="",
+                type=YamlVentingType.DIRECT_EMISSION,
             )
 
         assert (
@@ -71,8 +75,9 @@ class TestCategories:
         with pytest.raises(ValidationError) as exc_info:
             YamlVentingEmitter(
                 name="test",
-                emission=emission,
+                emissions=[emission],
                 category="FUEL_GAS",
+                type=YamlVentingType.DIRECT_EMISSION,
             )
 
         assert (
@@ -84,8 +89,9 @@ class TestCategories:
         assert (
             YamlVentingEmitter(
                 name="test",
-                emission=emission,
+                emissions=[emission],
                 category=ConsumerUserDefinedCategoryType.COLD_VENTING_FUGITIVE,
+                type=YamlVentingType.DIRECT_EMISSION,
             ).user_defined_category
             == ConsumerUserDefinedCategoryType.COLD_VENTING_FUGITIVE
         )

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -217,6 +217,7 @@ def test_venting_emitters():
         units=[Unit.KILO_PER_DAY],
         emission_names=["ch4"],
         rate_types=[RateType.STREAM_DAY],
+        names=["Venting emitter 1"],
     )
 
     installation_sd_tons_per_day = venting_emitter_yaml_factory(
@@ -225,6 +226,7 @@ def test_venting_emitters():
         rate_types=[RateType.STREAM_DAY],
         units=[Unit.TONS_PER_DAY],
         emission_names=["ch4"],
+        names=["Venting emitter 1"],
     )
 
     installation_cd_kg_per_day = venting_emitter_yaml_factory(
@@ -233,6 +235,7 @@ def test_venting_emitters():
         rate_types=[RateType.CALENDAR_DAY],
         units=[Unit.KILO_PER_DAY],
         emission_names=["ch4"],
+        names=["Venting emitter 1"],
     )
 
     ltp_result_input_sd_kg_per_day = get_consumption(
@@ -291,6 +294,7 @@ def test_only_venting_emitters_no_fuelconsumers():
         rate_types=[RateType.STREAM_DAY],
         include_emitters=True,
         include_fuel_consumers=False,
+        names=["Venting emitter 1"],
     )
     venting_emitter_results = get_consumption(
         model=installation_venting_emitters, variables=variables, time_vector=time_vector_yearly
@@ -316,6 +320,7 @@ def test_no_emitters_or_fuelconsumers():
             rate_types=[RateType.STREAM_DAY],
             include_emitters=False,
             include_fuel_consumers=False,
+            names=["Venting emitter 1"],
         )
 
     assert (

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -9,7 +9,6 @@ from libecalc.application.graph_result import GraphResult
 from libecalc.common.time_utils import Frequency
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
-from libecalc.dto.base import ConsumerUserDefinedCategoryType
 from libecalc.fixtures.cases.ltp_export.installation_setup import (
     expected_boiler_fuel_consumption,
     expected_ch4_from_diesel,
@@ -339,67 +338,6 @@ def test_no_emitters_or_fuelconsumers():
     ) in str(ee.value)
 
 
-def test_oil_loaded_new_method():
-    """Test reporting oil volumes associated with loading for ltp. This is based on using venting emitters,
-    and not the old method of using fuelconsumers and DIRECT.
-    """
-    time_vector = [
-        datetime(2027, 1, 1),
-        datetime(2028, 1, 1),
-    ]
-    regularity = 0.2
-    emission_rate_loading = 10
-    volume_factor_loading = 0.1
-
-    variables = dto.VariablesMap(time_vector=time_vector, variables={})
-
-    installation_loading = venting_emitter_yaml_factory(
-        emission_rates=[emission_rate_loading],
-        regularity=regularity,
-        units=[Unit.KILO_PER_DAY],
-        emission_names=["ch4"],
-        rate_types=[RateType.STREAM_DAY],
-        volume_factors=[volume_factor_loading],
-        categories=["LOADING"],
-    )
-
-    ltp_result_loading = get_consumption(model=installation_loading, variables=variables)
-
-    emission_loading = get_sum_ltp_column(ltp_result_loading, installation_nr=0, ltp_column_nr=0)
-    volume_loading = get_sum_ltp_column(ltp_result_loading, installation_nr=0, ltp_column_nr=1)
-
-    # Verify correct emissions associated with loading
-    assert emission_loading == (emission_rate_loading / 1000) * 365 * regularity
-
-    # Verify correct loading volumes
-    assert volume_loading == emission_loading / volume_factor_loading
-
-
-def test_wrong_category_oil_loaded():
-    """Verify that only STORAGE and LOADING are allowed categories, if specifying volume factor."""
-
-    category = "COLD-VENTING-FUGITIVE"
-
-    with pytest.raises(DtoValidationError) as ee:
-        venting_emitter_yaml_factory(
-            emission_rates=[10],
-            regularity=0.2,
-            units=[Unit.KILO_PER_DAY],
-            emission_names=["ch4"],
-            rate_types=[RateType.STREAM_DAY],
-            volume_factors=[0.1],
-            categories=[category],
-            names=["Emitter1"],
-        )
-
-    assert (
-        f"\nEmitter1:\nEMISSION:\tValue error, VentingEmitter with the name Emitter1: "
-        f"It is not possible to specify FACTOR for CATEGORY {category}. The volume/emission factor in "
-        f"EMISSION is only allowed for the categories {ConsumerUserDefinedCategoryType.LOADING} and "
-        f"{ConsumerUserDefinedCategoryType.STORAGE}."
-    ) in str(ee.value)
-
-
 def test_total_oil_loaded_old_method():
     """Test total oil loaded/stored for LTP export. Using original method where direct/venting emitters are
     modelled as FUELSCONSUMERS using DIRECT.
@@ -456,48 +394,3 @@ def test_total_oil_loaded_old_method():
     # Verify that total oil loaded/stored is the same if only loading is specified,
     # compared to a model with both loading and storage.
     assert loaded_and_stored_oil_loading_and_storage == loaded_and_stored_oil_loading_only
-
-
-def test_oil_loaded_new_vs_old_method():
-    time_vector = [
-        datetime(2027, 1, 1),
-        datetime(2028, 1, 1),
-    ]
-    variables = dto.VariablesMap(time_vector=time_vector, variables={})
-
-    regularity = 0.6
-    emission_factor = 2
-    fuel_rate = 100
-    volume_factor_loading = 0.1
-
-    # Multiply emission rate with volume factor, as volume is derived directly from emission rate.
-    # This to be comparable with old method, where volume is directly taken from the fuel rate.
-    # Multiply with 1000 as input is kg/d, and output is converted to t/d for venting emitters.
-
-    oil_loaded_new = venting_emitter_yaml_factory(
-        emission_rates=[fuel_rate * volume_factor_loading * 1000],
-        regularity=regularity,
-        units=[Unit.KILO_PER_DAY],
-        emission_names=["ch4"],
-        rate_types=[RateType.STREAM_DAY],
-        volume_factors=[volume_factor_loading],
-        categories=["LOADING"],
-    )
-
-    oil_loaded_old = ltp_oil_loaded_yaml_factory(
-        emission_factor=emission_factor,
-        rate_types=[RateType.STREAM_DAY],
-        fuel_rates=[fuel_rate],
-        emission_name="ch4",
-        regularity=regularity,
-        categories=["LOADING"],
-        consumer_names=["loading"],
-    )
-
-    ltp_result_oil_loaded_new = get_consumption(model=oil_loaded_new, variables=variables)
-    ltp_result_oil_loaded_old = get_consumption(model=oil_loaded_old, variables=variables)
-
-    volume_oil_loaded_new = get_sum_ltp_column(ltp_result_oil_loaded_new, installation_nr=0, ltp_column_nr=1)
-    volume_oil_loaded_old = get_sum_ltp_column(ltp_result_oil_loaded_old, installation_nr=0, ltp_column_nr=1)
-
-    assert volume_oil_loaded_new == volume_oil_loaded_old

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -66,3 +66,40 @@ def test_venting_emitter(variables_map):
 
     # Two first time steps using emitter_emission_function
     assert emissions_ch4.rate.values == pytest.approx([5.1e-06, 0.00153, 0.00306, 0.00408])
+
+
+def test_no_emissions_direct(variables_map):
+    """
+    Check that error message is given if no emissions are specified for TYPE DIRECT_EMISSION.
+    """
+    emitter_name = "venting_emitter"
+
+    with pytest.raises(ValueError) as exc:
+        YamlVentingEmitter(
+            name=emitter_name,
+            category=ConsumerUserDefinedCategoryType.COLD_VENTING_FUGITIVE,
+            type=YamlVentingType.DIRECT_EMISSION,
+        )
+
+    assert (
+        f"The keyword EMISSIONS is required for VENTING_EMITTERS of TYPE {YamlVentingType.DIRECT_EMISSION.name}"
+        in str(exc.value)
+    )
+
+
+def test_no_volume_oil(variables_map):
+    """
+    Check that error message is given if no volume is specified for TYPE OIL_VOLUME.
+    """
+    emitter_name = "venting_emitter"
+
+    with pytest.raises(ValueError) as exc:
+        YamlVentingEmitter(
+            name=emitter_name,
+            category=ConsumerUserDefinedCategoryType.COLD_VENTING_FUGITIVE,
+            type=YamlVentingType.OIL_VOLUME,
+        )
+
+    assert f"The keyword VOLUME is required for VENTING_EMITTERS of TYPE {YamlVentingType.OIL_VOLUME.name}" in str(
+        exc.value
+    )

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -10,6 +10,7 @@ from libecalc.expression import Expression
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingEmission,
     YamlVentingEmitter,
+    YamlVentingType,
 )
 from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
     YamlEmissionRate,
@@ -35,25 +36,28 @@ def test_venting_emitter(variables_map):
     venting_emitter = YamlVentingEmitter(
         name=emitter_name,
         category=ConsumerUserDefinedCategoryType.COLD_VENTING_FUGITIVE,
-        emission=YamlVentingEmission(
-            name="ch4",
-            rate=YamlEmissionRate(
-                value="TSC1;Methane_rate {*} 1.02",
-                unit=Unit.KILO_PER_DAY,
-                type=RateType.STREAM_DAY,
-            ),
-        ),
+        type=YamlVentingType.DIRECT_EMISSION,
+        emissions=[
+            YamlVentingEmission(
+                name="ch4",
+                rate=YamlEmissionRate(
+                    value="TSC1;Methane_rate {*} 1.02",
+                    unit=Unit.KILO_PER_DAY,
+                    type=RateType.STREAM_DAY,
+                ),
+            )
+        ],
     )
 
     regularity = {datetime(1900, 1, 1): Expression.setup_from_expression(1)}
 
-    emission_rate = venting_emitter.get_emission_rate(variables_map=variables_map, regularity=regularity).to_unit(
-        Unit.TONS_PER_DAY
-    )
+    emission_rate = venting_emitter.get_emission_rate(variables_map=variables_map, regularity=regularity)[
+        "ch4"
+    ].to_unit(Unit.TONS_PER_DAY)
 
     emission_result = {
-        venting_emitter.emission.name: EmissionResult(
-            name=venting_emitter.emission.name,
+        venting_emitter.emissions[0].name: EmissionResult(
+            name=venting_emitter.emissions[0].name,
             timesteps=variables_map.time_vector,
             rate=emission_rate,
         )

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -68,7 +68,7 @@ def test_venting_emitter(variables_map):
 
     regularity = {datetime(1900, 1, 1): Expression.setup_from_expression(1)}
 
-    emission_rate = venting_emitter.get_emission_rate(variables_map=variables_map, regularity=regularity)[
+    emission_rate = venting_emitter.get_emission_rates(variables_map=variables_map, regularity=regularity)[
         "ch4"
     ].to_unit(Unit.TONS_PER_DAY)
 
@@ -114,13 +114,13 @@ def test_venting_emitter_oil_volume(variables_map):
 
     regularity = {datetime(1900, 1, 1): Expression.setup_from_expression(1)}
 
-    emission_rate = venting_emitter.get_emission_rate(variables_map=variables_map, regularity=regularity)[
+    emission_rate = venting_emitter.get_emission_rates(variables_map=variables_map, regularity=regularity)[
         "ch4"
     ].to_unit(Unit.TONS_PER_DAY)
 
     emission_result = {
-        venting_emitter.oil_volume.emissions[0].name: EmissionResult(
-            name=venting_emitter.oil_volume.emissions[0].name,
+        venting_emitter.volume.emissions[0].name: EmissionResult(
+            name=venting_emitter.volume.emissions[0].name,
             timesteps=variables_map.time_vector,
             rate=emission_rate,
         )

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter_validation_errors.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter_validation_errors.py
@@ -22,13 +22,9 @@ def test_wrong_keyword_name_emitters():
             rate_types=[RateType.STREAM_DAY],
             emission_keyword_name="EMISSION2",
             names=["Venting emitter 1"],
-            volume_factors=[0.3],
         )
 
-    assert (
-        "Venting emitter 1:\nEMISSION:\tThis keyword is missing, it is required\n"
-        "EMISSION2:\tThis is not a valid keyword"
-    ) in str(exc.value)
+    assert ("EMISSION2:\tThis is not a valid keyword") in str(exc.value)
 
 
 def test_wrong_unit_emitters():
@@ -44,12 +40,11 @@ def test_wrong_unit_emitters():
             units=[Unit.STANDARD_CUBIC_METER_PER_DAY],
             emission_names=["ch4"],
             rate_types=[RateType.STREAM_DAY],
-            emission_keyword_name="EMISSION",
+            emission_keyword_name="EMISSIONS",
             names=["Venting emitter 1"],
-            volume_factors=[0.3],
         )
 
     assert (
-        "Venting emitter 1:\nEMISSION.RATE.UNIT:\tInput should be "
+        "Venting emitter 1:\nEMISSIONS[0].RATE.UNIT:\tInput should be "
         "<Unit.KILO_PER_DAY: 'kg/d'> or <Unit.TONS_PER_DAY: 't/d'>"
     ) in str(exc.value)


### PR DESCRIPTION
BREAKING CHANGE: Add `TYPE` to `VENTING_EMITTERS`.

ECALC-912

## Why is this pull request needed?

Add two separate types to distinguish between two main categories of venting emitters: venting emissions related to loading/storage of oil volumes, and venting emissions specified directly by user.

Allow multiple emissions per emitter, to simplify yaml.

## What does this pull request change?

- [x] Add new yaml classes for venting emitter
- [x] Implement type: OIL_VOLUME for loading/storage. Include volume-emission factor
- [x] Implement type: DIRECT_EMISSION: for emissions specified directly by user
- [x] Handle multiple emissions
- [x] Add tests
- [ ] Update snapshots

## Issues related to this change:
