### PR TITLE
chore: make sure all time series are resampled

### DIFF
--- a/src/libecalc/application/graph_result.py
+++ b/src/libecalc/application/graph_result.py
@@ -634,14 +634,12 @@ class GraphResult:
                                     else [math.nan] * len(model.timesteps),
                                     unit=Unit.NONE,
                                 ),
-                                density_kg_per_m3=TimeSeriesRate(
+                                density_kg_per_m3=TimeSeriesFloat(
                                     timesteps=model.timesteps,
                                     values=stage_result.inlet_stream_condition.density_kg_per_m3
                                     if stage_result.inlet_stream_condition.density_kg_per_m3 is not None
                                     else [math.nan] * len(model.timesteps),
                                     unit=Unit.KG_M3,
-                                    rate_type=RateType.STREAM_DAY,
-                                    regularity=regularity.for_timesteps(model.timesteps).values,
                                 ),
                                 pressure=TimeSeriesFloat(
                                     timesteps=model.timesteps,
@@ -671,6 +669,7 @@ class GraphResult:
                                     else [math.nan] * len(model.timesteps),
                                     unit=Unit.NONE,
                                 ),
+                                timesteps=model.timesteps,
                             ),
                             outlet_stream_condition=CompressorStreamConditionResult(
                                 actual_rate_m3_per_hr=TimeSeriesRate(
@@ -717,14 +716,12 @@ class GraphResult:
                                     else [math.nan] * len(model.timesteps),
                                     unit=Unit.NONE,
                                 ),
-                                density_kg_per_m3=TimeSeriesRate(
+                                density_kg_per_m3=TimeSeriesFloat(
                                     timesteps=model.timesteps,
                                     values=stage_result.outlet_stream_condition.density_kg_per_m3
                                     if stage_result.outlet_stream_condition.density_kg_per_m3 is not None
                                     else [math.nan] * len(model.timesteps),
                                     unit=Unit.KG_M3,
-                                    rate_type=RateType.STREAM_DAY,
-                                    regularity=regularity.for_timesteps(model.timesteps).values,
                                 ),
                                 pressure=TimeSeriesFloat(
                                     timesteps=model.timesteps,
@@ -754,7 +751,9 @@ class GraphResult:
                                     else [math.nan] * len(model.timesteps),
                                     unit=Unit.NONE,
                                 ),
+                                timesteps=model.timesteps,
                             ),
+                            timesteps=model.timesteps,
                         )
 
                         model_stage_results.append(model_stage_result)
@@ -818,6 +817,7 @@ class GraphResult:
                                 rate_type=RateType.STREAM_DAY,
                                 regularity=regularity.for_timesteps(model.timesteps).values,
                             ),
+                            timesteps=model.timesteps,
                         )
                         if model.turbine_result is not None
                         else None

--- a/src/libecalc/common/units.py
+++ b/src/libecalc/common/units.py
@@ -107,6 +107,8 @@ class Unit(str, Enum):
     POLYTROPIC_HEAD_METER_LIQUID_COLUMN = "N.m/kg"
 
     ACTUAL_VOLUMETRIC_M3_PER_HOUR = "Am3/h"
+    ACTUAL_VOLUMETRIC_M3_PER_DAY = "Am3/d"
+    ACTUAL_VOLUMETRIC_M3 = "Am3"
     STANDARD_CUBIC_METER_PER_DAY = "Sm3/d"
 
     SPEED_RPM = "RPM"
@@ -208,6 +210,8 @@ class Unit(str, Enum):
             return Unit.KILO_PER_DAY
         elif self == Unit.LITRES:
             return Unit.LITRES_PER_DAY
+        elif self == Unit.ACTUAL_VOLUMETRIC_M3:
+            return Unit.ACTUAL_VOLUMETRIC_M3_PER_DAY
         else:
             raise NotImplementedError(f"Unknown unit for cumulative calculation '{self}'")
 
@@ -225,5 +229,9 @@ class Unit(str, Enum):
             return Unit.KILO
         elif self == Unit.LITRES_PER_DAY:
             return Unit.LITRES
+        elif self == Unit.KILO_PER_HOUR:
+            return Unit.KILO
+        elif self == Unit.ACTUAL_VOLUMETRIC_M3_PER_HOUR:
+            return Unit.ACTUAL_VOLUMETRIC_M3
         else:
             raise NotImplementedError(f"Unknown unit for rate calculation '{self}'")

