### PR TITLE
fix: add volume query for venting emitters oil type

### DIFF
--- a/src/libecalc/presentation/exporter/configs/configs.py
+++ b/src/libecalc/presentation/exporter/configs/configs.py
@@ -22,6 +22,7 @@ from libecalc.presentation.exporter.queries import (
     FuelQuery,
     MaxUsageFromShoreQuery,
     PowerSupplyOnshoreQuery,
+    VolumeQuery,
 )
 
 """
@@ -596,6 +597,15 @@ class LTPConfig(ResultConfig):
                     title="Total Oil Loaded/Stored",
                     unit=Unit.STANDARD_CUBIC_METER,
                     query=FuelQuery(
+                        installation_category="FIXED",
+                        consumer_categories=["LOADING"],
+                    ),
+                ),
+                Applier(
+                    name="loadedAndStoredOil",  # TODO: Get correct Centuries name here
+                    title="Total Oil Loaded/Stored new",
+                    unit=Unit.TONS,
+                    query=VolumeQuery(
                         installation_category="FIXED",
                         consumer_categories=["LOADING"],
                     ),

--- a/src/libecalc/presentation/exporter/queries.py
+++ b/src/libecalc/presentation/exporter/queries.py
@@ -17,6 +17,7 @@ from libecalc.common.utils.rates import (
     TimeSeriesVolumes,
 )
 from libecalc.core.result import GeneratorSetResult
+from libecalc.dto.utils.validators import convert_expression
 from libecalc.expression import Expression
 
 
@@ -128,6 +129,97 @@ class FuelQuery(Query):
                     reindexed_result.timesteps[i]: reindexed_result.values[i] for i in range(len(reindexed_result))
                 }
         return aggregated_result_volume if aggregated_result_volume else None
+
+
+class VolumeQuery(Query):
+    def __init__(
+        self,
+        installation_category: Optional[str] = None,
+        consumer_categories: Optional[List[str]] = None,
+        fuel_type_category: Optional[str] = None,
+        emission_type: Optional[str] = None,
+    ):
+        self.installation_category = installation_category
+        self.consumer_categories = consumer_categories
+        self.fuel_type_category = fuel_type_category
+        self.emission_type = emission_type
+
+    def query(
+        self,
+        installation_graph: GraphResult,
+        unit: Unit,
+        frequency: Frequency,
+    ) -> Optional[Dict[datetime, float]]:
+        installation_dto = installation_graph.graph.get_node(installation_graph.graph.root)
+
+        installation_time_steps = installation_graph.timesteps
+        time_steps = resample_time_steps(
+            frequency=frequency,
+            time_steps=installation_time_steps,
+        )
+
+        regularity = TimeSeriesFloat(
+            timesteps=installation_time_steps,
+            values=TemporalExpression.evaluate(
+                temporal_expression=TemporalModel(installation_dto.regularity),
+                variables_map=installation_graph.variables_map,
+            ),
+            unit=Unit.NONE,
+        )
+
+        aggregated_emission_volume_output_unit = {}
+        aggregated_emission_volume: Dict[datetime, float] = defaultdict(float)
+        unit_in = None
+
+        if self.installation_category is None or installation_dto.user_defined_category == self.installation_category:
+            # Add loading and storage volumes related to venting emissions, but ensure that emissions are not counted twice.
+            # Venting emissions have no fuel, and should not count when asking for emissions for a given fuel
+            if self.fuel_type_category is None:
+                for venting_emitter in installation_dto.venting_emitters:
+                    if (
+                        self.consumer_categories is None
+                        or venting_emitter.user_defined_category in self.consumer_categories
+                    ):
+                        oil_volumes_values = Expression.evaluate(
+                            convert_expression(venting_emitter.volume.rate.value),
+                            variables=installation_graph.variables_map.variables,
+                            fill_length=len(installation_graph.variables_map.time_vector),
+                        )
+                        oil_volumes = TimeSeriesStreamDayRate(
+                            timesteps=installation_time_steps,
+                            unit=venting_emitter.volume.rate.unit,
+                            values=list(oil_volumes_values),
+                        )
+
+                        emission_volumes = TimeSeriesRate.from_timeseries_stream_day_rate(
+                            oil_volumes, regularity=regularity
+                        ).to_volumes()
+                        unit_in = emission_volumes.unit
+                        for timestep, emission_volume in emission_volumes.datapoints():
+                            if self.emission_type is None:
+                                aggregated_emission_volume[timestep] += emission_volume
+
+            if aggregated_emission_volume:
+                sorted_result = dict(
+                    dict(sorted(zip(aggregated_emission_volume.keys(), aggregated_emission_volume.values()))).items()
+                )
+                sorted_result = {**dict.fromkeys(installation_time_steps, 0.0), **sorted_result}
+                date_keys = list(sorted_result.keys())
+
+                reindexed_result = (
+                    TimeSeriesVolumes(timesteps=date_keys, values=list(sorted_result.values())[:-1], unit=unit_in)
+                    .to_unit(Unit.KILO)
+                    .to_unit(unit)
+                    .reindex(time_steps)
+                    .fill_nan(0)
+                )
+
+                aggregated_emission_volume_output_unit = {
+                    reindexed_result.timesteps[i]: reindexed_result.values[i] for i in range(len(reindexed_result))
+                }
+
+            return aggregated_emission_volume_output_unit if aggregated_emission_volume_output_unit else None
+        return None
 
 
 class EmissionQuery(Query):

--- a/src/libecalc/presentation/exporter/queries.py
+++ b/src/libecalc/presentation/exporter/queries.py
@@ -19,6 +19,9 @@ from libecalc.common.utils.rates import (
 from libecalc.core.result import GeneratorSetResult
 from libecalc.dto.utils.validators import convert_expression
 from libecalc.expression import Expression
+from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
+    YamlVentingType,
+)
 
 
 class Query(abc.ABC):
@@ -179,7 +182,7 @@ class VolumeQuery(Query):
                     if (
                         self.consumer_categories is None
                         or venting_emitter.user_defined_category in self.consumer_categories
-                    ):
+                    ) and venting_emitter.type == YamlVentingType.OIL_VOLUME:
                         oil_volumes_values = Expression.evaluate(
                             convert_expression(venting_emitter.volume.rate.value),
                             variables=installation_graph.variables_map.variables,

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -7,7 +7,7 @@ from libecalc import dto
 from libecalc.common.time_utils import calculate_delta_days
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
-from libecalc.fixtures.cases import ltp_export
+from libecalc.fixtures.cases import ltp_export, venting_emitters
 from libecalc.fixtures.cases.ltp_export.installation_setup import (
     expected_boiler_fuel_consumption,
     expected_ch4_from_diesel,
@@ -217,43 +217,46 @@ def test_venting_emitters():
 
     variables = dto.VariablesMap(time_vector=time_vector, variables={})
 
-    installation_sd_kg_per_day = venting_emitter_yaml_factory(
+    dto_sd_kg_per_day = venting_emitter_yaml_factory(
         emission_rates=[emission_rate],
         regularity=regularity,
         units=[Unit.KILO_PER_DAY],
         emission_names=["ch4"],
         rate_types=[RateType.STREAM_DAY],
         names=["Venting emitter 1"],
+        path=Path(venting_emitters.__path__[0]),
     )
 
-    installation_sd_tons_per_day = venting_emitter_yaml_factory(
+    dto_sd_tons_per_day = venting_emitter_yaml_factory(
         emission_rates=[emission_rate],
         regularity=regularity,
         rate_types=[RateType.STREAM_DAY],
         units=[Unit.TONS_PER_DAY],
         emission_names=["ch4"],
         names=["Venting emitter 1"],
+        path=Path(venting_emitters.__path__[0]),
     )
 
-    installation_cd_kg_per_day = venting_emitter_yaml_factory(
+    dto_cd_kg_per_day = venting_emitter_yaml_factory(
         emission_rates=[emission_rate],
         regularity=regularity,
         rate_types=[RateType.CALENDAR_DAY],
         units=[Unit.KILO_PER_DAY],
         emission_names=["ch4"],
         names=["Venting emitter 1"],
+        path=Path(venting_emitters.__path__[0]),
     )
 
     ltp_result_input_sd_kg_per_day = get_consumption(
-        model=installation_sd_kg_per_day, variables=variables, time_vector=time_vector_yearly
+        model=dto_sd_kg_per_day.ecalc_model, variables=variables, time_vector=time_vector_yearly
     )
 
     ltp_result_input_sd_tons_per_day = get_consumption(
-        model=installation_sd_tons_per_day, variables=variables, time_vector=time_vector_yearly
+        model=dto_sd_tons_per_day.ecalc_model, variables=variables, time_vector=time_vector_yearly
     )
 
     ltp_result_input_cd_kg_per_day = get_consumption(
-        model=installation_cd_kg_per_day, variables=variables, time_vector=time_vector_yearly
+        model=dto_cd_kg_per_day.ecalc_model, variables=variables, time_vector=time_vector_yearly
     )
 
     emission_input_sd_kg_per_day = get_sum_ltp_column(
@@ -292,7 +295,7 @@ def test_only_venting_emitters_no_fuelconsumers():
 
     variables = dto.VariablesMap(time_vector=time_vector, variables={})
 
-    installation_venting_emitters = venting_emitter_yaml_factory(
+    dto_case = venting_emitter_yaml_factory(
         emission_rates=[emission_rate],
         regularity=regularity,
         units=[Unit.KILO_PER_DAY],
@@ -301,9 +304,10 @@ def test_only_venting_emitters_no_fuelconsumers():
         include_emitters=True,
         include_fuel_consumers=False,
         names=["Venting emitter 1"],
+        path=Path(venting_emitters.__path__[0]),
     )
     venting_emitter_results = get_consumption(
-        model=installation_venting_emitters, variables=variables, time_vector=time_vector_yearly
+        model=dto_case.ecalc_model, variables=variables, time_vector=time_vector_yearly
     )
     emissions_ch4 = get_sum_ltp_column(venting_emitter_results, installation_nr=0, ltp_column_nr=0)
     assert emissions_ch4 == (emission_rate / 1000) * 365 * regularity
@@ -327,6 +331,7 @@ def test_no_emitters_or_fuelconsumers():
             include_emitters=False,
             include_fuel_consumers=False,
             names=["Venting emitter 1"],
+            path=Path(venting_emitters.__path__[0]),
         )
 
     assert (

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter_validation_errors.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter_validation_errors.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 import pytest
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
+from libecalc.fixtures.cases import venting_emitters
 from libecalc.fixtures.cases.venting_emitters.venting_emitter_yaml import (
     venting_emitter_yaml_factory,
 )
@@ -22,6 +25,7 @@ def test_wrong_keyword_name_emitters():
             rate_types=[RateType.STREAM_DAY],
             emission_keyword_name="EMISSION2",
             names=["Venting emitter 1"],
+            path=Path(venting_emitters.__path__[0]),
         )
 
     assert ("EMISSION2:\tThis is not a valid keyword") in str(exc.value)
@@ -42,6 +46,7 @@ def test_wrong_unit_emitters():
             rate_types=[RateType.STREAM_DAY],
             emission_keyword_name="EMISSIONS",
             names=["Venting emitter 1"],
+            path=Path(venting_emitters.__path__[0]),
         )
 
     assert (


### PR DESCRIPTION
## Why is this pull request needed?

Oil volume query is mistakenly removed in previous PR #424. 

## What does this pull request change?

- [x] Add volume query to capture oil volumes for venting emitters of type OIL_VOLUME
- [x] Add check to verify that oil volume is output in LTP, for emitter of type OIL_VOLUME

## Issues related to this change:
