### PR TITLE
chore: create new yaml builders for testing

### DIFF
--- a/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_electricity_consumer.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_electricity_consumer.py
@@ -32,7 +32,7 @@ class YamlElectricityConsumer(YamlBase):
         title="NAME",
         description="Name of the consumer.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
     )
-    category: ConsumerUserDefinedCategoryType = CategoryField(...)
+    category: YamlTemporalModel[ConsumerUserDefinedCategoryType] = CategoryField(...)
     energy_usage_model: YamlTemporalModel[YamlElectricityEnergyUsageModel] = Field(
         ...,
         title="ENERGY_USAGE_MODEL",

--- a/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_fuel_consumer.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/legacy/yaml_fuel_consumer.py
@@ -32,7 +32,7 @@ class YamlFuelConsumer(YamlBase):
         title="NAME",
         description="Name of the consumer.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
     )
-    category: ConsumerUserDefinedCategoryType = CategoryField(...)
+    category: YamlTemporalModel[ConsumerUserDefinedCategoryType] = CategoryField(...)
     energy_usage_model: YamlTemporalModel[YamlFuelEnergyUsageModel] = Field(
         ...,
         title="ENERGY_USAGE_MODEL",

--- a/src/libecalc/testing/yaml_builder.py
+++ b/src/libecalc/testing/yaml_builder.py
@@ -5,7 +5,11 @@ from typing import List, Self, TypeVar, Generic, get_args, cast, Union, Literal
 from typing_extensions import get_original_bases
 
 from libecalc.common.utils.rates import RateType
-from libecalc.dto.types import ConsumerUserDefinedCategoryType
+from libecalc.dto.types import (
+    ConsumerUserDefinedCategoryType,
+    FuelTypeUserDefinedCategoryType,
+    InstallationUserDefinedCategoryType,
+)
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.legacy.energy_usage_model import (
     YamlFuelEnergyUsageModel,
@@ -284,8 +288,12 @@ class YamlFuelConsumerBuilder(Builder[YamlFuelConsumer]):
         self.name = name
         return self
 
-    def with_fuel(self, fuel: str) -> Self:
+    def with_fuel(self, fuel: YamlTemporalModel[str]):
         self.fuel = fuel
+        return self
+
+    def with_category(self, category: YamlTemporalModel[ConsumerUserDefinedCategoryType]):
+        self.category = category
         return self
 
     def with_energy_usage_model(self, energy_usage_model: YamlTemporalModel[YamlFuelEnergyUsageModel]) -> Self:
@@ -511,6 +519,18 @@ class YamlInstallationBuilder(Builder[YamlInstallation]):
 
         self._yaml_model_containers = []
 
+    def with_category(self, category: InstallationUserDefinedCategoryType) -> Self:
+        self.category = category
+        return self
+
+    def with_regularity(self, regularity: YamlTemporalModel[YamlExpressionType]) -> Self:
+        self.regularity = regularity
+        return self
+
+    def with_fuel(self, fuel=YamlTemporalModel[str]):
+        self.fuel = fuel
+        return self
+
     def with_test_data(self):
         self.name = "DefaultInstallation"
         self.hydrocarbon_export = 0
@@ -549,6 +569,14 @@ class YamlEmissionBuilder(Builder[YamlEmission]):
         self.name = None
         self.factor = None
 
+    def with_name(self, name: str) -> Self:
+        self.name = name
+        return self
+
+    def with_factor(self, factor: YamlExpressionType) -> Self:
+        self.factor = factor
+        return self
+
     def with_test_data(self) -> Self:
         self.name = "CO2"
         self.factor = 2
@@ -569,6 +597,19 @@ class YamlFuelTypeBuilder(Builder[YamlFuelType]):
 
     def with_name(self, name: str) -> Self:
         self.name = name
+        return self
+
+    def with_emissions(self, emissions: list[YamlEmission]) -> Self:
+        self.emissions = emissions
+        return self
+
+    def with_category(self, category: FuelTypeUserDefinedCategoryType) -> Self:
+        self.category = category
+        return self
+
+    def with_emission_names_and_factors(self, names: list[str], factors: list[YamlExpressionType]) -> Self:
+        for name, factor in zip(names, factors):
+            self.emissions.append(YamlEmissionBuilder().with_name(name).with_factor(factor).validate())
         return self
 
 


### PR DESCRIPTION
ECALC-1813

## Why is this pull request needed?

Test data for ltp is currently created using data transfer objects (dtos) in installation_setup.

Yaml builders represent a more generic way of setting up input data for testing. Yaml builders should replace the dtos in th current ltp test installation setup. Missing builders (e.g. for generator sets etc.) should be created.

Tests will be added when replacing dtos with builders in ltp tests, in a separate pull request.

## What does this pull request change?

- [x] Create builder for `YamlGeneratorSet`
- [x] Create builder for `YamlElectricityConsumer`
- [x] Create builder for facilitiy input: `YamlGeneratorSetModel` (`ELECTRICITY2FUEL`)
- [x] Create builder for facilitiy input: `YamlCompressorTabularModel` (`COMPRESSOR_TABULAR`)
- [x] Create builder for compressor energy usage model: `YamlEnergyUsageModelCompressor`
- [x] Create builder for venting emitters: `YamlDirectTypeEmitter`
- [x] Create builder for venting emitters: `YamlOilTypeEmitter`
- [x] Create builder for venting emissions: `YamlVentingEmission`
- [x] Create builder for time series: `YamlDefaultTimeSeriesCollection`
- [x] YamlElectricalConsumer and YamlFuelConsumer: Allow temporal model for category (has been allowed before v8.22)
- [x] Extend builders with new functionality

## Issues related to this change:
https://equinor-ecalc.atlassian.net/browse/ECALC-1813?atlOrigin=eyJpIjoiMjAyODY0MmFmMmU4NGU5MGJmNzc3NzRjYjE4NTcxYzciLCJwIjoiaiJ9