### PR TITLE
chore: make venting emitters emission names case insensitive

### DIFF
--- a/docs/docs/about/references/keywords/EMISSIONS.md
+++ b/docs/docs/about/references/keywords/EMISSIONS.md
@@ -44,6 +44,8 @@ EMISSIONS:
 ~~~~~~~~
 
 ## For venting emitters (type: DIRECT_EMISSION)
+Note that the emission name is case-insensitive.
+
 ### Format
 ~~~~~~~~yaml
 EMISSIONS:
@@ -67,6 +69,8 @@ EMISSIONS:
       TYPE: STREAM_DAY
 ~~~~~~~~
 ## For venting emitters (type: OIL_VOLUME)
+Note that the emission name is case-insensitive.
+
 ### Format
 ~~~~~~~~yaml
 EMISSIONS:

--- a/docs/docs/changelog/v8-15.md
+++ b/docs/docs/changelog/v8-15.md
@@ -12,3 +12,5 @@ sidebar_position: -1001
 
 - Add volume query for venting emitters of type `OIL_VOLUME`. This query was removed by mistake in earlier version. This ensures that oil loading/storage volumes are reported when the type is `OIL_VOLUME`.
 - Fix unit for oil rates/volumes for venting emitters of type `OIL_VOLUME`. Required input volume unit is `Sm3/d`, and reported unit in LTP is changed from `t` to `Sm3` for oil loading/storage volumes.
+- Ensure that regularity is evaluated for all installations when only venting emitters are defined for a particular installation. This caused eCalc to crash, if only venting emitters were defined.
+- Make emission names for venting emitters case-insensitive, as it is for other emissions. This solves the problem of splitting/reporting the same emission type as separate ones - if e.g. nmvoc and nmVOC is given as input by user. The problem was discovered in v8.12.

--- a/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
+++ b/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
@@ -50,6 +50,11 @@ class YamlVentingVolumeEmission(YamlBase):
         None, title="EMISSION_FACTOR", description="Loading/storage volume-emission factor"
     )
 
+    @field_validator("name", mode="before")
+    def check_name(cls, name, info: ValidationInfo):
+        """Make name case-insensitive"""
+        return name.lower()
+
 
 class YamlVentingVolume(YamlBase):
     rate: YamlOilVolumeRate = Field(..., title="RATE", description="The oil loading/storage volume or volume/rate")
@@ -67,6 +72,11 @@ class YamlVentingEmission(YamlBase):
         description="Name of emission",
     )
     rate: YamlEmissionRate = Field(..., title="RATE", description="The emission rate")
+
+    @field_validator("name", mode="before")
+    def check_name(cls, name, info: ValidationInfo):
+        """Make name case-insensitive"""
+        return name.lower()
 
 
 class YamlDirectTypeEmitter(YamlBase):

--- a/src/tests/libecalc/integration/snapshots/test_all_energy_usage_models/test_all_results/all_energy_usage_models_v3.json
+++ b/src/tests/libecalc/integration/snapshots/test_all_energy_usage_models/test_all_results/all_energy_usage_models_v3.json
@@ -23508,8 +23508,8 @@
             }
         },
         "methane_venting": {
-            "CH4": {
-                "name": "CH4",
+            "ch4": {
+                "name": "ch4",
                 "rate": {
                     "timesteps": [
                         "2017-01-01 00:00:00",

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -273,3 +273,53 @@ def test_venting_emitters_volume_multiple_emissions_ltp():
     # Oil volume (input rate in stream day) / oil volume (input rates calendar day) = regularity.
     # Given that the actual rate input values are the same.
     assert oil_volume_stream_day / oil_volume == regularity
+
+
+def test_venting_emitters_direct_uppercase_emissions_name():
+    """
+    Check emission names are case-insensitive for venting emitters of type DIRECT_EMISSION.
+    """
+
+    regularity = 0.2
+    emission_rates = [10, 5]
+    dto_case = venting_emitter_yaml_factory(
+        emission_rates=emission_rates,
+        regularity=regularity,
+        units=[Unit.KILO_PER_DAY, Unit.KILO_PER_DAY],
+        emission_names=["CO2", "nmVOC"],
+        rate_types=[RateType.STREAM_DAY],
+        emission_keyword_name="EMISSIONS",
+        categories=["COLD-VENTING-FUGITIVE"],
+        names=["Venting emitter 1"],
+        path=Path(venting_emitters.__path__[0]),
+    )
+
+    assert dto_case.ecalc_model.installations[0].venting_emitters[0].emissions[0].name == "co2"
+    assert dto_case.ecalc_model.installations[0].venting_emitters[0].emissions[1].name == "nmvoc"
+
+
+def test_venting_emitters_volume_uppercase_emissions_name():
+    """
+    Check emission names are case-insensitive for venting emitters of type OIL_VOLUME.
+    """
+
+    regularity = 0.2
+    emission_factors = [0.1, 0.1]
+    oil_rates = [100]
+
+    dto_case = venting_emitter_yaml_factory(
+        regularity=regularity,
+        units=[Unit.KILO_PER_DAY, Unit.KILO_PER_DAY],
+        units_oil_rates=[Unit.STANDARD_CUBIC_METER_PER_DAY, Unit.STANDARD_CUBIC_METER_PER_DAY],
+        emission_names=["CO2", "nmVOC"],
+        emitter_types=["OIL_VOLUME"],
+        rate_types=[RateType.CALENDAR_DAY],
+        categories=["LOADING"],
+        names=["Venting emitter 1"],
+        emission_factors=emission_factors,
+        oil_rates=oil_rates,
+        path=Path(venting_emitters.__path__[0]),
+    )
+
+    assert dto_case.ecalc_model.installations[0].venting_emitters[0].volume.emissions[0].name == "co2"
+    assert dto_case.ecalc_model.installations[0].venting_emitters[0].volume.emissions[1].name == "nmvoc"


### PR DESCRIPTION
ECALC-1148

## Have you remembered and considered?

- [x] I have remembered to update documentation
- [x] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [x] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [x] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Emission name, e.g. nmVOC and nmvoc, should be case insensitive for venting emitters to avoid splitting/interpreting the same emission type as different types.

## What does this pull request change?

Convert input emission names to lower case, for venting emitters.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1148?atlOrigin=eyJpIjoiY2YyMmY5N2ExMjk4NDVhY2E4Y2E3ZDZkMTM2Y2YwNDgiLCJwIjoiaiJ9