### PR TITLE
fix: honor rate type for oil type venting emitter

### DIFF
--- a/src/libecalc/presentation/exporter/queries.py
+++ b/src/libecalc/presentation/exporter/queries.py
@@ -17,7 +17,6 @@ from libecalc.common.utils.rates import (
     TimeSeriesVolumes,
 )
 from libecalc.core.result import GeneratorSetResult
-from libecalc.dto.utils.validators import convert_expression
 from libecalc.expression import Expression
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingType,
@@ -183,17 +182,9 @@ class VolumeQuery(Query):
                         self.consumer_categories is None
                         or venting_emitter.user_defined_category in self.consumer_categories
                     ) and venting_emitter.type == YamlVentingType.OIL_VOLUME:
-                        oil_volumes_values = Expression.evaluate(
-                            convert_expression(venting_emitter.volume.rate.value),
-                            variables=installation_graph.variables_map.variables,
-                            fill_length=len(installation_graph.variables_map.time_vector),
+                        oil_volumes = venting_emitter.get_oil_rates(
+                            variables_map=installation_graph.variables_map, regularity=regularity
                         )
-                        oil_volumes = TimeSeriesStreamDayRate(
-                            timesteps=installation_time_steps,
-                            unit=venting_emitter.volume.rate.unit,
-                            values=list(oil_volumes_values),
-                        )
-
                         emission_volumes = TimeSeriesRate.from_timeseries_stream_day_rate(
                             oil_volumes, regularity=regularity
                         ).to_volumes()


### PR DESCRIPTION
ECALC-1060

## Why is this pull request needed?

The results are identical when input is `STREAM_DAY` and `CALENDAR_DAY`, for volume calculations of venting emitters of type `OIL_VOLUME`.

## What does this pull request change?

- [x] Update yaml venting emitters to return evaluated volume rates instead of doing it in ltp query
- [x] Ensure input is accounting for rate type
- [x] Add test to verify stream day is different from calendar day


## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1060?atlOrigin=eyJpIjoiYjIwMDA0ZDRhMjk1NGI2ZWE5MWM2MmQ5ZDRhZDg1MDgiLCJwIjoiaiJ9