### PR TITLE
feat: implement adjustment factors for genset

### DIFF
--- a/src/libecalc/core/models/generator.py
+++ b/src/libecalc/core/models/generator.py
@@ -10,10 +10,16 @@ class GeneratorModelSampled:
         self,
         data_transfer_object: dto.GeneratorSetSampled,
     ):
+        fuel_values = data_transfer_object.fuel_values
+        if data_transfer_object.energy_usage_adjustment_factor is not None:
+            fuel_values = list(np.array(fuel_values) * data_transfer_object.energy_usage_adjustment_factor)
+        if data_transfer_object.energy_usage_adjustment_constant is not None:
+            fuel_values = list(np.array(fuel_values) + data_transfer_object.energy_usage_adjustment_constant)
+
         self._func = interp1d(
             data_transfer_object.power_values,
-            data_transfer_object.fuel_values,
-            fill_value=(min(data_transfer_object.fuel_values), max(data_transfer_object.fuel_values)),
+            fuel_values,
+            fill_value=(min(fuel_values), max(fuel_values)),
             bounds_error=False,
         )
 


### PR DESCRIPTION
ECALC-1369

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Adjustment factor and adjustment constant are not implemented for genset. It is already implemented as a part of facility inputs.

## What does this pull request change?
Make sure fuel consumption is scaled according to the adjustment factor and constant given in facility inputs.


## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1369?atlOrigin=eyJpIjoiM2MxNDJhZjNhZDkyNDUzMGExODg3NjJiNzYzMzg3MmQiLCJwIjoiaiJ9