### PR TITLE
test: add test for total power

### DIFF
--- a/docs/docs/changelog/v8-11.md
+++ b/docs/docs/changelog/v8-11.md
@@ -15,5 +15,5 @@ sidebar_position: 20
 ## Fixes
 
 ## Breaking changes
-- Sum and split mechanical power at installation level: The total power is now the sum of mechanical (e.g. compressor with turbine) power and electrical power. Previously, the total power included only electrical power.
+- Sum and split mechanical power at installation level: The total power is now the sum of mechanical (e.g. compressor with turbine) power and electrical power. *NB!* This may lead to big changes in power usage, as mechanical power was previously not included in the total!
 

--- a/docs/docs/changelog/v8-11.md
+++ b/docs/docs/changelog/v8-11.md
@@ -1,0 +1,19 @@
+---
+slug: v8.11-release
+title: v8.11
+authors: ecalc-team
+tags: [release, eCalc]
+sidebar_position: 20
+---
+
+# eCalc
+
+
+
+## New Features
+
+## Fixes
+
+## Breaking changes
+- Sum and split mechanical power at installation level: The total power is now the sum of mechanical (e.g. compressor with turbine) power and electrical power. Previously, the total power included only electrical power.
+

--- a/src/libecalc/fixtures/cases/ltp_export/installation_setup.py
+++ b/src/libecalc/fixtures/cases/ltp_export/installation_setup.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict
+from typing import Dict, List
 
 import numpy as np
 
@@ -307,13 +307,13 @@ def generator_set_offshore_wind_temporal_model() -> dto.GeneratorSet:
     )
 
 
-def generator_set_compressor_temporal_model() -> dto.GeneratorSet:
+def generator_set_compressor_temporal_model(consumers: List[dto.ElectricityConsumer]) -> dto.GeneratorSet:
     return dto.GeneratorSet(
         name="genset",
         user_defined_category={date1: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR},
         fuel={date1: fuel_turbine()},
         generator_set_model={date1: generator_set_fuel()},
-        consumers=[no_el_consumption()],
+        consumers=consumers,
         regularity=regularity_temporal_consumer,
     )
 
@@ -464,12 +464,12 @@ def installation_offshore_wind_dto() -> dto.Installation:
     )
 
 
-def installation_compressor_dto() -> dto.Installation:
+def installation_compressor_dto(el_consumers: List[dto.ElectricityConsumer]) -> dto.Installation:
     return dto.Installation(
         name="INSTALLATION_A",
         regularity=regularity_temporal_installation,
-        hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression("sim1;var1")},
-        fuel_consumers=[generator_set_compressor_temporal_model(), compressor()],
+        hydrocarbon_export={datetime(1900, 1, 1): Expression.setup_from_expression(0)},
+        fuel_consumers=[generator_set_compressor_temporal_model(el_consumers), compressor()],
         user_defined_category=dto.base.InstallationUserDefinedCategoryType.FIXED,
     )
 

--- a/src/libecalc/fixtures/cases/ltp_export/utilities.py
+++ b/src/libecalc/fixtures/cases/ltp_export/utilities.py
@@ -31,7 +31,7 @@ def get_consumption(
     return ltp_result
 
 
-def get_consumption_graph_result(
+def get_consumption_asset_result(
     model: Union[dto.Installation, dto.Asset],
     variables: dto.VariablesMap,
 ):

--- a/src/libecalc/fixtures/cases/ltp_export/utilities.py
+++ b/src/libecalc/fixtures/cases/ltp_export/utilities.py
@@ -31,6 +31,29 @@ def get_consumption(
     return ltp_result
 
 
+def get_consumption_graph_result(
+    model: Union[dto.Installation, dto.Asset],
+    variables: dto.VariablesMap,
+):
+    model = model
+    graph = model.get_graph()
+    energy_calculator = EnergyCalculator(graph=graph)
+
+    consumer_results = energy_calculator.evaluate_energy_usage(variables)
+    emission_results = energy_calculator.evaluate_emissions(variables, consumer_results)
+
+    results_core = GraphResult(
+        graph=graph,
+        variables_map=variables,
+        consumer_results=consumer_results,
+        emission_results=emission_results,
+    )
+
+    results_dto = results_core.get_asset_result()
+
+    return results_dto
+
+
 def get_sum_ltp_column(ltp_result, installation_nr, ltp_column_nr) -> float:
     ltp_sum = sum(
         float(v) for (k, v) in ltp_result.query_results[installation_nr].query_results[ltp_column_nr].values.items()

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -406,12 +406,25 @@ def test_electrical_and_mechanical_power_installation():
     )
 
     asset_result = get_consumption_asset_result(model=asset, variables=variables)
+    power_fuel_driven_compressor = asset_result.get_component_by_name(
+        "single_1d_compressor_sampled"
+    ).power_cumulative.values[-1]
+    power_generator_set = asset_result.get_component_by_name("genset").power_cumulative.values[-1]
+
+    # Extract cumulative electrical-, mechanical- and total power.
     power_electrical_installation = asset_result.get_component_by_name(
         "INSTALLATION_A"
     ).power_electrical_cumulative.values[-1]
+
     power_mechanical_installation = asset_result.get_component_by_name(
         "INSTALLATION_A"
     ).power_mechanical_cumulative.values[-1]
+
     power_total_installation = asset_result.get_component_by_name("INSTALLATION_A").power_cumulative.values[-1]
 
+    # Verify that total power is correct
     assert power_total_installation == power_electrical_installation + power_mechanical_installation
+
+    # Verify that electrical power equals genset power, and mechanical power includes power from gas driven compressor:
+    assert power_generator_set == power_electrical_installation
+    assert power_fuel_driven_compressor == power_mechanical_installation

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -35,7 +35,7 @@ from libecalc.fixtures.cases.ltp_export.loading_storage_ltp_yaml import (
 )
 from libecalc.fixtures.cases.ltp_export.utilities import (
     get_consumption,
-    get_consumption_graph_result,
+    get_consumption_asset_result,
     get_sum_ltp_column,
 )
 from libecalc.fixtures.cases.venting_emitters.venting_emitter_yaml import (
@@ -405,7 +405,7 @@ def test_electrical_and_mechanical_power_installation():
         ],
     )
 
-    asset_result = get_consumption_graph_result(model=asset, variables=variables)
+    asset_result = get_consumption_asset_result(model=asset, variables=variables)
     power_electrical_installation = asset_result.get_component_by_name(
         "INSTALLATION_A"
     ).power_electrical_cumulative.values[-1]

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -425,6 +425,6 @@ def test_electrical_and_mechanical_power_installation():
     # Verify that total power is correct
     assert power_total_installation == power_electrical_installation + power_mechanical_installation
 
-    # Verify that electrical power equals genset power, and mechanical power includes power from gas driven compressor:
+    # Verify that electrical power equals genset power, and mechanical power equals power from gas driven compressor:
     assert power_generator_set == power_electrical_installation
     assert power_fuel_driven_compressor == power_mechanical_installation


### PR DESCRIPTION
ECALC-881

## Why is this pull request needed?

There is no test to verify that total power at installation level is the sum of electrical- and mechanical power. The changelog is also lacking info about breaking changes.

## What does this pull request change?

- [x] Add test to verify that electrical- and mechanical power sums up to total power
- [x] Update changelog with breaking change for eCalc v8.11

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-881