### PR TITLE
feat: get json schema for ecalc yaml in cli

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -32,7 +32,12 @@ jobs:
     - name: Generate CLI reference
       run: |
         cd src
-        poetry run python generate_docs.py > ../docs/docs/about/references/cli_reference.md
+        poetry run python generate_docs.py > ../docs/docs/about/getting_started/cli/cli_reference.md
+
+    - name: Generate JSON Schema
+      run: |
+        cd src
+        poetry run python generate_json_schema.py > ../docs/docs/about/getting_started/yaml/ecalc_json_schema.json
 
     - name: Setup node
       uses: actions/setup-node@v4

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -38,7 +38,12 @@ jobs:
     - name: Generate CLI reference
       run: |
         cd src
-        poetry run python generate_docs.py > ../docs/docs/about/references/cli_reference.md
+        poetry run python generate_docs.py > ../docs/docs/about/getting_started/cli/cli_reference.md
+
+    - name: Generate JSON Schema
+      run: |
+        cd src
+        poetry run python generate_json_schema.py > ../docs/docs/about/getting_started/yaml/ecalc_json_schema.json
 
     - name: Setup node
       uses: actions/setup-node@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,7 +117,14 @@ $ npm run serve
 In order to generate the CLI reference documentation, use the following (from `src`):
 ```
 $ cd src
-$ poetry run python generate_docs.py > ../docs/docs/about/references/cli_reference.md
+$ poetry run python generate_docs.py > ../docs/docs/about/getting_started/cli/cli_reference.md
+```
+
+### Generate JSON Schema
+In order to generate the JSON Schema documentation, use the following (from `src`):
+```
+$ cd src
+$ poetry run python generate_json_schema.py > ../docs/docs/about/getting_started/yaml/ecalc_json_schema.json
 ```
 
 Then build the documentation:

