### PR TITLE
fix: error message for new pfs columns

### DIFF
--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
@@ -76,7 +76,7 @@ class YamlGeneratorSet(YamlBase):
             else:
                 if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.category.values():
                     raise ValueError(
-                        f"{self.cable_loss.title} and {self.max_usage_from_shore.title} are only valid for the "
+                        f"{self.model_fields['cable_loss'].alias} and {self.model_fields['max_usage_from_shore'].alias} are only valid for the "
                         f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}."
                     )
         return self

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
@@ -69,7 +69,7 @@ class YamlGeneratorSet(YamlBase):
             if isinstance(self.category, ConsumerUserDefinedCategoryType):
                 if self.category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
                     raise ValueError(
-                        f"{self.cable_loss.title} and {self.max_usage_from_shore.title} are only valid for the "
+                        f"{self.model_fields['cable_loss'].alias} and {self.model_fields['max_usage_from_shore'].alias} are only valid for the "
                         f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
                         f"{self.category}."
                     )


### PR DESCRIPTION
ECALC-1267

## Have you remembered and considered?

- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Error occurs when creating error message related to wrong category for power from shore columns/variables (`CABLE_LOSS` and `MAX_USAGE_FROM_SHORE` only valid for category `POWER_FROM_SHORE`)

## What does this pull request change?

Use model_fields to obtain titles/names in error message.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1267?atlOrigin=eyJpIjoiZWMzNDlhNTI5NmM0NDkwMTgwNTljZTM1ZmQ3NWNkM2QiLCJwIjoiaiJ9