### PR TITLE
chore: refine unit format alignment

### DIFF
--- a/src/libecalc/fixtures/cases/all_energy_usage_models/all_models_dto.py
+++ b/src/libecalc/fixtures/cases/all_energy_usage_models/all_models_dto.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import pytest
 
 from libecalc import dto
-from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
 from libecalc.dto.base import (
     ComponentType,
@@ -20,6 +19,7 @@ from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import 
 )
 from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
     YamlEmissionRate,
+    YamlEmissionRateUnits,
 )
 
 
@@ -990,7 +990,7 @@ def methane_venting(regularity) -> YamlVentingEmitter:
             YamlVentingEmission(
                 name="CH4",
                 rate=YamlEmissionRate(
-                    value="FLARE;METHANE_RATE", unit=Unit.KILO_PER_DAY.name, type=RateType.STREAM_DAY
+                    value="FLARE;METHANE_RATE", unit=YamlEmissionRateUnits.KILO_PER_DAY, type=RateType.STREAM_DAY
                 ),
             )
         ],

--- a/src/libecalc/fixtures/cases/all_energy_usage_models/data/all_energy_usage_models.yaml
+++ b/src/libecalc/fixtures/cases/all_energy_usage_models/data/all_energy_usage_models.yaml
@@ -621,5 +621,5 @@ INSTALLATIONS:
           - NAME: CH4
             RATE:
               VALUE: FLARE;METHANE_RATE
-              UNIT: KILO_PER_DAY
+              UNIT: KG_PER_DAY
               TYPE: STREAM_DAY

--- a/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
+++ b/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
@@ -14,11 +14,15 @@ from libecalc.presentation.yaml.parse_input import map_yaml_to_dto
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingType,
 )