--- a/docs/docs/about/getting_started/yaml/ecalc_json_schema.json
+++ b/docs/docs/about/getting_started/yaml/ecalc_json_schema.json
@@ -1,0 +1,4413 @@
+{
+  "$defs": {
+    "ConsumerUserDefinedCategoryType": {
+      "description": "Consumer category",
+      "enum": [
+        "BASE-LOAD",
+        "COLD-VENTING-FUGITIVE",
+        "COMPRESSOR",
+        "FIXED-PRODUCTION-LOAD",
+        "FLARE",
+        "MISCELLANEOUS",
+        "PUMP",
+        "GAS-DRIVEN-COMPRESSOR",
+        "TURBINE-GENERATOR",
+        "POWER-FROM-SHORE",
+        "OFFSHORE-WIND",
+        "LOADING",
+        "STORAGE",
+        "STEAM-TURBINE-GENERATOR",
+        "BOILER",
+        "HEATER"
+      ],
+      "title": "ConsumerUserDefinedCategoryType",
+      "type": "string"
+    },
+    "ConsumptionRateType": {
+      "enum": [
+        "STREAM_DAY",
+        "CALENDAR_DAY"
+      ],
+      "title": "ConsumptionRateType",
+      "type": "string"
+    },
+    "FuelTypeUserDefinedCategoryType": {
+      "enum": [
+        "FUEL-GAS",
+        "DIESEL"
+      ],
+      "title": "FuelTypeUserDefinedCategoryType",
+      "type": "string"
+    },
+    "InstallationUserDefinedCategoryType": {
+      "description": "Installation category",
+      "enum": [
+        "FIXED",
+        "MOBILE"
+      ],
+      "title": "InstallationUserDefinedCategoryType",
+      "type": "string"
+    },
+    "Unit": {
+      "description": "A very simple unit registry to convert between common eCalc units.",
+      "enum": [
+        "N/A",
+        "kg/BOE",
+        "kg/Sm3",
+        "kg/m3",
+        "Sm3",
+        "BOE",
+        "t/d",
+        "t",
+        "kg/d",
+        "kg/h",
+        "kg",
+        "L/d",
+        "L",
+        "MWd",
+        "GWh",
+        "MW",
+        "Y",
+        "bara",
+        "kPa",
+        "Pa",
+        "C",
+        "K",
+        "frac",
+        "%",
+        "kJ/kg",
+        "J/kg",
+        "N.m/kg",
+        "Am3/h",
+        "Sm3/d",
+        "RPM"
+      ],
+      "title": "Unit",
+      "type": "string"
+    },
+    "YamlComposition": {
+      "additionalProperties": false,
+      "properties": {
+        "CO2": {
+          "default": 0.0,
+          "title": "Co2",
+          "type": "number"
+        },
+        "ethane": {
+          "default": 0.0,
+          "title": "Ethane",
+          "type": "number"
+        },
+        "i_butane": {
+          "default": 0.0,
+          "title": "I Butane",
+          "type": "number"
+        },
+        "i_pentane": {
+          "default": 0.0,
+          "title": "I Pentane",
+          "type": "number"
+        },
+        "methane": {
+          "title": "Methane",
+          "type": "number"
+        },
+        "n_butane": {
+          "default": 0.0,
+          "title": "N Butane",
+          "type": "number"
+        },
+        "n_hexane": {
+          "default": 0.0,
+          "title": "N Hexane",
+          "type": "number"
+        },
+        "n_pentane": {
+          "default": 0.0,
+          "title": "N Pentane",
+          "type": "number"
+        },
+        "nitrogen": {
+          "default": 0.0,
+          "title": "Nitrogen",
+          "type": "number"
+        },
+        "propane": {
+          "default": 0.0,
+          "title": "Propane",
+          "type": "number"
+        },
+        "water": {
+          "default": 0.0,
+          "title": "Water",
+          "type": "number"
+        }
+      },
+      "required": [
+        "methane"
+      ],
+      "title": "YamlComposition",
+      "type": "object"
+    },
+    "YamlCompositionFluidModel": {
+      "additionalProperties": false,
+      "properties": {
+        "COMPOSITION": {
+          "$ref": "#/$defs/YamlComposition",
+          "description": "Components in fluid and amount (relative to the others) in mole weights",
+          "title": "COMPOSITION"
+        },
+        "EOS_MODEL": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/YamlEosModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "SRK"
+        },
+        "FLUID_MODEL_TYPE": {
+          "const": "COMPOSITION",
+          "default": "COMPOSITION",
+          "enum": [
+            "COMPOSITION"
+          ],
+          "title": "Fluid Model Type",
+          "type": "string"
+        },
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "FLUID",
+          "default": "FLUID",
+          "enum": [
+            "FLUID"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "COMPOSITION",
+        "NAME"
+      ],
+      "title": "YamlCompositionFluidModel",
+      "type": "object"
+    },
+    "YamlCompressor": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Consumer name",
+          "pattern": "^[A-Z\u00c6\u00d8\u00c5a-z\u00e6\u00f8\u00e5\\d_/\\- ]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "User defined category",
+          "title": "CATEGORY"
+        },
+        "TYPE": {
+          "const": "COMPRESSOR@v2",
+          "description": "The type of the component",
+          "enum": [
+            "COMPRESSOR@v2"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "ENERGY_USAGE_MODEL": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ],
+          "title": "Energy Usage Model"
+        }
+      },
+      "required": [
+        "NAME",
+        "TYPE",
+        "ENERGY_USAGE_MODEL"
+      ],
+      "title": "Compressor",
+      "type": "object"
+    },
+    "YamlCompressorStage": {
+      "additionalProperties": false,
+      "properties": {
+        "INLET_TEMPERATURE": {
+          "description": "Inlet temperature in Celsius for stage",
+          "title": "INLET_TEMPERATURE",
+          "type": "number"
+        },
+        "COMPRESSOR_CHART": {
+          "description": "Reference to compressor chart model for stage, must be defined in MODELS or FACILITY_INPUTS",
+          "title": "COMPRESSOR_CHART",
+          "type": "string"
+        }
+      },
+      "required": [
+        "INLET_TEMPERATURE",
+        "COMPRESSOR_CHART"
+      ],
+      "title": "YamlCompressorStage",
+      "type": "object"
+    },
+    "YamlCompressorStageMultipleStreams": {
+      "additionalProperties": false,
+      "properties": {
+        "INLET_TEMPERATURE": {
+          "description": "Inlet temperature in Celsius for stage",
+          "title": "INLET_TEMPERATURE",
+          "type": "number"
+        },
+        "COMPRESSOR_CHART": {
+          "description": "Reference to compressor chart model for stage, must be defined in MODELS or FACILITY_INPUTS",
+          "title": "COMPRESSOR_CHART",
+          "type": "string"
+        },
+        "PRESSURE_DROP_AHEAD_OF_STAGE": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0.0,
+          "description": "Pressure drop before compression stage [in bar]",
+          "title": "PRESSURE_DROP_AHEAD_OF_STAGE"
+        },
+        "CONTROL_MARGIN": {
+          "description": "Surge control margin, see documentation for more details.",
+          "minimum": 0.0,
+          "title": "CONTROL_MARGIN",
+          "type": "number"
+        },
+        "CONTROL_MARGIN_UNIT": {
+          "$ref": "#/$defs/YamlControlMarginUnits",
+          "description": "The unit of the surge control margin.",
+          "title": "CONTROL_MARGIN_UNIT"
+        },
+        "STREAM": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "default": null,
+          "description": "Reference to stream from STREAMS.",
+          "title": "STREAM"
+        },
+        "INTERSTAGE_CONTROL_PRESSURE": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/YamlInterstageControlPressure"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Pressure control. Can only be specified for one (only one) of the stages 2, ..., N.",
+          "title": "INTERSTAGE_CONTROL_PRESSURE"
+        }
+      },
+      "required": [
+        "INLET_TEMPERATURE",
+        "COMPRESSOR_CHART",
+        "CONTROL_MARGIN",
+        "CONTROL_MARGIN_UNIT"
+      ],
+      "title": "YamlCompressorStageMultipleStreams",
+      "type": "object"
+    },
+    "YamlCompressorStageWithMarginAndPressureDrop": {
+      "additionalProperties": false,
+      "properties": {
+        "INLET_TEMPERATURE": {
+          "description": "Inlet temperature in Celsius for stage",
+          "title": "INLET_TEMPERATURE",
+          "type": "number"
+        },
+        "COMPRESSOR_CHART": {
+          "description": "Reference to compressor chart model for stage, must be defined in MODELS or FACILITY_INPUTS",
+          "title": "COMPRESSOR_CHART",
+          "type": "string"
+        },
+        "PRESSURE_DROP_AHEAD_OF_STAGE": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0.0,
+          "description": "Pressure drop before compression stage [in bar]",
+          "title": "PRESSURE_DROP_AHEAD_OF_STAGE"
+        },
+        "CONTROL_MARGIN": {
+          "description": "Surge control margin, see documentation for more details.",
+          "minimum": 0.0,
+          "title": "CONTROL_MARGIN",
+          "type": "number"
+        },
+        "CONTROL_MARGIN_UNIT": {
+          "$ref": "#/$defs/YamlControlMarginUnits",
+          "description": "The unit of the surge control margin.",
+          "title": "CONTROL_MARGIN_UNIT"
+        }
+      },
+      "required": [
+        "INLET_TEMPERATURE",
+        "COMPRESSOR_CHART",
+        "CONTROL_MARGIN",
+        "CONTROL_MARGIN_UNIT"
+      ],
+      "title": "YamlCompressorStageWithMarginAndPressureDrop",
+      "type": "object"
+    },
+    "YamlCompressorStages_YamlCompressorStageWithMarginAndPressureDrop_": {
+      "additionalProperties": false,
+      "properties": {
+        "STAGES": {
+          "description": "List of compressor stages",
+          "items": {
+            "$ref": "#/$defs/YamlCompressorStageWithMarginAndPressureDrop"
+          },
+          "title": "STAGES",
+          "type": "array"
+        }
+      },
+      "required": [
+        "STAGES"
+      ],
+      "title": "YamlCompressorStages[YamlCompressorStageWithMarginAndPressureDrop]",
+      "type": "object"
+    },
+    "YamlCompressorStages_YamlCompressorStage_": {
+      "additionalProperties": false,
+      "properties": {
+        "STAGES": {
+          "description": "List of compressor stages",
+          "items": {
+            "$ref": "#/$defs/YamlCompressorStage"
+          },
+          "title": "STAGES",
+          "type": "array"
+        }
+      },
+      "required": [
+        "STAGES"
+      ],
+      "title": "YamlCompressorStages[YamlCompressorStage]",
+      "type": "object"
+    },
+    "YamlCompressorSystemCompressor": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the compressor",
+          "title": "NAME",
+          "type": "string"
+        },
+        "COMPRESSOR_MODEL": {
+          "description": "Reference to a compressor type facility model defined in FACILITY_INPUTS",
+          "title": "COMPRESSOR_MODEL",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "COMPRESSOR_MODEL"
+      ],
+      "title": "YamlCompressorSystemCompressor",
+      "type": "object"
+    },
+    "YamlCompressorSystemOperationalSetting": {
+      "additionalProperties": false,
+      "properties": {
+        "CROSSOVER": {
+          "default": null,
+          "description": "Set cross over rules in system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#crossover",
+          "items": {
+            "type": "integer"
+          },
+          "title": "CROSSOVER",
+          "type": "array"
+        },
+        "RATES": {
+          "default": null,
+          "description": "Set rate per consumer in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#rates",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "RATES",
+          "type": "array"
+        },
+        "RATE_FRACTIONS": {
+          "default": null,
+          "description": "List of expressions defining fractional rate (of total system rate) per consumer.  \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#rate-fractions",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "RATE_FRACTIONS",
+          "type": "array"
+        },
+        "SUCTION_PRESSURES": {
+          "default": null,
+          "description": "Set suction pressure per consumer in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#suction-pressures",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "SUCTION_PRESSURES",
+          "type": "array"
+        },
+        "DISCHARGE_PRESSURES": {
+          "default": null,
+          "description": "Set discharge pressure per consumer in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#discharge-pressures",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "DISCHARGE_PRESSURES",
+          "type": "array"
+        },
+        "DISCHARGE_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Set discharge pressure equal for all consumers in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/DISCHARGE_PRESSURE",
+          "title": "DISCHARGE_PRESSURE"
+        },
+        "SUCTION_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Set suction pressure equal for all consumers in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/SUCTION_PRESSURE",
+          "title": "SUCTION_PRESSURE"
+        }
+      },
+      "title": "YamlCompressorSystemOperationalSetting",
+      "type": "object"
+    },
+    "YamlCompressorTabularModel": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the facility input.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FILE": {
+          "description": "Specifies the name of an input file.\n\n$ECALC_DOCS_KEYWORDS_URL/FILE",
+          "title": "FILE",
+          "type": "string"
+        },
+        "ADJUSTMENT": {
+          "$ref": "#/$defs/YamlFacilityAdjustment",
+          "default": null,
+          "description": "Definition of adjustments to correct for mismatches in facility energy usage.\n\n$ECALC_DOCS_KEYWORDS_URL/ADJUSTMENT",
+          "title": "ADJUSTMENT"
+        },
+        "TYPE": {
+          "const": "COMPRESSOR_TABULAR",
+          "description": "Defines the type of model applied on the data in the file.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "COMPRESSOR_TABULAR"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "FILE",
+        "TYPE"
+      ],
+      "title": "YamlCompressorTabularModel",
+      "type": "object"
+    },
+    "YamlCompressorWithTurbine": {
+      "additionalProperties": false,
+      "properties": {
+        "COMPRESSOR_MODEL": {
+          "description": "Reference to a compressor model",
+          "title": "COMPRESSOR_MODEL",
+          "type": "string"
+        },
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "POWER_ADJUSTMENT_CONSTANT": {
+          "default": 0.0,
+          "description": "Constant to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_CONSTANT",
+          "type": "number"
+        },
+        "POWER_ADJUSTMENT_FACTOR": {
+          "default": 1.0,
+          "description": "Factor to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_FACTOR",
+          "type": "number"
+        },
+        "TURBINE_MODEL": {
+          "description": "Reference to a turbine model",
+          "title": "TURBINE_MODEL",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "COMPRESSOR_WITH_TURBINE",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "COMPRESSOR_WITH_TURBINE"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        }
+      },
+      "required": [
+        "COMPRESSOR_MODEL",
+        "NAME",
+        "TURBINE_MODEL",
+        "TYPE"
+      ],
+      "title": "YamlCompressorWithTurbine",
+      "type": "object"
+    },
+    "YamlConsumerSystem": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Consumer name",
+          "pattern": "^[A-Z\u00c6\u00d8\u00c5a-z\u00e6\u00f8\u00e5\\d_/\\- ]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "User defined category",
+          "title": "CATEGORY"
+        },
+        "TYPE": {
+          "const": "CONSUMER_SYSTEM@v2",
+          "description": "The type of the component",
+          "enum": [
+            "CONSUMER_SYSTEM@v2"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "COMPONENT_CONDITIONS": {
+          "$ref": "#/$defs/YamlSystemComponentConditions",
+          "default": null,
+          "description": "Contains conditions for the component, in this case the system.",
+          "title": "System component conditions"
+        },
+        "STREAM_CONDITIONS_PRIORITIES": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "$ref": "#/$defs/YamlStreamConditions"
+              },
+              "type": "object"
+            },
+            "type": "object"
+          },
+          "description": "A list of prioritised stream conditions per consumer.",
+          "title": "Stream conditions priorities",
+          "type": "object"
+        },
+        "CONSUMERS": {
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/YamlCompressor"
+              },
+              {
+                "$ref": "#/$defs/YamlPump"
+              },
+              {
+                "$ref": "#/$defs/YamlTrain"
+              }
+            ]
+          },
+          "title": "Consumers",
+          "type": "array"
+        }
+      },
+      "required": [
+        "NAME",
+        "TYPE",
+        "STREAM_CONDITIONS_PRIORITIES",
+        "CONSUMERS"
+      ],
+      "title": "ConsumerSystem",
+      "type": "object"
+    },
+    "YamlControlMarginUnits": {
+      "enum": [
+        "FRACTION",
+        "PERCENTAGE"
+      ],
+      "title": "YamlControlMarginUnits",
+      "type": "string"
+    },
+    "YamlCrossover": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "default": null,
+          "description": "The name of the stream. Can be used to identify the crossover stream in multiple streams compressor train",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FROM": {
+          "description": "Source component for crossover",
+          "title": "FROM",
+          "type": "string"
+        },
+        "TO": {
+          "description": "Target component for crossover",
+          "title": "TO",
+          "type": "string"
+        }
+      },
+      "required": [
+        "FROM",
+        "TO"
+      ],
+      "title": "YamlCrossover",
+      "type": "object"
+    },
+    "YamlCurve": {
+      "additionalProperties": false,
+      "properties": {
+        "SPEED": {
+          "default": 1,
+          "title": "Speed",
+          "type": "number"
+        },
+        "RATE": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Rate",
+          "type": "array"
+        },
+        "HEAD": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Head",
+          "type": "array"
+        },
+        "EFFICIENCY": {
+          "items": {
+            "type": "number"
+          },
+          "title": "Efficiency",
+          "type": "array"
+        }
+      },
+      "required": [
+        "RATE",
+        "HEAD",
+        "EFFICIENCY"
+      ],
+      "title": "YamlCurve",
+      "type": "object"
+    },
+    "YamlDefaultTimeSeriesCollection": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the time series.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FILE": {
+          "description": "Specifies the name of a time series input file.\n\n$ECALC_DOCS_KEYWORDS_URL/FILE",
+          "title": "FILE",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "DEFAULT",
+          "description": "Defines the type of time series input file.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "DEFAULT"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "INFLUENCE_TIME_VECTOR": {
+          "default": true,
+          "description": "Determines if the time steps in this input source will contribute to the global time vector.\n\n$ECALC_DOCS_KEYWORDS_URL/INFLUENCE_TIME_VECTOR",
+          "title": "INFLUENCE_TIME_VECTOR",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "NAME",
+        "FILE",
+        "TYPE"
+      ],
+      "title": "TimeSeries",
+      "type": "object"
+    },
+    "YamlDensity": {
+      "additionalProperties": false,
+      "properties": {
+        "VALUE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "title": "Value"
+        },
+        "UNIT": {
+          "$ref": "#/$defs/Unit",
+          "default": "kg/Sm3"
+        }
+      },
+      "required": [
+        "VALUE"
+      ],
+      "title": "Density",
+      "type": "object"
+    },
+    "YamlDirectTypeEmitter": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of venting emitter",
+          "pattern": "^[A-Z\u00c6\u00d8\u00c5a-z\u00e6\u00f8\u00e5\\d_/\\- ]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "$ref": "#/$defs/ConsumerUserDefinedCategoryType",
+          "description": "Output category/tag.\n\n$ECALC_DOCS_KEYWORDS_URL/CATEGORY",
+          "title": "CATEGORY"
+        },
+        "TYPE": {
+          "const": "DIRECT_EMISSION",
+          "description": "Type of venting emitter",
+          "enum": [
+            "DIRECT_EMISSION"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "EMISSIONS": {
+          "description": "The emissions for the emitter of type DIRECT_EMISSION",
+          "items": {
+            "$ref": "#/$defs/YamlVentingEmission"
+          },
+          "title": "EMISSIONS",
+          "type": "array"
+        }
+      },
+      "required": [
+        "NAME",
+        "CATEGORY",
+        "TYPE",
+        "EMISSIONS"
+      ],
+      "title": "VentingEmitter",
+      "type": "object"
+    },
+    "YamlEfficiencyUnits": {
+      "enum": [
+        "FRACTION",
+        "PERCENTAGE"
+      ],
+      "title": "YamlEfficiencyUnits",
+      "type": "string"
+    },
+    "YamlElectricityConsumer": {
+      "additionalProperties": false,
+      "properties": {
+        "TYPE": {
+          "const": "ELECTRICITY_CONSUMER",
+          "default": "ELECTRICITY_CONSUMER",
+          "description": "The type of the component",
+          "enum": [
+            "ELECTRICITY_CONSUMER"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "NAME": {
+          "description": "Name of the consumer.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "description": "Output category/tag.\n\n$ECALC_DOCS_KEYWORDS_URL/CATEGORY",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ConsumerUserDefinedCategoryType"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/ConsumerUserDefinedCategoryType"
+              },
+              "type": "object"
+            }
+          ],
+          "title": "CATEGORY"
+        },
+        "ENERGY_USAGE_MODEL": {
+          "description": "Definition of the energy usage model for the consumer.\n\n$ECALC_DOCS_KEYWORDS_URL/ENERGY_USAGE_MODEL",
+          "oneOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "COMPRESSOR": "#/$defs/YamlEnergyUsageModelCompressor",
+                  "COMPRESSOR_SYSTEM": "#/$defs/YamlEnergyUsageModelCompressorSystem",
+                  "DIRECT": "#/$defs/YamlEnergyUsageModelDirect",
+                  "PUMP": "#/$defs/YamlEnergyUsageModelPump",
+                  "PUMP_SYSTEM": "#/$defs/YamlEnergyUsageModelPumpSystem",
+                  "TABULATED": "#/$defs/YamlEnergyUsageModelTabulated",
+                  "VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES": "#/$defs/YamlEnergyUsageModelCompressorTrainMultipleStreams"
+                },
+                "propertyName": "TYPE"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelDirect"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelCompressor"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelPump"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelCompressorSystem"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelPumpSystem"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelTabulated"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelCompressorTrainMultipleStreams"
+                }
+              ]
+            },
+            {
+              "additionalProperties": {
+                "discriminator": {
+                  "mapping": {
+                    "COMPRESSOR": "#/$defs/YamlEnergyUsageModelCompressor",
+                    "COMPRESSOR_SYSTEM": "#/$defs/YamlEnergyUsageModelCompressorSystem",
+                    "DIRECT": "#/$defs/YamlEnergyUsageModelDirect",
+                    "PUMP": "#/$defs/YamlEnergyUsageModelPump",
+                    "PUMP_SYSTEM": "#/$defs/YamlEnergyUsageModelPumpSystem",
+                    "TABULATED": "#/$defs/YamlEnergyUsageModelTabulated",
+                    "VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES": "#/$defs/YamlEnergyUsageModelCompressorTrainMultipleStreams"
+                  },
+                  "propertyName": "TYPE"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelDirect"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelCompressor"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelPump"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelCompressorSystem"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelPumpSystem"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelTabulated"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelCompressorTrainMultipleStreams"
+                  }
+                ]
+              },
+              "type": "object"
+            }
+          ],
+          "title": "ENERGY_USAGE_MODEL"
+        }
+      },
+      "required": [
+        "NAME",
+        "CATEGORY",
+        "ENERGY_USAGE_MODEL"
+      ],
+      "title": "ELECTRICITY_CONSUMER",
+      "type": "object"
+    },
+    "YamlEmission": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the emission.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "pattern": "^\\w*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FACTOR": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Emission factor for fuel in kg emission/Sm3 fuel. May be a constant number or an expression using vectors from a time series input.\n\n$ECALC_DOCS_KEYWORDS_URL/FACTOR",
+          "title": "FACTOR"
+        }
+      },
+      "required": [
+        "NAME",
+        "FACTOR"
+      ],
+      "title": "Emission",
+      "type": "object"
+    },
+    "YamlEmissionRate": {
+      "additionalProperties": false,
+      "properties": {
+        "VALUE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "title": "Value"
+        },
+        "UNIT": {
+          "$ref": "#/$defs/YamlEmissionRateUnits",
+          "default": "KG_PER_DAY"
+        },
+        "TYPE": {
+          "default": "STREAM_DAY",
+          "enum": [
+            "STREAM_DAY",
+            "CALENDAR_DAY"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "VALUE"
+      ],
+      "title": "Rate",
+      "type": "object"
+    },
+    "YamlEmissionRateUnits": {
+      "enum": [
+        "KG_PER_DAY",
+        "TONS_PER_DAY"
+      ],
+      "title": "YamlEmissionRateUnits",
+      "type": "string"
+    },
+    "YamlEnergyUsageModelCompressor": {
+      "additionalProperties": false,
+      "properties": {
+        "CONDITION": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Logical condition for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "title": "CONDITION"
+        },
+        "CONDITIONS": {
+          "default": null,
+          "description": "Logical conditions for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "CONDITIONS",
+          "type": "array"
+        },
+        "POWERLOSSFACTOR": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "A factor that may be added to account for power line losses.\n\n$ECALC_DOCS_KEYWORDS_URL/POWERLOSSFACTOR",
+          "title": "POWERLOSSFACTOR"
+        },
+        "TYPE": {
+          "const": "COMPRESSOR",
+          "description": "Defines the energy usage model type.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "COMPRESSOR"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "ENERGYFUNCTION": {
+          "description": "The compressor energy function, reference to a compressor type facility model defined in FACILITY_INPUTS",
+          "title": "ENERGY_FUNCTION",
+          "type": "string"
+        },
+        "RATE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Fluid (gas) rate through the compressor in Sm3/day \n\n$ECALC_DOCS_KEYWORDS_URL/RATE",
+          "title": "RATE"
+        },
+        "SUCTION_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Fluid (gas) pressure at compressor inlet in bars \n\n$ECALC_DOCS_KEYWORDS_URL/SUCTION_PRESSURE",
+          "title": "SUCTION_PRESSURE"
+        },
+        "DISCHARGE_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Fluid (gas) pressure at compressor outlet in bars \n\n$ECALC_DOCS_KEYWORDS_URL/DISCHARGE_PRESSURE",
+          "title": "DISCHARGE_PRESSURE"
+        }
+      },
+      "required": [
+        "TYPE",
+        "ENERGYFUNCTION"
+      ],
+      "title": "YamlEnergyUsageModelCompressor",
+      "type": "object"
+    },
+    "YamlEnergyUsageModelCompressorSystem": {
+      "additionalProperties": false,
+      "properties": {
+        "CONDITION": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Logical condition for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "title": "CONDITION"
+        },
+        "CONDITIONS": {
+          "default": null,
+          "description": "Logical conditions for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "CONDITIONS",
+          "type": "array"
+        },
+        "POWERLOSSFACTOR": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "A factor that may be added to account for power line losses.\n\n$ECALC_DOCS_KEYWORDS_URL/POWERLOSSFACTOR",
+          "title": "POWERLOSSFACTOR"
+        },
+        "TYPE": {
+          "const": "COMPRESSOR_SYSTEM",
+          "description": "Defines the energy usage model type.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "COMPRESSOR_SYSTEM"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "COMPRESSORS": {
+          "description": "The compressors in a compressor system. \n\n$ECALC_DOCS_KEYWORDS_URL/COMPRESSORS#compressors",
+          "items": {
+            "$ref": "#/$defs/YamlCompressorSystemCompressor"
+          },
+          "title": "COMPRESSORS",
+          "type": "array"
+        },
+        "TOTAL_SYSTEM_RATE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Total fluid rate through the system \n\n$ECALC_DOCS_KEYWORDS_URL/TOTAL_SYSTEM_RATE",
+          "title": "TOTAL_SYSTEM_RATE"
+        },
+        "OPERATIONAL_SETTINGS": {
+          "description": "Operational settings of the system. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS",
+          "items": {
+            "$ref": "#/$defs/YamlCompressorSystemOperationalSetting"
+          },
+          "title": "OPERATIONAL_SETTINGS",
+          "type": "array"
+        }
+      },
+      "required": [
+        "TYPE",
+        "COMPRESSORS",
+        "OPERATIONAL_SETTINGS"
+      ],
+      "title": "YamlEnergyUsageModelCompressorSystem",
+      "type": "object"
+    },
+    "YamlEnergyUsageModelCompressorTrainMultipleStreams": {
+      "additionalProperties": false,
+      "properties": {
+        "CONDITION": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Logical condition for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "title": "CONDITION"
+        },
+        "CONDITIONS": {
+          "default": null,
+          "description": "Logical conditions for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "CONDITIONS",
+          "type": "array"
+        },
+        "POWERLOSSFACTOR": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "A factor that may be added to account for power line losses.\n\n$ECALC_DOCS_KEYWORDS_URL/POWERLOSSFACTOR",
+          "title": "POWERLOSSFACTOR"
+        },
+        "TYPE": {
+          "const": "VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES",
+          "description": "Defines the energy usage model type.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "RATE_UNIT": {
+          "const": "SM3_PER_DAY",
+          "default": "SM3_PER_DAY",
+          "description": "Defaults to SM3_PER_DAY, only SM3_PER_DAY implemented for now",
+          "enum": [
+            "SM3_PER_DAY"
+          ],
+          "title": "RATE_UNIT",
+          "type": "string"
+        },
+        "COMPRESSOR_TRAIN_MODEL": {
+          "description": "The compressor train model, reference to a compressor type model defined in MODELS",
+          "title": "COMPRESSOR_TRAIN_MODEL",
+          "type": "string"
+        },
+        "RATE_PER_STREAM": {
+          "description": "Fluid (gas) rate for each of the streams going into or out of the compressor train (excluding the outlet of the last compressor stage) in Sm3/day \n\n$ECALC_DOCS_KEYWORDS_URL/RATE",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "RATE_PER_STREAM",
+          "type": "array"
+        },
+        "SUCTION_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Fluid (gas) pressure at compressor train inlet in bars \n\n$ECALC_DOCS_KEYWORDS_URL/SUCTION_PRESSURE",
+          "title": "SUCTION_PRESSURE"
+        },
+        "DISCHARGE_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Fluid (gas) pressure at compressor train outlet in bars \n\n$ECALC_DOCS_KEYWORDS_URL/DISCHARGE_PRESSURE",
+          "title": "DISCHARGE_PRESSURE"
+        },
+        "INTERSTAGE_CONTROL_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Fluid (gas) pressure at an intermediate step in the compressor train \n\n$ECALC_DOCS_KEYWORDS_URL/INTERSTAGE_CONTROL_PRESSURE",
+          "title": "INTERSTAGE_CONTROL_PRESSURE"
+        }
+      },
+      "required": [
+        "TYPE",
+        "COMPRESSOR_TRAIN_MODEL",
+        "RATE_PER_STREAM",
+        "SUCTION_PRESSURE",
+        "DISCHARGE_PRESSURE"
+      ],
+      "title": "YamlEnergyUsageModelCompressorTrainMultipleStreams",
+      "type": "object"
+    },
+    "YamlEnergyUsageModelDirect": {
+      "additionalProperties": false,
+      "properties": {
+        "CONDITION": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Logical condition for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "title": "CONDITION"
+        },
+        "CONDITIONS": {
+          "default": null,
+          "description": "Logical conditions for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "CONDITIONS",
+          "type": "array"
+        },
+        "POWERLOSSFACTOR": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "A factor that may be added to account for power line losses.\n\n$ECALC_DOCS_KEYWORDS_URL/POWERLOSSFACTOR",
+          "title": "POWERLOSSFACTOR"
+        },
+        "TYPE": {
+          "const": "DIRECT",
+          "description": "Defines the energy usage model type.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "DIRECT"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "LOAD": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Fixed power consumer with constant load.\n\n$ECALC_DOCS_KEYWORDS_URL/LOAD",
+          "title": "LOAD"
+        },
+        "FUELRATE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Fixed power consumer with constant load.\n\n$ECALC_DOCS_KEYWORDS_URL/LOAD",
+          "title": "FUEL_RATE"
+        },
+        "CONSUMPTION_RATE_TYPE": {
+          "$ref": "#/$defs/ConsumptionRateType",
+          "default": null,
+          "description": "Defines the energy usage rate as stream day or calendar day.\n\n$ECALC_DOCS_KEYWORDS_URL/CONSUMPTION_RATE_TYPE#consumption-rate-type",
+          "title": "CONSUMPTION_RATE_TYPE"
+        }
+      },
+      "required": [
+        "TYPE"
+      ],
+      "title": "YamlEnergyUsageModelDirect",
+      "type": "object"
+    },
+    "YamlEnergyUsageModelPump": {
+      "additionalProperties": false,
+      "properties": {
+        "CONDITION": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Logical condition for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "title": "CONDITION"
+        },
+        "CONDITIONS": {
+          "default": null,
+          "description": "Logical conditions for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "CONDITIONS",
+          "type": "array"
+        },
+        "POWERLOSSFACTOR": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "A factor that may be added to account for power line losses.\n\n$ECALC_DOCS_KEYWORDS_URL/POWERLOSSFACTOR",
+          "title": "POWERLOSSFACTOR"
+        },
+        "TYPE": {
+          "const": "PUMP",
+          "description": "Defines the energy usage model type.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "PUMP"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "ENERGYFUNCTION": {
+          "description": "The pump energy function, reference to a pump type facility model defined in FACILITY_INPUTS",
+          "title": "ENERGY_FUNCTION",
+          "type": "string"
+        },
+        "RATE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Fluid rate through the pump in Sm3/day \n\n$ECALC_DOCS_KEYWORDS_URL/RATE",
+          "title": "RATE"
+        },
+        "SUCTION_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Fluid pressure at pump inlet in bars \n\n$ECALC_DOCS_KEYWORDS_URL/SUCTION_PRESSURE",
+          "title": "SUCTION_PRESSURE"
+        },
+        "DISCHARGE_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Fluid pressure at pump outlet in bars \n\n$ECALC_DOCS_KEYWORDS_URL/DISCHARGE_PRESSURE",
+          "title": "DISCHARGE_PRESSURE"
+        },
+        "FLUID_DENSITY": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Density of the fluid in kg/m3. \n\n$ECALC_DOCS_KEYWORDS_URL/FLUID_DENSITY",
+          "title": "FLUID_DENSITY"
+        }
+      },
+      "required": [
+        "TYPE",
+        "ENERGYFUNCTION",
+        "FLUID_DENSITY"
+      ],
+      "title": "YamlEnergyUsageModelPump",
+      "type": "object"
+    },
+    "YamlEnergyUsageModelPumpSystem": {
+      "additionalProperties": false,
+      "properties": {
+        "CONDITION": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Logical condition for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "title": "CONDITION"
+        },
+        "CONDITIONS": {
+          "default": null,
+          "description": "Logical conditions for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "CONDITIONS",
+          "type": "array"
+        },
+        "POWERLOSSFACTOR": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "A factor that may be added to account for power line losses.\n\n$ECALC_DOCS_KEYWORDS_URL/POWERLOSSFACTOR",
+          "title": "POWERLOSSFACTOR"
+        },
+        "TYPE": {
+          "const": "PUMP_SYSTEM",
+          "description": "Defines the energy usage model type.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "PUMP_SYSTEM"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "PUMPS": {
+          "description": "The pumps in a pump system. \n\n$ECALC_DOCS_KEYWORDS_URL/PUMPS#pumps",
+          "items": {
+            "$ref": "#/$defs/YamlPumpSystemPump"
+          },
+          "title": "PUMPS",
+          "type": "array"
+        },
+        "FLUID_DENSITY": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Density of the fluid in kg/m3. \n\n$ECALC_DOCS_KEYWORDS_URL/FLUID_DENSITY",
+          "title": "FLUID_DENSITY"
+        },
+        "TOTAL_SYSTEM_RATE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Total fluid rate through the system \n\n$ECALC_DOCS_KEYWORDS_URL/TOTAL_SYSTEM_RATE",
+          "title": "TOTAL_SYSTEM_RATE"
+        },
+        "OPERATIONAL_SETTINGS": {
+          "description": "Operational settings of the system. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS",
+          "items": {
+            "$ref": "#/$defs/YamlPumpSystemOperationalSettings"
+          },
+          "title": "OPERATIONAL_SETTINGS",
+          "type": "array"
+        }
+      },
+      "required": [
+        "TYPE",
+        "PUMPS",
+        "OPERATIONAL_SETTINGS"
+      ],
+      "title": "YamlEnergyUsageModelPumpSystem",
+      "type": "object"
+    },
+    "YamlEnergyUsageModelTabulated": {
+      "additionalProperties": false,
+      "properties": {
+        "CONDITION": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Logical condition for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "title": "CONDITION"
+        },
+        "CONDITIONS": {
+          "default": null,
+          "description": "Logical conditions for the consumer to be used.\n\n$ECALC_DOCS_KEYWORDS_URL/CONDITION",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "CONDITIONS",
+          "type": "array"
+        },
+        "POWERLOSSFACTOR": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "A factor that may be added to account for power line losses.\n\n$ECALC_DOCS_KEYWORDS_URL/POWERLOSSFACTOR",
+          "title": "POWERLOSSFACTOR"
+        },
+        "TYPE": {
+          "const": "TABULATED",
+          "description": "Defines the energy usage model type.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "TABULATED"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "ENERGYFUNCTION": {
+          "description": "The tabulated energy function, reference to a tabular type facility model defined in FACILITY_INPUTS",
+          "title": "ENERGY_FUNCTION",
+          "type": "string"
+        },
+        "VARIABLES": {
+          "description": "Variables for the tabulated energy function \n\n$ECALC_DOCS_KEYWORDS_URL/VARIABLES#variables",
+          "items": {
+            "$ref": "#/$defs/YamlTabulatedVariable"
+          },
+          "title": "VARIABLES",
+          "type": "array"
+        }
+      },
+      "required": [
+        "TYPE",
+        "ENERGYFUNCTION",
+        "VARIABLES"
+      ],
+      "title": "YamlEnergyUsageModelTabulated",
+      "type": "object"
+    },
+    "YamlEosModel": {
+      "enum": [
+        "SRK",
+        "PR",
+        "GERG_SRK",
+        "GERG_PR"
+      ],
+      "title": "YamlEosModel",
+      "type": "string"
+    },
+    "YamlFacilityAdjustment": {
+      "additionalProperties": false,
+      "properties": {
+        "CONSTANT": {
+          "default": 0,
+          "description": "Adjust input data with a constant value.\n\n$ECALC_DOCS_KEYWORDS_URL/CONSTANT",
+          "title": "CONSTANT",
+          "type": "number"
+        },
+        "FACTOR": {
+          "default": 1,
+          "description": "Adjust input data with a constant multiplier.\n\n$ECALC_DOCS_KEYWORDS_URL/FACTOR",
+          "title": "FACTOR",
+          "type": "number"
+        }
+      },
+      "title": "YamlFacilityAdjustment",
+      "type": "object"
+    },
+    "YamlFile": {
+      "additionalProperties": false,
+      "properties": {
+        "FILE": {
+          "description": "Specifies the name of an input file. See documentation for more information.",
+          "title": "FILE",
+          "type": "string"
+        }
+      },
+      "required": [
+        "FILE"
+      ],
+      "title": "YamlFile",
+      "type": "object"
+    },
+    "YamlFuelConsumer": {
+      "additionalProperties": false,
+      "properties": {
+        "TYPE": {
+          "const": "FUEL_CONSUMER",
+          "default": "FUEL_CONSUMER",
+          "description": "The type of the component",
+          "enum": [
+            "FUEL_CONSUMER"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "NAME": {
+          "description": "Name of the consumer.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "description": "Output category/tag.\n\n$ECALC_DOCS_KEYWORDS_URL/CATEGORY",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ConsumerUserDefinedCategoryType"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/ConsumerUserDefinedCategoryType"
+              },
+              "type": "object"
+            }
+          ],
+          "title": "CATEGORY"
+        },
+        "ENERGY_USAGE_MODEL": {
+          "description": "Definition of the energy usage model for the consumer.\n\n$ECALC_DOCS_KEYWORDS_URL/ENERGY_USAGE_MODEL",
+          "oneOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "COMPRESSOR": "#/$defs/YamlEnergyUsageModelCompressor",
+                  "COMPRESSOR_SYSTEM": "#/$defs/YamlEnergyUsageModelCompressorSystem",
+                  "DIRECT": "#/$defs/YamlEnergyUsageModelDirect",
+                  "TABULATED": "#/$defs/YamlEnergyUsageModelTabulated",
+                  "VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES": "#/$defs/YamlEnergyUsageModelCompressorTrainMultipleStreams"
+                },
+                "propertyName": "TYPE"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelDirect"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelCompressor"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelCompressorSystem"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelTabulated"
+                },
+                {
+                  "$ref": "#/$defs/YamlEnergyUsageModelCompressorTrainMultipleStreams"
+                }
+              ]
+            },
+            {
+              "additionalProperties": {
+                "discriminator": {
+                  "mapping": {
+                    "COMPRESSOR": "#/$defs/YamlEnergyUsageModelCompressor",
+                    "COMPRESSOR_SYSTEM": "#/$defs/YamlEnergyUsageModelCompressorSystem",
+                    "DIRECT": "#/$defs/YamlEnergyUsageModelDirect",
+                    "TABULATED": "#/$defs/YamlEnergyUsageModelTabulated",
+                    "VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES": "#/$defs/YamlEnergyUsageModelCompressorTrainMultipleStreams"
+                  },
+                  "propertyName": "TYPE"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelDirect"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelCompressor"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelCompressorSystem"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelTabulated"
+                  },
+                  {
+                    "$ref": "#/$defs/YamlEnergyUsageModelCompressorTrainMultipleStreams"
+                  }
+                ]
+              },
+              "type": "object"
+            }
+          ],
+          "title": "ENERGY_USAGE_MODEL"
+        },
+        "FUEL": {
+          "default": null,
+          "description": "The fuel used by the consumer.\n\n$ECALC_DOCS_KEYWORDS_URL/FUEL",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ],
+          "title": "FUEL"
+        }
+      },
+      "required": [
+        "NAME",
+        "CATEGORY",
+        "ENERGY_USAGE_MODEL"
+      ],
+      "title": "FUEL_CONSUMER",
+      "type": "object"
+    },
+    "YamlFuelType": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the fuel.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "$ref": "#/$defs/FuelTypeUserDefinedCategoryType",
+          "default": null,
+          "description": "Output category/tag.\n\n$ECALC_DOCS_KEYWORDS_URL/CATEGORY",
+          "title": "CATEGORY"
+        },
+        "EMISSIONS": {
+          "description": "Emission types and their attributes for this fuel.\n\n$ECALC_DOCS_KEYWORDS_URL/EMISSIONS",
+          "items": {
+            "$ref": "#/$defs/YamlEmission"
+          },
+          "title": "EMISSIONS",
+          "type": "array"
+        },
+        "LOWER_HEATING_VALUE": {
+          "default": null,
+          "description": "Warning! Deprecated. Does not have any effect. Lower heating value [MJ/Sm3] of fuel. Lower heating value is also known as net calorific value",
+          "title": "LOWER_HEATING_VALUE",
+          "type": "number"
+        }
+      },
+      "required": [
+        "NAME",
+        "EMISSIONS"
+      ],
+      "title": "FuelType",
+      "type": "object"
+    },
+    "YamlGeneratorSet": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the generator set.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "pattern": "^[A-Z\u00c6\u00d8\u00c5a-z\u00e6\u00f8\u00e5\\d_/\\- ]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "description": "Output category/tag.\n\n$ECALC_DOCS_KEYWORDS_URL/CATEGORY",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ConsumerUserDefinedCategoryType"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/ConsumerUserDefinedCategoryType"
+              },
+              "type": "object"
+            }
+          ],
+          "title": "CATEGORY"
+        },
+        "FUEL": {
+          "default": null,
+          "description": "The fuel used by the generator set.\n\n$ECALC_DOCS_KEYWORDS_URL/FUEL",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ],
+          "title": "FUEL"
+        },
+        "ELECTRICITY2FUEL": {
+          "description": "Specifies the correlation between the electric power delivered and the fuel burned by a generator set.\n\n$ECALC_DOCS_KEYWORDS_URL/ELECTRICITY2FUEL",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ],
+          "title": "ELECTRICITY2FUEL"
+        },
+        "CABLE_LOSS": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cable loss from shore, fraction of from shore consumption",
+          "title": "CABLE_LOSS"
+        },
+        "MAX_USAGE_FROM_SHORE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The peak load/effect that is expected for one hour, per year (MW)",
+          "title": "MAX_USAGE_FROM_SHORE"
+        },
+        "CONSUMERS": {
+          "description": "Consumers getting electrical power from the generator set.\n\n$ECALC_DOCS_KEYWORDS_URL/CONSUMERS",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "CONSUMER_SYSTEM@v2": "#/$defs/YamlConsumerSystem",
+                "ELECTRICITY_CONSUMER": "#/$defs/YamlElectricityConsumer"
+              },
+              "propertyName": "TYPE"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/YamlElectricityConsumer"
+              },
+              {
+                "$ref": "#/$defs/YamlConsumerSystem"
+              }
+            ]
+          },
+          "title": "CONSUMERS",
+          "type": "array"
+        }
+      },
+      "required": [
+        "NAME",
+        "CATEGORY",
+        "ELECTRICITY2FUEL",
+        "CONSUMERS"
+      ],
+      "title": "GeneratorSet",
+      "type": "object"
+    },
+    "YamlGeneratorSetModel": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the facility input.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FILE": {
+          "description": "Specifies the name of an input file.\n\n$ECALC_DOCS_KEYWORDS_URL/FILE",
+          "title": "FILE",
+          "type": "string"
+        },
+        "ADJUSTMENT": {
+          "$ref": "#/$defs/YamlFacilityAdjustment",
+          "default": null,
+          "description": "Definition of adjustments to correct for mismatches in facility energy usage.\n\n$ECALC_DOCS_KEYWORDS_URL/ADJUSTMENT",
+          "title": "ADJUSTMENT"
+        },
+        "TYPE": {
+          "const": "ELECTRICITY2FUEL",
+          "description": "Defines the type of model applied on the data in the file.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "ELECTRICITY2FUEL"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "FILE",
+        "TYPE"
+      ],
+      "title": "YamlGeneratorSetModel",
+      "type": "object"
+    },
+    "YamlGenericFromDesignPointChart": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "COMPRESSOR_CHART",
+          "default": "COMPRESSOR_CHART",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "COMPRESSOR_CHART"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "CHART_TYPE": {
+          "const": "GENERIC_FROM_DESIGN_POINT",
+          "default": "GENERIC_FROM_DESIGN_POINT",
+          "enum": [
+            "GENERIC_FROM_DESIGN_POINT"
+          ],
+          "title": "Chart Type",
+          "type": "string"
+        },
+        "POLYTROPIC_EFFICIENCY": {
+          "description": "Polytropic efficiency for compressor chart",
+          "title": "POLYTROPIC_EFFICIENCY",
+          "type": "number"
+        },
+        "DESIGN_RATE": {
+          "description": "Design rate for generic compressor chart",
+          "title": "DESIGN_RATE",
+          "type": "number"
+        },
+        "DESIGN_HEAD": {
+          "description": "Design head for generic compressor chart",
+          "title": "DESIGN_HEAD",
+          "type": "number"
+        },
+        "UNITS": {
+          "$ref": "#/$defs/YamlUnits"
+        }
+      },
+      "required": [
+        "NAME",
+        "POLYTROPIC_EFFICIENCY",
+        "DESIGN_RATE",
+        "DESIGN_HEAD",
+        "UNITS"
+      ],
+      "title": "YamlGenericFromDesignPointChart",
+      "type": "object"
+    },
+    "YamlGenericFromInputChart": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "COMPRESSOR_CHART",
+          "default": "COMPRESSOR_CHART",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "COMPRESSOR_CHART"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "CHART_TYPE": {
+          "const": "GENERIC_FROM_INPUT",
+          "default": "GENERIC_FROM_INPUT",
+          "enum": [
+            "GENERIC_FROM_INPUT"
+          ],
+          "title": "Chart Type",
+          "type": "string"
+        },
+        "POLYTROPIC_EFFICIENCY": {
+          "description": "Polytropic efficiency for compressor chart",
+          "title": "POLYTROPIC_EFFICIENCY",
+          "type": "number"
+        },
+        "UNITS": {
+          "$ref": "#/$defs/YamlUnits",
+          "description": "Defines the units",
+          "title": "UNITS"
+        }
+      },
+      "required": [
+        "NAME",
+        "POLYTROPIC_EFFICIENCY"
+      ],
+      "title": "YamlGenericFromInputChart",
+      "type": "object"
+    },
+    "YamlHeadUnits": {
+      "enum": [
+        "M",
+        "KJ_PER_KG",
+        "JOULE_PER_KG"
+      ],
+      "title": "YamlHeadUnits",
+      "type": "string"
+    },
+    "YamlInstallation": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the installation.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "pattern": "^[A-Z\u00c6\u00d8\u00c5a-z\u00e6\u00f8\u00e5\\d_/\\- ]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "$ref": "#/$defs/InstallationUserDefinedCategoryType",
+          "default": null,
+          "description": "Output category/tag.\n\n$ECALC_DOCS_KEYWORDS_URL/CATEGORY",
+          "title": "CATEGORY"
+        },
+        "HCEXPORT": {
+          "default": 0,
+          "description": "Defines the export of hydrocarbons as number of oil equivalents in Sm3.\n\n$ECALC_DOCS_KEYWORDS_URL/HCEXPORT",
+          "oneOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              },
+              "type": "object"
+            }
+          ],
+          "title": "HCEXPORT"
+        },
+        "FUEL": {
+          "default": null,
+          "description": "Main fuel type for installation.\n\n$ECALC_DOCS_KEYWORDS_URL/FUEL",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ],
+          "title": "FUEL"
+        },
+        "REGULARITY": {
+          "default": 1,
+          "description": "Regularity of the installation can be specified by a single number or as an expression. USE WITH CARE.\n\n$ECALC_DOCS_KEYWORDS_URL/REGULARITY",
+          "oneOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              },
+              "type": "object"
+            }
+          ],
+          "title": "REGULARITY"
+        },
+        "GENERATORSETS": {
+          "default": null,
+          "description": "Defines one or more generator sets.\n\n$ECALC_DOCS_KEYWORDS_URL/GENERATORSETS",
+          "items": {
+            "$ref": "#/$defs/YamlGeneratorSet"
+          },
+          "title": "GENERATORSETS",
+          "type": "array"
+        },
+        "FUELCONSUMERS": {
+          "default": null,
+          "description": "Defines fuel consumers on the installation which are not generators.\n\n$ECALC_DOCS_KEYWORDS_URL/FUELCONSUMERS",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "CONSUMER_SYSTEM@v2": "#/$defs/YamlConsumerSystem",
+                "FUEL_CONSUMER": "#/$defs/YamlFuelConsumer"
+              },
+              "propertyName": "TYPE"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/YamlFuelConsumer"
+              },
+              {
+                "$ref": "#/$defs/YamlConsumerSystem"
+              }
+            ]
+          },
+          "title": "FUELCONSUMERS",
+          "type": "array"
+        },
+        "VENTING_EMITTERS": {
+          "default": null,
+          "description": "Covers the direct emissions on the installation that are not consuming energy",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "DIRECT_EMISSION": "#/$defs/YamlDirectTypeEmitter",
+                "OIL_VOLUME": "#/$defs/YamlOilTypeEmitter"
+              },
+              "propertyName": "TYPE"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/YamlOilTypeEmitter"
+              },
+              {
+                "$ref": "#/$defs/YamlDirectTypeEmitter"
+              }
+            ]
+          },
+          "title": "VENTING_EMITTERS",
+          "type": "array"
+        }
+      },
+      "required": [
+        "NAME"
+      ],
+      "title": "Installation",
+      "type": "object"
+    },
+    "YamlInterstageControlPressure": {
+      "additionalProperties": false,
+      "properties": {
+        "UPSTREAM_PRESSURE_CONTROL": {
+          "$ref": "#/$defs/YamlPressureControl",
+          "description": "Pressure control.",
+          "title": "UPSTREAM_PRESSURE_CONTROL"
+        },
+        "DOWNSTREAM_PRESSURE_CONTROL": {
+          "$ref": "#/$defs/YamlPressureControl",
+          "description": "Pressure control.",
+          "title": "DOWNSTREAM_PRESSURE_CONTROL"
+        }
+      },
+      "required": [
+        "UPSTREAM_PRESSURE_CONTROL",
+        "DOWNSTREAM_PRESSURE_CONTROL"
+      ],
+      "title": "YamlInterstageControlPressure",
+      "type": "object"
+    },
+    "YamlMiscellaneousTimeSeriesCollection": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the time series.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FILE": {
+          "description": "Specifies the name of a time series input file.\n\n$ECALC_DOCS_KEYWORDS_URL/FILE",
+          "title": "FILE",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "MISCELLANEOUS",
+          "description": "Defines the type of time series input file.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "MISCELLANEOUS"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "INFLUENCE_TIME_VECTOR": {
+          "default": true,
+          "description": "Determines if the time steps in this input source will contribute to the global time vector.\n\n$ECALC_DOCS_KEYWORDS_URL/INFLUENCE_TIME_VECTOR",
+          "title": "INFLUENCE_TIME_VECTOR",
+          "type": "boolean"
+        },
+        "EXTRAPOLATION": {
+          "default": false,
+          "description": "Defines whether the rates in the source should be set to 0 after last time step or constant equal to value at last time step after time interval.\n\n$ECALC_DOCS_KEYWORDS_URL/EXTRAPOLATION",
+          "title": "EXTRAPOLATION",
+          "type": "boolean"
+        },
+        "INTERPOLATION_TYPE": {
+          "description": "Defines how the time series are interpolated between input time steps.\n\n$ECALC_DOCS_KEYWORDS_URL/INTERPOLATION_TYPE",
+          "enum": [
+            "LEFT",
+            "RIGHT",
+            "LINEAR"
+          ],
+          "title": "INTERPOLATION_TYPE",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "FILE",
+        "TYPE",
+        "INTERPOLATION_TYPE"
+      ],
+      "title": "TimeSeries",
+      "type": "object"
+    },
+    "YamlMultipleStreamsStream": {
+      "additionalProperties": false,
+      "properties": {
+        "TYPE": {
+          "enum": [
+            "INGOING",
+            "OUTGOING"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "NAME": {
+          "title": "Name",
+          "type": "string"
+        },
+        "FLUID_MODEL": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Reference to a fluid model",
+          "title": "FLUID_MODEL"
+        }
+      },
+      "required": [
+        "TYPE",
+        "NAME"
+      ],
+      "title": "YamlMultipleStreamsStream",
+      "type": "object"
+    },
+    "YamlOilRateUnits": {
+      "const": "SM3_PER_DAY",
+      "enum": [
+        "SM3_PER_DAY"
+      ],
+      "title": "YamlOilRateUnits",
+      "type": "string"
+    },
+    "YamlOilTypeEmitter": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of venting emitter",
+          "pattern": "^[A-Z\u00c6\u00d8\u00c5a-z\u00e6\u00f8\u00e5\\d_/\\- ]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "$ref": "#/$defs/ConsumerUserDefinedCategoryType",
+          "description": "Output category/tag.\n\n$ECALC_DOCS_KEYWORDS_URL/CATEGORY",
+          "title": "CATEGORY"
+        },
+        "TYPE": {
+          "const": "OIL_VOLUME",
+          "description": "Type of venting emitter",
+          "enum": [
+            "OIL_VOLUME"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "VOLUME": {
+          "$ref": "#/$defs/YamlVentingVolume",
+          "description": "The volume rate and emissions for the emitter of type OIL_VOLUME",
+          "title": "VOLUME"
+        }
+      },
+      "required": [
+        "NAME",
+        "CATEGORY",
+        "TYPE",
+        "VOLUME"
+      ],
+      "title": "VentingEmitter",
+      "type": "object"
+    },
+    "YamlOilVolumeRate": {
+      "additionalProperties": false,
+      "properties": {
+        "VALUE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "title": "Value"
+        },
+        "UNIT": {
+          "$ref": "#/$defs/YamlOilRateUnits",
+          "default": "SM3_PER_DAY"
+        },
+        "TYPE": {
+          "default": "STREAM_DAY",
+          "enum": [
+            "STREAM_DAY",
+            "CALENDAR_DAY"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "VALUE"
+      ],
+      "title": "Rate",
+      "type": "object"
+    },
+    "YamlPredefinedFluidModel": {
+      "additionalProperties": false,
+      "properties": {
+        "EOS_MODEL": {
+          "$ref": "#/$defs/YamlEosModel",
+          "default": "SRK"
+        },
+        "FLUID_MODEL_TYPE": {
+          "const": "PREDEFINED",
+          "default": "PREDEFINED",
+          "enum": [
+            "PREDEFINED"
+          ],
+          "title": "Fluid Model Type",
+          "type": "string"
+        },
+        "GAS_TYPE": {
+          "$ref": "#/$defs/YamlPredefinedFluidType",
+          "default": null
+        },
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "FLUID",
+          "enum": [
+            "FLUID"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "TYPE"
+      ],
+      "title": "YamlPredefinedFluidModel",
+      "type": "object"
+    },
+    "YamlPredefinedFluidType": {
+      "enum": [
+        "ULTRA_DRY",
+        "DRY",
+        "MEDIUM",
+        "RICH",
+        "ULTRA_RICH"
+      ],
+      "title": "YamlPredefinedFluidType",
+      "type": "string"
+    },
+    "YamlPressure": {
+      "additionalProperties": false,
+      "properties": {
+        "VALUE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "title": "Value"
+        },
+        "UNIT": {
+          "$ref": "#/$defs/Unit",
+          "default": "bara"
+        }
+      },
+      "required": [
+        "VALUE"
+      ],
+      "title": "Pressure",
+      "type": "object"
+    },
+    "YamlPressureControl": {
+      "enum": [
+        "DOWNSTREAM_CHOKE",
+        "UPSTREAM_CHOKE",
+        "INDIVIDUAL_ASV_PRESSURE",
+        "INDIVIDUAL_ASV_RATE",
+        "COMMON_ASV"
+      ],
+      "title": "YamlPressureControl",
+      "type": "string"
+    },
+    "YamlPump": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Consumer name",
+          "pattern": "^[A-Z\u00c6\u00d8\u00c5a-z\u00e6\u00f8\u00e5\\d_/\\- ]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "User defined category",
+          "title": "CATEGORY"
+        },
+        "TYPE": {
+          "const": "PUMP@v2",
+          "description": "The type of the component",
+          "enum": [
+            "PUMP@v2"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "ENERGY_USAGE_MODEL": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          ],
+          "title": "Energy Usage Model"
+        }
+      },
+      "required": [
+        "NAME",
+        "TYPE",
+        "ENERGY_USAGE_MODEL"
+      ],
+      "title": "Pump",
+      "type": "object"
+    },
+    "YamlPumpChartSingleSpeed": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the facility input.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FILE": {
+          "description": "Specifies the name of an input file.\n\n$ECALC_DOCS_KEYWORDS_URL/FILE",
+          "title": "FILE",
+          "type": "string"
+        },
+        "ADJUSTMENT": {
+          "$ref": "#/$defs/YamlFacilityAdjustment",
+          "default": null,
+          "description": "Definition of adjustments to correct for mismatches in facility energy usage.\n\n$ECALC_DOCS_KEYWORDS_URL/ADJUSTMENT",
+          "title": "ADJUSTMENT"
+        },
+        "HEAD_MARGIN": {
+          "default": 0.0,
+          "description": "Adjustment of the head margin for power calibration.\n\n$ECALC_DOCS_KEYWORDS_URL/HEAD_MARGIN",
+          "title": "HEAD_MARGIN",
+          "type": "number"
+        },
+        "UNITS": {
+          "$ref": "#/$defs/YamlPumpChartUnits",
+          "description": "Units for pump charts: RATE, HEAD and EFFICIENCY.",
+          "title": "UNITS"
+        },
+        "TYPE": {
+          "const": "PUMP_CHART_SINGLE_SPEED",
+          "description": "Defines the type of model applied on the data in the file.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "PUMP_CHART_SINGLE_SPEED"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "FILE",
+        "UNITS",
+        "TYPE"
+      ],
+      "title": "YamlPumpChartSingleSpeed",
+      "type": "object"
+    },
+    "YamlPumpChartUnits": {
+      "additionalProperties": false,
+      "properties": {
+        "RATE": {
+          "const": "AM3_PER_HOUR",
+          "description": "Unit for rate in pump chart. Currently only AM3_PER_HOUR is supported",
+          "enum": [
+            "AM3_PER_HOUR"
+          ],
+          "title": "RATE",
+          "type": "string"
+        },
+        "HEAD": {
+          "description": "Unit for head in pump chart. Supported units are M (default), KJ_PER_KG and JOULE_PER_KG",
+          "enum": [
+            "M",
+            "KJ_PER_KG",
+            "JOULE_PER_KG"
+          ],
+          "title": "HEAD",
+          "type": "string"
+        },
+        "EFFICIENCY": {
+          "description": "Unit of efficiency in pump chart. Supported units are PERCENTAGE (default) and FRACTION.",
+          "enum": [
+            "PERCENTAGE",
+            "FRACTION"
+          ],
+          "title": "EFFICIENCY",
+          "type": "string"
+        }
+      },
+      "required": [
+        "RATE",
+        "HEAD",
+        "EFFICIENCY"
+      ],
+      "title": "YamlPumpChartUnits",
+      "type": "object"
+    },
+    "YamlPumpChartVariableSpeed": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the facility input.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FILE": {
+          "description": "Specifies the name of an input file.\n\n$ECALC_DOCS_KEYWORDS_URL/FILE",
+          "title": "FILE",
+          "type": "string"
+        },
+        "ADJUSTMENT": {
+          "$ref": "#/$defs/YamlFacilityAdjustment",
+          "default": null,
+          "description": "Definition of adjustments to correct for mismatches in facility energy usage.\n\n$ECALC_DOCS_KEYWORDS_URL/ADJUSTMENT",
+          "title": "ADJUSTMENT"
+        },
+        "HEAD_MARGIN": {
+          "default": 0.0,
+          "description": "Adjustment of the head margin for power calibration.\n\n$ECALC_DOCS_KEYWORDS_URL/HEAD_MARGIN",
+          "title": "HEAD_MARGIN",
+          "type": "number"
+        },
+        "UNITS": {
+          "$ref": "#/$defs/YamlPumpChartUnits",
+          "description": "Units for pump charts: RATE, HEAD and EFFICIENCY.",
+          "title": "UNITS"
+        },
+        "TYPE": {
+          "const": "PUMP_CHART_VARIABLE_SPEED",
+          "description": "Defines the type of model applied on the data in the file.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "PUMP_CHART_VARIABLE_SPEED"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "FILE",
+        "UNITS",
+        "TYPE"
+      ],
+      "title": "YamlPumpChartVariableSpeed",
+      "type": "object"
+    },
+    "YamlPumpSystemOperationalSettings": {
+      "additionalProperties": false,
+      "properties": {
+        "CROSSOVER": {
+          "default": null,
+          "description": "Set cross over rules in system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#crossover",
+          "items": {
+            "type": "integer"
+          },
+          "title": "CROSSOVER",
+          "type": "array"
+        },
+        "RATES": {
+          "default": null,
+          "description": "Set rate per consumer in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#rates",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "RATES",
+          "type": "array"
+        },
+        "RATE_FRACTIONS": {
+          "default": null,
+          "description": "List of expressions defining fractional rate (of total system rate) per consumer.  \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#rate-fractions",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "RATE_FRACTIONS",
+          "type": "array"
+        },
+        "SUCTION_PRESSURES": {
+          "default": null,
+          "description": "Set suction pressure per consumer in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#suction-pressures",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "SUCTION_PRESSURES",
+          "type": "array"
+        },
+        "DISCHARGE_PRESSURES": {
+          "default": null,
+          "description": "Set discharge pressure per consumer in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#discharge-pressures",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "DISCHARGE_PRESSURES",
+          "type": "array"
+        },
+        "DISCHARGE_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Set discharge pressure equal for all consumers in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/DISCHARGE_PRESSURE",
+          "title": "DISCHARGE_PRESSURE"
+        },
+        "SUCTION_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "default": null,
+          "description": "Set suction pressure equal for all consumers in a consumer system operational setting. \n\n$ECALC_DOCS_KEYWORDS_URL/SUCTION_PRESSURE",
+          "title": "SUCTION_PRESSURE"
+        },
+        "FLUID_DENSITIES": {
+          "default": null,
+          "description": "Set fluid density per consumer in a consumer system operational setting. Will overwrite the systems common fluid density expression \n\n$ECALC_DOCS_KEYWORDS_URL/OPERATIONAL_SETTINGS#fluid-densities",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "title": "FLUID_DENSITIES",
+          "type": "array"
+        }
+      },
+      "title": "YamlPumpSystemOperationalSettings",
+      "type": "object"
+    },
+    "YamlPumpSystemPump": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the pump",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CHART": {
+          "description": "Reference to a pump type facility model defined in FACILITY_INPUTS",
+          "title": "COMPRESSOR_MODEL",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "CHART"
+      ],
+      "title": "YamlPumpSystemPump",
+      "type": "object"
+    },
+    "YamlRate": {
+      "additionalProperties": false,
+      "properties": {
+        "VALUE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "title": "Value"
+        },
+        "UNIT": {
+          "$ref": "#/$defs/Unit",
+          "default": "Sm3/d"
+        },
+        "TYPE": {
+          "default": "STREAM_DAY",
+          "enum": [
+            "STREAM_DAY",
+            "CALENDAR_DAY"
+          ],
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "VALUE"
+      ],
+      "title": "Rate",
+      "type": "object"
+    },
+    "YamlRateUnits": {
+      "const": "AM3_PER_HOUR",
+      "enum": [
+        "AM3_PER_HOUR"
+      ],
+      "title": "YamlRateUnits",
+      "type": "string"
+    },
+    "YamlSimplifiedVariableSpeedCompressorTrain": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "MAXIMUM_POWER": {
+          "default": null,
+          "description": "Optional constant MW maximum power the compressor train can require",
+          "title": "MAXIMUM_POWER",
+          "type": "number"
+        },
+        "TYPE": {
+          "const": "SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "SIMPLIFIED_VARIABLE_SPEED_COMPRESSOR_TRAIN"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "COMPRESSOR_TRAIN": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/YamlCompressorStages_YamlCompressorStage_"
+            },
+            {
+              "$ref": "#/$defs/YamlUnknownCompressorStages"
+            }
+          ],
+          "description": "Compressor train definition",
+          "title": "COMPRESSOR_TRAIN"
+        },
+        "CALCULATE_MAX_RATE": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "Optional compressor train max standard rate [Sm3/day] in result if set to true. Default false. Use with caution. This will increase runtime significantly.",
+          "title": "CALCULATE_MAX_RATE"
+        },
+        "FLUID_MODEL": {
+          "description": "Reference to a fluid model",
+          "title": "FLUID_MODEL",
+          "type": "string"
+        },
+        "POWER_ADJUSTMENT_CONSTANT": {
+          "default": 0.0,
+          "description": "Constant to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_CONSTANT",
+          "type": "number"
+        },
+        "POWER_ADJUSTMENT_FACTOR": {
+          "default": 1.0,
+          "description": "Factor to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_FACTOR",
+          "type": "number"
+        }
+      },
+      "required": [
+        "NAME",
+        "TYPE",
+        "COMPRESSOR_TRAIN",
+        "FLUID_MODEL"
+      ],
+      "title": "YamlSimplifiedVariableSpeedCompressorTrain",
+      "type": "object"
+    },
+    "YamlSingleSpeedChart": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "COMPRESSOR_CHART",
+          "default": "COMPRESSOR_CHART",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "COMPRESSOR_CHART"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "CHART_TYPE": {
+          "const": "SINGLE_SPEED",
+          "default": "SINGLE_SPEED",
+          "enum": [
+            "SINGLE_SPEED"
+          ],
+          "title": "Chart Type",
+          "type": "string"
+        },
+        "CURVE": {
+          "description": "One single compressor chart curve.",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/YamlCurve"
+            },
+            {
+              "$ref": "#/$defs/YamlFile"
+            }
+          ],
+          "title": "CURVE"
+        },
+        "UNITS": {
+          "$ref": "#/$defs/YamlUnits",
+          "description": "Defines the units",
+          "title": "UNITS"
+        }
+      },
+      "required": [
+        "NAME",
+        "CURVE"
+      ],
+      "title": "YamlSingleSpeedChart",
+      "type": "object"
+    },
+    "YamlSingleSpeedCompressorTrain": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "MAXIMUM_POWER": {
+          "default": null,
+          "description": "Optional constant MW maximum power the compressor train can require",
+          "title": "MAXIMUM_POWER",
+          "type": "number"
+        },
+        "TYPE": {
+          "const": "SINGLE_SPEED_COMPRESSOR_TRAIN",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "SINGLE_SPEED_COMPRESSOR_TRAIN"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "COMPRESSOR_TRAIN": {
+          "$ref": "#/$defs/YamlCompressorStages_YamlCompressorStageWithMarginAndPressureDrop_",
+          "description": "Compressor train definition",
+          "title": "COMPRESSOR_TRAIN"
+        },
+        "PRESSURE_CONTROL": {
+          "$ref": "#/$defs/YamlPressureControl",
+          "default": "DOWNSTREAM_CHOKE",
+          "description": "Method for pressure control",
+          "title": "PRESSURE_CONTROL"
+        },
+        "MAXIMUM_DISCHARGE_PRESSURE": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum discharge pressure in bar (can only use if pressure control is DOWNSTREAM_CHOKE)",
+          "title": "MAXIMUM_DISCHARGE_PRESSURE"
+        },
+        "CALCULATE_MAX_RATE": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "Optional compressor train max standard rate [Sm3/day] in result if set to true. Default false. Use with caution. This will increase runtime significantly.",
+          "title": "CALCULATE_MAX_RATE"
+        },
+        "POWER_ADJUSTMENT_CONSTANT": {
+          "default": 0.0,
+          "description": "Constant to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_CONSTANT",
+          "type": "number"
+        },
+        "POWER_ADJUSTMENT_FACTOR": {
+          "default": 1.0,
+          "description": "Factor to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_FACTOR",
+          "type": "number"
+        },
+        "FLUID_MODEL": {
+          "description": "Reference to a fluid model",
+          "title": "FLUID_MODEL",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "TYPE",
+        "COMPRESSOR_TRAIN",
+        "FLUID_MODEL"
+      ],
+      "title": "YamlSingleSpeedCompressorTrain",
+      "type": "object"
+    },
+    "YamlSingleVariable": {
+      "additionalProperties": false,
+      "description": "A variable in YAML that can be set to a valid eCalc Expression",
+      "properties": {
+        "VALUE": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "title": "Value"
+        }
+      },
+      "required": [
+        "VALUE"
+      ],
+      "title": "YamlSingleVariable",
+      "type": "object"
+    },
+    "YamlStream": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "default": null,
+          "description": "The name of the stream. ",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FROM": {
+          "description": "The component the stream comes from.",
+          "title": "FROM",
+          "type": "string"
+        },
+        "TO": {
+          "description": "The component the stream goes to.",
+          "title": "TO",
+          "type": "string"
+        }
+      },
+      "required": [
+        "FROM",
+        "TO"
+      ],
+      "title": "YamlStream",
+      "type": "object"
+    },
+    "YamlStreamConditions": {
+      "additionalProperties": false,
+      "properties": {
+        "RATE": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/YamlRate"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Rate...",
+          "title": "Rate"
+        },
+        "PRESSURE": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/YamlPressure"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Pressure..",
+          "title": "Pressure"
+        },
+        "TEMPERATURE": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/YamlTemperature"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Temperature...",
+          "title": "Temperature"
+        },
+        "FLUID_DENSITY": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/YamlDensity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The fluid density...",
+          "title": "Fluid density"
+        }
+      },
+      "title": "Stream",
+      "type": "object"
+    },
+    "YamlSystemComponentConditions": {
+      "additionalProperties": false,
+      "properties": {
+        "CROSSOVER": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/YamlCrossover"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "CROSSOVER specifies if rates are to be crossed over to another consumer if rate capacity is exceeded. If the energy consumption calculation is not successful for a consumer, and the consumer has a valid cross-over defined, the consumer will be allocated its maximum rate and the exceeding rate will be added to the cross-over consumer.\nTo avoid loops, a consumer can only be either receiving or giving away rate. For a cross-over to be valid, the discharge pressure at the consumer \"receiving\" overshooting rate must be higher than or equal to the discharge pressure of the \"sending\" consumer. This is because it is possible to choke pressure down to meet the outlet pressure in a flow line with lower pressure, but not possible to \"pressure up\" in the crossover flow line.\nSome examples show how the crossover logic works:\nCrossover is given as and list of integer values for the first position is the first consumer, second position is the second consumer, etc. The number specifies which consumer to send cross-over flow to, and 0 signifies no cross-over possible. Note that we use 1-index here.\nExample 1:\nTwo consumers where there is a cross-over such that if the rate for the first consumer exceeds its capacity, the excess rate will be processed by the second consumer. The second consumer can not cross-over to anyone.\nCROSSOVER: \n  - FROM: consumer1 \n    TO: consumer2 \nExample 2:\nThe first and second consumers may both send exceeding rate to the third consumer if their capacity is exceeded.\nCROSSOVER: \n  - FROM: consumer1 \n    TO: consumer3 \n  - FROM: consumer2 \n    TO: consumer3 \n",
+          "title": "Crossover"
+        }
+      },
+      "title": "YamlSystemComponentConditions",
+      "type": "object"
+    },
+    "YamlTabularModel": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the facility input.\n\n$ECALC_DOCS_KEYWORDS_URL/NAME",
+          "title": "NAME",
+          "type": "string"
+        },
+        "FILE": {
+          "description": "Specifies the name of an input file.\n\n$ECALC_DOCS_KEYWORDS_URL/FILE",
+          "title": "FILE",
+          "type": "string"
+        },
+        "ADJUSTMENT": {
+          "$ref": "#/$defs/YamlFacilityAdjustment",
+          "default": null,
+          "description": "Definition of adjustments to correct for mismatches in facility energy usage.\n\n$ECALC_DOCS_KEYWORDS_URL/ADJUSTMENT",
+          "title": "ADJUSTMENT"
+        },
+        "TYPE": {
+          "const": "TABULAR",
+          "description": "Defines the type of model applied on the data in the file.\n\n$ECALC_DOCS_KEYWORDS_URL/TYPE",
+          "enum": [
+            "TABULAR"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "FILE",
+        "TYPE"
+      ],
+      "title": "YamlTabularModel",
+      "type": "object"
+    },
+    "YamlTabulatedVariable": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of variable. Must correspond exactly to header/column name in the energy function",
+          "title": "NAME",
+          "type": "string"
+        },
+        "EXPRESSION": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Expression defining the variable",
+          "title": "EXPRESSION"
+        }
+      },
+      "required": [
+        "NAME",
+        "EXPRESSION"
+      ],
+      "title": "YamlTabulatedVariable",
+      "type": "object"
+    },
+    "YamlTemperature": {
+      "additionalProperties": false,
+      "properties": {
+        "VALUE": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "title": "Value"
+        },
+        "UNIT": {
+          "$ref": "#/$defs/Unit",
+          "default": "K"
+        }
+      },
+      "required": [
+        "VALUE"
+      ],
+      "title": "Temperature",
+      "type": "object"
+    },
+    "YamlTrain": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Consumer name",
+          "pattern": "^[A-Z\u00c6\u00d8\u00c5a-z\u00e6\u00f8\u00e5\\d_/\\- ]*$",
+          "title": "NAME",
+          "type": "string"
+        },
+        "CATEGORY": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "User defined category",
+          "title": "CATEGORY"
+        },
+        "TYPE": {
+          "const": "TRAIN@V2",
+          "default": "TRAIN@V2",
+          "description": "The type of the component",
+          "enum": [
+            "TRAIN@V2"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "STAGES": {
+          "items": {
+            "$ref": "#/$defs/YamlCompressor"
+          },
+          "title": "Stages",
+          "type": "array"
+        },
+        "STREAMS": {
+          "description": "List of streams",
+          "items": {
+            "$ref": "#/$defs/YamlStream"
+          },
+          "title": "Streams",
+          "type": "array"
+        }
+      },
+      "required": [
+        "NAME",
+        "STAGES"
+      ],
+      "title": "YamlTrain",
+      "type": "object"
+    },
+    "YamlTurbine": {
+      "additionalProperties": false,
+      "examples": [
+        {
+          "LOWER_HEATING_VALUE": "38 # MJ/Sm3",
+          "NAME": "compressor_train_turbine",
+          "POWER_ADJUSTMENT_CONSTANT": 10,
+          "TURBINE_EFFICIENCIES": [
+            0,
+            0.138,
+            0.21,
+            0.255,
+            0.286,
+            0.31,
+            0.328,
+            0.342,
+            0.353,
+            0.36,
+            0.362
+          ],
+          "TURBINE_LOADS": [
+            0,
+            2.352,
+            4.589,
+            6.853,
+            9.125,
+            11.399,
+            13.673,
+            15.947,
+            18.223,
+            20.496,
+            22.767
+          ],
+          "TYPE": "TURBINE"
+        }
+      ],
+      "properties": {
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "TURBINE",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "TURBINE"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "LOWER_HEATING_VALUE": {
+          "description": "Lower heating value [MJ/Sm3] of fuel. Lower heating value is also known as net calorific value",
+          "title": "LOWER_HEATING_VALUE",
+          "type": "number"
+        },
+        "TURBINE_LOADS": {
+          "description": "Load values [MW] in load vs efficiency table for turbine. Number of elements must correspond to number of elements in TURBINE_EFFICIENCIES. See documentation for more information.",
+          "items": {
+            "type": "number"
+          },
+          "title": "TURBINE_LOADS",
+          "type": "array"
+        },
+        "TURBINE_EFFICIENCIES": {
+          "description": "Efficiency values in load vs efficiency table for turbine. Efficiency is given as fraction between 0 and 1 corresponding to 0-100%. Number of elements must correspond to number of elements in TURBINE_LOADS. See documentation for more information.",
+          "items": {
+            "type": "number"
+          },
+          "title": "TURBINE_EFFICIENCIES",
+          "type": "array"
+        },
+        "POWER_ADJUSTMENT_CONSTANT": {
+          "default": 0,
+          "description": "Constant to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_CONSTANT",
+          "type": "number"
+        },
+        "POWER_ADJUSTMENT_FACTOR": {
+          "default": 1.0,
+          "description": "Factor to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_FACTOR",
+          "type": "number"
+        }
+      },
+      "required": [
+        "NAME",
+        "TYPE",
+        "LOWER_HEATING_VALUE",
+        "TURBINE_LOADS",
+        "TURBINE_EFFICIENCIES"
+      ],
+      "title": "TURBINE",
+      "type": "object"
+    },
+    "YamlUnits": {
+      "additionalProperties": false,
+      "properties": {
+        "RATE": {
+          "$ref": "#/$defs/YamlRateUnits",
+          "default": "AM3_PER_HOUR",
+          "description": "Unit for rate in compressor chart. Currently only AM3_PER_HOUR is supported",
+          "title": "RATE"
+        },
+        "HEAD": {
+          "$ref": "#/$defs/YamlHeadUnits",
+          "default": "M",
+          "description": "Unit for head in compressor chart. Supported units are M, KJ_PER_KG, JOULE_PER_KG",
+          "title": "HEAD"
+        },
+        "EFFICIENCY": {
+          "$ref": "#/$defs/YamlEfficiencyUnits",
+          "default": "PERCENTAGE",
+          "description": "Unit of efficiency in compressor chart. Supported units are PERCENTAGE and FRACTION.",
+          "title": "EFFICIENCY"
+        }
+      },
+      "title": "YamlUnits",
+      "type": "object"
+    },
+    "YamlUnknownCompressorStages": {
+      "additionalProperties": false,
+      "properties": {
+        "MAXIMUM_PRESSURE_RATIO_PER_STAGE": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum pressure ratio per stage. Number of compressors will be large enough to ensure no pressure ratios are above a given maximum pressure ratio per stage, but not larger",
+          "title": "MAXIMUM_PRESSURE_RATIO_PER_STAGE"
+        },
+        "INLET_TEMPERATURE": {
+          "description": "Inlet temperature in Celsius for stage",
+          "title": "INLET_TEMPERATURE",
+          "type": "number"
+        },
+        "COMPRESSOR_CHART": {
+          "description": "Reference to compressor chart model for stage, must be defined in MODELS or FACILITY_INPUTS",
+          "title": "COMPRESSOR_CHART",
+          "type": "string"
+        }
+      },
+      "required": [
+        "INLET_TEMPERATURE",
+        "COMPRESSOR_CHART"
+      ],
+      "title": "YamlUnknownCompressorStages",
+      "type": "object"
+    },
+    "YamlVariableSpeedChart": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "TYPE": {
+          "const": "COMPRESSOR_CHART",
+          "default": "COMPRESSOR_CHART",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "COMPRESSOR_CHART"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "CHART_TYPE": {
+          "const": "VARIABLE_SPEED",
+          "default": "VARIABLE_SPEED",
+          "enum": [
+            "VARIABLE_SPEED"
+          ],
+          "title": "Chart Type",
+          "type": "string"
+        },
+        "CURVES": {
+          "description": "Compressor chart curves, one per speed.",
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/YamlCurve"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/YamlFile"
+            }
+          ],
+          "title": "CURVES"
+        },
+        "UNITS": {
+          "$ref": "#/$defs/YamlUnits",
+          "description": "Defines the units",
+          "title": "UNITS"
+        }
+      },
+      "required": [
+        "NAME",
+        "CURVES"
+      ],
+      "title": "YamlVariableSpeedChart",
+      "type": "object"
+    },
+    "YamlVariableSpeedCompressorTrain": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "MAXIMUM_POWER": {
+          "default": null,
+          "description": "Optional constant MW maximum power the compressor train can require",
+          "title": "MAXIMUM_POWER",
+          "type": "number"
+        },
+        "TYPE": {
+          "const": "VARIABLE_SPEED_COMPRESSOR_TRAIN",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "VARIABLE_SPEED_COMPRESSOR_TRAIN"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "COMPRESSOR_TRAIN": {
+          "$ref": "#/$defs/YamlCompressorStages_YamlCompressorStageWithMarginAndPressureDrop_",
+          "description": "Compressor train definition",
+          "title": "COMPRESSOR_TRAIN"
+        },
+        "PRESSURE_CONTROL": {
+          "$ref": "#/$defs/YamlPressureControl",
+          "default": "DOWNSTREAM_CHOKE",
+          "description": "Method for pressure control",
+          "title": "PRESSURE_CONTROL"
+        },
+        "CALCULATE_MAX_RATE": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "Optional compressor train max standard rate [Sm3/day] in result if set to true. Default false. Use with caution. This will increase runtime significantly.",
+          "title": "CALCULATE_MAX_RATE"
+        },
+        "POWER_ADJUSTMENT_CONSTANT": {
+          "default": 0.0,
+          "description": "Constant to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_CONSTANT",
+          "type": "number"
+        },
+        "POWER_ADJUSTMENT_FACTOR": {
+          "default": 1.0,
+          "description": "Factor to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_FACTOR",
+          "type": "number"
+        },
+        "FLUID_MODEL": {
+          "description": "Reference to a fluid model",
+          "title": "FLUID_MODEL",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NAME",
+        "TYPE",
+        "COMPRESSOR_TRAIN",
+        "FLUID_MODEL"
+      ],
+      "title": "YamlVariableSpeedCompressorTrain",
+      "type": "object"
+    },
+    "YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of the model. See documentation for more information.",
+          "title": "NAME",
+          "type": "string"
+        },
+        "MAXIMUM_POWER": {
+          "default": null,
+          "description": "Optional constant MW maximum power the compressor train can require",
+          "title": "MAXIMUM_POWER",
+          "type": "number"
+        },
+        "TYPE": {
+          "const": "VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES",
+          "description": "Defines the type of model. See documentation for more information.",
+          "enum": [
+            "VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES"
+          ],
+          "title": "TYPE",
+          "type": "string"
+        },
+        "STREAMS": {
+          "description": "A list of all in- and out-going streams for the compressor train. The same equation of state (EOS) must be used for each INGOING stream fluid models",
+          "items": {
+            "$ref": "#/$defs/YamlMultipleStreamsStream"
+          },
+          "title": "STREAMS",
+          "type": "array"
+        },
+        "STAGES": {
+          "description": "A list of all stages in compressor model.",
+          "items": {
+            "$ref": "#/$defs/YamlCompressorStageMultipleStreams"
+          },
+          "title": "STAGES",
+          "type": "array"
+        },
+        "PRESSURE_CONTROL": {
+          "$ref": "#/$defs/YamlPressureControl",
+          "default": "DOWNSTREAM_CHOKE",
+          "description": "Method for pressure control",
+          "title": "PRESSURE_CONTROL"
+        },
+        "POWER_ADJUSTMENT_CONSTANT": {
+          "default": 0.0,
+          "description": "Constant to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_CONSTANT",
+          "type": "number"
+        },
+        "POWER_ADJUSTMENT_FACTOR": {
+          "default": 1.0,
+          "description": "Factor to adjust power usage in MW",
+          "title": "POWER_ADJUSTMENT_FACTOR",
+          "type": "number"
+        }
+      },
+      "required": [
+        "NAME",
+        "TYPE",
+        "STREAMS",
+        "STAGES"
+      ],
+      "title": "YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures",
+      "type": "object"
+    },
+    "YamlVentingEmission": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of emission",
+          "title": "NAME",
+          "type": "string"
+        },
+        "RATE": {
+          "$ref": "#/$defs/YamlEmissionRate",
+          "description": "The emission rate",
+          "title": "RATE"
+        }
+      },
+      "required": [
+        "NAME",
+        "RATE"
+      ],
+      "title": "YamlVentingEmission",
+      "type": "object"
+    },
+    "YamlVentingVolume": {
+      "additionalProperties": false,
+      "properties": {
+        "RATE": {
+          "$ref": "#/$defs/YamlOilVolumeRate",
+          "description": "The oil loading/storage volume or volume/rate",
+          "title": "RATE"
+        },
+        "EMISSIONS": {
+          "description": "The emission types and volume-emission-factors associated with oil loading/storage",
+          "items": {
+            "$ref": "#/$defs/YamlVentingVolumeEmission"
+          },
+          "title": "EMISSIONS",
+          "type": "array"
+        }
+      },
+      "required": [
+        "RATE",
+        "EMISSIONS"
+      ],
+      "title": "YamlVentingVolume",
+      "type": "object"
+    },
+    "YamlVentingVolumeEmission": {
+      "additionalProperties": false,
+      "properties": {
+        "NAME": {
+          "description": "Name of emission",
+          "title": "NAME",
+          "type": "string"
+        },
+        "EMISSION_FACTOR": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "Loading/storage volume-emission factor",
+          "title": "EMISSION_FACTOR"
+        }
+      },
+      "required": [
+        "NAME",
+        "EMISSION_FACTOR"
+      ],
+      "title": "YamlVentingVolumeEmission",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "An eCalc\u2122 yaml file",
+  "properties": {
+    "TIME_SERIES": {
+      "default": null,
+      "description": "Defines the inputs for time dependent variables, or 'reservoir variables'.\n\n$ECALC_DOCS_KEYWORDS_URL/TIME_SERIES",
+      "items": {
+        "discriminator": {
+          "mapping": {
+            "DEFAULT": "#/$defs/YamlDefaultTimeSeriesCollection",
+            "MISCELLANEOUS": "#/$defs/YamlMiscellaneousTimeSeriesCollection"
+          },
+          "propertyName": "TYPE"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/$defs/YamlDefaultTimeSeriesCollection"
+          },
+          {
+            "$ref": "#/$defs/YamlMiscellaneousTimeSeriesCollection"
+          }
+        ]
+      },
+      "title": "TIME_SERIES",
+      "type": "array"
+    },
+    "FACILITY_INPUTS": {
+      "default": null,
+      "description": "Defines input files which characterize various facility elements.\n\n$ECALC_DOCS_KEYWORDS_URL/FACILITY_INPUTS",
+      "items": {
+        "discriminator": {
+          "mapping": {
+            "COMPRESSOR_TABULAR": "#/$defs/YamlCompressorTabularModel",
+            "ELECTRICITY2FUEL": "#/$defs/YamlGeneratorSetModel",
+            "PUMP_CHART_SINGLE_SPEED": "#/$defs/YamlPumpChartSingleSpeed",
+            "PUMP_CHART_VARIABLE_SPEED": "#/$defs/YamlPumpChartVariableSpeed",
+            "TABULAR": "#/$defs/YamlTabularModel"
+          },
+          "propertyName": "TYPE"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/$defs/YamlGeneratorSetModel"
+          },
+          {
+            "$ref": "#/$defs/YamlTabularModel"
+          },
+          {
+            "$ref": "#/$defs/YamlCompressorTabularModel"
+          },
+          {
+            "$ref": "#/$defs/YamlPumpChartSingleSpeed"
+          },
+          {
+            "$ref": "#/$defs/YamlPumpChartVariableSpeed"
+          }
+        ]
+      },
+      "title": "FACILITY_INPUTS",
+      "type": "array"
+    },
+    "MODELS": {
+      "default": null,
+      "description": "Defines input files which characterize various facility elements.\n\n$ECALC_DOCS_KEYWORDS_URL/MODELS",
+      "items": {
+        "oneOf": [
+          {
+            "discriminator": {
+              "mapping": {
+                "GENERIC_FROM_DESIGN_POINT": "#/$defs/YamlGenericFromDesignPointChart",
+                "GENERIC_FROM_INPUT": "#/$defs/YamlGenericFromInputChart",
+                "SINGLE_SPEED": "#/$defs/YamlSingleSpeedChart",
+                "VARIABLE_SPEED": "#/$defs/YamlVariableSpeedChart"
+              },
+              "propertyName": "CHART_TYPE"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/YamlSingleSpeedChart"
+              },
+              {
+                "$ref": "#/$defs/YamlVariableSpeedChart"
+              },
+              {
+                "$ref": "#/$defs/YamlGenericFromDesignPointChart"
+              },
+              {
+                "$ref": "#/$defs/YamlGenericFromInputChart"
+              }
+            ]
+          },
+          {
+            "$ref": "#/$defs/YamlCompressorWithTurbine"
+          },
+          {
+            "discriminator": {
+              "mapping": {
+                "COMPOSITION": "#/$defs/YamlCompositionFluidModel",
+                "PREDEFINED": "#/$defs/YamlPredefinedFluidModel"
+              },
+              "propertyName": "FLUID_MODEL_TYPE"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/YamlPredefinedFluidModel"
+              },
+              {
+                "$ref": "#/$defs/YamlCompositionFluidModel"
+              }
+            ]
+          },
+          {
+            "$ref": "#/$defs/YamlTurbine"
+          },
+          {
+            "$ref": "#/$defs/YamlVariableSpeedCompressorTrain"
+          },
+          {
+            "$ref": "#/$defs/YamlSimplifiedVariableSpeedCompressorTrain"
+          },
+          {
+            "$ref": "#/$defs/YamlSingleSpeedCompressorTrain"
+          },
+          {
+            "$ref": "#/$defs/YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures"
+          }
+        ]
+      },
+      "title": "MODELS",
+      "type": "array"
+    },
+    "FUEL_TYPES": {
+      "description": "Specifies the various fuel types and associated emissions used in the model.\n\n$ECALC_DOCS_KEYWORDS_URL/FUEL_TYPES",
+      "items": {
+        "$ref": "#/$defs/YamlFuelType"
+      },
+      "title": "FUEL_TYPES",
+      "type": "array"
+    },
+    "VARIABLES": {
+      "default": null,
+      "description": "Defines variables used in an energy usage model by means of expressions or constants.\n\n$ECALC_DOCS_KEYWORDS_URL/VARIABLES",
+      "patternProperties": {
+        "^[A-Za-z][A-Za-z0-9_]*$": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/YamlSingleVariable"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/YamlSingleVariable"
+              },
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "title": "VARIABLES",
+      "type": "object"
+    },
+    "INSTALLATIONS": {
+      "description": "Description of the system of energy consumers.\n\n$ECALC_DOCS_KEYWORDS_URL/INSTALLATIONS",
+      "items": {
+        "$ref": "#/$defs/YamlInstallation"
+      },
+      "title": "INSTALLATIONS",
+      "type": "array"
+    },
+    "START": {
+      "default": null,
+      "description": "Global start date for eCalc calculations in <YYYY-MM-DD> format.\n\n$ECALC_DOCS_KEYWORDS_URL/START",
+      "format": "date",
+      "title": "START",
+      "type": "string"
+    },
+    "END": {
+      "default": null,
+      "description": "Global end date for eCalc calculations in <YYYY-MM-DD> format.\n\n$ECALC_DOCS_KEYWORDS_URL/END",
+      "format": "date",
+      "title": "END",
+      "type": "string"
+    }
+  },
+  "required": [
+    "FUEL_TYPES",
+    "INSTALLATIONS"
+  ],
+  "title": "Asset",
+  "type": "object"
+}

