### PR TITLE
fix: issue with invalid dates in temporal model

### DIFF
--- a/src/libecalc/common/errors/exceptions.py
+++ b/src/libecalc/common/errors/exceptions.py
@@ -69,3 +69,7 @@ class InvalidReferenceException(EcalcError):
 
     def __init__(self, message: str):
         super().__init__("Invalid reference", message, error_type=EcalcErrorType.CLIENT_ERROR)
+
+
+class InvalidDateException(EcalcError):
+    ...

--- a/src/libecalc/common/time_utils.py
+++ b/src/libecalc/common/time_utils.py
@@ -9,7 +9,10 @@ import numpy as np
 import pandas as pd
 from numpy.typing import ArrayLike, NDArray
 
-from libecalc.common.errors.exceptions import EcalcError, ProgrammingError
+from libecalc.common.errors.exceptions import (
+    InvalidDateException,
+    ProgrammingError,
+)
 from libecalc.common.units import UnitConstants
 
 
@@ -245,7 +248,7 @@ def is_temporal_model(data: Dict) -> bool:
                     is_date.append(False)
         if any(is_date):
             if not all(is_date):
-                raise EcalcError(
+                raise InvalidDateException(
                     title="Invalid model",
                     message="Temporal models should only contain date keys. "
                     f"Invalid date(s): {','.join(is_not_date_keys)}",

--- a/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
@@ -264,6 +264,12 @@ class PyYamlYamlModel(YamlValidator, YamlModel):
 
     @property
     def variables(self) -> YamlVariables:
+        """
+        Get variables, invalid variable definitions will be skipped.
+
+        Returns: valid variables
+
+        """
         if not isinstance(self._internal_datamodel, dict):
             return {}
 
@@ -275,7 +281,7 @@ class PyYamlYamlModel(YamlValidator, YamlModel):
                 reference = TypeAdapter(YamlVariableReferenceId).validate_python(reference)
                 variable = TypeAdapter(YamlVariable).validate_python(variable)
                 valid_variables[reference] = variable
-            except ValidationError:
+            except PydanticValidationError:
                 continue
 
         return valid_variables

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_temporal_model.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_temporal_model.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, TypeVar, Union
 from pydantic import Discriminator, Tag
 from typing_extensions import Annotated, Literal
 
+from libecalc.common.errors.exceptions import InvalidDateException
 from libecalc.common.time_utils import is_temporal_model
 from libecalc.presentation.yaml.yaml_types.yaml_default_datetime import (
     YamlDefaultDatetime,
@@ -19,10 +20,14 @@ def discriminate_temporal_model(v: Any) -> Literal["single", "temporal"]:
 
     """
     if isinstance(v, dict):
-        if is_temporal_model(v):
+        try:
+            if is_temporal_model(v):
+                return "temporal"
+            else:
+                return "single"
+        except InvalidDateException:
+            # is_temporal_model validation of dates failed -> pass data to temporal validation and handle error there
             return "temporal"
-        else:
-            return "single"
 
     # No need to check whether temporal or not as a temporal model always is a dict
     return "single"


### PR DESCRIPTION
Validation where a temporal model had invalid dates failed because of error raised that is not ValueError.

Refs: ECALC-763