### PR TITLE
chore!: do not allow 0 efficiency in input chart

### DIFF
--- a/src/libecalc/dto/models/chart.py
+++ b/src/libecalc/dto/models/chart.py
@@ -13,7 +13,7 @@ class ChartCurve(EcalcBaseModel):
     speed_rpm: float = Field(..., ge=0)
     rate_actual_m3_hour: List[Annotated[float, Field(ge=0)]]
     polytropic_head_joule_per_kg: List[Annotated[float, Field(ge=0)]]
-    efficiency_fraction: List[Annotated[float, Field(ge=0, le=1)]]
+    efficiency_fraction: List[Annotated[float, Field(gt=0, le=1)]]
 
     @model_validator(mode="after")
     def validate_equal_lengths_and_sort(self) -> Self:

--- a/src/libecalc/dto/models/chart.py
+++ b/src/libecalc/dto/models/chart.py
@@ -95,11 +95,11 @@ class VariableSpeedChart(EcalcBaseModel):
 
 class GenericChartFromDesignPoint(EcalcBaseModel):
     typ: Literal[ChartType.GENERIC_FROM_DESIGN_POINT] = ChartType.GENERIC_FROM_DESIGN_POINT
-    polytropic_efficiency_fraction: float = Field(..., ge=0, le=1)
+    polytropic_efficiency_fraction: float = Field(..., gt=0, le=1)
     design_rate_actual_m3_per_hour: float = Field(..., ge=0)
     design_polytropic_head_J_per_kg: float = Field(..., ge=0)
 
 
 class GenericChartFromInput(EcalcBaseModel):
     typ: Literal[ChartType.GENERIC_FROM_INPUT] = ChartType.GENERIC_FROM_INPUT
-    polytropic_efficiency_fraction: float = Field(..., ge=0, le=1)
+    polytropic_efficiency_fraction: float = Field(..., gt=0, le=1)


### PR DESCRIPTION
BREAKING CHANGE: 0 efficiency is not allowed in input charts.

ECALC-977

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [x] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Errors with 0 efficiency in input chart is catched late, and the error message does not point to the actual input file with the problem.

## What does this pull request change?

Do not allow 0 efficiency in input file. It will give feedback much earlier, and points to the relevant file.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-977?atlOrigin=eyJpIjoiZDljMWJlYTczYzhjNGMwMTliM2FjNjU2YzVlNzJlNTAiLCJwIjoiaiJ9