### PR TITLE
chore: refix additional python 3.11 ruff complaints

### DIFF
--- a/src/tests/libecalc/presentation/yaml/yaml_types/models/conftest.py
+++ b/src/tests/libecalc/presentation/yaml/yaml_types/models/conftest.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, cast
+from typing import Optional, cast
 
 from libecalc.presentation.yaml.configuration_service import ConfigurationService
 from libecalc.presentation.yaml.yaml_entities import ResourceStream
@@ -6,7 +6,7 @@ from libecalc.presentation.yaml.yaml_models.yaml_model import ReaderType, YamlCo
 
 
 class OverridableStreamConfigurationService(ConfigurationService):
-    def __init__(self, stream: ResourceStream, overrides: Optional[Dict] = None):
+    def __init__(self, stream: ResourceStream, overrides: Optional[dict] = None):
         self._overrides = overrides
         self._stream = stream
 


### PR DESCRIPTION
due to incorrect conflict resolving due to commit that was pushed with python 3.8 defaults while i was working on ruff 3.11 defaults.