### PR TITLE
Ecalc-1531 numpy2 ready

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ build-backend = "poetry.core.masonry.api"
 
 # plugins, plugin config etc
 [tool.pytest.ini_options]
+filterwarnings = [
+    "error::DeprecationWarning", # Treat all DeprecationWarnings as errors and ignore explicitly below if needed
+    "ignore:Avoid using the dto.*:DeprecationWarning", # Ignore internal deprecation warnings
+]
 markers = [
     "e2e: e2e tests.",
     "integtest: integration test",

--- a/test/README.md
+++ b/test/README.md
@@ -16,10 +16,14 @@ configured in *docker-compose.yml* file. To run tests, simply run (from test/ di
 docker compose run test
 ```
 
-or (since we currently only have one service, and default is to run the docker-snapshot test)
+## Updating and running 'dockersnapshot' marked tests in Docker (STP/LTP snapshot tests)
+
+Some snapshot tests marked with `dockersnapshot` need to run in a x86_64 environment to produce consistent snapshots. 
+This is relevant for those with macbooks.
+To run the relevant tests and update their snapshot run (from test/ dir):
 
 ```bash
-docker compose up
+docker compose run dockersnapshots
 ```
 
 This will build the container and run the tests marked 'dockersnapshot'. If the snapshot has changed, it will fail with exit code 1, and

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  test:
+  dockersnapshots:
     build:
       context: ../
       dockerfile: ./Dockerfile
@@ -8,3 +8,13 @@ services:
     volumes:
       - ../:/project/libecalc
     command: ["poetry", "run", "pytest", "-m", "dockersnapshot", "--snapshot-update"]
+
+  test:
+    build:
+      context: ../
+      dockerfile: ./Dockerfile
+      target: build
+    working_dir: /project/libecalc
+    volumes:
+      - ../:/project/libecalc
+    command: ["poetry", "run", "pytest"]


### PR DESCRIPTION
## Have you remembered and considered?

- [x] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Need to run some tests marked dockersnapshot in docker container to make them pass. The snapshot update should also be run in docker container. New docker compose service will run all tests in docker container in one run.

In the future, e.g. when updating numpy to version >2, it seems that tests 

## Issues related to this change:
ECALC-1531 