### PR TITLE
chore: improve error messages for invalid characters in variables names

### DIFF
--- a/src/libecalc/presentation/yaml/validation_errors.py
+++ b/src/libecalc/presentation/yaml/validation_errors.py
@@ -22,7 +22,8 @@ PydanticLoc = Tuple[PydanticKey, ...]
 CUSTOM_MESSAGES = {
     "missing": "This keyword is missing, it is required",
     "extra_forbidden": "This is not a valid keyword",
-    "string_pattern_mismatch": "The string/name contains illegal characters. Allowed characters are: {pattern}",
+    "string_pattern_mismatch": "The string/name contains illegal characters. Allowed characters are: {pattern}. "
+    "A good start can be to check the string/name for space, which is not allowed.",
 }
 
 

--- a/src/libecalc/presentation/yaml/validation_errors.py
+++ b/src/libecalc/presentation/yaml/validation_errors.py
@@ -22,6 +22,7 @@ PydanticLoc = Tuple[PydanticKey, ...]
 CUSTOM_MESSAGES = {
     "missing": "This keyword is missing, it is required",
     "extra_forbidden": "This is not a valid keyword",
+    "string_pattern_mismatch": "The string/name contains illegal characters. Allowed characters are: {pattern}",
 }
 
 

--- a/src/tests/libecalc/input/mappers/variables_mapper/test_timeseries.py
+++ b/src/tests/libecalc/input/mappers/variables_mapper/test_timeseries.py
@@ -268,7 +268,11 @@ class TestTimeSeries:
                     interpolation_type=None,
                 )
             )
-        assert "String should match pattern '^[A-Za-z][A-Za-z0-9_.,\\-\\s#+:\\/]*$'" in str(ve.value)
+        assert (
+            "SIM1:\nDEFAULT.headers[0]:\t"
+            "The string/name contains illegal characters. "
+            "Allowed characters are: ^[A-Za-z][A-Za-z0-9_.,\\-\\s#+:\\/]*$"
+        ) in str(ve.value)
 
     @pytest.mark.parametrize(
         "header",
@@ -321,7 +325,11 @@ class TestTimeSeries:
                     interpolation_type=None,
                 )
             )
-        assert "String should match pattern '^[A-Za-z][A-Za-z0-9_]*$'" in str(ve.value)
+        assert (
+            f"\n{resource_name}:\nDEFAULT.name:\t"
+            f"The string/name contains illegal characters. "
+            f"Allowed characters are: ^[A-Za-z][A-Za-z0-9_]*$"
+        ) in str(ve.value)
 
     def test_interpretation_of_interpolation_type_for_default_resource(self):
         """Check default interpolation for DEFAULT time series."""


### PR DESCRIPTION
ECALC-647

## Have you remembered and considered?

- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Difficult to understand error messages related to invalid characters in VARIABLES names, no information about where the issue is in the eCalc model.

## What does this pull request change?

Included validation errors of type `string_pattern_mismatch` into CUSTOM_MESSAGES, to ensure better and customized feedback to user for these kind of errors.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-647?atlOrigin=eyJpIjoiZmY2NzNlNWE2NTdjNGE5MjhmOTEzYWZlNzQ2Yjg4MzEiLCJwIjoiaiJ9