### PR TITLE
chore!: do not allow pressure drop ahead of stage for simplified trains

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/model.py
+++ b/src/libecalc/presentation/yaml/mappers/model.py
@@ -26,6 +26,7 @@ from libecalc.presentation.yaml.yaml_entities import Resource, Resources
 from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_trains import (
     YamlCompatibleTrainsControlMargin,
+    YamlCompatibleTrainsPressureDropAheadOfStage,
 )
 
 
@@ -554,6 +555,15 @@ def _simplified_variable_speed_compressor_train_mapper(
                     f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} "
                     f"is only supported for the following train-types: "
                     f"{', '.join(YamlCompatibleTrainsControlMargin)}."
+                )
+            if stage.get(EcalcYamlKeywords.models_type_compressor_train_pressure_drop_ahead_of_stage):
+                name = model_config.get(EcalcYamlKeywords.name)
+                raise ValueError(
+                    f"{name}: {EcalcYamlKeywords.models_type_compressor_train_pressure_drop_ahead_of_stage}"
+                    f" is not allowed for {model_config.get(EcalcYamlKeywords.type)}. "
+                    f"{EcalcYamlKeywords.models_type_compressor_train_pressure_drop_ahead_of_stage} "
+                    f"is only supported for the following train-types: "
+                    f"{', '.join(YamlCompatibleTrainsPressureDropAheadOfStage)}."
                 )
         return dto.CompressorTrainSimplifiedWithKnownStages(
             fluid_model=fluid_model,

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_stages.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_stages.py
@@ -102,11 +102,3 @@ class YamlCompressorStages(YamlBase, Generic[TStage]):
         description="List of compressor stages",
         title="STAGES",
     )
-
-
-# class YamlCompressorStages(YamlBase):
-#     stages: List[YamlCompressorStageWithMarginAndPressureDrop] = Field(
-#         ...,
-#         description="List of compressor stages",
-#         title="STAGES",
-#     )

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_stages.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_stages.py
@@ -1,5 +1,5 @@
 import enum
-from typing import List, Optional, Union
+from typing import Generic, List, Optional, TypeVar, Union
 
 from pydantic import Field
 
@@ -41,6 +41,9 @@ class YamlCompressorStage(YamlBase):
         description="Reference to compressor chart model for stage, must be defined in MODELS or FACILITY_INPUTS",
         title="COMPRESSOR_CHART",
     )
+
+
+class YamlCompressorStageWithMarginAndPressureDrop(YamlCompressorStage):
     pressure_drop_ahead_of_stage: Optional[float] = Field(
         None,
         description="Pressure drop before compression stage [in bar]",
@@ -58,7 +61,7 @@ class YamlCompressorStage(YamlBase):
     )
 
 
-class YamlCompressorStageMultipleStreams(YamlCompressorStage):
+class YamlCompressorStageMultipleStreams(YamlCompressorStageWithMarginAndPressureDrop):
     stream: Union[str, List[str]] = Field(
         None,
         description="Reference to stream from STREAMS.",
@@ -90,9 +93,20 @@ class YamlUnknownCompressorStages(YamlBase):
     )
 
 
-class YamlCompressorStages(YamlBase):
-    stages: List[YamlCompressorStage] = Field(
+TStage = TypeVar("TStage", bound=Union[YamlCompressorStage, YamlCompressorStageWithMarginAndPressureDrop])
+
+
+class YamlCompressorStages(YamlBase, Generic[TStage]):
+    stages: List[TStage] = Field(
         ...,
         description="List of compressor stages",
         title="STAGES",
     )
+
+
+# class YamlCompressorStages(YamlBase):
+#     stages: List[YamlCompressorStageWithMarginAndPressureDrop] = Field(
+#         ...,
+#         description="List of compressor stages",
+#         title="STAGES",
+#     )

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
@@ -127,7 +127,7 @@ class YamlSimplifiedVariableSpeedCompressorTrain(YamlCompressorTrainBase):
     )
 
     @model_validator(mode="after")
-    def check_control_margin(self):
+    def check_control_margin_and_pressure_drop_ahead_of_stage(self):
         compressor_train = self.compressor_train
         if not isinstance(compressor_train, YamlUnknownCompressorStages):
             for stage in compressor_train.stages:
