### PR TITLE
fix: bug in get maximum standard rate for variable speed train with m…

### DIFF
--- a/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft.py
+++ b/src/libecalc/core/models/compressor/train/variable_speed_compressor_train_common_shaft.py
@@ -550,7 +550,7 @@ class VariableSpeedCompressorTrainCommonShaft(CompressorTrainModel):
                 # iterate between rate with minimum power, and the previously found rate to return, to find the
                 # maximum rate that gives power consumption below maximum power
                 return find_root(
-                    lower_bound=result_with_minimum_rate.mass_rate_asv_corrected_kg_per_hour,
+                    lower_bound=result_with_minimum_rate.stage_results[0].mass_rate_asv_corrected_kg_per_hour,
                     upper_bound=rate_to_return,
                     func=lambda x: self.evaluate_rate_ps_pd(
                         rate=np.asarray([self.fluid.mass_rate_to_standard_rate(x)]),

--- a/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
@@ -385,3 +385,40 @@ def test_adjustment_constant_and_factor_one_compressor(variable_speed_compressor
         discharge_pressure=np.asarray([100.0]),
     )
     assert result_adjusted.power[0] == result.power[0] * 1.5 + adjustment_constant
+
+
+def test_get_max_standard_rate_with_and_without_maximum_power(
+    variable_speed_compressor_train_one_compressor,
+    variable_speed_compressor_train_one_compressor_maximum_power,
+):
+    max_standard_rate_without_maximum_power = variable_speed_compressor_train_one_compressor.get_max_standard_rate(
+        suction_pressures=np.asarray([30], dtype=float),
+        discharge_pressures=np.asarray([100], dtype=float),
+    )
+    max_standard_rate_with_maximum_power = (
+        variable_speed_compressor_train_one_compressor_maximum_power.get_max_standard_rate(
+            suction_pressures=np.asarray([30], dtype=float),
+            discharge_pressures=np.asarray([100], dtype=float),
+        )
+    )
+    power_at_max_standard_rate_without_maximum_power = (
+        variable_speed_compressor_train_one_compressor.evaluate_rate_ps_pd(
+            rate=np.asarray(max_standard_rate_without_maximum_power, dtype=float),
+            suction_pressure=np.asarray([30], dtype=float),
+            discharge_pressure=np.asarray([100], dtype=float),
+        ).power
+    )
+    power_at_max_standard_rate_with_maximum_power = (
+        variable_speed_compressor_train_one_compressor_maximum_power.evaluate_rate_ps_pd(
+            rate=np.asarray(max_standard_rate_with_maximum_power, dtype=float),
+            suction_pressure=np.asarray([30], dtype=float),
+            discharge_pressure=np.asarray([100], dtype=float),
+        ).power
+    )
+
+    assert max_standard_rate_without_maximum_power > max_standard_rate_with_maximum_power
+    assert power_at_max_standard_rate_without_maximum_power > power_at_max_standard_rate_with_maximum_power
+    assert (
+        power_at_max_standard_rate_with_maximum_power[0]
+        < variable_speed_compressor_train_one_compressor_maximum_power.maximum_power
+    )


### PR DESCRIPTION
…aximum power


After previous refactoring the compressor train result does not have mass_rate_asv_corrected anymore - the recirculation is connected to the individual stages. 

A part of the code has seemingly not been covered by testing, so this bug has not been discovered until it was encountered while running a model.

Updated the code and added testing for max standard rate with and without maximum power (where the bug was encountered)
