### PR TITLE
Ecalc 1331 update example to reflect that units are required

### DIFF
--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md
@@ -137,6 +137,7 @@ MODELS:
     FLUID_MODEL_TYPE: PREDEFINED
     EOS_MODEL: SRK
     GAS_TYPE: MEDIUM
+
   - NAME: simplified_compressor_model
     TYPE: SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN
     FLUID_MODEL: medium_fluid
@@ -206,11 +207,13 @@ MODELS:
               - NAME: generic_from_input_compressor_chart
                 TYPE: COMPRESSOR_CHART
                 CHART_TYPE: GENERIC_FROM_INPUT
+
               - NAME: dry_fluid
                 TYPE: FLUID
                 FLUID_MODEL_TYPE: PREDEFINED
                 EOS_MODEL: SRK
                 GAS_TYPE: DRY
+
               - NAME: simplified_compressor_train_model
                 TYPE: SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN
                 FLUID_MODEL: dry_fluid

--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md
@@ -207,6 +207,9 @@ MODELS:
               - NAME: generic_from_input_compressor_chart
                 TYPE: COMPRESSOR_CHART
                 CHART_TYPE: GENERIC_FROM_INPUT
+                POLYTROPIC_EFFICIENCY: 0.75
+                UNITS:
+                  EFFICIENCY: FRACTION
 
               - NAME: dry_fluid
                 TYPE: FLUID


### PR DESCRIPTION
## Have you remembered and considered?

- [x] I have remembered to update documentation
- [x] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [x] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [x] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Ref. ECALC-1331 issue about missing required units in example _"A compressor train where the number of stages are unknown"_in section _"Simplified variable speed compressor train"_.

## What does this pull request change?
- Added some newlines some places to adhere to general doc styling. 
- Added POLYTROPIC_EFFICIENCY and UNITS, same as as found in the GENERIC_FROM_INPUT example in the compressor charts section.

## Issues related to this change:
ECALC-1331
