### PR TITLE
docs: swap order of migration guides

### DIFF
--- a/docs/docs/about/migration_guides/v8-1_to_v8-2.md
+++ b/docs/docs/about/migration_guides/v8-1_to_v8-2.md
@@ -1,7 +1,7 @@
 ---
 title: v8.1 to v8.2
 description: v8.1 to v8.2 migration
-sidebar_position: 2
+sidebar_position: -2
 ---
 
 # v8.1 to v8.2

--- a/docs/docs/about/migration_guides/v8-2_to_v8-3.md
+++ b/docs/docs/about/migration_guides/v8-2_to_v8-3.md
@@ -1,7 +1,7 @@
 ---
 title: v8.2 to v8.3
 description: v8.2 to v8.3 migration
-sidebar_position: 3
+sidebar_position: -3
 ---
 
 # v8.2 to v8.3

--- a/docs/docs/about/migration_guides/v8-3_to_v8-4.md
+++ b/docs/docs/about/migration_guides/v8-3_to_v8-4.md
@@ -1,7 +1,7 @@
 ---
 title: v8.3 to v8.4
 description: v8.3 to v8.4 migration
-sidebar_position: 4
+sidebar_position: -4
 ---
 
 # v8.3 to v8.4

--- a/docs/docs/about/migration_guides/v8-5_to_v8-6.md
+++ b/docs/docs/about/migration_guides/v8-5_to_v8-6.md
@@ -1,7 +1,7 @@
 ---
 title: v8.5 to v8.6
 description: v8.5 to v8.6 migration
-sidebar_position: 5
+sidebar_position: -5
 ---
 
 # v8.5 to v8.6

--- a/docs/docs/about/migration_guides/v8-6_to_v8-7.md
+++ b/docs/docs/about/migration_guides/v8-6_to_v8-7.md
@@ -1,7 +1,7 @@
 ---
 title: v8.6 to v8.7
 description: v8.6 to v8.7 migration
-sidebar_position: 6
+sidebar_position: -6
 ---
 
 # v8.6 to v8.7

--- a/docs/docs/about/migration_guides/v8.12_to_v8.13.md
+++ b/docs/docs/about/migration_guides/v8.12_to_v8.13.md
@@ -1,7 +1,7 @@
 ---
 title: v8.12 to v8.13
 description: v8.12 to v8.13 migration
-sidebar_position: 8
+sidebar_position: -8
 ---
 
 # v8.12 to v8.13

--- a/docs/docs/about/migration_guides/v8.13_to_v8.14.md
+++ b/docs/docs/about/migration_guides/v8.13_to_v8.14.md
@@ -1,7 +1,7 @@
 ---
 title: v8.13 to v8.14
 description: v8.13 to v8.14 migration
-sidebar_position: 9
+sidebar_position: -9
 ---
 
 # v8.13 to v8.14

--- a/docs/docs/about/migration_guides/v8.15_to_v8.16.md
+++ b/docs/docs/about/migration_guides/v8.15_to_v8.16.md
@@ -1,7 +1,7 @@
 ---
 title: v8.15 to v8.16
 description: v8.15 to v8.16 migration
-sidebar_position: 10
+sidebar_position: -10
 ---
 
 # v8.15 to v8.16

--- a/docs/docs/about/migration_guides/v8.7_to_v8.8.md
+++ b/docs/docs/about/migration_guides/v8.7_to_v8.8.md
@@ -1,7 +1,7 @@
 ---
 title: v8.7 to v8.8
 description: v8.7 to v8.8 migration
-sidebar_position: 7
+sidebar_position: -7
 ---
 
 # v8.7 to v8.8

--- a/docs/docs/about/migration_guides/v8_to_v81.md
+++ b/docs/docs/about/migration_guides/v8_to_v81.md
@@ -1,7 +1,7 @@
 ---
 title: v8 to v8.1
 description: v8 to v8.1 migration
-sidebar_position: 1
+sidebar_position: -1
 ---
 
 # v8 to v8.1


### PR DESCRIPTION
ECALC-1246

## Why is this pull request needed?

Have the most important (i.e. last updated) info at the top, and align with changelog.

## What does this pull request change?

Swap order of migration guide versions.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1246?atlOrigin=eyJpIjoiYmY1MWU2MWQ2MmU2NDUzYzlhYTk4ZTZlZDFhZDFjY2MiLCJwIjoiaiJ9