### PR TITLE
refactor: reusable protocols for tabular data

### DIFF
--- a/src/libecalc/domain/tabular/tabular.py
+++ b/src/libecalc/domain/tabular/tabular.py
@@ -1,11 +1,13 @@
 import abc
-from typing import List, Protocol, TypeVar, Union
+from typing import List, Protocol, TypeVar
 
 ColumnIndex = TypeVar("ColumnIndex")
 RowIndex = TypeVar("RowIndex")
 
+TValue = TypeVar("TValue", covariant=True)
 
-class Tabular(Protocol[RowIndex, ColumnIndex]):
+
+class Tabular(Protocol[RowIndex, ColumnIndex, TValue]):
     @property
     @abc.abstractmethod
     def row_ids(self) -> List[RowIndex]:
@@ -17,5 +19,20 @@ class Tabular(Protocol[RowIndex, ColumnIndex]):
         ...
 
     @abc.abstractmethod
-    def get_value(self, row_id: RowIndex, column_id: ColumnIndex) -> Union[int, float]:
+    def get_value(self, row_id: RowIndex, column_id: ColumnIndex) -> TValue:
+        ...
+
+
+class Column(Protocol):
+    @abc.abstractmethod
+    def get_title(self) -> str:
+        ...
+
+
+TColumn = TypeVar("TColumn", bound=Column, covariant=True)
+
+
+class HasColumns(Protocol[TColumn]):
+    @abc.abstractmethod
+    def get_column(self, column_id: ColumnIndex) -> TColumn:
         ...

--- a/src/libecalc/presentation/exporter/dto/dtos.py
+++ b/src/libecalc/presentation/exporter/dto/dtos.py
@@ -18,6 +18,9 @@ class DataSeries:
     title: str
     values: List[Union[str, float]]
 
+    def get_title(self) -> str:
+        return self.title
+
     @property
     def id(self) -> str:
         return self.name
@@ -35,6 +38,9 @@ class QueryResult:
     title: str
     unit: Unit  # Needed! in order to know how to handler further....parse
     values: Dict[datetime, float]
+
+    def get_title(self) -> str:
+        return f"{self.title}[{self.unit}]"
 
     @property
     def id(self) -> str:

--- a/src/tests/libecalc/presentation/exporter/formatters/test_csv_formatter.py
+++ b/src/tests/libecalc/presentation/exporter/formatters/test_csv_formatter.py
@@ -13,7 +13,10 @@ from libecalc.presentation.exporter.formatters.formatter import (
 class Column:
     id: str
     title: str
-    unit: Unit
+    unit: Unit = Unit.TONS
+
+    def get_title(self) -> str:
+        return f"{self.title}[{self.unit}]"
 
 
 @dataclass
@@ -26,7 +29,6 @@ class Data(Formattable):
         return Column(
             id=column_id,
             title=column_id.upper(),
-            unit=Unit.TONS,
         )
 
     @property


### PR DESCRIPTION
Create reusable protocols for data that is table-like.

HasColumn requires get_title instead of specific attributes, i.e. the title of a column is decided by the column instead of the formatter in this case.
