### PR TITLE
fix: wrong unit max power from shore

### DIFF
--- a/src/libecalc/presentation/exporter/configs/configs.py
+++ b/src/libecalc/presentation/exporter/configs/configs.py
@@ -657,7 +657,7 @@ class LTPConfig(ResultConfig):
                 Applier(
                     name="fromShorePeakMaximum",
                     title="Max Usage from Shore",
-                    unit=Unit.GIGA_WATT_HOURS,
+                    unit=Unit.MEGA_WATT,
                     query=MaxUsageFromShoreQuery(
                         producer_categories=["POWER-FROM-SHORE"],
                     ),

--- a/src/libecalc/presentation/exporter/queries.py
+++ b/src/libecalc/presentation/exporter/queries.py
@@ -511,7 +511,6 @@ class MaxUsageFromShoreQuery(Query):
 
         aggregated_result: DefaultDict[datetime, float] = defaultdict(float)
         aggregated_result_volume = {}
-        unit_in = None
 
         if self.installation_category is None or installation_dto.user_defined_category == self.installation_category:
             for fuel_consumer in installation_dto.fuel_consumers:
@@ -532,15 +531,13 @@ class MaxUsageFromShoreQuery(Query):
                                         fill_length=len(installation_graph.variables_map.time_vector),
                                     )
                                 ),
-                                unit=Unit.MEGA_WATT,
+                                unit=unit,
                                 timesteps=installation_graph.variables_map.time_vector,
                             )
 
                             results = TimeSeriesRate.from_timeseries_stream_day_rate(
                                 max_usage_from_shore, regularity=regularity
                             ).for_period(period)
-
-                            unit_in = results.unit
 
                             for timestep, result in results.datapoints():
                                 aggregated_result[timestep] += result
@@ -551,7 +548,7 @@ class MaxUsageFromShoreQuery(Query):
                 date_keys = list(sorted_result.keys())
 
                 reindexed_result = (
-                    TimeSeriesVolumes(timesteps=date_keys, values=list(sorted_result.values())[:-1], unit=unit_in)
+                    TimeSeriesVolumes(timesteps=date_keys, values=list(sorted_result.values())[:-1], unit=unit)
                     .reindex(time_steps)
                     .fill_nan(0)
                 )

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -593,3 +593,6 @@ def test_power_from_shore(ltp_pfs_yaml_factory):
 
     # Check that reading cable loss from csv-file gives same result as using constant
     assert power_supply_onshore == power_supply_onshore_csv
+
+    # Verify correct unit for max usage from shore
+    assert ltp_result.query_results[0].query_results[3].unit == Unit.MEGA_WATT


### PR DESCRIPTION
ECALC-1190

## Have you remembered and considered?

- [x] I have remembered to update documentation
- [x] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [x] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [x] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

The unit for `Max Usage from Shore` column in LTP-report is GWh, but should be MW.

## What does this pull request change?

Change unit from GWh to MW. In query: remove option for input-unit, it should always be MW.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1190?atlOrigin=eyJpIjoiZTc1OTcxYThmMmJhNDU3NThkMDlmOGVkOTMxMmNhZTgiLCJwIjoiaiJ9