### PR TITLE
feat: add control margin to single speed compressor charts

### DIFF
--- a/docs/docs/about/references/keywords/CONTROL_MARGIN.md
+++ b/docs/docs/about/references/keywords/CONTROL_MARGIN.md
@@ -6,18 +6,52 @@
 
 ## Description
 
-This keyword defines the surge control margin for a variable speed compressor chart.
+This keyword defines the surge control margin for a single speed compressor chart or a variable speed compressor chart.
 
-The `CONTROL_MARGIN` behaves as an alternate to the minimum flow line: The input will be 'cropped' to only include points to the right of the control line - modelling recirculation (ASV) from the correct control line.
+The `CONTROL_MARGIN` behaves as an alternate to the minimum flow line: For each chart curve (a single speed chart will have one, a variable speed chart will have at least two) the input will be 'cropped' to only include points to the right of the control line - modelling recirculation (ASV) from the correct control line.
 
 The `CONTROL_MARGIN` is given as a percentage or fraction ([CONTROL_MARGIN_UNIT](/about/references/keywords/CONTROL_MARGIN_UNIT.md)) of the rate difference between minimum- and maximum flow, 
 for the given speed. It is used to calculate the increase in minimum flow for each individual speed curve. 
-It is defined when setting up the stages in a [Variable speed compressor train model](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md) or [Variable speed compressor train model with multiple streams and pressures](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md).
-
-It is currently only possible to define a surge control margin for variable speed compressors.
+It is defined when setting up the stages in a [Single speed compressor train model](/about/modelling/setup/models/compressor_modelling/compressor_models_types/single_speed_compressor_train_model.md), [Variable speed compressor train model](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md) or [Variable speed compressor train model with multiple streams and pressures](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md).
 
 See [Surge control margin for variable speed compressor chart](/about/modelling/setup/models/compressor_modelling/compressor_charts/index.md) for more details.
 
+## Use in [Single speed compressor train model](/about/modelling/setup/models/compressor_modelling/compressor_models_types/single_speed_compressor_train_model.md)
+### Format
+
+~~~~yaml
+MODELS:
+  - NAME: <model name>
+    TYPE: SINGLE_SPEED_COMPRESSOR_TRAIN
+    FLUID_MODEL: <reference to fluid model, must be defined in MODELS>
+    ...
+    COMPRESSOR_TRAIN:
+      STAGES:
+        - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
+          COMPRESSOR_CHART: <reference to compressor chart model for first stage, must be defined in MODELS or FACILITY_INPUTS>
+          CONTROL_MARGIN: <Default value is zero>
+          CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
+          ....
+~~~~
+
+### Example
+~~~~yaml
+MODELS:
+  - NAME: compressor_model
+    TYPE: SINGLE_SPEED_COMPRESSOR_TRAIN
+    FLUID_MODEL: fluid_model
+    ...
+    COMPRESSOR_TRAIN:
+      STAGES:
+        - INLET_TEMPERATURE: 20
+          COMPRESSOR_CHART: 1_stage_chart
+          CONTROL_MARGIN: 0.1
+          CONTROL_MARGIN_UNIT: FRACTION
+          ....
+~~~~
+
+
+>>>>>>> Stashed changes
 ## Use in [Variable speed compressor train model](/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md)
 ### Format
 

