### PR TITLE
docs: update changelog and migration guide for v8.4

### DIFF
--- a/docs/docs/about/migration_guides/v8-3_to_v8-4.md
+++ b/docs/docs/about/migration_guides/v8-3_to_v8-4.md
@@ -6,4 +6,4 @@ sidebar_position: 4
 
 # v8.3 to v8.4
 
-No migration is needed.
+CSV resource files must now include headings. If there is a column without a header (for example `HEADING1,HEADING2,` - the last `,` creates an empty column), you will get an error messages saying "CSV input file must include header". You can solve this by giving the column a name, or removing it.

--- a/docs/docs/changelog/v8-4.md
+++ b/docs/docs/changelog/v8-4.md
@@ -22,3 +22,4 @@ sidebar_position: 14
 
 ## Breaking changes
 
+- CSV resource files must include headings. If there is a column without a header (for example `HEADING1,HEADING2,` - the last `,` creates an empty column), you will get an error messages saying "CSV input file must include header". You can solve this by giving the column a name, or removing it.


### PR DESCRIPTION
The changelog was missing info on a change that now requires CSV resource files to include headings.

ECALC-931

