### PR TITLE
fix: missing validation on venting emitter type oil volume

### DIFF
--- a/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
+++ b/src/libecalc/presentation/yaml/yaml_types/emitters/yaml_venting_emitter.py
@@ -48,7 +48,7 @@ class YamlVentingVolumeEmission(YamlBase):
         description="Name of emission",
     )
     emission_factor: ExpressionType = Field(
-        None, title="EMISSION_FACTOR", description="Loading/storage volume-emission factor"
+        ..., title="EMISSION_FACTOR", description="Loading/storage volume-emission factor"
     )
 
     @field_validator("name", mode="before")


### PR DESCRIPTION
ECALC-1714

## Why is this pull request needed?

There is no warning in yaml file (no wiggly lines) when specifying a venting emitter with type `OIL_VOLUME`, without specifying `EMISSION_FACTOR`.

## What does this pull request change?

Update validation of venting emitter with type `OIL_VOLUME`: Get validation error before actually running the model, if missing `EMISSION_FACTOR`.

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1714?atlOrigin=eyJpIjoiMmViMWY1ZTRjNGI1NGE1N2ExYjlmZWQ5OTcxZDRjYzkiLCJwIjoiaiJ9