@@ -139,6 +139,15 @@ class YamlSimplifiedVariableSpeedCompressorTrain(YamlCompressorTrainBase):
                         f"is only supported for the following train-types: "
                         f"{', '.join(YamlCompatibleTrainsControlMargin)}."
                     )
+                if stage.pressure_drop_ahead_of_stage is not None:
+                    raise ValueError(
+                        f"{self.name}: {EcalcYamlKeywords.models_type_compressor_train_pressure_drop_ahead_of_stage}"
+                        f" is not allowed for {self.type.value}. "
+                        f"{EcalcYamlKeywords.models_type_compressor_train_pressure_drop_ahead_of_stage} "
+                        f"is only supported for the following train-types: "
+                        f"{', '.join(YamlCompatibleTrainsPressureDropAheadOfStage)}."
+                    )
+
         return self
 
     def to_dto(self):
@@ -193,6 +202,12 @@ YamlCompressorTrain = Union[
 ]
 
 YamlCompatibleTrainsControlMargin = [
+    EcalcYamlKeywords.models_type_compressor_train_single_speed,
+    EcalcYamlKeywords.models_type_compressor_train_variable_speed,
+    EcalcYamlKeywords.models_type_compressor_train_variable_speed_multiple_streams_and_pressures,
+]
+
+YamlCompatibleTrainsPressureDropAheadOfStage = [
     EcalcYamlKeywords.models_type_compressor_train_single_speed,
     EcalcYamlKeywords.models_type_compressor_train_variable_speed,
     EcalcYamlKeywords.models_type_compressor_train_variable_speed_multiple_streams_and_pressures,

--- a/src/tests/libecalc/presentation/yaml/yaml_types/models/test_yaml_simplified_compressor_train.py
+++ b/src/tests/libecalc/presentation/yaml/yaml_types/models/test_yaml_simplified_compressor_train.py
@@ -6,6 +6,7 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import 
 )
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_trains import (
     YamlCompatibleTrainsControlMargin,
+    YamlCompatibleTrainsPressureDropAheadOfStage,
     YamlSimplifiedVariableSpeedCompressorTrain,
 )
 from libecalc.presentation.yaml.yaml_types.models.yaml_enums import YamlModelType
@@ -34,4 +35,30 @@ def test_control_margin_not_allowed():
         f"{EcalcYamlKeywords.models_type_compressor_train_stage_control_margin} is only "
         f"supported for the following train-types: "
         f"{', '.join(YamlCompatibleTrainsControlMargin)}"
+    ) in str(exc.value)
+
+
+def test_pressure_drop_ahead_of_stage_not_allowed():
+    stage = YamlCompressorStage(
+        compressor_chart="compressor_chart1",
+        inlet_temperature=25,
+        pressure_drop_ahead_of_stage=2.0,
+    )
+
+    stages = YamlCompressorStages(stages=[stage])
+
+    with pytest.raises(ValueError) as exc:
+        YamlSimplifiedVariableSpeedCompressorTrain(
+            name="simplified_train1",
+            type=YamlModelType.SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN,
+            compressor_train=stages,
+            fluid_model="fluid_model1",
+        )
+
+    assert (
+        f"simplified_train1: {EcalcYamlKeywords.models_type_compressor_train_pressure_drop_ahead_of_stage} "
+        f"is not allowed for {EcalcYamlKeywords.models_type_compressor_train_simplified}. "
+        f"{EcalcYamlKeywords.models_type_compressor_train_pressure_drop_ahead_of_stage} is only "
+        f"supported for the following train-types: "
+        f"{', '.join(YamlCompatibleTrainsPressureDropAheadOfStage)}"
     ) in str(exc.value)


### PR DESCRIPTION
BREAKING CHANGE: `PRESSURE_DROP_AHEAD_OF_STAGE` not allowed for `SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN`

ECALC-1512

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [x] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Defining `PRESSURE_DROP_AHEAD_OF_STAGE` for a `SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN` does not have any effect. eCalc allows it to be specified in the yaml, but silently ignores it.

## What does this pull request change?

- [x] Do not allow `PRESSURE_DROP_AHEAD_OF_STAGE` for `SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN`
- [x] Give clear error message

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1512?atlOrigin=eyJpIjoiMTEzOGZkMjdmMzM2NDgzMWFjMGJjZjA5NGUxZDU2ZjciLCJwIjoiaiJ9