### PR TITLE
docs: update docs and migration guide with new requirements for control margin and generic charts

### DIFF
--- a/docs/docs/about/migration_guides/v8.26_to_v9.0.md
+++ b/docs/docs/about/migration_guides/v8.26_to_v9.0.md
@@ -1,0 +1,84 @@
+---
+title: v8.26 to v9.0
+description: v8.26 to v9.0 migration
+sidebar_position: -12
+---
+
+# v8.26 to v9.0
+
+In this migration guide you will find:
+
+1. [YAML changes](#yaml-migration)
+
+## Yaml migration
+
+### Migration overview
+
+This doc guides you through migrating an existing eCalc™ model from version v8.26 to v9.0.
+
+We try to make this as easy as possible, and provide a step-by-step migration guide.
+
+### 1. Changes to compressor trains in MODELS
+- `CONTROL_MARGIN` and `CONTROL_MARGIN_UNIT` are now required for `SINGLE_SPEED_COMPRESSOR_TRAIN`, `VARIABLE_SPEED_COMPRESSOR_TRAIN` and `VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES`.
+
+An example with new yaml implementation is shown below:
+
+```yaml 
+MODELS:
+  - NAME: <model name>
+    TYPE: SINGLE_SPEED_COMPRESSOR_TRAIN
+    FLUID_MODEL: <reference to fluid model>
+    PRESSURE_CONTROL: <method for pressure control, DOWNSTREAM_CHOKE (default), UPSTREAM_CHOKE, , INDIVIDUAL_ASV_PRESSURE, INDIVIDUAL_ASV_RATE or COMMON_ASV>
+    MAXIMUM_DISCHARGE_PRESSURE: <Maximum discharge pressure in bar (can only use if pressure control is DOWNSTREAM_CHOKE)>
+    COMPRESSOR_TRAIN:
+      STAGES:
+        - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
+          COMPRESSOR_CHART: <reference to compressor chart model for first stage, must be defined in MODELS or FACILITY_INPUTS>
+          PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
+          # This is new
+          CONTROL_MARGIN: <Default value is zero>
+          # This is new
+          CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
+        - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
+          COMPRESSOR_CHART: <reference to compressor chart model for second stage, must be defined in MODELS or FACILITY_INPUTS>
+          PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
+          # This is new
+          CONTROL_MARGIN: <Default value is zero>
+          # This is new
+          CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
+        - ... and so forth for each stage in the train
+    POWER_ADJUSTMENT_CONSTANT: <Optional constant MW adjustment added to the model>
+    MAXIMUM_POWER: <Optional constant MW maximum power the compressor train can require>
+    CALCULATE_MAX_RATE: <Optional compressor train max standard rate [Sm3/day] in result if set to true. Default false. Use with caution. This will increase runtime significantly. >
+```
+
+### 2. Changes to simplified compressor trains in MODELS
+- `CONTROL_MARGIN` and `CONTROL_MARGIN_UNIT` are not allowed for `SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN`.
+
+The new yaml implementation is described below, for simplified compressor train model with known compressor stages:
+
+```yaml 
+MODELS:
+  - NAME: <model name>
+    TYPE: SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN
+    FLUID_MODEL: <reference to fluid model>
+    COMPRESSOR_TRAIN:
+      STAGES:
+        - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
+          COMPRESSOR_CHART: <reference to compressor chart model for first stage, must be defined in MODELS or FACILITY_INPUTS>
+          # This is old
+          CONTROL_MARGIN: <Default value is zero>
+          # This is old
+          CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
+        - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
+          COMPRESSOR_CHART: <reference to compressor chart model for second stage, must be defined in MODELS or FACILITY_INPUTS>
+          # This is old
+          CONTROL_MARGIN: <Default value is zero>
+          # This is old
+          CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
+        - ... and so forth for each stage in the train
+    POWER_ADJUSTMENT_CONSTANT: <Optional constant MW adjustment added to the model>
+    MAXIMUM_POWER: <Optional constant MW maximum power the compressor train can require>
+```
+- Simplified compressor trains have to use generic compressor charts
+  - `SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN` is restricted to generic compressor charts, i.e. the `COMPRESSOR_CHART` must be of type `GENERIC_FROM_INPUT` or `GENERIC_FROM_DESIGN_POINT`. The chart types `SINGLE_SPEED` and `VARIABLE_SPEED` are not allowed anymore.

--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md
@@ -11,6 +11,11 @@ the same shaft and thus have a common speed.
 This model supports only 
 `generic compressor charts`. See [compressor charts](/about/modelling/setup/models/compressor_modelling/compressor_charts/index.md) for more information. 
 
+<span className="changed-from-version">
+**Changed in version 9.0:** Only generic compressor charts are allowed. SINGLE_SPEED- and VARIABLE_SPEED charts are not allowed.
+</span>
+<br/>
+
 In addition, a [FLUID MODEL](/about/modelling/setup/models/fluid_model.md) must be specified.
 
 The model comes in two versions, one where the compressor stages are known (pre defined), and one where the compressor

--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/simplified_variable_speed_compressor_train_model.md
@@ -8,7 +8,7 @@ are assumed based on an assumption of equal pressure fractions for each stage. B
 calculated independently for each compressor as if it was a standalone compressor, neglecting that they are in fact on
 the same shaft and thus have a common speed.
 
-This model supports both `user defined compressor charts` and
+This model supports only 
 `generic compressor charts`. See [compressor charts](/about/modelling/setup/models/compressor_modelling/compressor_charts/index.md) for more information. 
 
 In addition, a [FLUID MODEL](/about/modelling/setup/models/fluid_model.md) must be specified.
@@ -72,25 +72,15 @@ MODELS:
 
 ## Examples
 
-### A (single) compressor with a user-defined variable speed compressor chart and fluid composition
+### A (single) compressor with a generic compressor chart, with design point calculated from input data, and fluid composition
 ~~~~~~~~yaml
 MODELS:
-  - NAME: predefined_variable_speed_compressor_chart
+  - NAME: generic_from_input_compressor_chart
     TYPE: COMPRESSOR_CHART
-    CHART_TYPE: VARIABLE_SPEED
+    CHART_TYPE: GENERIC_FROM_INPUT
+    POLYTROPIC_EFFICIENCY: 0.75
     UNITS:
-      RATE: AM3_PER_HOUR
-      HEAD: M
       EFFICIENCY: FRACTION
-    CURVES:
-      - SPEED: 7500
-        RATE: [2900, 3503, 4002, 4595.0]
-        HEAD: [8412.9, 7996, 7363, 6127]
-        EFFICIENCY: [0.72, 0.75, 0.74, 0.70]
-      - SPEED: 10767
-        RATE: [4052, 4500, 4999, 5492, 6000, 6439,]
-        HEAD: [16447, 16081, 15546, 14640, 13454, 11973,]
-        EFFICIENCY: [0.72, 0.73, 0.74, 0.74, 0.72, 0.70]
 
   - NAME: fluid_model_1
     TYPE: FLUID
@@ -114,7 +104,7 @@ MODELS:
     COMPRESSOR_TRAIN:
       STAGES:
         - INLET_TEMPERATURE: 30
-          COMPRESSOR_CHART: predefined_variable_speed_compressor_chart
+          COMPRESSOR_CHART: generic_from_input_compressor_chart
 ~~~~~~~~
 
 ### A (single) turbine driven compressor with a generic compressor chart with design point and predefined composition
@@ -158,7 +148,7 @@ MODELS:
     TURBINE_MODEL: compressor_train_turbine
 ~~~~~~~~
 
-### A compressor train with two stages where the first stage has unknown spec while the second has a predefined chart
+### A compressor train with two stages where the first stage has unknown spec while the second generic compressor chart from design point
 
 ~~~~~~~~yaml
             MODELS:
@@ -166,22 +156,16 @@ MODELS:
                 TYPE: COMPRESSOR_CHART
                 CHART_TYPE: GENERIC_FROM_INPUT
 
-              - NAME: predefined_variable_speed_compressor_chart
+              - NAME: generic_from_design_point_compressor_chart
                 TYPE: COMPRESSOR_CHART
-                CHART_TYPE: VARIABLE_SPEED
+                CHART_TYPE: GENERIC_FROM_DESIGN_POINT
+                POLYTROPIC_EFFICIENCY: 0.75
+                DESIGN_RATE: 7000
+                DESIGN_HEAD: 50
                 UNITS:
                   RATE: AM3_PER_HOUR
-                  HEAD: M
+                  HEAD: KJ_PER_KG
                   EFFICIENCY: FRACTION
-                CURVES:
-                  - SPEED: 7500
-                    RATE: [2900, 3503, 4002, 4595.0]
-                    HEAD: [8412.9, 7996, 7363, 6127]
-                    EFFICIENCY: [0.72, 0.75, 0.74, 0.70]
-                  - SPEED: 10767
-                    RATE: [4052, 4500, 4999, 5492, 6000, 6439,]
-                    HEAD: [16447, 16081, 15546, 14640, 13454, 11973,]
-                    EFFICIENCY: [0.72, 0.73, 0.74, 0.74, 0.72, 0.70]
 
               - NAME: dry_fluid
                 TYPE: FLUID
@@ -197,7 +181,7 @@ MODELS:
                     - INLET_TEMPERATURE: 30
                       COMPRESSOR_CHART: generic_from_input_compressor_chart
                     - INLET_TEMPERATURE: 30
-                      COMPRESSOR_CHART: predefined_variable_speed_compressor_chart
+                      COMPRESSOR_CHART: generic_from_design_point_compressor_chart
 ~~~~~~~~
 
 ### A compressor train where the number of stages are unknown

--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/single_speed_compressor_train_model.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/single_speed_compressor_train_model.md
@@ -13,8 +13,9 @@ This means that a single speed compressor model needs the following to be define
 
 - A polytropic compressor chart for every compressor stage in the compressor train. For single speed trains, eCalc
   only supports user defined single speed compressor charts.
-- A [FLUID_MODEL](/about/references/FLUID_MODEL.md).
-- A [PRESSURE_CONTROL](/about/references/PRESSURE_CONTROL.md).
+- [CONTROL_MARGIN](/about/references/CONTROL_MARGIN.md) and [CONTROL_MARGIN_UNIT](/about/references/CONTROL_MARGIN_UNIT.md) for each compressor stage in the train
+- [FLUID_MODEL](/about/references/FLUID_MODEL.md)
+- [PRESSURE_CONTROL](/about/references/PRESSURE_CONTROL.md)
 
 The following keywords are optional for a single speed compressor model:
 
@@ -38,9 +39,13 @@ MODELS:
       STAGES:
         - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
           COMPRESSOR_CHART: <reference to compressor chart model for first stage, must be defined in MODELS or FACILITY_INPUTS>
+          CONTROL_MARGIN: <Surge control margin for the compressor stage. Set to 0.0 if no margin>
+          CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
           PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
         - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
           COMPRESSOR_CHART: <reference to compressor chart model for second stage, must be defined in MODELS or FACILITY_INPUTS>
+          CONTROL_MARGIN: <Surge control margin for the compressor stage. Set to 0.0 if no margin>
+          CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
           PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
         - ... and so forth for each stage in the train
     POWER_ADJUSTMENT_CONSTANT: <Optional constant MW adjustment added to the model>

--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/single_speed_compressor_train_model.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/single_speed_compressor_train_model.md
@@ -17,6 +17,11 @@ This means that a single speed compressor model needs the following to be define
 - [FLUID_MODEL](/about/references/FLUID_MODEL.md)
 - [PRESSURE_CONTROL](/about/references/PRESSURE_CONTROL.md)
 
+<span className="changed-from-version">
+**Changed in version 9.0:** CONTROL_MARGIN and CONTROL_MARGIN_UNIT are required
+</span>
+<br/>
+
 The following keywords are optional for a single speed compressor model:
 
 - [MAXIMUM_DISCHARGE_PRESSURE](/about/references/MAXIMUM_DISCHARGE_PRESSURE.md)

--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md
@@ -11,7 +11,10 @@ requested discharge pressure by iterating on speed only, an attempt is made to f
 
 This model only supports `User defined variable speed compressor chart`.
 
-In addition, a [FLUID MODEL](/about/modelling/setup/models/fluid_model.md) must be specified.
+In addition, the following keywords are required:
+- [FLUID MODEL](/about/modelling/setup/models/fluid_model.md)
+- [CONTROL_MARGIN](/about/references/CONTROL_MARGIN.md) and [CONTROL_MARGIN_UNIT](/about/references/CONTROL_MARGIN_UNIT.md) for each compressor stage in the train
+
 
 **Control mechanisms**
 
@@ -42,12 +45,12 @@ MODELS:
       STAGES:
         - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
           COMPRESSOR_CHART: <reference to compressor chart model for first stage, must be defined in MODELS or FACILITY_INPUTS>
-          CONTROL_MARGIN: <Surge control margin for the compressor stage. Default value 0.0>
+          CONTROL_MARGIN: <Surge control margin for the compressor stage. Set to 0.0 if no margin>
           PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
           CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
         - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
           COMPRESSOR_CHART: <reference to compressor chart model for second stage, must be defined in MODELS or FACILITY_INPUTS>
-          CONTROL_MARGIN: <Surge control margin for the compressor stage. Default value 0.0>
+          CONTROL_MARGIN: <Surge control margin for the compressor stage. Set to 0.0 if no margin>
           PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
           CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
         - ... and so forth for each stage in the train

--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model.md
@@ -15,6 +15,10 @@ In addition, the following keywords are required:
 - [FLUID MODEL](/about/modelling/setup/models/fluid_model.md)
 - [CONTROL_MARGIN](/about/references/CONTROL_MARGIN.md) and [CONTROL_MARGIN_UNIT](/about/references/CONTROL_MARGIN_UNIT.md) for each compressor stage in the train
 
+<span className="changed-from-version">
+**Changed in version 9.0:** CONTROL_MARGIN and CONTROL_MARGIN_UNIT are required
+</span>
+<br/>
 
 **Control mechanisms**
 

--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md
@@ -80,6 +80,11 @@ As of now, only a single value is supported - i.e. a time series cannot be used 
 
 - `CONTROL_MARGIN_UNIT` is the unit of the surge control margin. This keyword is required for each stage.
 
+<span className="changed-from-version">
+**Changed in version 9.0:** CONTROL_MARGIN and CONTROL_MARGIN_UNIT are required
+</span>
+<br/>
+
 ### INTERSTAGE_PRESSURE_CONTROL
 
 :::note

--- a/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md
+++ b/docs/docs/about/modelling/setup/models/compressor_modelling/compressor_models_types/variable_speed_compressor_train_model_with_multiple_streams_and_pressures.md
@@ -31,7 +31,7 @@ MODELS:
       - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
         COMPRESSOR_CHART: <reference to a compressor chart model defined in MODELS>
         STREAM: <reference stream from STREAMS. Needs to be an INGOING type stream.>
-        CONTROL_MARGIN: <Default value 0.0>
+        CONTROL_MARGIN: <Surge control margin for the compressor stage. Set to 0.0 if no margin>
         PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
         CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
       - ...
@@ -40,7 +40,7 @@ MODELS:
         STREAM: <Optional>
         - <reference stream from STREAMS for one in- or outgoing stream. Optional>
         - <reference stream from STREAMS for another in- or outgoing stream. Optional>
-        CONTROL_MARGIN: <Default value 0.0>
+        CONTROL_MARGIN: <Surge control margin for the compressor stage. Set to 0.0 if no margin>
         CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
         PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
         INTERSTAGE_CONTROL_PRESSURE:
@@ -49,7 +49,7 @@ MODELS:
       - ...
       - INLET_TEMPERATURE: <inlet temperature in Celsius for stage>
         COMPRESSOR_CHART: <reference to a compressor chart model defined in MODELS>
-        CONTROL_MARGIN: <Default value 0.0>
+        CONTROL_MARGIN: <Surge control margin for the compressor stage. Set to 0.0 if no margin>
         CONTROL_MARGIN_UNIT: <FRACTION or PERCENTAGE, default is PERCENTAGE>
         PRESSURE_DROP_AHEAD_OF_STAGE: <Pressure drop before compression stage [in bar]>
       - ...
@@ -76,9 +76,9 @@ be subtracted the rate of the outgoing stream.
 - `PRESSURE_DROP_AHEAD_OF_STAGE` is optional, but if defined it will reduce the inlet pressure of that particular stage by a fixed value.
 As of now, only a single value is supported - i.e. a time series cannot be used here.
 
-- `CONTROL_MARGIN` is a surge control margin, see [Surge control margin for variable speed compressor chart](/about/modelling/setup/models/compressor_modelling/compressor_charts/index.md).
+- `CONTROL_MARGIN` is a surge control margin, see [Surge control margin for variable speed compressor chart](/about/modelling/setup/models/compressor_modelling/compressor_charts/index.md). This keyword is required for each stage.
 
-- `CONTROL_MARGIN_UNIT` is the unit of the surge control margin.
+- `CONTROL_MARGIN_UNIT` is the unit of the surge control margin. This keyword is required for each stage.
 
 ### INTERSTAGE_PRESSURE_CONTROL
 
@@ -136,12 +136,18 @@ MODELS:
     STAGES:
       - COMPRESSOR_CHART: 1_stage_chart
         INLET_TEMPERATURE: 20
+        CONTROL_MARGIN: 0.0
+        CONTROL_MARGIN_UNIT: PERCENTAGE
         STREAM: 
           - 1_stage_inlet
       - COMPRESSOR_CHART: 2_stage_chart 
         INLET_TEMPERATURE: 30
+        CONTROL_MARGIN: 0.0
+        CONTROL_MARGIN_UNIT: PERCENTAGE
       - COMPRESSOR_CHART: 3_stage_chart 
         INLET_TEMPERATURE: 35
+        CONTROL_MARGIN: 0.0
+        CONTROL_MARGIN_UNIT: PERCENTAGE
         STREAM: 
           - 2_stage_outlet
           - 3_stage_inlet
@@ -150,4 +156,6 @@ MODELS:
           DOWNSTREAM_PRESSURE_CONTROL: INDIVIDUAL_ASV_RATE #3rd and 4th stage
       - COMPRESSOR_CHART: 4_stage_chart 
         INLET_TEMPERATURE: 15
+        CONTROL_MARGIN: 0.0
+        CONTROL_MARGIN_UNIT: PERCENTAGE
 ~~~~~~~~

--- a/docs/docs/changelog/v9-0.md
+++ b/docs/docs/changelog/v9-0.md
@@ -16,4 +16,5 @@ sidebar_position: -36
 
 * Removing support for Python 3.8, 3.9, 3.10. If you have downloaded/installed libeCalc manually, you will need to
 run with at least Python 3.11 from now on.
-* control margin is required for compressors, except for simplified trains (control margin not allowed). Simplified trains have to use generic charts.
+* control margin is required for compressors, except for simplified trains (control margin not allowed).
+* Simplified trains have to use generic charts. Single speed- and variable speed charts are not allowed.

--- a/docs/docs/changelog/v9-0.md
+++ b/docs/docs/changelog/v9-0.md
@@ -16,6 +16,6 @@ sidebar_position: -36
 
 * Removing support for Python 3.8, 3.9, 3.10. If you have downloaded/installed libeCalc manually, you will need to
 run with at least Python 3.11 from now on.
-* CONTROL_MARGIN and CONTROL_MARGIN_UNIT are required for compressors, except for simplified trains.
+* CONTROL_MARGIN and CONTROL_MARGIN_UNIT are required for compressors, except for simplified compressor trains.
 * CONTROL_MARGIN and CONTROL_MARGIN_UNIT not allowed for simplified compressor trains.
 * Simplified trains have to use generic charts. Single speed- and variable speed charts are not allowed.

--- a/docs/docs/changelog/v9-0.md
+++ b/docs/docs/changelog/v9-0.md
@@ -16,5 +16,6 @@ sidebar_position: -36
 
 * Removing support for Python 3.8, 3.9, 3.10. If you have downloaded/installed libeCalc manually, you will need to
 run with at least Python 3.11 from now on.
-* control margin is required for compressors, except for simplified trains (control margin not allowed).
+* CONTROL_MARGIN and CONTROL_MARGIN_UNIT are required for compressors, except for simplified trains.
+* CONTROL_MARGIN and CONTROL_MARGIN_UNIT not allowed for simplified compressor trains.
 * Simplified trains have to use generic charts. Single speed- and variable speed charts are not allowed.

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -58,3 +58,10 @@
   padding: 0 var(--ifm-pre-padding);
   border-left: 3px solid rgba(14, 201, 41, 0.88);
 }
+.changed-from-version {
+  background-color: rgba(100, 100, 100, 0);
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+  border-left: 3px solid rgba(14, 201, 41, 0.88);
+}


### PR DESCRIPTION
ECALC-1790

## Why is this pull request needed?

CONTROL_MARGIN and CONTROL_MARGIN_UNIT are required for all compressor trains except simplified trains. Generic charts are restricted to simplified trains. These are breaking changes and should be reflected in documentation and migration guide.

## What does this pull request change?

- [x] Update migration guide
- [x] Update docs

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1790?atlOrigin=eyJpIjoiZDEyN2VkNGFhOTE2NDc0Mjg5MWY4ZjFhOTg0MzUwN2EiLCJwIjoiaiJ9