### PR TITLE
fix: error when only venting emitters are specified for an installation

### DIFF
--- a/src/libecalc/application/graph_result.py
+++ b/src/libecalc/application/graph_result.py
@@ -1251,16 +1251,17 @@ class GraphResult:
 
         # When only venting emitters are specified, without a generator set: the installation result is empty.
         # Ensure that the installation regularity is found, even if only venting emitters are defined:
-        regularity_emitters = {
-            installation.id: TimeSeriesFloat(
-                values=TemporalExpression.evaluate(
-                    temporal_expression=TemporalModel(installation.regularity), variables_map=self.variables_map
-                ),
-                unit=Unit.NONE,
-                timesteps=self.variables_map.time_vector,
-            )
-            for installation in asset.installations
-        }
+        if not installation_results:
+            regularities = {
+                installation.id: TimeSeriesFloat(
+                    values=TemporalExpression.evaluate(
+                        temporal_expression=TemporalModel(installation.regularity), variables_map=self.variables_map
+                    ),
+                    unit=Unit.NONE,
+                    timesteps=self.variables_map.time_vector,
+                )
+                for installation in asset.installations
+            }
 
         time_series_zero = TimeSeriesRate(
             values=[0] * self.variables_map.length,
@@ -1281,7 +1282,7 @@ class GraphResult:
                         component_level=ComponentLevel.CONSUMER,
                         parent=installation.id,
                         emissions=self._parse_emissions(
-                            self.emission_results[venting_emitter.id], regularity_emitters[installation.id]
+                            self.emission_results[venting_emitter.id], regularities[installation.id]
                         ),
                         timesteps=self.variables_map.time_vector,
                         is_valid=TimeSeriesBoolean(
@@ -1306,7 +1307,7 @@ class GraphResult:
 
         emission_dto_results = self.convert_to_timeseries(
             self.emission_results,
-            regularity_emitters,
+            regularities,
         )
         asset_aggregated_emissions = aggregate_emissions(list(emission_dto_results.values()))
 

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -7,6 +7,7 @@ from libecalc import dto
 from libecalc.common.time_utils import calculate_delta_days
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
+from libecalc.dto.result.results import EcalcModelResult
 from libecalc.fixtures.cases import ltp_export, venting_emitters
 from libecalc.fixtures.cases.ltp_export.installation_setup import (
     expected_boiler_fuel_consumption,
@@ -309,6 +310,12 @@ def test_only_venting_emitters_no_fuelconsumers():
     venting_emitter_results = get_consumption(
         model=dto_case.ecalc_model, variables=variables, time_vector=time_vector_yearly
     )
+
+    # Verify that eCalc, is not failing in get_asset_result, with only venting emitters -
+    # when installation result is empty, i.e. with no genset and fuel consumers:
+    assert isinstance(get_consumption_asset_result(model=dto_case.ecalc_model, variables=variables), EcalcModelResult)
+
+    # Verify correct emissions:
     emissions_ch4 = get_sum_ltp_column(venting_emitter_results, installation_nr=0, ltp_column_nr=0)
     assert emissions_ch4 == (emission_rate / 1000) * 365 * regularity
 


### PR DESCRIPTION
ECALC-1061

## Why is this pull request needed?

Error when venting emitters are defined alone, without a generator set - for a given installation. The reason is that the installation results are empty, and the installation regularity cannot be found for the particular venting emitters.

## What does this pull request change?

More robust reading of regularity for venting emitters, independent of installation results: Reading from the asset object directly.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1061?atlOrigin=eyJpIjoiNWUwMDMwMjkxMzc2NGEyMmJmMGY5ZTg3NTBlOThkZDQiLCJwIjoiaiJ9