### PR TITLE
fix: use custom type pydantic class to wrap ndarray and avoid validation problem

### DIFF
--- a/src/libecalc/core/consumers/legacy_consumer/system/results.py
+++ b/src/libecalc/core/consumers/legacy_consumer/system/results.py
@@ -19,6 +19,7 @@ from libecalc.core.consumers.legacy_consumer.system.operational_setting import (
 )
 from libecalc.core.models.results import CompressorTrainResult, PumpModelResult
 from libecalc.core.result.results import ConsumerModelResult
+from libecalc.core.utils.array_type import PydanticNDArray
 
 
 class ConsumerSystemComponentResult(BaseModel):
@@ -30,7 +31,7 @@ class ConsumerSystemComponentResult(BaseModel):
         return self.consumer_model_result.energy_usage
 
     @property
-    def power(self) -> NDArray[np.float64]:
+    def power(self) -> PydanticNDArray:
         if self.consumer_model_result.power is not None:
             return np.asarray(self.consumer_model_result.power)
         else:
@@ -58,7 +59,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     @property
-    def total_energy_usage(self) -> NDArray[np.float64]:
+    def total_energy_usage(self) -> PydanticNDArray:
         total_energy_usage = np.sum(
             [np.asarray(result.energy_usage) for result in self.consumer_results],
             axis=0,
@@ -66,7 +67,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
         return np.array(total_energy_usage)
 
     @property
-    def total_power(self) -> NDArray[np.float64]:
+    def total_power(self) -> PydanticNDArray:
         total_power = np.sum(
             [np.asarray(result.power) for result in self.consumer_results],
             axis=0,
@@ -74,7 +75,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
         return np.array(total_power)
 
     @property
-    def indices_outside_capacity(self) -> NDArray[np.float64]:
+    def indices_outside_capacity(self) -> PydanticNDArray:
         invalid_indices = np.full_like(self.total_energy_usage, fill_value=0)
 
         for result in self.consumer_results:
@@ -110,12 +111,12 @@ class ConsumerSystemConsumerFunctionResult(ConsumerFunctionResultBase):
 
     typ: Literal[ConsumerFunctionType.SYSTEM] = ConsumerFunctionType.SYSTEM  # type: ignore[valid-type]
 
-    operational_setting_used: NDArray[np.float64]  # integers in the range of number of operational settings
+    operational_setting_used: PydanticNDArray  # integers in the range of number of operational settings
     operational_settings: List[List[ConsumerSystemOperationalSetting]]
     operational_settings_results: List[List[ConsumerSystemOperationalSettingResult]]
     consumer_results: List[List[ConsumerSystemComponentResult]]
     cross_over_used: Optional[
-        NDArray[np.float64]
+        PydanticNDArray
     ] = None  # 0 or 1 whether cross over is used for this result (1=True, 0=False)
 
     def extend(self, other) -> ConsumerSystemConsumerFunctionResult:

--- a/src/libecalc/core/consumers/legacy_consumer/system/results.py
+++ b/src/libecalc/core/consumers/legacy_consumer/system/results.py
@@ -31,7 +31,7 @@ class ConsumerSystemComponentResult(BaseModel):
         return self.consumer_model_result.energy_usage
 
     @property
-    def power(self) -> PydanticNDArray:
+    def power(self) -> PydanticNDArray[np.float64]:
         if self.consumer_model_result.power is not None:
             return np.asarray(self.consumer_model_result.power)
         else:
@@ -59,7 +59,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     @property
-    def total_energy_usage(self) -> PydanticNDArray:
+    def total_energy_usage(self) -> PydanticNDArray[np.float64]:
         total_energy_usage = np.sum(
             [np.asarray(result.energy_usage) for result in self.consumer_results],
             axis=0,
@@ -67,7 +67,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
         return np.array(total_energy_usage)
 
     @property
-    def total_power(self) -> PydanticNDArray:
+    def total_power(self) -> PydanticNDArray[np.float64]:
         total_power = np.sum(
             [np.asarray(result.power) for result in self.consumer_results],
             axis=0,
@@ -75,7 +75,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
         return np.array(total_power)
 
     @property
-    def indices_outside_capacity(self) -> PydanticNDArray:
+    def indices_outside_capacity(self) -> PydanticNDArray[np.float64]:
         invalid_indices = np.full_like(self.total_energy_usage, fill_value=0)
 
         for result in self.consumer_results:
@@ -111,12 +111,12 @@ class ConsumerSystemConsumerFunctionResult(ConsumerFunctionResultBase):
 
     typ: Literal[ConsumerFunctionType.SYSTEM] = ConsumerFunctionType.SYSTEM  # type: ignore[valid-type]
 
-    operational_setting_used: PydanticNDArray  # integers in the range of number of operational settings
+    operational_setting_used: PydanticNDArray[np.float64]  # integers in the range of number of operational settings
     operational_settings: List[List[ConsumerSystemOperationalSetting]]
     operational_settings_results: List[List[ConsumerSystemOperationalSettingResult]]
     consumer_results: List[List[ConsumerSystemComponentResult]]
     cross_over_used: Optional[
-        PydanticNDArray
+        PydanticNDArray[np.float64]
     ] = None  # 0 or 1 whether cross over is used for this result (1=True, 0=False)
 
     def extend(self, other) -> ConsumerSystemConsumerFunctionResult:

--- a/src/libecalc/core/consumers/legacy_consumer/system/results.py
+++ b/src/libecalc/core/consumers/legacy_consumer/system/results.py
@@ -31,7 +31,7 @@ class ConsumerSystemComponentResult(BaseModel):
         return self.consumer_model_result.energy_usage
 
     @property
-    def power(self) -> PydanticNDArray[np.float64]:
+    def power(self) -> PydanticNDArray:
         if self.consumer_model_result.power is not None:
             return np.asarray(self.consumer_model_result.power)
         else:
@@ -59,7 +59,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     @property
-    def total_energy_usage(self) -> PydanticNDArray[np.float64]:
+    def total_energy_usage(self) -> PydanticNDArray:
         total_energy_usage = np.sum(
             [np.asarray(result.energy_usage) for result in self.consumer_results],
             axis=0,
@@ -67,7 +67,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
         return np.array(total_energy_usage)
 
     @property
-    def total_power(self) -> PydanticNDArray[np.float64]:
+    def total_power(self) -> PydanticNDArray:
         total_power = np.sum(
             [np.asarray(result.power) for result in self.consumer_results],
             axis=0,
@@ -75,7 +75,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
         return np.array(total_power)
 
     @property
-    def indices_outside_capacity(self) -> PydanticNDArray[np.float64]:
+    def indices_outside_capacity(self) -> PydanticNDArray:
         invalid_indices = np.full_like(self.total_energy_usage, fill_value=0)
 
         for result in self.consumer_results:
@@ -111,12 +111,12 @@ class ConsumerSystemConsumerFunctionResult(ConsumerFunctionResultBase):
 
     typ: Literal[ConsumerFunctionType.SYSTEM] = ConsumerFunctionType.SYSTEM  # type: ignore[valid-type]
 
-    operational_setting_used: PydanticNDArray[np.float64]  # integers in the range of number of operational settings
+    operational_setting_used: PydanticNDArray  # integers in the range of number of operational settings
     operational_settings: List[List[ConsumerSystemOperationalSetting]]
     operational_settings_results: List[List[ConsumerSystemOperationalSettingResult]]
     consumer_results: List[List[ConsumerSystemComponentResult]]
     cross_over_used: Optional[
-        PydanticNDArray[np.float64]
+        PydanticNDArray
     ] = None  # 0 or 1 whether cross over is used for this result (1=True, 0=False)
 
     def extend(self, other) -> ConsumerSystemConsumerFunctionResult:

--- a/src/libecalc/expression/expression_evaluator.py
+++ b/src/libecalc/expression/expression_evaluator.py
@@ -406,7 +406,7 @@ class Operators(Enum):
 
 class Token(BaseModel):
     tag: TokenTag
-    value: Union[float, int, bool, PydanticNDArray[np.float64], str] = Field(union_mode="left_to_right")
+    value: Union[float, int, bool, PydanticNDArray, str] = Field(union_mode="left_to_right")
 
     def __str__(self):
         return str(self.value)

--- a/src/libecalc/expression/expression_evaluator.py
+++ b/src/libecalc/expression/expression_evaluator.py
@@ -12,6 +12,7 @@ from numpy.typing import NDArray
 from pydantic import BaseModel, ConfigDict, Field
 
 from libecalc.common.logger import logger
+from libecalc.core.utils.array_type import PydanticNDArray
 
 """
 Module for expression parsing used in Energy/CO2/emissions calculator
@@ -405,7 +406,7 @@ class Operators(Enum):
 
 class Token(BaseModel):
     tag: TokenTag
-    value: Union[float, int, bool, NDArray[np.float64], str] = Field(union_mode="left_to_right")
+    value: Union[float, int, bool, PydanticNDArray, str] = Field(union_mode="left_to_right")
 
     def __str__(self):
         return str(self.value)

--- a/src/libecalc/expression/expression_evaluator.py
+++ b/src/libecalc/expression/expression_evaluator.py
@@ -406,7 +406,7 @@ class Operators(Enum):
 
 class Token(BaseModel):
     tag: TokenTag
-    value: Union[float, int, bool, PydanticNDArray, str] = Field(union_mode="left_to_right")
+    value: Union[float, int, bool, PydanticNDArray[np.float64], str] = Field(union_mode="left_to_right")
 
     def __str__(self):
         return str(self.value)


### PR DESCRIPTION
ECALC-965
fixes #482 

## Have you remembered and considered?

- [x] I have remembered to update documentation
- [x] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [x] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [x] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

When users are using eCalc directly on CLI, they will be met with a few warnings that will most likely be difficult for them to understand, so we should either handle them or silence them. 

## What does this pull request change?

The problem is caused by sending numpy.ndarrays directly into pydantic, giving validation problems. Avoiding the problem using custom type PydanticNDArray to wrap numpy.ndarray, and use that type instead of numpy.ndarray directly.

A more long term solution is to return List and Float from core.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-965?atlOrigin=eyJpIjoiNjUxNmVlMmY4ZWEyNGU5YzhmN2RhM2MyZTY0NGE2OWYiLCJwIjoiaiJ9