--- a/src/libecalc/core/models/compressor/train/chart/single_speed_compressor_chart.py
+++ b/src/libecalc/core/models/compressor/train/chart/single_speed_compressor_chart.py
@@ -1,4 +1,5 @@
-from typing import Tuple
+from copy import deepcopy
+from typing import Optional, Tuple
 
 from libecalc.core.models.chart import SingleSpeedChart
 from libecalc.core.models.compressor.train.chart.types import (
@@ -14,6 +15,14 @@ class SingleSpeedCompressorChart(SingleSpeedChart):
     calculations and must be converted to J/kg before using this class
     Chart may be used with or without efficiency values.
     """
+
+    def get_chart_adjusted_for_control_margin(self, control_margin: Optional[float]) -> SingleSpeedChart:
+        """Sets a new minimum rate and corresponding head and efficiency for each curve in a compressor chart."""
+        if control_margin is None:
+            return deepcopy(self)
+        new_chart = deepcopy(self)
+
+        return new_chart.adjust_for_control_margin(control_margin=control_margin)
 
     def _evaluate_point_validity_chart_area_flag_and_adjusted_rate(
         self,

--- a/src/libecalc/core/models/compressor/utils.py
+++ b/src/libecalc/core/models/compressor/utils.py
@@ -53,19 +53,7 @@ def _create_undefined_compressor_train_stage(
     )
 
 
-def _create_single_speed_compressor_train_stage(
-    stage_data: dto.CompressorStage,
-) -> CompressorTrainStage:
-    compressor_chart = _create_compressor_chart(stage_data.compressor_chart)
-    return CompressorTrainStage(
-        compressor_chart=compressor_chart,
-        inlet_temperature_kelvin=stage_data.inlet_temperature_kelvin,
-        pressure_drop_ahead_of_stage=stage_data.pressure_drop_before_stage,
-        remove_liquid_after_cooling=stage_data.remove_liquid_after_cooling,
-    )
-
-
-def _create_variable_speed_compressor_train_stage(
+def _create_compressor_train_stage(
     stage_data: dto.CompressorStage,
 ) -> CompressorTrainStage:
     compressor_chart = _create_compressor_chart(stage_data.compressor_chart)
@@ -84,10 +72,10 @@ def _create_variable_speed_compressor_train_stage(
 def map_compressor_train_stage_to_domain(stage_dto: dto.CompressorStage) -> CompressorTrainStage:
     """Todo: Add multiple streams and pressures here."""
     if isinstance(stage_dto, dto.CompressorStage):
-        if isinstance(stage_dto.compressor_chart, (dto.VariableSpeedChart, dto.GenericChartFromDesignPoint)):
-            return _create_variable_speed_compressor_train_stage(stage_dto)
-        elif isinstance(stage_dto.compressor_chart, dto.SingleSpeedChart):
-            return _create_single_speed_compressor_train_stage(stage_dto)
+        if isinstance(
+            stage_dto.compressor_chart, (dto.VariableSpeedChart, dto.GenericChartFromDesignPoint, dto.SingleSpeedChart)
+        ):
+            return _create_compressor_train_stage(stage_dto)
         elif isinstance(stage_dto.compressor_chart, dto.GenericChartFromInput):
             return _create_undefined_compressor_train_stage(stage_dto)
     raise ValueError(f"Compressor stage typ {stage_dto.type_} has not been implemented.")

--- a/src/libecalc/presentation/yaml/mappers/model.py
+++ b/src/libecalc/presentation/yaml/mappers/model.py
@@ -423,7 +423,15 @@ def _single_speed_compressor_train_mapper(
             pressure_drop_before_stage=stage.get(
                 EcalcYamlKeywords.models_type_compressor_train_pressure_drop_ahead_of_stage, 0.0
             ),
-            control_margin=0,
+            control_margin=convert_control_margin_to_fraction(
+                stage.get(EcalcYamlKeywords.models_type_compressor_train_stage_control_margin, 0.0),
+                YAML_UNIT_MAPPING[
+                    stage.get(
+                        EcalcYamlKeywords.models_type_compressor_train_stage_control_margin_unit,
+                        EcalcYamlKeywords.models_type_compressor_train_stage_control_margin_unit_percentage,
+                    )
+                ],
+            ),
         )
         for stage in stages_data
     ]


### PR DESCRIPTION
## Have you remembered and considered?

- [x] Update documentation, if relevant
- [x] Update manual changelog, if relevant
- [x] Update migration guide, if relevant
- [x] Tagged commit with `BREAKING:` in footer or `!` in header if breaking
- [x] Considered to add tests
- [x] Used conventional commits syntax

## Why is this pull request needed?

It has been possible to define a CONTROL_MARGIN on single speed compressor trains, but it has not had any effect. It has always been defaulted to zero.

## What does this pull request change?

This PR adds the CONTROL_MARGIN functionality also to single speed compressor charts.

Write summary of what this pull request changes if needed.

## Issues related to this change:

Refs ECALC-947
