### PR TITLE
docs: wrong units venting emitters docs

### DIFF
--- a/docs/docs/about/references/keywords/EMISSIONS.md
+++ b/docs/docs/about/references/keywords/EMISSIONS.md
@@ -61,12 +61,12 @@ EMISSIONS:
   - NAME: co2
     RATE:
       VALUE: 4
-      UNIT: kg/d
+      UNIT: KG_PER_DAY
       TYPE: STREAM_DAY
   - NAME: ch4
     RATE:
       VALUE: 2
-      UNIT: kg/d
+      UNIT: KG_PER_DAY
       TYPE: STREAM_DAY
 ~~~~~~~~
 ## For venting emitters (type: OIL_VOLUME, from eCalc v8.13)

--- a/docs/docs/about/references/keywords/VENTING_EMITTERS.md
+++ b/docs/docs/about/references/keywords/VENTING_EMITTERS.md
@@ -108,12 +108,12 @@ VENTING_EMITTERS:
       - NAME: co2
         RATE:
           VALUE: 4
-          UNIT: kg/d
+          UNIT: KG_PER_DAY
           TYPE: STREAM_DAY
       - NAME: ch4
         RATE:
           VALUE: 2
-          UNIT: kg/d
+          UNIT: KG_PER_DAY
           TYPE: STREAM_DAY
 ~~~~~~~~
 
@@ -139,7 +139,7 @@ VENTING_EMITTERS:
     VOLUME:
       RATE:
         VALUE: 10
-        UNIT: Sm3/d
+        UNIT: SM3_PER_DAY
         TYPE: STREAM_DAY
       EMISSIONS:
       - NAME: co2

--- a/docs/docs/about/references/keywords/VOLUME.md
+++ b/docs/docs/about/references/keywords/VOLUME.md
@@ -33,7 +33,7 @@ VOLUME:
     VOLUME:
       RATE:
         VALUE: 10
-        UNIT: Sm3/d
+        UNIT: SM3_PER_DAY
         TYPE: STREAM_DAY
       EMISSIONS:
       - NAME: co2


### PR DESCRIPTION
ECALC-1334

## Have you remembered and considered?

- [x] I have remembered to update documentation
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

All units for venting emitters have been changed to align with yaml input. This should be reflected in all parts of docs. Some examples still have old units.

## What does this pull request change?

Update docs to have correct units for venting emitters.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1334?atlOrigin=eyJpIjoiZmZmNGJhNmFhYzJmNGMzZWEzY2VlMTdmMDZiZmJkZDIiLCJwIjoiaiJ9