### PR TITLE
chore: do not allow multiple energy model types

### DIFF
--- a/src/libecalc/presentation/yaml/energy_model_validation.py
+++ b/src/libecalc/presentation/yaml/energy_model_validation.py
@@ -1,0 +1,17 @@
+import datetime
+
+from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
+
+
+def validate_energy_usage_models(model: dict, consumer_name: str):
+    energy_models = []
+    for key, value in model.items():
+        if isinstance(key, datetime.date) and value[EcalcYamlKeywords.type] not in energy_models:
+            energy_models.append(value[EcalcYamlKeywords.type])
+
+    if len(energy_models) > 1:
+        energy_models_list = ", ".join(energy_models)
+        raise ValueError(
+            "Energy model type cannot change over time within a single consumer."
+            f" The model type is changed for '{consumer_name}': {energy_models_list}",
+        )

--- a/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_electricity_consumer.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_electricity_consumer.py
@@ -1,8 +1,12 @@
 from typing import Literal
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, model_validator
 
 from libecalc.dto.base import ConsumerUserDefinedCategoryType
+from libecalc.presentation.yaml.energy_model_validation import (
+    validate_energy_usage_models,
+)
+from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.legacy.energy_usage_model import (
     YamlElectricityEnergyUsageModel,
@@ -36,3 +40,9 @@ class YamlElectricityConsumer(YamlBase):
         description="Definition of the energy usage model for the consumer."
         "\n\n$ECALC_DOCS_KEYWORDS_URL/ENERGY_USAGE_MODEL",
     )
+
+    @model_validator(mode="before")
+    def check_energy_usage_models(self):
+        model = self[EcalcYamlKeywords.energy_usage_model]
+        _check_multiple_energy_usage_models = validate_energy_usage_models(model, self[EcalcYamlKeywords.name])
+        return self

--- a/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_electricity_consumer.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_electricity_consumer.py
@@ -42,7 +42,7 @@ class YamlElectricityConsumer(YamlBase):
     )
 
     @model_validator(mode="before")
-    def check_energy_usage_models(self):
-        model = self[EcalcYamlKeywords.energy_usage_model]
-        _check_multiple_energy_usage_models = validate_energy_usage_models(model, self[EcalcYamlKeywords.name])
-        return self
+    def check_energy_usage_models(cls, data):
+        model = data[EcalcYamlKeywords.energy_usage_model]
+        _check_multiple_energy_usage_models = validate_energy_usage_models(model, data[EcalcYamlKeywords.name])
+        return data

--- a/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_fuel_consumer.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_fuel_consumer.py
@@ -1,8 +1,12 @@
 from typing import Literal
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, model_validator
 
 from libecalc.dto.base import ConsumerUserDefinedCategoryType
+from libecalc.presentation.yaml.energy_model_validation import (
+    validate_energy_usage_models,
+)
+from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.legacy.energy_usage_model import (
     YamlFuelEnergyUsageModel,
@@ -42,3 +46,9 @@ class YamlFuelConsumer(YamlBase):
         title="FUEL",
         description="The fuel used by the consumer." "\n\n$ECALC_DOCS_KEYWORDS_URL/FUEL",
     )
+
+    @model_validator(mode="before")
+    def check_energy_usage_models(self):
+        model = self[EcalcYamlKeywords.energy_usage_model]
+        _check_multiple_energy_usage_models = validate_energy_usage_models(model, self[EcalcYamlKeywords.name])
+        return self

--- a/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_fuel_consumer.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_fuel_consumer.py
@@ -48,7 +48,7 @@ class YamlFuelConsumer(YamlBase):
     )
 
     @model_validator(mode="before")
-    def check_energy_usage_models(self):
-        model = self[EcalcYamlKeywords.energy_usage_model]
-        _check_multiple_energy_usage_models = validate_energy_usage_models(model, self[EcalcYamlKeywords.name])
-        return self
+    def check_energy_usage_models(cls, data):
+        model = data[EcalcYamlKeywords.energy_usage_model]
+        _check_multiple_energy_usage_models = validate_energy_usage_models(model, data[EcalcYamlKeywords.name])
+        return data

--- a/src/tests/ecalc_cli/test_app.py
+++ b/src/tests/ecalc_cli/test_app.py
@@ -742,7 +742,7 @@ class TestYamlFile:
         Returns:
 
         """
-        with pytest.raises(EcalcError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             runner.invoke(
                 main.app,
                 _get_args(
@@ -757,5 +757,5 @@ class TestYamlFile:
 
         assert (
             "Energy model type cannot change over time within a single consumer. "
-            "The model type is changed for gasinj: ['DIRECT', 'COMPRESSOR']" in str(exc_info.value)
+            "The model type is changed for 'gasinj': DIRECT, COMPRESSOR" in str(exc_info.value)
         )


### PR DESCRIPTION
ECALC-1026

## Have you remembered and considered?

- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

It should not be allowed to switch types of energy_usage_models when using temporal models. We already have validation for this in the dto objects, and similar should be done in the yaml validation 

## What does this pull request change?

- [x] Update yaml validation for electrical- and fuel consumers.
- [x] Use same validation error for dto and yaml

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1026?atlOrigin=eyJpIjoiZTczNDgyYjNmYWY5NGM4Y2FiZmQxODMwY2Q2NGFlMzQiLCJwIjoiaiJ9