### PR TITLE
Ecalc 1745 pydantic deprecationwarnings

### DIFF
--- a/src/ecalc_cli/io/output.py
+++ b/src/ecalc_cli/io/output.py
@@ -17,9 +17,7 @@ from libecalc.presentation.exporter.formatters.formatter import CSVFormatter
 from libecalc.presentation.exporter.handlers.handler import MultiFileHandler
 from libecalc.presentation.exporter.infrastructure import ExportableGraphResult
 from libecalc.presentation.flow_diagram.EcalcModelMapper import EcalcModelMapper
-from libecalc.presentation.json_result.result import (
-    EcalcModelResult as EcalcModelResultDTO,
-)
+from libecalc.presentation.json_result.result import EcalcModelResult as EcalcModelResultDTO
 
 
 def write_output(output: str, output_file: Path = None):
@@ -70,7 +68,7 @@ def write_json(
     write_output(output=json_v3, output_file=json_v3_path)
 
     run_info_path = output_folder / f"{name_prefix}_run_info.json"
-    run_info_json = run_info.json()
+    run_info_json = run_info.model_dump_json()
     write_output(output=run_info_json, output_file=run_info_path)
 
 
@@ -193,6 +191,6 @@ def write_flow_diagram(model_dto: Asset, result_options: ResultOptions, output_f
     flow_diagram_filename = f"{name_prefix}.flow-diagram.json" if name_prefix != "" else "flow-diagram.json"
     flow_diagram_path = output_folder / flow_diagram_filename
     try:
-        flow_diagram_path.write_text(json.dumps([json.loads(flow_diagram.json(by_alias=True))]))
+        flow_diagram_path.write_text(json.dumps([json.loads(flow_diagram.model_dump_json(by_alias=True))]))
     except OSError as e:
         raise EcalcCLIError(f"Failed to write flow diagram: {str(e)}") from e

--- a/src/ecalc_neqsim_wrapper/thermo.py
+++ b/src/ecalc_neqsim_wrapper/thermo.py
@@ -419,7 +419,7 @@ def mix_neqsim_streams(
             else:
                 composition_dict[composition_name] = composition_moles
 
-    ecalc_fluid_composition = FluidComposition.parse_obj(
+    ecalc_fluid_composition = FluidComposition.model_validate(
         {_map_fluid_component_from_neqsim[key]: value for (key, value) in composition_dict.items()}
     )
 

--- a/src/ecalc_neqsim_wrapper/thermo.py
+++ b/src/ecalc_neqsim_wrapper/thermo.py
@@ -110,7 +110,7 @@ class NeqsimFluid:
             neqsim_fluid_state = NeqsimFluidState(
                 fluid_composition=fluid_composition, fluid_properties=fluid_properties
             )
-            return neqsim_fluid_state.json()
+            return neqsim_fluid_state.model_dump_json()
 
         except Exception as e:
             logger.warning(f"Failed to parse NeqSimState dump for JSON Serialization. Not critical: {e}")

--- a/src/libecalc/fixtures/cases/all_energy_usage_models/conftest.py
+++ b/src/libecalc/fixtures/cases/all_energy_usage_models/conftest.py
@@ -120,7 +120,9 @@ def variable_speed_pump() -> PumpModel:
 @pytest.fixture
 def simplified_variable_speed_compressor_train_with_gerg_fluid2(predefined_variable_speed_compressor_chart_dto):
     return CompressorTrainSimplifiedWithKnownStages(
-        fluid_model=FluidModel(eos_model=EoSModel.GERG_SRK, composition=FluidComposition.parse_obj(MEDIUM_MW_19P4)),
+        fluid_model=FluidModel(
+            eos_model=EoSModel.GERG_SRK, composition=FluidComposition.model_validate(MEDIUM_MW_19P4)
+        ),
         stages=[
             CompressorStage(
                 inlet_temperature_kelvin=303.15,

--- a/src/libecalc/fixtures/conftest.py
+++ b/src/libecalc/fixtures/conftest.py
@@ -13,12 +13,12 @@ from libecalc.presentation.yaml.mappers.fluid_mapper import MEDIUM_MW_19P4, RICH
 
 @pytest.fixture
 def medium_fluid_dto() -> FluidModel:
-    return FluidModel(eos_model=EoSModel.SRK, composition=FluidComposition.parse_obj(MEDIUM_MW_19P4))
+    return FluidModel(eos_model=EoSModel.SRK, composition=FluidComposition.model_validate(MEDIUM_MW_19P4))
 
 
 @pytest.fixture
 def rich_fluid_dto() -> FluidModel:
-    return FluidModel(eos_model=EoSModel.SRK, composition=FluidComposition.parse_obj(RICH_MW_21P4))
+    return FluidModel(eos_model=EoSModel.SRK, composition=FluidComposition.model_validate(RICH_MW_21P4))
 
 
 @pytest.fixture

--- a/src/libecalc/presentation/flow_diagram/fde_models.py
+++ b/src/libecalc/presentation/flow_diagram/fde_models.py
@@ -76,4 +76,4 @@ class Node(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
-FlowDiagram.update_forward_refs()
+FlowDiagram.model_rebuild()

--- a/src/tests/libecalc/core/conftest.py
+++ b/src/tests/libecalc/core/conftest.py
@@ -12,26 +12,28 @@ from libecalc.core.models.compressor.sampled import CompressorModelSampled
 from libecalc.core.models.pump import PumpSingleSpeed, PumpVariableSpeed
 from libecalc.core.models.turbine import TurbineModel
 from libecalc.expression import Expression
-from libecalc.presentation.yaml.mappers.fluid_mapper import (
-    DRY_MW_18P3,
-    MEDIUM_MW_19P4,
-    RICH_MW_21P4,
-)
+from libecalc.presentation.yaml.mappers.fluid_mapper import DRY_MW_18P3, MEDIUM_MW_19P4, RICH_MW_21P4
 
 
 @pytest.fixture
 def medium_fluid() -> dto.FluidModel:
-    return dto.FluidModel(eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.parse_obj(MEDIUM_MW_19P4))
+    return dto.FluidModel(
+        eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.model_validate(MEDIUM_MW_19P4)
+    )
 
 
 @pytest.fixture
 def rich_fluid() -> dto.FluidModel:
-    return dto.FluidModel(eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.parse_obj(RICH_MW_21P4))
+    return dto.FluidModel(
+        eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.model_validate(RICH_MW_21P4)
+    )
 
 
 @pytest.fixture
 def dry_fluid() -> dto.FluidModel:
-    return dto.FluidModel(eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.parse_obj(DRY_MW_18P3))
+    return dto.FluidModel(
+        eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.model_validate(DRY_MW_18P3)
+    )
 
 
 @pytest.fixture

--- a/src/tests/libecalc/core/models/compressor_modelling/conftest.py
+++ b/src/tests/libecalc/core/models/compressor_modelling/conftest.py
@@ -16,35 +16,35 @@ from libecalc.core.models.compressor.train.single_speed_compressor_train_common_
     SingleSpeedCompressorTrainCommonShaft,
 )
 from libecalc.core.models.compressor.train.stage import CompressorTrainStage
-from libecalc.core.models.compressor.train.types import (
-    FluidStreamObjectForMultipleStreams,
-)
+from libecalc.core.models.compressor.train.types import FluidStreamObjectForMultipleStreams
 from libecalc.core.models.compressor.train.variable_speed_compressor_train_common_shaft import (
     VariableSpeedCompressorTrainCommonShaft,
 )
 from libecalc.core.models.compressor.train.variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures import (
     VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures,
 )
-from libecalc.presentation.yaml.mappers.fluid_mapper import (
-    DRY_MW_18P3,
-    MEDIUM_MW_19P4,
-    RICH_MW_21P4,
-)
+from libecalc.presentation.yaml.mappers.fluid_mapper import DRY_MW_18P3, MEDIUM_MW_19P4, RICH_MW_21P4
 
 
 @pytest.fixture
 def medium_fluid() -> dto.FluidModel:
-    return dto.FluidModel(eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.parse_obj(MEDIUM_MW_19P4))
+    return dto.FluidModel(
+        eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.model_validate(MEDIUM_MW_19P4)
+    )
 
 
 @pytest.fixture
 def rich_fluid() -> dto.FluidModel:
-    return dto.FluidModel(eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.parse_obj(RICH_MW_21P4))
+    return dto.FluidModel(
+        eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.model_validate(RICH_MW_21P4)
+    )
 
 
 @pytest.fixture
 def dry_fluid() -> dto.FluidModel:
-    return dto.FluidModel(eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.parse_obj(DRY_MW_18P3))
+    return dto.FluidModel(
+        eos_model=dto.types.EoSModel.SRK, composition=dto.FluidComposition.model_validate(DRY_MW_18P3)
+    )
 
 
 @pytest.fixture

--- a/src/tests/libecalc/dto/test_composition.py
+++ b/src/tests/libecalc/dto/test_composition.py
@@ -17,7 +17,7 @@ def test_composition(caplog):
         "n_pentane": 0.197937,
         "n_hexane": 0.368786,
     }
-    composition = dto.FluidComposition.parse_obj(composition_spec)
+    composition = dto.FluidComposition.model_validate(composition_spec)
 
     assert all(x in composition.model_dump() for x in composition_spec)
     assert all(x in composition.model_dump().values() for x in composition_spec.values())
@@ -25,4 +25,4 @@ def test_composition(caplog):
     # Composition with invalid component name
     with pytest.raises(ValidationError):
         caplog.set_level("CRITICAL")
-        dto.FluidComposition.parse_obj({"invalid": 0.74373, "CO2": 2.415619, "methane": 85.60145})
+        dto.FluidComposition.model_validate({"invalid": 0.74373, "CO2": 2.415619, "methane": 85.60145})


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Removing pydantic DeprecationWarnings

## What does this pull request change?

Only changed some deprecated methods for pydantic.

## Issues related to this change:
ECALC-1745