### PR TITLE
fix: implement YamlModel specific errors

### DIFF
--- a/src/libecalc/presentation/yaml/file_context.py
+++ b/src/libecalc/presentation/yaml/file_context.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from typing_extensions import Self
+
+from libecalc.presentation.yaml.yaml_entities import YamlDict
+
+
+@dataclass
+class FileMark:
+    line_number: int
+    column_number: int
+
+    def __str__(self) -> str:
+        return f" line {self.line_number}, column {self.column_number}"
+
+
+@dataclass
+class FileContext:
+    start: FileMark
+    end: Optional[FileMark] = None
+    name: Optional[str] = None
+
+    def __str__(self) -> str:
+        file_context_string = ""
+        if self.name is not None:
+            file_context_string += f" in '{self.name}',"
+
+        file_context_string += str(self.start)
+
+        return file_context_string
+
+    @classmethod
+    def from_yaml_dict(cls, data: YamlDict) -> Self:
+        if not hasattr(data, "end_mark") or not hasattr(data, "start_mark"):
+            return None
+
+        # This only works with our implementation of pyyaml read
+        # In the future, we can move this logic into PyYamlYamlModel with a better interface in YamlValidator.
+        # Specifically with our own definition of the returned data in each property in YamlValidator.
+        start_mark = data.start_mark
+        end_mark = data.end_mark
+        return FileContext(
+            start=FileMark(
+                line_number=start_mark.line + 1,
+                column_number=start_mark.column,
+            ),
+            end=FileMark(
+                line_number=end_mark.line + 1,
+                column_number=end_mark.column,
+            ),
+        )

--- a/src/libecalc/presentation/yaml/yaml_models/exceptions.py
+++ b/src/libecalc/presentation/yaml/yaml_models/exceptions.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from libecalc.presentation.yaml.file_context import FileContext
+
+
+class YamlError(Exception):
+    def __init__(self, problem: str, file_context: Optional[FileContext] = None):
+        self.problem = problem
+        self.file_context = file_context
+        message = f"{problem}"
+        if file_context is not None:
+            message += str(file_context)
+
+        super().__init__(message)
+
+
+class DuplicateKeyError(YamlError):
+    def __init__(self, key: str, file_context: FileContext):
+        self.key = key
+        super().__init__(f"Duplicate key {key!r} is found", file_context)

--- a/src/tests/ecalc_cli/test_app.py
+++ b/src/tests/ecalc_cli/test_app.py
@@ -15,6 +15,7 @@ from libecalc.common.errors.exceptions import EcalcError
 from libecalc.common.run_info import RunInfo
 from libecalc.dto.utils.validators import COMPONENT_NAME_ALLOWED_CHARS
 from libecalc.presentation.yaml.yaml_entities import ResourceStream
+from libecalc.presentation.yaml.yaml_models.exceptions import YamlError
 from libecalc.presentation.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
 from typer.testing import CliRunner
 
@@ -671,7 +672,7 @@ class TestYamlFile:
         stream = StringIO("")
         yaml_stream = ResourceStream(name=yaml_wrong_name.name, stream=stream)
 
-        with pytest.raises(EcalcError) as ee:
+        with pytest.raises(YamlError) as ee:
             yaml_reader.load(yaml_file=yaml_stream)
 
         assert (

--- a/src/tests/libecalc/input/test_file_io.py
+++ b/src/tests/libecalc/input/test_file_io.py
@@ -10,8 +10,8 @@ from libecalc.fixtures.cases import input_file_examples
 from libecalc.infrastructure import file_io
 from libecalc.presentation.yaml import yaml_entities
 from libecalc.presentation.yaml.model import YamlModel
-from libecalc.presentation.yaml.validation_errors import DataValidationError
 from libecalc.presentation.yaml.yaml_entities import YamlTimeseriesType
+from libecalc.presentation.yaml.yaml_models.exceptions import DuplicateKeyError
 from libecalc.presentation.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
 
 
@@ -288,7 +288,7 @@ class TestReadYaml:
             name="main.yaml",
         )
 
-        with pytest.raises(DataValidationError) as ve:
+        with pytest.raises(DuplicateKeyError) as ve:
             PyYamlYamlModel.read_yaml(main_yaml=main_yaml)
         assert "Duplicate key" in str(ve.value)
 

--- a/src/tests/libecalc/presentation/yaml/yaml_models/test_pyyaml_yaml_model.py
+++ b/src/tests/libecalc/presentation/yaml/yaml_models/test_pyyaml_yaml_model.py
@@ -33,13 +33,13 @@ class TestYamlValidation:
 
         assert len(errors) == 3
 
-        assert errors[0].details["type"] == "union_tag_not_found"
+        assert "Unable to extract tag" in errors[0].message
         assert errors[0].location.keys == ["TIME_SERIES", 0]
 
-        assert errors[1].details["type"] == "missing"
+        assert "This keyword is missing, it is required" in errors[1].message
         assert errors[1].location.keys == ["FUEL_TYPES"]
 
-        assert errors[2].details["type"] == "missing"
+        assert "This keyword is missing, it is required" in errors[2].message
         assert errors[2].location.keys == ["INSTALLATIONS"]
 
     def test_invalid_expression_token(self, minimal_model_yaml_factory):
@@ -51,8 +51,6 @@ class TestYamlValidation:
 
         errors = exc_info.value.errors()
         assert len(errors) == 1
-        assert errors[0].details["type"] == "expression_reference_not_found"
-        assert errors[0].details["ctx"]["expression_references"] == ["SIM1;NOTHING"]
         assert errors[0].message == "Expression reference(s) SIM1;NOTHING does not exist."
 
     def test_expression_token_validation_ignored_if_no_context(self, minimal_model_yaml_factory):

--- a/src/tests/libecalc/presentation/yaml/yaml_models/test_yaml_model_errors.py
+++ b/src/tests/libecalc/presentation/yaml/yaml_models/test_yaml_model_errors.py
@@ -1,0 +1,39 @@
+from io import StringIO
+
+import pytest
+from libecalc.presentation.yaml.yaml_entities import ResourceStream
+from libecalc.presentation.yaml.yaml_models.exceptions import YamlError
+from libecalc.presentation.yaml.yaml_models.yaml_model import YamlModel, YamlModelType
+
+invalid_models = [
+    (
+        """
+`INSTALLATIONS: []
+""",
+        "invalid_token_start",
+    ),
+    (
+        """
+{}INSTALLATIONS: []
+""",
+        "invalid_object_start",
+    ),
+    (
+        """
+VARIABLES:
+    some_var: 1
+    some_var: 2
+""",
+        "duplicate_keys",
+    ),
+]
+
+
+@pytest.mark.parametrize("invalid_model,description", invalid_models)
+@pytest.mark.parametrize("yaml_model_type", YamlModelType)
+def test_invalid_models(invalid_model: str, description: str, yaml_model_type: YamlModelType):
+    yaml_reader = YamlModel.Builder.get_yaml_model(yaml_model_type)
+    with pytest.raises(YamlError) as exc_info:
+        yaml_reader.read(ResourceStream(name=description, stream=StringIO(invalid_model)))
+
+    assert str(exc_info.value)


### PR DESCRIPTION
YamlError gives additional info about the error in yaml, in addition to ensuring a consistent interface across different yaml readers.