### PR TITLE
chore: improve error message for extra pfs columns

### DIFF
--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -333,14 +333,14 @@ class GeneratorSet(BaseEquipment):
             if isinstance(self.user_defined_category, ConsumerUserDefinedCategoryType):
                 if self.user_defined_category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
                     raise ValueError(
-                        f"{feedback_text} only valid for the "
+                        f"{feedback_text} for the "
                         f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
                         f"{self.user_defined_category}."
                     )
             else:
                 if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.user_defined_category.values():
                     raise ValueError(
-                        f"{feedback_text} only valid for the "
+                        f"{feedback_text} for the "
                         f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for "
                         f"{self.user_defined_category[datetime(1900, 1,1)].value}."
                     )

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -42,6 +42,9 @@ from libecalc.dto.utils.validators import (
 )
 from libecalc.dto.variables import VariablesMap
 from libecalc.expression import Expression
+from libecalc.presentation.yaml.ltp_validation import (
+    validate_generator_set_power_from_shore,
+)
 from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingEmitter,
@@ -323,27 +326,13 @@ class GeneratorSet(BaseEquipment):
 
     @model_validator(mode="after")
     def check_power_from_shore(self):
-        if self.cable_loss is not None or self.max_usage_from_shore is not None:
-            feedback_text = f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid"
-            if self.cable_loss is None:
-                feedback_text = f"{self.model_fields['max_usage_from_shore'].title} is only valid"
-            if self.max_usage_from_shore is None:
-                feedback_text = f"{self.model_fields['cable_loss'].title} is only valid"
+        _check_power_from_shore_attributes = validate_generator_set_power_from_shore(
+            cable_loss=self.cable_loss,
+            max_usage_from_shore=self.max_usage_from_shore,
+            model_fields=self.model_fields,
+            category=self.user_defined_category,
+        )
 
-            if isinstance(self.user_defined_category, ConsumerUserDefinedCategoryType):
-                if self.user_defined_category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
-                    raise ValueError(
-                        f"{feedback_text} for the "
-                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
-                        f"{self.user_defined_category}."
-                    )
-            else:
-                if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.user_defined_category.values():
-                    raise ValueError(
-                        f"{feedback_text} for the "
-                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for "
-                        f"{self.user_defined_category[datetime(1900, 1,1)].value}."
-                    )
         return self
 
     def get_graph(self) -> ComponentGraph:

--- a/src/libecalc/dto/components.py
+++ b/src/libecalc/dto/components.py
@@ -324,18 +324,24 @@ class GeneratorSet(BaseEquipment):
     @model_validator(mode="after")
     def check_power_from_shore(self):
         if self.cable_loss is not None or self.max_usage_from_shore is not None:
+            feedback_text = f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid"
+            if self.cable_loss is None:
+                feedback_text = f"{self.model_fields['max_usage_from_shore'].title} is only valid"
+            if self.max_usage_from_shore is None:
+                feedback_text = f"{self.model_fields['cable_loss'].title} is only valid"
+
             if isinstance(self.user_defined_category, ConsumerUserDefinedCategoryType):
                 if self.user_defined_category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
                     raise ValueError(
-                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} "
-                        f"are only valid for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for "
+                        f"{feedback_text} only valid for the "
+                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
                         f"{self.user_defined_category}."
                     )
             else:
                 if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.user_defined_category.values():
                     raise ValueError(
-                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} "
-                        f"are only valid for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for "
+                        f"{feedback_text} only valid for the "
+                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for "
                         f"{self.user_defined_category[datetime(1900, 1,1)].value}."
                     )
         return self

--- a/src/libecalc/presentation/yaml/ltp_validation.py
+++ b/src/libecalc/presentation/yaml/ltp_validation.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Union
+
+from libecalc.dto.base import ConsumerUserDefinedCategoryType
+
+
+def validate_generator_set_power_from_shore(
+    cable_loss: Union[int, float],
+    max_usage_from_shore: Union[int, float],
+    model_fields: dict,
+    category: Union[dict, ConsumerUserDefinedCategoryType],
+):
+    if cable_loss is not None or max_usage_from_shore is not None:
+        feedback_text = (
+            f"{model_fields['cable_loss'].title} and " f"{model_fields['max_usage_from_shore'].title} are only valid"
+        )
+        if cable_loss is None:
+            feedback_text = f"{model_fields['max_usage_from_shore'].title} is only valid"
+        if max_usage_from_shore is None:
+            feedback_text = f"{model_fields['cable_loss'].title} is only valid"
+
+        if isinstance(category, ConsumerUserDefinedCategoryType):
+            message = f"{feedback_text} for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for {category}."
+            raise ValueError(message)
+        else:
+            if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in category.values():
+                message = (
+                    f"{feedback_text} for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}"
+                    f", not for {category[datetime(1900, 1, 1)].value}."
+                )
+                raise ValueError(message)

