### PR TITLE
chore: change from dto to builder in test ltp installation setup

### DIFF
--- a/src/tests/libecalc/presentation/exporter/conftest.py
+++ b/src/tests/libecalc/presentation/exporter/conftest.py
@@ -1,0 +1,44 @@
+import pytest
+from yaml_builder import YamlEmissionBuilder, YamlFuelTypeBuilder
+
+from libecalc.dto.types import FuelTypeUserDefinedCategoryType
+from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_emission import YamlEmission
+
+co2_factor = 1
+ch4_factor = 0.1
+nox_factor = 0.5
+nmvoc_factor = 0
+
+
+@pytest.fixture
+def emissions_factory():
+    def emissions(names: list[str], factors: list[float]):
+        emissions_list = []
+        for name, factor in zip(names, factors):
+            emissions_list.append(YamlEmissionBuilder().with_name(name=name).with_factor(factor=factor).validate())
+        return emissions_list
+
+    return emissions
+
+
+@pytest.fixture
+def fuel_factory():
+    def fuel(name: str, emissions: list[YamlEmission], category: FuelTypeUserDefinedCategoryType):
+        fuel = YamlFuelTypeBuilder().with_name(name=name)
+        fuel.category = category
+        fuel.emissions = emissions
+        return fuel.validate()
+
+    return fuel
+
+
+def test_fuel_emissions(emissions_factory, fuel_factory):
+    emissions_multi = emissions_factory(
+        names=["CO2", "CH4", "NOX", "NMVOC"], factors=[co2_factor, ch4_factor, nox_factor, nmvoc_factor]
+    )
+    fuel = fuel_factory(
+        name="fuel_turbine", emissions=emissions_multi, category=FuelTypeUserDefinedCategoryType.FUEL_GAS
+    )
+    assert fuel
+    # installation = YamlInstallationBuilder.with_generator_sets()
+    # test = 1

--- a/src/tests/libecalc/yaml_builder.py
+++ b/src/tests/libecalc/yaml_builder.py
@@ -242,6 +242,14 @@ class YamlEmissionBuilder(Builder[YamlEmission]):
         self.factor = 2
         return self
 
+    def with_name(self, name: str) -> Self:
+        self.name = name
+        return self
+
+    def with_factor(self, factor: float) -> Self:
+        self.factor = factor
+        return self
+
 
 class YamlFuelTypeBuilder(Builder[YamlFuelType]):
     def __init__(self):


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Simplify and improve ltp test setup by replacing dtos with builders in installation setup.

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
