### PR TITLE
chore!: do not allow control margin for simplified variable speed train

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/model.py
+++ b/src/libecalc/presentation/yaml/mappers/model.py
@@ -24,6 +24,9 @@ from libecalc.presentation.yaml.validation_errors import (
 )
 from libecalc.presentation.yaml.yaml_entities import Resource, Resources
 from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
+from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_trains import (
+    YamlCompatibleTrainsControlMargin,
+)
 
 
 def _compressor_chart_mapper(
@@ -542,6 +545,16 @@ def _simplified_variable_speed_compressor_train_mapper(
     if EcalcYamlKeywords.models_type_compressor_train_stages in train_spec:
         # The stages are pre defined, known
         stages = train_spec.get(EcalcYamlKeywords.models_type_compressor_train_stages)
+        for stage in stages:
+            if stage.get(EcalcYamlKeywords.models_type_compressor_train_stage_control_margin):
+                name = model_config.get(EcalcYamlKeywords.name)
+                raise ValueError(
+                    f"{name}: {EcalcYamlKeywords.models_type_compressor_train_stage_control_margin}"
+                    f" is not allowed for {model_config.get(EcalcYamlKeywords.type)}. "
+                    f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} "
+                    f"is only supported for the following train-types: "
+                    f"{', '.join(YamlCompatibleTrainsControlMargin)}."
+                )
         return dto.CompressorTrainSimplifiedWithKnownStages(
             fluid_model=fluid_model,
             stages=[

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
@@ -135,10 +135,9 @@ class YamlSimplifiedVariableSpeedCompressorTrain(YamlCompressorTrainBase):
                     raise ValueError(
                         f"{self.name}: {EcalcYamlKeywords.models_type_compressor_train_stage_control_margin}"
                         f" is not allowed for {self.type}. "
-                        f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} is only supported for "
-                        f"{EcalcYamlKeywords.models_type_compressor_train_single_speed}, "
-                        f"{EcalcYamlKeywords.models_type_compressor_train_variable_speed} and "
-                        f"{EcalcYamlKeywords.models_type_compressor_train_variable_speed_multiple_streams_and_pressures}."
+                        f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} "
+                        f"is only supported for the following train-types: "
+                        f"{', '.join(YamlCompatibleTrainsControlMargin)}."
                     )
         return self
 
@@ -191,4 +190,10 @@ YamlCompressorTrain = Union[
     YamlSimplifiedVariableSpeedCompressorTrain,
     YamlSingleSpeedCompressorTrain,
     YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures,
+]
+
+YamlCompatibleTrainsControlMargin = [
+    EcalcYamlKeywords.models_type_compressor_train_single_speed,
+    EcalcYamlKeywords.models_type_compressor_train_variable_speed,
+    EcalcYamlKeywords.models_type_compressor_train_variable_speed_multiple_streams_and_pressures,
 ]

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
@@ -127,19 +127,19 @@ class YamlSimplifiedVariableSpeedCompressorTrain(YamlCompressorTrainBase):
     )
 
     @model_validator(mode="after")
-    def validate_compressor_model(self):
+    def check_control_margin(self):
         compressor_train = self.compressor_train