--- a/docs/docs/about/getting_started/yaml/index.md
+++ b/docs/docs/about/getting_started/yaml/index.md
@@ -11,3 +11,9 @@ The eCalc YAML model can either be run directly with the [eCalc CLI](/about/gett
 
 For getting started setting up your first eCalc YAML model, please see [Setup an eCalc Model](/about/modelling/setup/index.md),
 look at some example YAMLs [here](/about/modelling/examples/index.md) and refer to the vocabulary that we use [here](/about/references/index.md).
+
+# JSON Schema
+
+If you want to generate your own YAML to use with CLI eCalc, you can use the JSON schema that we have provided [here](ecalc_json_schema.json).
+This schema is used to validate the YAMLs that are run in eCalc.
+

--- a/docs/docs/about/migration_guides/v7_to_v8.md
+++ b/docs/docs/about/migration_guides/v7_to_v8.md
@@ -335,7 +335,7 @@ When running eCalc™ you will now need to set the model file argument last.
 
 `ecalc [OPTIONS] COMMAND [ARGS] [MODEL YAML-file]`
 
-See the [CLI Docs](../references/cli_reference) or run `ecalc --help` for the full documentation.
+See the [CLI Docs](../getting_started/cli/cli_reference) or run `ecalc --help` for the full documentation.
 
 #### 4. Extrapolation correction is no longer optional
 
@@ -346,10 +346,10 @@ Let us know if you have a use-case where this was needed.
 #### 5. Argument for LTP export has changed from: `--centuries-ltp-export` to `--ltp-export`
 
 To prepare for Open Source and to make the LTP export more agnostic (even though the column names are heavily 
-affected by Centuries), we simplify the argument to get LTP results. See [CLI Docs](../references/cli_reference) for 
+affected by Centuries), we simplify the argument to get LTP results. See [CLI Docs](../getting_started/cli/cli_reference) for 
 full documentation.
 
 #### 6. Simple results are now default for json
 Detailed output (or any json) should mainly be used for QA and advanced users, and is no longer shown by default. To keep old behavior, the user now
