### PR TITLE
Ecalc 1531 numpy2 ready

### DIFF
--- a/src/libecalc/core/models/compressor/train/simplified_train.py
+++ b/src/libecalc/core/models/compressor/train/simplified_train.py
@@ -506,29 +506,18 @@ class CompressorTrainSimplifiedKnownStages(CompressorTrainSimplified):
         expected_diff = 1e-3
         max_iterations = 20
         while not converged and i < max_iterations:
-            maximum_actual_volume_rate = float(
+            maximum_actual_volume_rate: float = float(
                 maximum_rate_function(
                     heads=polytropic_head,
                     extrapolate_heads_below_minimum=False,
                 )
             )
 
-            try:
-                efficiency_array: NDArray[np.float64] = compressor_chart.efficiency_as_function_of_rate_and_head(
-                    rates=np.atleast_1d(maximum_actual_volume_rate),
-                    heads=np.atleast_1d(polytropic_head),
-                )
-
-                if efficiency_array.size == 0:
-                    raise ValueError("Efficiency array is empty, cannot proceed with calculation.")
-
-                polytropic_efficiency = efficiency_array[0]
-
-            except IndexError as e:
-                raise IndexError("Failed to extract efficiency: array index out of range.") from e
-
-            except Exception as e:
-                raise RuntimeError("An unexpected error occurred during efficiency extraction.") from e
+            efficiency_array: NDArray[np.float64] = compressor_chart.efficiency_as_function_of_rate_and_head(
+                rates=np.atleast_1d(maximum_actual_volume_rate),
+                heads=np.atleast_1d(polytropic_head),
+            )
+            polytropic_efficiency = efficiency_array[0]
 
             polytropic_head = calculate_polytropic_head_campbell(
                 polytropic_efficiency=polytropic_efficiency,

--- a/src/libecalc/core/models/results/compressor.py
+++ b/src/libecalc/core/models/results/compressor.py
@@ -227,11 +227,11 @@ class CompressorTrainResult(EnergyFunctionResult):
         )
 
         stage_results_are_valid = (
-            np.alltrue([stage.is_valid for stage in self.stage_results], axis=0)
+            np.all([stage.is_valid for stage in self.stage_results], axis=0)
             if self.stage_results is not None
             else [not isnan(x) for x in self.energy_usage]
         )
-        return list(np.alltrue([failure_status_are_valid, turbine_are_valid, stage_results_are_valid], axis=0))
+        return list(np.all([failure_status_are_valid, turbine_are_valid, stage_results_are_valid], axis=0))
 
     @property
     def inlet_stream(self) -> CompressorStreamCondition:

--- a/src/libecalc/expression/expression.py
+++ b/src/libecalc/expression/expression.py
@@ -10,13 +10,7 @@ from pydantic_core import CoreSchema, core_schema
 
 from libecalc.common.errors.exceptions import EcalcError, EcalcErrorType
 from libecalc.common.logger import logger
-from libecalc.expression.expression_evaluator import (
-    Operators,
-    Token,
-    TokenTag,
-    eval_tokens,
-    lexer,
-)
+from libecalc.expression.expression_evaluator import Operators, Token, TokenTag, eval_tokens, lexer
 
 LEFT_PARENTHESIS_TOKEN = Token(tag=TokenTag.operator, value=Operators.left_parenthesis.value)
 RIGHT_PARENTHESIS_TOKEN = Token(tag=TokenTag.operator, value=Operators.right_parenthesis.value)

--- a/src/libecalc/fixtures/cases/ltp_export/installation_setup.py
+++ b/src/libecalc/fixtures/cases/ltp_export/installation_setup.py
@@ -363,107 +363,112 @@ def generator_set_mobile_diesel() -> GeneratorSet:
     )
 
 
-def expected_fuel_consumption():
-    consumption = float(fuel_rate * days_year2_second_half * regularity_consumer)
+def expected_fuel_consumption() -> float:
+    n_days = np.sum(days_year2_second_half)
+    consumption = float(fuel_rate * n_days * regularity_consumer)
     return consumption
 
 