--- a/src/libecalc/common/utils/rates.py
+++ b/src/libecalc/common/utils/rates.py
@@ -1038,6 +1038,11 @@ class TimeSeriesRate(TimeSeries[float]):
         if freq is Frequency.NONE:
             return self.model_copy()
 
+        # Resampling everything requires resampling of e.g. stage results, inlet/outlet stream conditions.
+        # These include rates per hour, not only per day. Need to check this and convert to per day:
+        if self.unit in [Unit.KILO_PER_HOUR, Unit.ACTUAL_VOLUMETRIC_M3_PER_HOUR]:
+            self.values = [v * 24 for v in self.values]
+
         # make resampled calendar day volumes via cumulative calendar day volumes
         calendar_day_volumes = (
             TimeSeriesVolumesCumulative(

--- a/src/libecalc/dto/result/results.py
+++ b/src/libecalc/dto/result/results.py
@@ -162,7 +162,7 @@ class PumpModelResult(ConsumerModelResultBase):
     is_valid: TimeSeriesBoolean
 
 
-class TurbineModelResult(EcalcResultBaseModel):
+class TurbineModelResult(TabularTimeSeries):
     energy_usage_unit: Unit
     power_unit: Unit
     efficiency: TimeSeriesFloat
@@ -174,20 +174,20 @@ class TurbineModelResult(EcalcResultBaseModel):
     power: TimeSeriesRate
 
 
-class CompressorStreamConditionResult(EcalcResultBaseModel):
+class CompressorStreamConditionResult(TabularTimeSeries):
     actual_rate_m3_per_hr: TimeSeriesRate
     actual_rate_before_asv_m3_per_hr: TimeSeriesRate
     standard_rate_sm3_per_day: TimeSeriesRate
     standard_rate_before_asv_sm3_per_day: TimeSeriesRate
     kappa: TimeSeriesFloat
-    density_kg_per_m3: TimeSeriesRate
+    density_kg_per_m3: TimeSeriesFloat
     pressure: TimeSeriesFloat
     pressure_before_choking: TimeSeriesFloat
     temperature_kelvin: TimeSeriesFloat
     z: TimeSeriesFloat
 
 
-class CompressorModelStageResult(EcalcResultBaseModel):
+class CompressorModelStageResult(TabularTimeSeries):
     chart: Optional[Union[SingleSpeedChart, VariableSpeedChart]]
     chart_area_flags: List[str]
     energy_usage_unit: Unit

--- a/src/libecalc/dto/result/tabular_time_series.py
+++ b/src/libecalc/dto/result/tabular_time_series.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import pandas as pd
 from typing_extensions import Self
 
+import libecalc.dto as dto
 from libecalc.common.time_utils import Frequency, resample_time_steps
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
@@ -18,7 +19,7 @@ from libecalc.dto.result.base import EcalcResultBaseModel
 
 
 class TabularTimeSeries(ABC, EcalcResultBaseModel):
-    name: str
+    name: Optional[str] = None
     timesteps: List[datetime]
 
     def to_dataframe(
@@ -110,6 +111,12 @@ class TabularTimeSeries(ABC, EcalcResultBaseModel):
                 else:
                     # NOTE: Operational settings are not resampled. Should add support?
                     pass
+
+            # Resampling compressor stream results must be done separately:
+            elif isinstance(values, dto.result.results.CompressorStreamConditionResult):
+                for stream_attribute, stream_values in values:
+                    if isinstance(stream_values, TimeSeries):
+                        values.__setattr__(stream_attribute, stream_values.resample(freq=freq))
             else:
                 # NOTE: turbine_result is not resampled. Should add support?
                 pass


### PR DESCRIPTION
ECALC-1003

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Currently only results in classes that inherits from TabularTimeSeries are resampled. This means that currently for example time series within stage_results (CompressorStageResult) and inlet/outlet_stream_conditions (CompressorStreamCondition) are not resampled. 

All time series should be resampled to avoid inconsistent results when date frequency is mot data defined.

## What does this pull request change?

- [ ] Ensure the remaining classes inherit from `TabularTimeSeries` 
- [ ] Update units to allow for resampling of `KILO_PER_HOUR` and `ACTUAL_VOLUMETRIC_M3_PER_HOUR`
- [ ] Ensure "per hour" is accounted for before resampling


## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1003?atlOrigin=eyJpIjoiZjNmZDE5OGE1ZTM3NGZmZDk3NjYzZGJiOTM3ZDRkZmUiLCJwIjoiaiJ9