+from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
+    YamlEmissionRateUnits,
+    YamlOilRateUnits,
+)
 
 
 def venting_emitter_yaml_factory(
     rate_types: List[RateType],
-    units: List[str],
+    units: List[YamlEmissionRateUnits],
     emission_names: List[str],
     regularity: float,
     names: List[str],
@@ -30,7 +34,7 @@ def venting_emitter_yaml_factory(
     installation_name: str = "minimal_installation",
     emission_factors: List[float] = None,
     oil_rates: List[float] = None,
-    units_oil_rates: List[str] = None,
+    units_oil_rates: List[YamlOilRateUnits] = None,
     include_emitters: bool = True,
     include_fuel_consumers: bool = True,
 ) -> DTOCase:
@@ -120,8 +124,8 @@ def create_venting_emitters_yaml(
     emitter_names: List[str],
     emission_names: List[str],
     emission_rates: List[float],
-    units: List[str],
-    units_oil_rates: List[Unit],
+    units: List[YamlEmissionRateUnits],
+    units_oil_rates: List[YamlOilRateUnits],
     emission_keyword_name: str,
     emission_factors: List[float],
     oil_rates: List[float],
@@ -148,7 +152,7 @@ def create_venting_emitters_yaml(
                     - NAME: {emission_name}
                       RATE:
                         VALUE: {emission_rate}
-                        UNIT:  {unit}
+                        UNIT:  {unit.value}
                         TYPE: {rate_type.value}
                     """
                     emissions = emissions + emission
@@ -157,7 +161,7 @@ def create_venting_emitters_yaml(
                 emissions = f"""
                 RATE:
                   VALUE: {oil_rate}
-                  UNIT: {unit_oil_rate}
+                  UNIT: {unit_oil_rate.value}
                   TYPE: {rate_type.value}
                 EMISSIONS:
                 """

--- a/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
+++ b/src/libecalc/fixtures/cases/venting_emitters/venting_emitter_yaml.py
@@ -152,7 +152,7 @@ def create_venting_emitters_yaml(
                     - NAME: {emission_name}
                       RATE:
                         VALUE: {emission_rate}
-                        UNIT:  {unit.value}
+                        UNIT:  {unit.value if isinstance(unit, YamlEmissionRateUnits) else unit}
                         TYPE: {rate_type.value}
                     """
                     emissions = emissions + emission

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_stream_conditions.py
@@ -25,7 +25,7 @@ class YamlRate(YamlTimeSeries):
 
 
 class YamlEmissionRateUnits(enum.Enum):
-    KILO_PER_DAY = "KILO_PER_DAY"
+    KILO_PER_DAY = "KG_PER_DAY"
     TONS_PER_DAY = "TONS_PER_DAY"
 
     def to_unit(self) -> Unit:
@@ -44,7 +44,7 @@ class YamlEmissionRate(YamlTimeSeries):
 
 
 class YamlOilRateUnits(enum.Enum):
-    STANDARD_CUBIC_METER_PER_DAY = "STANDARD_CUBIC_METER_PER_DAY"
+    STANDARD_CUBIC_METER_PER_DAY = "SM3_PER_DAY"
 
     def to_unit(self) -> Unit:
         if self == YamlOilRateUnits.STANDARD_CUBIC_METER_PER_DAY:

--- a/src/tests/libecalc/dto/test_categories.py
+++ b/src/tests/libecalc/dto/test_categories.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 import pytest
 from libecalc import dto
-from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
 from libecalc.dto.components import (
     ComponentType,
@@ -19,6 +18,7 @@ from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import 
 )
 from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
     YamlEmissionRate,
+    YamlEmissionRateUnits,
 )
 from pydantic import ValidationError
 
@@ -26,7 +26,8 @@ from pydantic import ValidationError
 class TestCategories:
     def test_venting_emitter_categories(self):
         emission = YamlVentingEmission(
-            name="CH4", rate=YamlEmissionRate(value=4, type=RateType.STREAM_DAY, unit=Unit.KILO_PER_DAY.name)
+            name="CH4",
+            rate=YamlEmissionRate(value=4, type=RateType.STREAM_DAY, unit=YamlEmissionRateUnits.KILO_PER_DAY),
         )
 
         # Check that illegal category raises error

--- a/src/tests/libecalc/output/results/test_ltp.py
+++ b/src/tests/libecalc/output/results/test_ltp.py
@@ -47,6 +47,9 @@ from libecalc.fixtures.cases.venting_emitters.venting_emitter_yaml import (
 )
 from libecalc.presentation.yaml.validation_errors import DtoValidationError
 from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
+from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
+    YamlEmissionRateUnits,
+)
 
 time_vector_installation = [
     datetime(2027, 1, 1),
@@ -221,7 +224,7 @@ def test_venting_emitters():
     dto_sd_kg_per_day = venting_emitter_yaml_factory(
         emission_rates=[emission_rate],
         regularity=regularity,
-        units=[Unit.KILO_PER_DAY.name],
+        units=[YamlEmissionRateUnits.KILO_PER_DAY],
         emission_names=["ch4"],
         rate_types=[RateType.STREAM_DAY],
         names=["Venting emitter 1"],
@@ -232,7 +235,7 @@ def test_venting_emitters():
         emission_rates=[emission_rate],
         regularity=regularity,
         rate_types=[RateType.STREAM_DAY],
-        units=[Unit.TONS_PER_DAY.name],
+        units=[YamlEmissionRateUnits.TONS_PER_DAY],
         emission_names=["ch4"],
         names=["Venting emitter 1"],
         path=Path(venting_emitters.__path__[0]),
@@ -242,7 +245,7 @@ def test_venting_emitters():
         emission_rates=[emission_rate],
         regularity=regularity,
         rate_types=[RateType.CALENDAR_DAY],
-        units=[Unit.KILO_PER_DAY.name],
+        units=[YamlEmissionRateUnits.KILO_PER_DAY],
         emission_names=["ch4"],
         names=["Venting emitter 1"],
         path=Path(venting_emitters.__path__[0]),
@@ -300,7 +303,7 @@ def test_only_venting_emitters_no_fuelconsumers():
     dto_case_emitters = venting_emitter_yaml_factory(
         emission_rates=[emission_rate],
         regularity=regularity,
-        units=[Unit.KILO_PER_DAY.name],
+        units=[YamlEmissionRateUnits.KILO_PER_DAY],
         emission_names=["ch4"],
         rate_types=[RateType.STREAM_DAY],
         include_emitters=True,
@@ -328,7 +331,7 @@ def test_only_venting_emitters_no_fuelconsumers():
     dto_case_fuel = venting_emitter_yaml_factory(
         emission_rates=[emission_rate],
         regularity=regularity,
-        units=[Unit.KILO_PER_DAY],
+        units=[YamlEmissionRateUnits.KILO_PER_DAY],
         emission_names=["ch4"],
         rate_types=[RateType.STREAM_DAY],
         include_emitters=False,
@@ -374,7 +377,7 @@ def test_no_emitters_or_fuelconsumers():
         venting_emitter_yaml_factory(
             emission_rates=[emission_rate],
             regularity=regularity,
-            units=[Unit.KILO_PER_DAY],
+            units=[YamlEmissionRateUnits.KILO_PER_DAY],
             emission_names=["ch4"],
             rate_types=[RateType.STREAM_DAY],
             include_emitters=False,

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -183,7 +183,7 @@ def test_venting_emitters_direct_multiple_emissions_ltp():
     dto_case = venting_emitter_yaml_factory(
         emission_rates=emission_rates,
         regularity=regularity,
-        units=[Unit.KILO_PER_DAY.name, Unit.KILO_PER_DAY.name],
+        units=[YamlEmissionRateUnits.KILO_PER_DAY, YamlEmissionRateUnits.KILO_PER_DAY],
         emission_names=["co2", "ch4"],
         rate_types=[RateType.STREAM_DAY],
         emission_keyword_name="EMISSIONS",
@@ -220,8 +220,8 @@ def test_venting_emitters_volume_multiple_emissions_ltp():
     path = Path(venting_emitters.__path__[0])
     dto_case = venting_emitter_yaml_factory(
         regularity=regularity,
-        units=[Unit.KILO_PER_DAY.name, Unit.KILO_PER_DAY.name],
-        units_oil_rates=[Unit.STANDARD_CUBIC_METER_PER_DAY.name, Unit.STANDARD_CUBIC_METER_PER_DAY.name],
+        units=[YamlEmissionRateUnits.KILO_PER_DAY, YamlEmissionRateUnits.KILO_PER_DAY],
+        units_oil_rates=[YamlOilRateUnits.STANDARD_CUBIC_METER_PER_DAY, YamlOilRateUnits.STANDARD_CUBIC_METER_PER_DAY],
         emission_names=["ch4", "nmvoc"],
         emitter_types=["OIL_VOLUME"],
         rate_types=[RateType.CALENDAR_DAY],
@@ -234,8 +234,8 @@ def test_venting_emitters_volume_multiple_emissions_ltp():
 
     dto_case_stream_day = venting_emitter_yaml_factory(
         regularity=regularity,
-        units=[Unit.KILO_PER_DAY, Unit.KILO_PER_DAY],
-        units_oil_rates=[Unit.STANDARD_CUBIC_METER_PER_DAY.name, Unit.STANDARD_CUBIC_METER_PER_DAY.name],
+        units=[YamlEmissionRateUnits.KILO_PER_DAY, YamlEmissionRateUnits.KILO_PER_DAY],
+        units_oil_rates=[YamlOilRateUnits.STANDARD_CUBIC_METER_PER_DAY, YamlOilRateUnits.STANDARD_CUBIC_METER_PER_DAY],
         emission_names=["ch4", "nmvoc"],
         emitter_types=["OIL_VOLUME"],
         rate_types=[RateType.STREAM_DAY],
@@ -287,7 +287,7 @@ def test_venting_emitters_direct_uppercase_emissions_name():
     dto_case = venting_emitter_yaml_factory(
         emission_rates=emission_rates,
         regularity=regularity,
-        units=[Unit.KILO_PER_DAY.name, Unit.KILO_PER_DAY.name],
+        units=[YamlEmissionRateUnits.KILO_PER_DAY, YamlEmissionRateUnits.KILO_PER_DAY],
         emission_names=["CO2", "nmVOC"],
         rate_types=[RateType.STREAM_DAY],
         emission_keyword_name="EMISSIONS",
@@ -311,8 +311,8 @@ def test_venting_emitters_volume_uppercase_emissions_name():
 
     dto_case = venting_emitter_yaml_factory(
         regularity=regularity,
-        units=[Unit.KILO_PER_DAY, Unit.KILO_PER_DAY],
-        units_oil_rates=[Unit.STANDARD_CUBIC_METER_PER_DAY.name, Unit.STANDARD_CUBIC_METER_PER_DAY.name],
+        units=[YamlEmissionRateUnits.KILO_PER_DAY, YamlEmissionRateUnits.KILO_PER_DAY],
+        units_oil_rates=[YamlOilRateUnits.STANDARD_CUBIC_METER_PER_DAY, YamlOilRateUnits.STANDARD_CUBIC_METER_PER_DAY],
         emission_names=["CO2", "nmVOC"],
         emitter_types=["OIL_VOLUME"],
         rate_types=[RateType.CALENDAR_DAY],

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter_validation_errors.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter_validation_errors.py
@@ -1,13 +1,16 @@
 from pathlib import Path
 
 import pytest
-from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
 from libecalc.fixtures.cases import venting_emitters
 from libecalc.fixtures.cases.venting_emitters.venting_emitter_yaml import (
     venting_emitter_yaml_factory,
 )
 from libecalc.presentation.yaml.validation_errors import DtoValidationError
+from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
+    YamlEmissionRateUnits,
+    YamlOilRateUnits,
+)
 
 
 def test_wrong_keyword_name_emitters():
@@ -20,7 +23,7 @@ def test_wrong_keyword_name_emitters():
         venting_emitter_yaml_factory(
             emission_rates=[emission_rate],
             regularity=regularity,
-            units=[Unit.KILO_PER_DAY.name],
+            units=[YamlEmissionRateUnits.KILO_PER_DAY],
             emission_names=["ch4"],
             rate_types=[RateType.STREAM_DAY],
             emission_keyword_name="EMISSION2",
@@ -41,7 +44,7 @@ def test_wrong_unit_emitters():
         venting_emitter_yaml_factory(
             emission_rates=[emission_rate],
             regularity=regularity,
-            units=[Unit.STANDARD_CUBIC_METER_PER_DAY.name],
+            units=[YamlOilRateUnits.STANDARD_CUBIC_METER_PER_DAY],
             emission_names=["ch4"],
             rate_types=[RateType.STREAM_DAY],
             emission_keyword_name="EMISSIONS",
@@ -51,7 +54,7 @@ def test_wrong_unit_emitters():
 
     assert (
         "\nVenting emitter 1:\nDIRECT_EMISSION.EMISSIONS[0].RATE.UNIT:\tInput should be "
-        f"'{Unit.KILO_PER_DAY.name}' or '{Unit.TONS_PER_DAY.name}'"
+        f"'{YamlEmissionRateUnits.KILO_PER_DAY.value}' or '{YamlEmissionRateUnits.TONS_PER_DAY.value}'"
     ) in str(exc.value)
 
 
@@ -75,5 +78,5 @@ def test_wrong_unit_format_emitters():
 
     assert (
         "\nVenting emitter 1:\nDIRECT_EMISSION.EMISSIONS[0].RATE.UNIT:\tInput should be "
-        f"'{Unit.KILO_PER_DAY.name}' or '{Unit.TONS_PER_DAY.name}'"
+        f"'{YamlEmissionRateUnits.KILO_PER_DAY.value}' or '{YamlEmissionRateUnits.TONS_PER_DAY.value}'"
     ) in str(exc.value)


### PR DESCRIPTION
ECALC-1059

## Have you remembered and considered?

- [x] I have remembered to update documentation
- [x] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [x] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [x] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Simplify unit definitions in yaml. It is basically a part of the BREAKING CHANGES belonging to the #495.

## What does this pull request change?

Write `SM3_PER_DAY` instead of `STANDARD_CUBIC_METERS_PER_DAY`. Write `KG_PER_DAY` instead of `KILO_PER_DAY`.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1059?atlOrigin=eyJpIjoiMzA1NzA0MTdiM2NhNDE0YmFiYTBlZmY3N2E1MzMyNjkiLCJwIjoiaiJ9