-def expected_diesel_consumption():
-    consumption = float(diesel_rate * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
+def expected_diesel_consumption() -> float:
+    n_days = np.sum([days_year1_first_half, days_year2_first_half])
+    consumption = float(diesel_rate * n_days * regularity_consumer)
     return consumption
 
 
-def expected_pfs_el_consumption():
-    consumption_mw_per_day = power_usage_mw * days_year1_second_half * regularity_consumer
+def expected_pfs_el_consumption() -> float:
+    n_days = np.sum(days_year1_second_half)
+    consumption_mw_per_day = power_usage_mw * n_days * regularity_consumer
     consumption = float(Unit.MEGA_WATT_DAYS.to(Unit.GIGA_WATT_HOURS)(consumption_mw_per_day))
     return consumption
 
 
-def expected_gas_turbine_el_generated():
-    consumption_mw_per_day = (
-        power_usage_mw * (days_year1_first_half + days_year2_first_half + days_year2_second_half) * regularity_consumer
-    )
+def expected_gas_turbine_el_generated() -> float:
+    n_days = np.sum([(days_year1_first_half + days_year2_first_half + days_year2_second_half)])
+    consumption_mw_per_day = power_usage_mw * n_days * regularity_consumer
     consumption = float(Unit.MEGA_WATT_DAYS.to(Unit.GIGA_WATT_HOURS)(consumption_mw_per_day))
     return consumption
 
 
-def expected_co2_from_fuel():
+def expected_co2_from_fuel() -> float:
     emission_kg_per_day = float(fuel_rate * co2_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * days_year2_second_half * regularity_consumer)
+    n_days = np.sum(days_year2_second_half)
+    emission_tons = float(emission_tons_per_day * n_days * regularity_consumer)
     return emission_tons
 
 
-def expected_co2_from_diesel():
+def expected_co2_from_diesel() -> float:
     emission_kg_per_day = float(diesel_rate * co2_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
+    n_days = np.sum([days_year1_first_half, days_year2_first_half])
+    emission_tons = float(emission_tons_per_day * n_days * regularity_consumer)
     return emission_tons
 
 
-def expected_ch4_from_diesel():
+def expected_ch4_from_diesel() -> float:
     emission_kg_per_day = float(diesel_rate * ch4_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
+    n_days = np.sum([days_year1_first_half, days_year2_first_half])
+    emission_tons = float(emission_tons_per_day * n_days * regularity_consumer)
     return emission_tons
 
 
-def expected_nox_from_diesel():
+def expected_nox_from_diesel() -> float:
     emission_kg_per_day = float(diesel_rate * nox_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
+    n_days = np.sum([days_year1_first_half, days_year2_first_half])
+    emission_tons = float(emission_tons_per_day * n_days * regularity_consumer)
     return emission_tons
 
 
-def expected_nmvoc_from_diesel():
+def expected_nmvoc_from_diesel() -> float:
     emission_kg_per_day = float(diesel_rate * nmvoc_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * (days_year1_first_half + days_year2_first_half) * regularity_consumer)
+    n_days = np.sum([days_year1_first_half, days_year2_first_half])
+    emission_tons = float(emission_tons_per_day * n_days * regularity_consumer)
     return emission_tons
 
 
-def expected_offshore_wind_el_consumption():
-    consumption_mw_per_day = (
-        power_offshore_wind_mw * (days_year1_second_half + days_year2_second_half) * regularity_consumer
-    )
+def expected_offshore_wind_el_consumption() -> float:
+    n_days = np.sum([days_year1_second_half, days_year2_second_half])
+    consumption_mw_per_day = power_offshore_wind_mw * n_days * regularity_consumer
     consumption = -float(Unit.MEGA_WATT_DAYS.to(Unit.GIGA_WATT_HOURS)(consumption_mw_per_day))
     return consumption
 
 
 # Why is this the only one without regularity?
-def expected_gas_turbine_compressor_el_consumption():
-    consumption_mw_per_day = power_compressor_mw * (days_year1_second_half + days_year2_second_half)
+def expected_gas_turbine_compressor_el_consumption() -> float:
+    n_days = np.sum([days_year1_second_half, days_year2_second_half])
+    consumption_mw_per_day = power_compressor_mw * n_days
     consumption = float(Unit.MEGA_WATT_DAYS.to(Unit.GIGA_WATT_HOURS)(consumption_mw_per_day))
     return consumption
 
 
-def expected_boiler_fuel_consumption():
-    consumption = float(
-        fuel_rate * (days_year1_first_half + days_year1_second_half + days_year2_first_half) * regularity_consumer
-    )
+def expected_boiler_fuel_consumption() -> float:
+    n_days = np.sum([days_year1_first_half, days_year1_second_half, days_year2_first_half])
+    consumption = float(fuel_rate * n_days * regularity_consumer)
     return consumption
 
 
-def expected_heater_fuel_consumption():
-    consumption = float(fuel_rate * days_year2_second_half * regularity_consumer)
+def expected_heater_fuel_consumption() -> float:
+    n_days = np.sum(days_year2_second_half)
+    consumption = float(fuel_rate * n_days * regularity_consumer)
     return consumption
 
 
-def expected_co2_from_boiler():
-    emission_kg_per_day = float(fuel_rate * co2_factor)
+def expected_co2_from_boiler() -> float:
+    emission_kg_per_day = fuel_rate * co2_factor
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(
-        emission_tons_per_day
-        * (days_year1_first_half + days_year1_second_half + days_year2_first_half)
-        * regularity_consumer
-    )
+    n_days = np.sum([days_year1_first_half, days_year1_second_half, days_year2_first_half])
+    emission_tons = float(emission_tons_per_day * n_days * regularity_consumer)
     return emission_tons
 
 
-def expected_co2_from_heater():
+def expected_co2_from_heater() -> float:
     emission_kg_per_day = float(fuel_rate * co2_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
-    emission_tons = float(emission_tons_per_day * days_year2_second_half * regularity_consumer)
+    n_days = np.sum(days_year2_second_half)
+    emission_tons = float(emission_tons_per_day * n_days * regularity_consumer)
     return emission_tons
 
 

--- a/src/libecalc/fixtures/cases/ltp_export/installation_setup.py
+++ b/src/libecalc/fixtures/cases/ltp_export/installation_setup.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Dict, List
 
+import numpy as np
+
 import libecalc.common.component_type
 from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.time_utils import Period
@@ -457,7 +459,7 @@ def expected_heater_fuel_consumption() -> float:
 
 
 def expected_co2_from_boiler() -> float:
-    emission_kg_per_day = fuel_rate * co2_factor
+    emission_kg_per_day = float(fuel_rate * co2_factor)
     emission_tons_per_day = Unit.KILO_PER_DAY.to(Unit.TONS_PER_DAY)(emission_kg_per_day)
     n_days = np.sum([days_year1_first_half, days_year1_second_half, days_year2_first_half])
     emission_tons = float(emission_tons_per_day * n_days * regularity_consumer)

--- a/src/libecalc/presentation/flow_diagram/fde_models.py
+++ b/src/libecalc/presentation/flow_diagram/fde_models.py
@@ -76,4 +76,4 @@ class Node(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
-FlowDiagram.update_forward_refs()
+FlowDiagram.model_rebuild()

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -132,19 +132,7 @@ def test_venting_emitter_oil_volume(variables_map):
     }
     emissions_ch4 = emission_result["ch4"]
 
-    try:
-        regularity_array = Expression.evaluate(
-            regularity[Period(datetime(1900, 1, 1))], fill_length=1, variables=variables_map.variables
-        )
-
-        regularity_evaluated = float(regularity_array[0])
-
-    except IndexError as e:
-        raise IndexError("Failed to evaluate regularity: array index out of range.") from e
-
-    assert regularity_evaluated == regularity_expected
-
-    expected_result = [oil_value * regularity_evaluated * emission_factor / 1000 for oil_value in oil_values()]
+    expected_result = [oil_value * regularity_expected * emission_factor / 1000 for oil_value in oil_values()]
 
     assert emissions_ch4.rate.values == expected_result
 

--- a/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/src/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -96,6 +96,7 @@ def test_venting_emitter_oil_volume(variables_map):
     """
     emitter_name = "venting_emitter"
     emission_factor = 0.1
+    regularity_expected = 1.0
 
     venting_emitter = YamlOilTypeEmitter(
         name=emitter_name,
@@ -116,7 +117,7 @@ def test_venting_emitter_oil_volume(variables_map):
         ),
     )
 
-    regularity = {Period(datetime(1900, 1, 1)): Expression.setup_from_expression(1)}
+    regularity = {Period(datetime(1900, 1, 1)): Expression.setup_from_expression(regularity_expected)}
 
     emission_rate = venting_emitter.get_emissions(expression_evaluator=variables_map, regularity=regularity)[
         "ch4"
@@ -136,16 +137,12 @@ def test_venting_emitter_oil_volume(variables_map):
             regularity[Period(datetime(1900, 1, 1))], fill_length=1, variables=variables_map.variables
         )
 
-        if regularity_array.size == 0:
-            raise ValueError("Regularity array is empty, cannot proceed with test.")
-
         regularity_evaluated = float(regularity_array[0])
 
     except IndexError as e:
         raise IndexError("Failed to evaluate regularity: array index out of range.") from e
 
-    except Exception as e:
-        raise RuntimeError("An unexpected error occurred during regularity evaluation in the test.") from e
+    assert regularity_evaluated == regularity_expected
 
     expected_result = [oil_value * regularity_evaluated * emission_factor / 1000 for oil_value in oil_values()]
 


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because the project should be ready for numpy 2 upgrade in the future for its own sake, and in case the Komodo environment will upgrade to numpy 2 eventually.

Note: Since the deprecation warnings are found by running the tests, the refactoring is already tested for.

## What does this pull request change?

Refactoring some code related to numpy 2 deprecation warnings.

## Issues related to this change:

Ecalc 1531