--- a/src/libecalc/presentation/yaml/ltp_validation.py
+++ b/src/libecalc/presentation/yaml/ltp_validation.py
@@ -21,8 +21,9 @@ def validate_generator_set_power_from_shore(
             feedback_text = f"{model_fields['cable_loss'].title} is only valid"
 
         if isinstance(category, ConsumerUserDefinedCategoryType):
-            message = f"{feedback_text} for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for {category}."
-            raise ValueError(message)
+            if category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
+                message = f"{feedback_text} for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for {category}."
+                raise ValueError(message)
         else:
             if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in category.values():
                 message = (

--- a/src/libecalc/presentation/yaml/ltp_validation.py
+++ b/src/libecalc/presentation/yaml/ltp_validation.py
@@ -2,11 +2,12 @@ from datetime import datetime
 from typing import Union
 
 from libecalc.dto.base import ConsumerUserDefinedCategoryType
+from libecalc.dto.utils.validators import ExpressionType
 
 
 def validate_generator_set_power_from_shore(
-    cable_loss: Union[int, float],
-    max_usage_from_shore: Union[int, float],
+    cable_loss: ExpressionType,
+    max_usage_from_shore: ExpressionType,
     model_fields: dict,
     category: Union[dict, ConsumerUserDefinedCategoryType],
 ):

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
@@ -7,6 +7,9 @@ from libecalc.common.discriminator_fallback import DiscriminatorWithFallback
 from libecalc.dto.base import ConsumerUserDefinedCategoryType
 from libecalc.dto.utils.validators import ComponentNameStr
 from libecalc.expression.expression import ExpressionType
+from libecalc.presentation.yaml.ltp_validation import (
+    validate_generator_set_power_from_shore,
+)
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.legacy.yaml_electricity_consumer import (
     YamlElectricityConsumer,
@@ -65,23 +68,10 @@ class YamlGeneratorSet(YamlBase):
 
     @model_validator(mode="after")
     def check_power_from_shore(self):
-        if self.cable_loss is not None or self.max_usage_from_shore is not None:
-            feedback_text = f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid"
-            if self.cable_loss is None:
-                feedback_text = f"{self.model_fields['max_usage_from_shore'].title} is only valid"
-            if self.max_usage_from_shore is None:
-                feedback_text = f"{self.model_fields['cable_loss'].title} is only valid"
-
-            if isinstance(self.category, ConsumerUserDefinedCategoryType):
-                if self.category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
-                    raise ValueError(
-                        f"{feedback_text} for the "
-                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
-                        f"{self.category}."
-                    )
-            else:
-                if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.category.values():
-                    raise ValueError(
-                        f"{feedback_text} for the " f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}."
-                    )
+        _check_power_from_shore_attributes = validate_generator_set_power_from_shore(
+            cable_loss=self.cable_loss,
+            max_usage_from_shore=self.max_usage_from_shore,
+            model_fields=self.model_fields,
+            category=self.category,
+        )
         return self

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
@@ -75,14 +75,13 @@ class YamlGeneratorSet(YamlBase):
             if isinstance(self.category, ConsumerUserDefinedCategoryType):
                 if self.category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
                     raise ValueError(
-                        f"{feedback_text} only valid for the "
+                        f"{feedback_text} for the "
                         f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
                         f"{self.category}."
                     )
             else:
                 if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.category.values():
                     raise ValueError(
-                        f"{feedback_text} only valid for the "
-                        f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}."
+                        f"{feedback_text} for the " f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}."
                     )
         return self

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
@@ -66,17 +66,23 @@ class YamlGeneratorSet(YamlBase):
     @model_validator(mode="after")
     def check_power_from_shore(self):
         if self.cable_loss is not None or self.max_usage_from_shore is not None:
+            feedback_text = f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid"
+            if self.cable_loss is None:
+                feedback_text = f"{self.model_fields['max_usage_from_shore'].title} is only valid"
+            if self.max_usage_from_shore is None:
+                feedback_text = f"{self.model_fields['cable_loss'].title} is only valid"
+
             if isinstance(self.category, ConsumerUserDefinedCategoryType):
                 if self.category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
                     raise ValueError(
-                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid for the "
+                        f"{feedback_text} only valid for the "
                         f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}, not for "
                         f"{self.category}."
                     )
             else:
                 if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in self.category.values():
                     raise ValueError(
-                        f"{self.model_fields['cable_loss'].title} and {self.model_fields['max_usage_from_shore'].title} are only valid for the "
+                        f"{feedback_text} only valid for the "
                         f"category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE}."
                     )
         return self

--- a/src/tests/libecalc/dto/test_generator_set.py
+++ b/src/tests/libecalc/dto/test_generator_set.py
@@ -108,9 +108,7 @@ class TestGeneratorSet:
                 cable_loss=0,
             )
 
-        assert (
-            "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, not for BOILER"
-        ) in str(exc_info.value)
+        assert ("CABLE_LOSS is only valid for the category POWER-FROM-SHORE, not for BOILER") in str(exc_info.value)
 
         # Check for MAX_USAGE_FROM_SHORE
         with pytest.raises(ValueError) as exc_info:
@@ -122,6 +120,22 @@ class TestGeneratorSet:
                 consumers=[],
                 fuel={},
                 max_usage_from_shore=20,
+            )
+
+        assert ("MAX_USAGE_FROM_SHORE is only valid for the category POWER-FROM-SHORE, not for BOILER") in str(
+            exc_info.value
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            dto.GeneratorSet(
+                name="Test",
+                user_defined_category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.BOILER},
+                generator_set_model={},
+                regularity={datetime(1900, 1, 1): Expression.setup_from_expression(1)},
+                consumers=[],
+                fuel={},
+                max_usage_from_shore=20,
+                cable_loss=0,
             )
 
         assert (


### PR DESCRIPTION
ECALC-1342

## Have you remembered and considered?

- [x] I have added tests 
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Error message if illegal category is used for extra power from shore columns (`CABLE_LOSS` and `MAX_USAGE_FROM_SHORE`) is the same, even if only one of them is used in the model. Can be confusing for user.

## What does this pull request change?

- [x] Improve error message to point at the problematic column (or both columns if they are in the model)
- [x] Add and update tests

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1342?atlOrigin=eyJpIjoiMzljZmE4MjlkZWZjNGFmM2EwYmIxNDU4ZGQyNTdkOWUiLCJwIjoiaiJ9