### PR TITLE
chore: change volume-unit venting emitters

### DIFF
--- a/src/libecalc/presentation/exporter/configs/configs.py
+++ b/src/libecalc/presentation/exporter/configs/configs.py
@@ -603,8 +603,8 @@ class LTPConfig(ResultConfig):
                 ),
                 Applier(
                     name="loadedAndStoredOil",  # TODO: Get correct Centuries name here
-                    title="Total Oil Loaded/Stored new",
-                    unit=Unit.TONS,
+                    title="Total Oil Loaded/Stored",
+                    unit=Unit.STANDARD_CUBIC_METER,
                     query=VolumeQuery(
                         installation_category="FIXED",
                         consumer_categories=["LOADING"],

--- a/src/libecalc/presentation/exporter/queries.py
+++ b/src/libecalc/presentation/exporter/queries.py
@@ -211,7 +211,6 @@ class VolumeQuery(Query):
 
                 reindexed_result = (
                     TimeSeriesVolumes(timesteps=date_keys, values=list(sorted_result.values())[:-1], unit=unit_in)
-                    .to_unit(Unit.KILO)
                     .to_unit(unit)
                     .reindex(time_steps)
                     .fill_nan(0)

--- a/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
+++ b/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
@@ -222,10 +222,11 @@ class YamlOilTypeEmitter(YamlBase):
                 .evaluate(variables=variables_map.variables, fill_length=len(variables_map.time_vector))
                 .tolist()
             )
+            oil_rates = Unit.to(self.volume.rate.unit, Unit.STANDARD_CUBIC_METER_PER_DAY)(oil_rates)
             emission_rate = [oil_rate * factor for oil_rate, factor in zip(oil_rates, factors)]
 
             # Emission factor is kg/Sm3 and oil rate/volume is Sm3/d. Hence, the emission rate is in kg/d:
-            emission_rate = Unit.to(Unit.KILO_PER_DAY, Unit.TONS_PER_DAY)(emission_rate)
+            emission_rate = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_rate)
 
             emissions[emission.name] = TimeSeriesStreamDayRate(
                 timesteps=variables_map.time_vector,

--- a/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
+++ b/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
@@ -30,6 +30,7 @@ from libecalc.presentation.yaml.yaml_types.components.yaml_category_field import
 )
 from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
     YamlEmissionRate,
+    YamlOilVolumeRate,
 )
 
 
@@ -50,7 +51,7 @@ class YamlVentingVolumeEmission(YamlBase):
 
 
 class YamlVentingVolume(YamlBase):
-    rate: YamlEmissionRate = Field(..., title="RATE", description="The oil loading/storage volume or volume/rate")
+    rate: YamlOilVolumeRate = Field(..., title="RATE", description="The oil loading/storage volume or volume/rate")
     emissions: List[YamlVentingVolumeEmission] = Field(
         ...,
         title="EMISSIONS",
@@ -222,7 +223,9 @@ class YamlOilTypeEmitter(YamlBase):
                 .tolist()
             )
             emission_rate = [oil_rate * factor for oil_rate, factor in zip(oil_rates, factors)]
-            emission_rate = Unit.to(self.volume.rate.unit, Unit.TONS_PER_DAY)(emission_rate)
+
+            # Emission factor is kg/Sm3 and oil rate/volume is Sm3/d. Hence, the emission rate is in kg/d:
+            emission_rate = Unit.to(Unit.KILO_PER_DAY, Unit.TONS_PER_DAY)(emission_rate)
 
             emissions[emission.name] = TimeSeriesStreamDayRate(
                 timesteps=variables_map.time_vector,

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
@@ -29,6 +29,13 @@ class YamlEmissionRate(YamlTimeSeries):
     type: Literal[RateType.STREAM_DAY, RateType.CALENDAR_DAY] = RateType.STREAM_DAY
 
 
+class YamlOilVolumeRate(YamlTimeSeries):
+    model_config = ConfigDict(title="Rate")
+
+    unit: Literal[Unit.STANDARD_CUBIC_METER_PER_DAY]
+    type: Literal[RateType.STREAM_DAY, RateType.CALENDAR_DAY] = RateType.STREAM_DAY
+
+
 class YamlPressure(YamlTimeSeries):
     model_config = ConfigDict(title="Pressure")
 

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -26,6 +26,7 @@ from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import 
 )
 from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
     YamlEmissionRate,
+    YamlOilVolumeRate,
 )
 
 
@@ -101,9 +102,9 @@ def test_venting_emitter_oil_volume(variables_map):
         category=ConsumerUserDefinedCategoryType.LOADING,
         type=YamlVentingType.OIL_VOLUME.value,
         volume=YamlVentingVolume(
-            rate=YamlEmissionRate(
+            rate=YamlOilVolumeRate(
                 value="TSC1;Oil_rate",
-                unit=Unit.KILO_PER_DAY,
+                unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
                 type=RateType.STREAM_DAY,
             ),
             emissions=[

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -218,6 +218,7 @@ def test_venting_emitters_volume_multiple_emissions_ltp():
     dto_case = venting_emitter_yaml_factory(
         regularity=regularity,
         units=[Unit.KILO_PER_DAY, Unit.KILO_PER_DAY],
+        units_oil_rates=[Unit.STANDARD_CUBIC_METER_PER_DAY, Unit.STANDARD_CUBIC_METER_PER_DAY],
         emission_names=["ch4", "nmvoc"],
         emitter_types=["OIL_VOLUME"],
         rate_types=[RateType.STREAM_DAY],
@@ -243,4 +244,4 @@ def test_venting_emitters_volume_multiple_emissions_ltp():
 
     assert ch4_emissions == sum(oil_rates[0] * days * regularity * emission_factors[0] / 1000 for days in delta_days)
     assert nmvoc_emissions == sum(oil_rates[0] * days * regularity * emission_factors[1] / 1000 for days in delta_days)
-    assert oil_volume == pytest.approx(sum(oil_rates[0] * days * regularity for days in delta_days) / 1000, abs=1e-5)
+    assert oil_volume == pytest.approx(sum(oil_rates[0] * days * regularity for days in delta_days), abs=1e-5)


### PR DESCRIPTION
ECALC-507

## Why is this pull request needed?

Unit for oil rates/volumes in venting emitters of type OIL_VOLUME should be `Sm3` and not `t`.

## What does this pull request change?

- [x] Change allowed input unit for volumes, to Sm3/d (only option)
- [x] Remove "new" from heading
- [x] Update calculations and unit conversions to reflect input/output units
- [x] Update test


## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-507?focusedCommentId=11764&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-11764