### PR TITLE
chore: align cli validation for power from shore

### DIFF
--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -327,15 +327,16 @@ class GeneratorSet(BaseEquipment):
             if isinstance(self.user_defined_category, ConsumerUserDefinedCategoryType):
                 if self.user_defined_category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
                     raise ValueError(
-                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid for the "
-                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
+                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} "
+                        f"are only valid for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
                         f"{self.user_defined_category}."
                     )
             else:
                 if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.user_defined_category.values():
                     raise ValueError(
-                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid for the "
-                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}."
+                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} "
+                        f"are only valid for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
+                        f"{self.user_defined_category[datetime(1900, 1,1)].value}."
                     )
         return self
 

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -328,14 +328,14 @@ class GeneratorSet(BaseEquipment):
                 if self.user_defined_category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
                     raise ValueError(
                         f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} "
-                        f"are only valid for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
+                        f"are only valid for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for "
                         f"{self.user_defined_category}."
                     )
             else:
                 if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.user_defined_category.values():
                     raise ValueError(
                         f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} "
-                        f"are only valid for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
+                        f"are only valid for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for "
                         f"{self.user_defined_category[datetime(1900, 1,1)].value}."
                     )
         return self

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -321,6 +321,24 @@ class GeneratorSet(BaseEquipment):
 
         return user_defined_category
 
+    @model_validator(mode="after")
+    def check_power_from_shore(self):
+        if self.cable_loss is not None or self.max_usage_from_shore is not None:
+            if isinstance(self.user_defined_category, ConsumerUserDefinedCategoryType):
+                if self.user_defined_category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
+                    raise ValueError(
+                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid for the "
+                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
+                        f"{self.user_defined_category}."
+                    )
+            else:
+                if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.user_defined_category.values():
+                    raise ValueError(
+                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid for the "
+                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}."
+                    )
+        return self
+
     def get_graph(self) -> ComponentGraph:
         graph = ComponentGraph()
         graph.add_node(self)

--- a/src/libecalc/presentation/yaml/mappers/component_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/component_mapper.py
@@ -6,7 +6,7 @@ from pydantic import TypeAdapter, ValidationError
 from libecalc import dto
 from libecalc.common.logger import logger
 from libecalc.common.time_utils import Period, define_time_model_for_period
-from libecalc.dto.base import ComponentType, ConsumerUserDefinedCategoryType
+from libecalc.dto.base import ComponentType
 from libecalc.dto.types import ConsumerType, ConsumptionType, EnergyModelType
 from libecalc.dto.utils.validators import convert_expression
 from libecalc.expression import Expression
@@ -219,12 +219,9 @@ class GeneratorSetMapper:
         user_defined_category = define_time_model_for_period(
             data.get(EcalcYamlKeywords.user_defined_tag), target_period=self._target_period
         )
-        cable_loss = None
-        max_usage_from_shore = None
 
-        if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE in user_defined_category.values():
-            cable_loss = convert_expression(data.get(EcalcYamlKeywords.cable_loss))
-            max_usage_from_shore = convert_expression(data.get(EcalcYamlKeywords.max_usage_from_shore))
+        cable_loss = convert_expression(data.get(EcalcYamlKeywords.cable_loss))
+        max_usage_from_shore = convert_expression(data.get(EcalcYamlKeywords.max_usage_from_shore))
 
         try:
             generator_set_name = data.get(EcalcYamlKeywords.name)

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
@@ -69,14 +69,14 @@ class YamlGeneratorSet(YamlBase):
             if isinstance(self.category, ConsumerUserDefinedCategoryType):
                 if self.category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
                     raise ValueError(
-                        f"{self.model_fields['cable_loss'].alias} and {self.model_fields['max_usage_from_shore'].alias} are only valid for the "
+                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid for the "
                         f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
                         f"{self.category}."
                     )
             else:
                 if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.category.values():
                     raise ValueError(
-                        f"{self.model_fields['cable_loss'].alias} and {self.model_fields['max_usage_from_shore'].alias} are only valid for the "
+                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid for the "
                         f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}."
                     )
         return self

--- a/src/tests/libecalc/dto/test_generator_set.py
+++ b/src/tests/libecalc/dto/test_generator_set.py
@@ -90,3 +90,40 @@ class TestGeneratorSet:
                 consumers=[fuel_consumer],
                 fuel={},
             )
+
+    def test_power_from_shore_wrong_category(self):
+        """
+        Check that CABLE_LOSS and MAX_USAGE_FROM_SHORE are only allowed if generator set category is POWER-FROM-SHORE
+        """
+
+        # Check for CABLE_LOSS
+        with pytest.raises(ValueError) as exc_info:
+            dto.GeneratorSet(
+                name="Test",
+                user_defined_category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.BOILER},
+                generator_set_model={},
+                regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
+                consumers=[],
+                fuel={},
+                cable_loss=0,
+            )
+
+        assert "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE" in str(
+            exc_info.value
+        )
+
+        # Check for MAX_USAGE_FROM_SHORE
+        with pytest.raises(ValueError) as exc_info:
+            dto.GeneratorSet(
+                name="Test",
+                user_defined_category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.BOILER},
+                generator_set_model={},
+                regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
+                consumers=[],
+                fuel={},
+                max_usage_from_shore=20,
+            )
+
+        assert "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE" in str(
+            exc_info.value
+        )

--- a/src/tests/libecalc/dto/test_generator_set.py
+++ b/src/tests/libecalc/dto/test_generator_set.py
@@ -109,7 +109,7 @@ class TestGeneratorSet:
             )
 
         assert (
-            "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, " "not for BOILER"
+            "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, not for BOILER"
         ) in str(exc_info.value)
 
         # Check for MAX_USAGE_FROM_SHORE
@@ -125,5 +125,5 @@ class TestGeneratorSet:
             )
 
         assert (
-            "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, " "not for BOILER"
+            "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, not for BOILER"
         ) in str(exc_info.value)

--- a/src/tests/libecalc/dto/test_generator_set.py
+++ b/src/tests/libecalc/dto/test_generator_set.py
@@ -108,9 +108,9 @@ class TestGeneratorSet:
                 cable_loss=0,
             )
 
-        assert "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE" in str(
-            exc_info.value
-        )
+        assert (
+            "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, " "not for BOILER"
+        ) in str(exc_info.value)
 
         # Check for MAX_USAGE_FROM_SHORE
         with pytest.raises(ValueError) as exc_info:
@@ -124,6 +124,6 @@ class TestGeneratorSet:
                 max_usage_from_shore=20,
             )
 
-        assert "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE" in str(
-            exc_info.value
-        )
+        assert (
+            "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, " "not for BOILER"
+        ) in str(exc_info.value)


### PR DESCRIPTION
## Have you remembered and considered?

- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Validation in CLI does not check if generator set is correct category (POWER-FROM-SHORE) when using CABLE_LOSS and MAX_USAGE_FROM_SHORE, just silently ignore if wrong category.

## What does this pull request change?

Update validation for power from shore in CLI.
