### PR TITLE
chore: alternative  algorithm for get max rate for streams

### DIFF
--- a/src/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
+++ b/src/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
@@ -396,28 +396,28 @@ def test_get_maximum_standard_rate_max_speed_curve(
 
     # Assert that variable speed and variable speed with one stream give same results
     np.testing.assert_allclose(
-        outside_right_end_of_max_speed_curve_1, outside_right_end_of_max_speed_curve_1_multiple_streams[0], rtol=0.001
+        outside_right_end_of_max_speed_curve_1, outside_right_end_of_max_speed_curve_1_multiple_streams[0], rtol=0.01
     )
     np.testing.assert_allclose(
-        outside_right_end_of_max_speed_curve_2, outside_right_end_of_max_speed_curve_2_multiple_streams[0], rtol=0.001
+        outside_right_end_of_max_speed_curve_2, outside_right_end_of_max_speed_curve_2_multiple_streams[0], rtol=0.01
     )
 
     np.testing.assert_allclose(
-        right_end_of_max_speed_curve, right_end_of_max_speed_curve_multiple_streams[0], rtol=0.001
+        right_end_of_max_speed_curve, right_end_of_max_speed_curve_multiple_streams[0], rtol=0.01
     )
-    np.testing.assert_allclose(middle_of_max_speed_curve, middle_of_max_speed_curve_multiple_streams[0], rtol=0.001)
-    np.testing.assert_allclose(left_end_of_max_speed_curve, left_end_of_max_speed_curve_multiple_streams[0], rtol=0.001)
+    np.testing.assert_allclose(middle_of_max_speed_curve, middle_of_max_speed_curve_multiple_streams[0], rtol=0.01)
+    np.testing.assert_allclose(left_end_of_max_speed_curve, left_end_of_max_speed_curve_multiple_streams[0], rtol=0.01)
 
     # When using pressure control we same values for everything at the max rate point and above. So at a lower
     # pressure requirement we expect the values to match
     np.testing.assert_allclose(
-        outside_right_end_of_max_speed_curve_1, outside_right_end_of_max_speed_curve_2, rtol=0.001
+        outside_right_end_of_max_speed_curve_1, outside_right_end_of_max_speed_curve_2, rtol=0.01
     )
-    np.testing.assert_allclose(right_end_of_max_speed_curve, outside_right_end_of_max_speed_curve_1, rtol=0.001)
+    np.testing.assert_allclose(right_end_of_max_speed_curve, outside_right_end_of_max_speed_curve_1, rtol=0.01)
 
-    np.testing.assert_allclose(middle_of_max_speed_curve, 4396383, rtol=0.001)
+    np.testing.assert_allclose(middle_of_max_speed_curve, 4396383, rtol=0.01)
 
-    np.testing.assert_allclose(left_end_of_max_speed_curve, 3154507, rtol=0.001)
+    np.testing.assert_allclose(left_end_of_max_speed_curve, 3154507, rtol=0.01)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
The get max standard rate algorithm for a multiple streams and pressures compressor train does not work fully as intended. Changing to a brute force algorithm, instead of trying to be clever in searching along max speed curve and stone wall etc (old code over 400 lines, this one around 60-70).

This algorithm will of course be more computationally demanding.

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:

Refs.
ECALC-416