-needs to use the --detailed-output option when running the CLI. See [CLI reference docs](../references/cli_reference#ecalc-run)
+needs to use the --detailed-output option when running the CLI. See [CLI reference docs](../getting_started/cli/cli_reference#ecalc-run)
 for more details.

--- a/src/ecalc_cli/commands/show.py
+++ b/src/ecalc_cli/commands/show.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Optional
 
 import typer
 
@@ -34,7 +35,7 @@ def show_yaml(
 
 @app.command("schema")
 def show_schema(
-    output_file: Path = typer.Option(
+    output_file: Optional[Path] = typer.Option(
         None,
         "--file",
         help="Write the schema to a file with the specified name. If not specified, it will print to stdout.",

--- a/src/ecalc_cli/commands/show.py
+++ b/src/ecalc_cli/commands/show.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import typer
@@ -5,6 +6,7 @@ import typer
 from ecalc_cli.io.output import write_output
 from libecalc.presentation.yaml.yaml_entities import ResourceStream
 from libecalc.presentation.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
+from libecalc.presentation.yaml.yaml_types.components.yaml_asset import YamlAsset
 
 app = typer.Typer()
 
@@ -28,3 +30,14 @@ def show_yaml(
             ResourceStream(name=model_file.name, stream=model_file), base_dir=model_filepath.parent
         )
         write_output(read_model, output_file)
+
+
+@app.command("schema")
+def show_schema(
+    output_file: Path = typer.Option(
+        None,
+        "--file",
+        help="Write the schema to a file with the specified name. If not specified, it will print to stdout.",
+    ),
+):
+    write_output(json.dumps(YamlAsset.model_json_schema(by_alias=True), indent=2), output_file)

--- a/src/ecalc_cli/io/output.py
+++ b/src/ecalc_cli/io/output.py
@@ -20,10 +20,10 @@ from libecalc.presentation.json_result.result import EcalcModelResult as EcalcMo
 
 
 def write_output(output: str, output_file: Path = None):
-    """Write output of eCalc run to either file (if output file path is specified) or to stdout.
+    """Write output of eCalc run to either file, or to sys.stdout, if not specified.
 
     Args:
-        output: Output of eCalc run
+        output: Text output of eCalc
         output_file: Optional path to output file
 
     Returns:

--- a/src/generate_docs.py
+++ b/src/generate_docs.py
@@ -15,7 +15,7 @@ sidebar_label: "CLI"
 
 
 @app.command()
-def generate(
+def generate_cli_reference(
     ctx: typer.Context,
     name: str = typer.Option("", help="The name of the CLI program to use in docs."),
     output: Path = typer.Option(

--- a/src/generate_json_schema.py
+++ b/src/generate_json_schema.py
@@ -1,0 +1,10 @@
+from ecalc_cli.commands import show
+
+
+def generate_json_schema_reference() -> None:
+    """Generate JSON schema and write to stdout"""
+    show.show_schema(output_file=None)
+
+
+if __name__ == "__main__":
+    generate_json_schema_reference()


### PR DESCRIPTION
* `ecalc show schema [--file my_file]` will write the current json schema for valid ecalc yaml to the file my_file. If no filename is provided, it will write to stdout
* fixed paths to cli reference that was incorrect, and updated it
* link to json schema from ecalc docs (will serve latest bleeding json schema from main)


## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
