### PR TITLE
chore: Make sure we remember chores for changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 - [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
 - [ ] I have added tests (if not, comment why)
 - [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
+- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)
 
 ## Why is this pull request needed?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
 ## Have you remembered and considered?
 
-- [ ] Update documentation, if relevant
-- [ ] Update manual changelog, if relevant
-- [ ] Update migration guide, if relevant
-- [ ] Tagged commit with `BREAKING:` in footer or `!` in header if breaking
-- [ ] Considered to add tests
-- [ ] Used conventional commits syntax
+- [ ] I have remembered to update documentation
+- [ ] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
+- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
+- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
+- [ ] I have added tests (if not, comment why)
+- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
 
 ## Why is this pull request needed?
 


### PR DESCRIPTION
## Have you remembered and considered?

- [x] Update documentation, if relevant
- [x] Update manual changelog, if relevant
- [x] Update migration guide, if relevant
- [x] Tagged commit with `BREAKING:` in footer or `!` in header if breaking
- [x] Considered to add tests
- [x] Used conventional commits syntax

## Why is this pull request needed?

We tend to forget common chores such as updating changelong and migration guide, making it difficult for release manager or person assigned to "post release" check what is needed to be updated, both context switching wise and annoying.

## What does this pull request change?

PR template

## Issues related to this change:

ECALC-1130