### PR TITLE
fix: ensure regularity is evaluated for all installations when only venting emitters

### DIFF
--- a/src/libecalc/application/graph_result.py
+++ b/src/libecalc/application/graph_result.py
@@ -1249,9 +1249,10 @@ class GraphResult:
 
             sub_components.append(obj)
 
-        # When only venting emitters are specified, without a generator set: the installation result is empty.
-        # Ensure that the installation regularity is found, even if only venting emitters are defined:
-        if not installation_results:
+        # When only venting emitters are specified, without a generator set: the installation result
+        # is empty for this installation. Ensure that the installation regularity is found, even if only
+        # venting emitters are defined for one installation:
+        if len(installation_results) < len(asset.installations):
             regularities = {
                 installation.id: TimeSeriesFloat(
                     values=TemporalExpression.evaluate(

--- a/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
+++ b/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
@@ -27,6 +27,7 @@ def venting_emitter_yaml_factory(
     emitter_types: List[str] = None,
     categories: List[str] = None,
     emission_keyword_name: str = "EMISSIONS",
+    installation_name: str = "minimal_installation",
     emission_factors: List[float] = None,
     oil_rates: List[float] = None,
     units_oil_rates: List[Unit] = None,
@@ -46,14 +47,6 @@ def venting_emitter_yaml_factory(
     if emission_rates is None:
         emission_rates = [10] * len(names)
 
-    f"""
-        {create_venting_emitters_yaml(
-        categories=categories, rate_types=rate_types, emitter_names=names, emission_names=emission_names,
-        emission_rates=emission_rates, units=units, emission_keyword_name=emission_keyword_name, include_emitters=include_emitters,
-        emitter_types=emitter_types, oil_rates=oil_rates, emission_factors=emission_factors, units_oil_rates=units_oil_rates,
-    )}
-    """
-
     input_text = f"""
         FACILITY_INPUTS:
           - NAME: generator_energy_function
@@ -69,7 +62,7 @@ def venting_emitter_yaml_factory(
         END: 2029-01-01
 
         INSTALLATIONS:
-        - NAME: minimal_installation
+        - NAME: {installation_name}
           HCEXPORT: 0
           FUEL: fuel
           CATEGORY: FIXED

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -314,7 +314,7 @@ def test_only_venting_emitters_no_fuelconsumers():
         model=dto_case_emitters.ecalc_model, variables=variables, time_vector=time_vector_yearly
     )
 
-    # Verify that eCalc, is not failing in get_asset_result, with only venting emitters -
+    # Verify that eCalc is not failing in get_asset_result with only venting emitters -
     # when installation result is empty, i.e. with no genset and fuel consumers:
     assert isinstance(
         get_consumption_asset_result(model=dto_case_emitters.ecalc_model, variables=variables), EcalcModelResult
@@ -343,10 +343,10 @@ def test_only_venting_emitters_no_fuelconsumers():
         installations=[dto_case_emitters.ecalc_model.installations[0], dto_case_fuel.ecalc_model.installations[0]],
     )
 
-    # Verify that eCalc, is not failing in get_asset_result, with only venting emitters -
+    # Verify that eCalc is not failing in get_asset_result, with only venting emitters -
     # when installation result is empty for one installation, i.e. with no genset and fuel consumers.
     # Include asset with two installations, one with only emitters and one with only fuel consumers -
-    # ensure that graph_result returns a result:
+    # ensure that get_asset_result returns a result:
 
     assert isinstance(
         get_consumption_asset_result(model=asset_multi_installations, variables=variables), EcalcModelResult


### PR DESCRIPTION
ECALC-1061

## Have you remembered and considered?

- [x] Update documentation, if relevant
- [x] Update manual changelog, if relevant
- [x] Update migration guide, if relevant
- [x] Tagged commit with `BREAKING:` in footer or `!` in header if breaking
- [x] Considered to add tests
- [x] Used conventional commits syntax

## Why is this pull request needed?

Installation results is empty if only venting emitters are specified for one installation. A check was done testing if installation result was empty, then regularity was evaluated for all installations. However, this check is not sufficient, as there can be several installations. One may have only venting emitters, while another can have genset and fuel consumers.

## What does this pull request change?

Change test: Check if length of installation_results is less than number of installations.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1061?atlOrigin=eyJpIjoiMDMwOGIwNzdkZmRiNGJhZDk5ZDBkMmM2YjVhY2Q2NjIiLCJwIjoiaiJ9