### PR TITLE
fix: typo get timesteps docstring

### DIFF
--- a/src/libecalc/common/time_utils.py
+++ b/src/libecalc/common/time_utils.py
@@ -71,7 +71,7 @@ class Period:
     def get_timesteps(self, timesteps: List[datetime]) -> List[datetime]:
         """
         Get all given timesteps that are within this period.
-        Returns empty list if no timesteps are outside period.
+        Returns empty list if all timesteps are outside period.
         """
         timesteps = [timestep for timestep in timesteps if self.__contains__(timestep)]
 


### PR DESCRIPTION
## Why is this pull request needed?

Typo in docstring for get_timesteps method. One word.

