### PR TITLE
chore: remove extensions from devcontainer not needed

### DIFF
--- a/.devcontainer/python/devcontainer.json
+++ b/.devcontainer/python/devcontainer.json
@@ -30,9 +30,7 @@
         "github.copilot",
         "charliermarsh.ruff",
         "shardulm94.trailing-spaces",
-        "esbenp.prettier-vscode",
-        "ms-vscode.test-adapter-converter",
-        "littlefoxteam.vscode-python-test-adapter"
+        "esbenp.prettier-vscode"
       ]
     }
   },


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Just removed two testing related extensions from the devcontainer which are not needed since their functionality is now covered by the python extension.

## Issues related to this change:
ECALC-1622