### PR TITLE
fix: detect duplicate keys in yaml file and raise error

### DIFF
--- a/docs/docs/changelog/v8-15.md
+++ b/docs/docs/changelog/v8-15.md
@@ -14,3 +14,4 @@ sidebar_position: -1001
 - Fix unit for oil rates/volumes for venting emitters of type `OIL_VOLUME`. Required input volume unit is `Sm3/d`, and reported unit in LTP is changed from `t` to `Sm3` for oil loading/storage volumes.
 - Ensure that regularity is evaluated for all installations when only venting emitters are defined for a particular installation. This caused eCalc to crash, if only venting emitters were defined.
 - Make emission names for venting emitters case-insensitive, as it is for other emissions. This solves the problem of splitting/reporting the same emission type as separate ones - if e.g. nmvoc and nmVOC is given as input by user. The problem was discovered in v8.12.
+- Detect duplicate keys in yaml-file, and raise error pointing to which line the error occurs

--- a/src/tests/libecalc/input/test_file_io.py
+++ b/src/tests/libecalc/input/test_file_io.py
@@ -7,6 +7,7 @@ from typing import IO
 import pytest
 from libecalc.infrastructure import file_io
 from libecalc.presentation.yaml import yaml_entities
+from libecalc.presentation.yaml.validation_errors import DataValidationError
 from libecalc.presentation.yaml.yaml_entities import YamlTimeseriesType
 from libecalc.presentation.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
 
@@ -270,6 +271,21 @@ class TestReadYaml:
 
         dump_yaml = PyYamlYamlModel.dump_and_load_yaml(main_yaml=main_yaml, resources=resources)
         assert dump_yaml == yaml_resource.stream.getvalue()
+
+    def test_detect_duplicate_keys_in_yaml(self):
+        main_text = """VARIABLES:
+          key1: a
+          key2: b
+          key1: c"""
+
+        main_yaml = yaml_entities.ResourceStream(
+            stream=StringIO(main_text),
+            name="main.yaml",
+        )
+
+        with pytest.raises(DataValidationError) as ve:
+            PyYamlYamlModel.read_yaml(main_yaml=main_yaml)
+        assert "Duplicate key" in str(ve.value)
 
 
 def valid_ecalc_file(


### PR DESCRIPTION
ECALC-650

If there are duplicate keys defined in the yaml file (for example several VARIABLES with the same name), the last one will be kept and no error given. 

This PR detects duplicate keys and raises and error pointing to where in the yaml file the problem occurs.