-        for stage in compressor_train.stages:
-            if stage.control_margin:
-                raise ValueError(
-                    f"{self.name}: {EcalcYamlKeywords.models_type_compressor_train_stage_control_margin}"
-                    f" is not allowed for {self.type}. "
-                    f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} is only supported for "
-                    f"{EcalcYamlKeywords.models_type_compressor_train_single_speed}, "
-                    f"{EcalcYamlKeywords.models_type_compressor_train_variable_speed} and "
-                    f"{EcalcYamlKeywords.models_type_compressor_train_variable_speed_multiple_streams_and_pressures}."
-                )
-
+        if not isinstance(compressor_train, YamlUnknownCompressorStages):
+            for stage in compressor_train.stages:
+                if stage.control_margin:
+                    raise ValueError(
+                        f"{self.name}: {EcalcYamlKeywords.models_type_compressor_train_stage_control_margin}"
+                        f" is not allowed for {self.type}. "
+                        f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} is only supported for "
+                        f"{EcalcYamlKeywords.models_type_compressor_train_single_speed}, "
+                        f"{EcalcYamlKeywords.models_type_compressor_train_variable_speed} and "
+                        f"{EcalcYamlKeywords.models_type_compressor_train_variable_speed_multiple_streams_and_pressures}."
+                    )
         return self
 
     def to_dto(self):

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
@@ -134,7 +134,7 @@ class YamlSimplifiedVariableSpeedCompressorTrain(YamlCompressorTrainBase):
                 if stage.control_margin:
                     raise ValueError(
                         f"{self.name}: {EcalcYamlKeywords.models_type_compressor_train_stage_control_margin}"
-                        f" is not allowed for {self.type}. "
+                        f" is not allowed for {self.type.value}. "
                         f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} "
                         f"is only supported for the following train-types: "
                         f"{', '.join(YamlCompatibleTrainsControlMargin)}."

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
@@ -133,7 +133,11 @@ class YamlSimplifiedVariableSpeedCompressorTrain(YamlCompressorTrainBase):
             if stage.control_margin:
                 raise ValueError(
                     f"{self.name}: {EcalcYamlKeywords.models_type_compressor_train_stage_control_margin}"
-                    f" is not allowed for {self.type}"
+                    f" is not allowed for {self.type}. "
+                    f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} is only supported for "
+                    f"{EcalcYamlKeywords.models_type_compressor_train_single_speed}, "
+                    f"{EcalcYamlKeywords.models_type_compressor_train_variable_speed} and "
+                    f"{EcalcYamlKeywords.models_type_compressor_train_variable_speed_multiple_streams_and_pressures}."
                 )
 
         return self

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
@@ -1,7 +1,8 @@
 from typing import List, Literal, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
+from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.models.model_reference_validation import (
     FluidModelReference,
@@ -124,6 +125,18 @@ class YamlSimplifiedVariableSpeedCompressorTrain(YamlCompressorTrainBase):
         description="Constant to adjust power usage in MW",
         title="POWER_ADJUSTMENT_CONSTANT",
     )
+
+    @model_validator(mode="after")
+    def validate_compressor_model(self):
+        compressor_train = self.compressor_train
+        for stage in compressor_train.stages:
+            if stage.control_margin:
+                raise ValueError(
+                    f"{self.name}: {EcalcYamlKeywords.models_type_compressor_train_stage_control_margin}"
+                    f" is not allowed for {self.type}"
+                )
+
+        return self
 
     def to_dto(self):
         raise NotImplementedError

--- a/src/tests/libecalc/presentation/yaml/yaml_types/models/test_yaml_simplified_compressor_train.py
+++ b/src/tests/libecalc/presentation/yaml/yaml_types/models/test_yaml_simplified_compressor_train.py
@@ -1,0 +1,37 @@
+import pytest
+from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
+from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import (
+    YamlCompressorStage,
+    YamlCompressorStages,
+)
+from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_trains import (
+    YamlCompatibleTrainsControlMargin,
+    YamlSimplifiedVariableSpeedCompressorTrain,
+)
+from libecalc.presentation.yaml.yaml_types.models.yaml_enums import YamlModelType
+
+
+def test_control_margin_not_allowed():
+    stage = YamlCompressorStage(
+        compressor_chart="compressor_chart1",
+        inlet_temperature=25,
+        control_margin=10,
+    )
+
+    stages = YamlCompressorStages(stages=[stage])
+
+    with pytest.raises(ValueError) as exc:
+        YamlSimplifiedVariableSpeedCompressorTrain(
+            name="simplified_train1",
+            type=YamlModelType.SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN,
+            compressor_train=stages,
+            fluid_model="fluid_model1",
+        )
+
+    assert (
+        f"simplified_train1: {EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} "
+        f"is not allowed for {EcalcYamlKeywords.models_type_compressor_train_simplified}. "
+        f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} is only "
+        f"supported for the following train-types: "
+        f"{', '.join(YamlCompatibleTrainsControlMargin)}"
+    ) in str(exc.value)


### PR DESCRIPTION
BREAKING CHANGE: `CONTROL_MARGIN` not allowed for `SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN`

ECALC-1483

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [x] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Adding a `CONTROL_MARGIN` to `SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN` has no effect. eCalc ignores it, but user is not notified. 

## What does this pull request change?

New behavior: eCalc will fail if `CONTROL_MARGIN` is specified (only pydantic yaml-validation for web, not cli)

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1483?atlOrigin=eyJpIjoiN2M0OWMzMTFiN2FlNDFkMDg1MmViNTdiODM2NTdjMDYiLCJwIjoiaiJ9