### PR TITLE
chore: clean up TimeSeriesRate and remove reindex from consumer

### DIFF
--- a/src/libecalc/presentation/exporter/queries.py
+++ b/src/libecalc/presentation/exporter/queries.py
@@ -274,7 +274,7 @@ class MaxUsageFromShoreQuery(Query):
             return {
                 period: TimeSeriesFloat(periods=Periods(period_keys), values=list(sorted_result.values()), unit=unit)
                 .for_period(period)
-                .max()
+                .max
                 for period in resample_periods(periods=installation_graph.get_periods(), frequency=frequency)
             }
         return None

--- a/src/tests/libecalc/common/utils/test_rates.py
+++ b/src/tests/libecalc/common/utils/test_rates.py
@@ -118,7 +118,7 @@ class TestBooleanTimeSeries:
         # resample including start and end date
         yearly_values = boolean_series.resample(freq=Frequency.YEAR)
         assert yearly_values.values == [False, True, False, False]
-        assert yearly_values.all_dates() == [
+        assert yearly_values.all_dates == [
             datetime(2019, 7, 1),
             datetime(2020, 1, 1),
             datetime(2021, 1, 1),
@@ -129,7 +129,7 @@ class TestBooleanTimeSeries:
         # resample including start and without end date
         yearly_values = boolean_series.resample(freq=Frequency.YEAR, include_end_date=False)
         assert yearly_values.values == [False, True, False]
-        assert yearly_values.all_dates() == [
+        assert yearly_values.all_dates == [
             datetime(2019, 7, 1),
             datetime(2020, 1, 1),
             datetime(2021, 1, 1),
@@ -139,7 +139,7 @@ class TestBooleanTimeSeries:
         # resample without start and including end date
         yearly_values = boolean_series.resample(freq=Frequency.YEAR, include_start_date=False)
         assert yearly_values.values == [True, False, False]
-        assert yearly_values.all_dates() == [
+        assert yearly_values.all_dates == [
             datetime(2020, 1, 1),
             datetime(2021, 1, 1),
             datetime(2022, 1, 1),
@@ -149,7 +149,7 @@ class TestBooleanTimeSeries:
         # resample without start and end date
         yearly_values = boolean_series.resample(freq=Frequency.YEAR, include_start_date=False, include_end_date=False)
         assert yearly_values.values == [True, False]
-        assert yearly_values.all_dates() == [
+        assert yearly_values.all_dates == [
             datetime(2020, 1, 1),
             datetime(2021, 1, 1),
             datetime(2022, 1, 1),
@@ -265,7 +265,7 @@ class TestTimeSeriesVolumesResample:
         )
 
         resampled_volumes = volumes.resample(freq=Frequency.YEAR)
-        assert resampled_volumes.all_dates() == [
+        assert resampled_volumes.all_dates == [
             datetime(2022, 1, 1),
             datetime(2023, 1, 1),
             datetime(2024, 1, 1),
@@ -463,7 +463,7 @@ class TestTimeseriesRateToVolumes:
         )
         volumes = rates.to_volumes()
         assert volumes.values == [9, 12, 10]
-        assert volumes.all_dates() == [
+        assert volumes.all_dates == [
             datetime(2023, 1, 1),
             datetime(2023, 1, 4),
             datetime(2023, 1, 7),

--- a/src/tests/libecalc/core/consumers/test_legacy_consumer.py
+++ b/src/tests/libecalc/core/consumers/test_legacy_consumer.py
@@ -21,19 +21,6 @@ from libecalc.core.consumers.legacy_consumer.consumer_function_mapper import Ene
 from libecalc.core.result import EcalcModelResult
 
 
-def test_compute_consumer_rate():
-    """Matching the energy usage rate of the EnergyFunctionResult with the result of the parent Consumer:"""
-    time_vector = pd.date_range(datetime(2020, 1, 1), datetime(2023, 1, 1), freq="YS").to_pydatetime().tolist()
-
-    consumer_rate = Consumer.reindex_time_vector(
-        values=np.array([1, 2]),
-        time_vector=time_vector[1:-1],
-        new_time_vector=time_vector,
-    )
-
-    assert consumer_rate.tolist() == [0, 1, 2, 0]  # Note that the consumer starts and ends 1 year before/after
-
-
 def test_evaluate_consumer_time_function(direct_el_consumer):
     """Testing using a direct el consumer for simplicity."""
     consumer = Consumer(


### PR DESCRIPTION
Some clean up in rates.py

Renaming `reindex` to `fill_values_for_new_periods` (as that is what is actually done)

Removing reindex_periods/time_vector from Consumer class


## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/docs/changelog/next.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
