### PR TITLE
fix: make sure default pressure control is set for all trains

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/model.py
+++ b/src/libecalc/presentation/yaml/mappers/model.py
@@ -85,7 +85,7 @@ def _pressure_control_mapper(
         YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures,
     ],
 ) -> FixedSpeedPressureControl:
-    return FixedSpeedPressureControl(model_config.pressure_control.value)  # TODO: Could this be none previously?
+    return FixedSpeedPressureControl(model_config.pressure_control.value)
 
 
 def _get_curve_data_from_resource(resource: Resource, speed: float = 0.0):

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
@@ -45,7 +45,7 @@ class YamlSingleSpeedCompressorTrain(YamlCompressorTrainBase):
         title="COMPRESSOR_TRAIN",
     )
     pressure_control: YamlPressureControl = Field(
-        None,
+        YamlPressureControl.DOWNSTREAM_CHOKE,
         description="Method for pressure control",
         title="PRESSURE_CONTROL",
     )
@@ -173,7 +173,7 @@ class YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures(YamlCompressor
         title="STAGES",
     )
     pressure_control: YamlPressureControl = Field(
-        None,
+        YamlPressureControl.DOWNSTREAM_CHOKE,
         description="Method for pressure control",
         title="PRESSURE_CONTROL",
     )


### PR DESCRIPTION
Default pressure control was added to variable speed train, but forgotten for single speed and multiple streams.
