### PR TITLE
chore: replace dtos in tests for genset

### DIFF
--- a/tests/libecalc/core/conftest.py
+++ b/tests/libecalc/core/conftest.py
@@ -42,19 +42,6 @@ def dry_fluid() -> FluidModel:
 
 
 @pytest.fixture
-def fuel_dto() -> libecalc.dto.fuel_type.FuelType:
-    return libecalc.dto.fuel_type.FuelType(
-        name="fuel_gas",
-        emissions=[
-            dto.Emission(
-                name="CO2",
-                factor=Expression.setup_from_expression(value=1),
-            )
-        ],
-    )
-
-
-@pytest.fixture
 def pump_single_speed() -> PumpSingleSpeed:
     chart_curve = SingleSpeedChart(
         libecalc.common.serializable_chart.SingleSpeedChartDTO(

--- a/tests/libecalc/core/conftest.py
+++ b/tests/libecalc/core/conftest.py
@@ -13,7 +13,6 @@ from libecalc.core.models.chart import SingleSpeedChart, VariableSpeedChart
 from libecalc.core.models.compressor.sampled import CompressorModelSampled
 from libecalc.core.models.pump import PumpSingleSpeed, PumpVariableSpeed
 from libecalc.core.models.turbine import TurbineModel
-from libecalc.expression import Expression
 from libecalc.presentation.yaml.mappers.fluid_mapper import DRY_MW_18P3, MEDIUM_MW_19P4, RICH_MW_21P4
 
 

--- a/tests/libecalc/core/consumers/conftest.py
+++ b/tests/libecalc/core/consumers/conftest.py
@@ -9,6 +9,10 @@ from libecalc.common.time_utils import Period
 from libecalc.common.utils.rates import RateType
 from libecalc.common.variables import VariablesMap
 from libecalc.expression import Expression
+from libecalc.presentation.yaml.yaml_types.components.legacy.energy_usage_model.yaml_energy_usage_model_direct import (
+    ConsumptionRateType,
+)
+from libecalc.testing.yaml_builder import YamlEnergyUsageModelDirectBuilder
 
 
 @pytest.fixture
@@ -131,3 +135,11 @@ def genset_1000mw_late_startup_dto(
         consumers=[direct_el_consumer],
         regularity={Period(datetime(1900, 1, 1)): Expression.setup_from_expression(1)},
     )
+
+
+@pytest.fixture
+def energy_usage_model_direct_load_factory():
+    def energy_usage_model(load: float, rate_type: ConsumptionRateType = ConsumptionRateType.STREAM_DAY):
+        return (YamlEnergyUsageModelDirectBuilder().with_load(load).with_consumption_rate_type(rate_type)).validate()
+
+    return energy_usage_model

--- a/tests/libecalc/core/consumers/conftest.py
+++ b/tests/libecalc/core/consumers/conftest.py
@@ -88,56 +88,6 @@ def direct_el_consumer() -> dto.ElectricityConsumer:
 
 
 @pytest.fixture
-def generator_set_sampled_model_2mw() -> dto.GeneratorSetSampled:
-    return dto.GeneratorSetSampled(
-        headers=["POWER", "FUEL"],
-        data=[[0, 0.5, 1, 2], [0, 0.6, 1, 2]],
-        energy_usage_adjustment_constant=0.0,
-        energy_usage_adjustment_factor=1.0,
-    )
-
-
-@pytest.fixture
-def generator_set_sampled_model_1000mw() -> dto.GeneratorSetSampled:
-    return dto.GeneratorSetSampled(
-        headers=["POWER", "FUEL"],
-        data=[[0, 0.1, 1, 1000], [0, 0.1, 1, 1000]],
-        energy_usage_adjustment_constant=0.0,
-        energy_usage_adjustment_factor=1.0,
-    )
-
-
-@pytest.fixture
-def genset_2mw_dto(fuel_dto, direct_el_consumer, generator_set_sampled_model_2mw) -> dto.GeneratorSet:
-    return dto.GeneratorSet(
-        name="genset",
-        user_defined_category={Period(datetime(1900, 1, 1)): "TURBINE-GENERATOR"},
-        fuel={Period(datetime(1900, 1, 1)): fuel_dto},
-        generator_set_model={
-            Period(datetime(1900, 1, 1)): generator_set_sampled_model_2mw,
-        },
-        consumers=[direct_el_consumer],
-        regularity={Period(datetime(1900, 1, 1)): Expression.setup_from_expression(1)},
-    )
-
-
-@pytest.fixture
-def genset_1000mw_late_startup_dto(
-    fuel_dto, direct_el_consumer, generator_set_sampled_model_1000mw
-) -> dto.GeneratorSet:
-    return dto.GeneratorSet(
-        name="genset_late_startup",
-        user_defined_category={Period(datetime(1900, 1, 1)): "TURBINE-GENERATOR"},
-        fuel={Period(datetime(1900, 1, 1)): fuel_dto},
-        generator_set_model={
-            Period(datetime(2022, 1, 1)): generator_set_sampled_model_1000mw,
-        },
-        consumers=[direct_el_consumer],
-        regularity={Period(datetime(1900, 1, 1)): Expression.setup_from_expression(1)},
-    )
-
-
-@pytest.fixture
 def energy_usage_model_direct_load_factory():
     def energy_usage_model(load: float, rate_type: ConsumptionRateType = ConsumptionRateType.STREAM_DAY):
         return (YamlEnergyUsageModelDirectBuilder().with_load(load).with_consumption_rate_type(rate_type)).validate()

--- a/tests/libecalc/core/consumers/test_genset.py
+++ b/tests/libecalc/core/consumers/test_genset.py
@@ -35,7 +35,6 @@ from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlF
 from libecalc.testing.yaml_builder import (
     YamlGeneratorSetBuilder,
     YamlFuelTypeBuilder,
-    YamlEnergyUsageModelDirectBuilder,
     YamlElectricityConsumerBuilder,
     YamlElectricity2fuelBuilder,
     YamlInstallationBuilder,

--- a/tests/libecalc/core/consumers/test_genset.py
+++ b/tests/libecalc/core/consumers/test_genset.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from io import StringIO
 from typing import Union
 
 import numpy as np
@@ -7,7 +8,7 @@ import pytest
 
 from libecalc.application.energy_calculator import EnergyCalculator
 from libecalc.common.temporal_model import TemporalModel
-from libecalc.common.time_utils import Period
+from libecalc.common.time_utils import Period, Frequency
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
     TimeSeriesBoolean,
@@ -18,14 +19,27 @@ from libecalc.common.variables import VariablesMap
 from libecalc.core.consumers.generator_set import Genset
 from libecalc.core.models.generator import GeneratorModelSampled
 from libecalc.core.result.results import GenericComponentResult
-from libecalc.dto.types import FuelTypeUserDefinedCategoryType, ConsumerUserDefinedCategoryType
-from libecalc.presentation.yaml.yaml_entities import MemoryResource
+from libecalc.dto.types import (
+    FuelTypeUserDefinedCategoryType,
+    ConsumerUserDefinedCategoryType,
+    InstallationUserDefinedCategoryType,
+)
+from libecalc.presentation.yaml.model import YamlModel
+from libecalc.presentation.yaml.yaml_entities import MemoryResource, ResourceStream
+from libecalc.presentation.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
+from libecalc.presentation.yaml.yaml_types.components.yaml_asset import YamlAsset
+from libecalc.presentation.yaml.yaml_types.components.yaml_generator_set import YamlGeneratorSet
+from libecalc.presentation.yaml.yaml_types.components.yaml_installation import YamlInstallation
+from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import YamlFacilityModelType
+from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.testing.yaml_builder import (
     YamlGeneratorSetBuilder,
     YamlFuelTypeBuilder,
     YamlEnergyUsageModelDirectBuilder,
     YamlElectricityConsumerBuilder,
     YamlElectricity2fuelBuilder,
+    YamlInstallationBuilder,
+    YamlAssetBuilder,
 )
 
 
@@ -36,18 +50,45 @@ class GensetTestHelper:
         self.d2021 = datetime(2021, 1, 1)
         self.d2022 = datetime(2022, 1, 1)
         self.d2023 = datetime(2023, 1, 1)
+        self.d2024 = datetime(2024, 1, 1)
+        self.d2025 = datetime(2025, 1, 1)
+        self.d2026 = datetime(2026, 1, 1)
 
         self.p1900 = Period(self.d1900)
         self.p2020 = Period(self.d2020, self.d2021)
         self.p2021 = Period(self.d2021, self.d2022)
         self.p2022 = Period(self.d2022, self.d2023)
-        self.p2023 = Period(self.d2023)
+        self.p2023 = Period(self.d2023, self.d2024)
+        self.p2024 = Period(self.d2024, self.d2025)
+        self.p2025 = Period(self.d2025, self.d2026)
+
+        self.time_vector = pd.date_range(self.d2020, self.d2026, freq="YS").to_pydatetime().tolist()
 
     def memory_resource_factory(self, data: list[list[Union[float, int, str]]], headers: list[str]) -> MemoryResource:
         return MemoryResource(
             data=data,
             headers=headers,
         )
+
+    def get_yaml_model(
+        self,
+        request,
+        asset: YamlAsset,
+        resources: dict[str, MemoryResource],
+        frequency: Frequency = Frequency.NONE,
+    ) -> YamlModel:
+        yaml_model_factory = request.getfixturevalue("yaml_model_factory")
+        asset_dict = asset.model_dump(
+            serialize_as_any=True,
+            mode="json",
+            exclude_unset=True,
+            by_alias=True,
+        )
+
+        yaml_string = PyYamlYamlModel.dump_yaml(yaml_dict=asset_dict)
+        stream = ResourceStream(name="", stream=StringIO(yaml_string))
+
+        return yaml_model_factory(resource_stream=stream, resources=resources, frequency=frequency)
 
     def generator_el2fuel_2mw_resource(self):
         return self.memory_resource_factory(
@@ -58,11 +99,20 @@ class GensetTestHelper:
             ],
         )
 
-    def generator_fuel_energy_function(self):
+    def generator_el2fuel_1000mw_resource(self):
+        return self.memory_resource_factory(
+            data=[[0, 0.1, 1, 1000], [0, 0.1, 1, 1000]],
+            headers=[
+                "POWER",
+                "FUEL",
+            ],
+        )
+
+    def generator_fuel_energy_function(self, name_extension="2mw"):
         return (
             YamlElectricity2fuelBuilder()
-            .with_name("generator_fuel_energy_function")
-            .with_file("generator_fuel_energy_function")
+            .with_name("generator_fuel_energy_function_" + name_extension)
+            .with_file("generator_fuel_energy_function_" + name_extension)
         ).validate()
 
     def fuel(self):
@@ -95,9 +145,45 @@ class GensetTestHelper:
             .with_name("genset")
             .with_category({self.d1900: "TURBINE-GENERATOR"})
             .with_fuel({self.d1900: self.fuel().name})
-            .electricity2fuel(self.generator_fuel_energy_function().name)
+            .with_electricity2fuel({self.d1900: self.generator_fuel_energy_function().name})
             .with_consumers([self.direct_electricity_consumer(request)])
         ).validate()
+
+    def genset_1000mw_late_start(self, request):
+        return (
+            YamlGeneratorSetBuilder()
+            .with_name("genset")
+            .with_category({self.d1900: "TURBINE-GENERATOR"})
+            .with_fuel({self.d1900: self.fuel().name})
+            .with_electricity2fuel({self.d2022: self.generator_fuel_energy_function("1000mw").name})
+            .with_consumers([self.direct_electricity_consumer(request)])
+        ).validate()
+
+    def installation(self, generator_set: YamlGeneratorSet, request):
+        return (
+            YamlInstallationBuilder()
+            .with_name("DefaultInstallation")
+            .with_generator_sets([generator_set])
+            .with_category(InstallationUserDefinedCategoryType.FIXED)
+            .with_regularity(1)
+        ).validate()
+
+    def asset(
+        self,
+        installation: YamlInstallation,
+        facility_inputs: list[YamlFacilityModelType] = None,
+        fuel_types: list[YamlFuelType] = None,
+    ):
+        asset = (
+            YamlAssetBuilder().with_installations([installation]).with_start(self.p2020.start).with_end(self.p2025.end)
+        )
+
+        if facility_inputs:
+            asset.facility_inputs = facility_inputs
+        if fuel_types:
+            asset.fuel_types = fuel_types
+
+        return asset.validate()
 
 
 @pytest.fixture
@@ -111,13 +197,191 @@ class TestGenset:
 
         Note that extrapcorrection does not have any effect on the Genset itself - but may have an effect on the elconsumer.
         """
-        energy_model_from_dto_factory = request.getfixturevalue("energy_model_from_dto_factory")
-        time_vector = pd.date_range(datetime(2020, 1, 1), datetime(2026, 1, 1), freq="YS").to_pydatetime().tolist()
+        time_vector = genset_test_helper.time_vector
         variables = VariablesMap(time_vector=time_vector)
+
         generator = genset_test_helper.genset_2mw(request)
-        energy_calculator = EnergyCalculator(
-            energy_model=energy_model_from_dto_factory(generator), expression_evaluator=variables
+        installation = genset_test_helper.installation(generator, request)
+        asset = genset_test_helper.asset(
+            installation=installation,
+            facility_inputs=[genset_test_helper.generator_fuel_energy_function()],
+            fuel_types=[genset_test_helper.fuel()],
         )
+        resources = {
+            genset_test_helper.generator_fuel_energy_function().name: genset_test_helper.generator_el2fuel_2mw_resource(),
+        }
+        yaml_model = genset_test_helper.get_yaml_model(request, asset, resources)
+
+        energy_calculator = EnergyCalculator(energy_model=yaml_model, expression_evaluator=variables)
+        consumer_results = energy_calculator.evaluate_energy_usage()
+
+        graph = yaml_model.get_graph()
+        generator_set_result = consumer_results[generator.name].component_result
+        components = [
+            consumer_results[successor].component_result for successor in graph.get_successors(generator.name)
+        ]
+
+        # Note that this discrepancy between power rate and fuel rate will normally not happen, since the el-consumer
+        # will also interpolate the same way as the genset does.
+        assert generator_set_result.power == TimeSeriesStreamDayRate(
+            periods=variables.periods,
+            values=[1, 2, 10, 0, 0, 0],
+            unit=Unit.MEGA_WATT,
+        )
+
+        assert generator_set_result.is_valid == TimeSeriesBoolean(
+            periods=variables.periods,
+            values=[True, True, False, True, True, True],
+            unit=Unit.NONE,
+        )
+        assert isinstance(components[0], GenericComponentResult)
+
+        emission_results = energy_calculator.evaluate_emissions()
+
+        genset_emissions = emission_results[generator.name]
+        assert genset_emissions["co2"].rate.values == [0.001, 0.002, 0.002, 0, 0, 0]
+        assert generator_set_result.periods == variables.periods
+
+    def test_genset_with_elconsumer_nan_results(self, genset_test_helper, request):
+        """Testing what happens when the el-consumers has nan-values in power. -> Genset should not do anything."""
+        time_vector = genset_test_helper.time_vector
+        variables = VariablesMap(time_vector=time_vector)
+
+        generator = genset_test_helper.genset_2mw(request)
+        installation = genset_test_helper.installation(generator, request)
+        asset = genset_test_helper.asset(
+            installation=installation,
+            facility_inputs=[genset_test_helper.generator_fuel_energy_function()],
+            fuel_types=[genset_test_helper.fuel()],
+        )
+        resources = {
+            genset_test_helper.generator_fuel_energy_function().name: genset_test_helper.generator_el2fuel_2mw_resource(),
+        }
+        yaml_model = genset_test_helper.get_yaml_model(request, asset, resources)
+
+        generator_set_model = yaml_model.get_graph().get_node(generator.name).generator_set_model
+        genset = Genset(
+            id=generator.name,
+            name=generator.name,
+            temporal_generator_set_model=TemporalModel(
+                {
+                    start_time: GeneratorModelSampled(
+                        fuel_values=model.fuel_values,
+                        power_values=model.power_values,
+                        energy_usage_adjustment_constant=model.energy_usage_adjustment_constant,
+                        energy_usage_adjustment_factor=model.energy_usage_adjustment_factor,
+                    )
+                    for start_time, model in generator_set_model.items()
+                }
+            ),
+        )
+
+        results = genset.evaluate(
+            expression_evaluator=variables,
+            power_requirement=TimeSeriesFloat(
+                values=[np.nan, np.nan, 0.5, 0.5, np.nan, np.nan],
+                periods=variables.get_periods(),
+                unit=Unit.MEGA_WATT,
+            ),
+        )
+
+        # The Genset is not supposed to handle NaN-values from the el-consumers.
+        np.testing.assert_equal(results.power.values, [np.nan, np.nan, 0.5, 0.5, np.nan, np.nan])
+        assert results.power.unit == Unit.MEGA_WATT
+        assert results.power.periods == variables.periods
+
+        # The resulting fuel rate will be zero and the result is invalid for the NaN periods.
+        assert results.energy_usage == TimeSeriesStreamDayRate(
+            periods=variables.periods,
+            values=[0, 0, 0.6, 0.6, 0.0, 0.0],
+            unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
+        )
+        assert results.is_valid == TimeSeriesBoolean(
+            periods=variables.periods,
+            values=[False, False, True, True, False, False],
+            unit=Unit.NONE,
+        )
+
+    def test_genset_outside_capacity(self, genset_test_helper, request):
+        """Testing what happens when the power rate is outside of genset capacity. -> Genset will extrapolate (forward fill)."""
+        time_vector = genset_test_helper.time_vector
+        variables = VariablesMap(time_vector=time_vector)
+
+        generator = genset_test_helper.genset_2mw(request)
+        installation = genset_test_helper.installation(generator, request)
+        asset = genset_test_helper.asset(
+            installation=installation,
+            facility_inputs=[genset_test_helper.generator_fuel_energy_function()],
+            fuel_types=[genset_test_helper.fuel()],
+        )
+        resources = {
+            genset_test_helper.generator_fuel_energy_function().name: genset_test_helper.generator_el2fuel_2mw_resource(),
+        }
+        yaml_model = genset_test_helper.get_yaml_model(request, asset, resources)
+
+        generator_set_model = yaml_model.get_graph().get_node(generator.name).generator_set_model
+        genset = Genset(
+            id=generator.name,
+            name=generator.name,
+            temporal_generator_set_model=TemporalModel(
+                {
+                    start_time: GeneratorModelSampled(
+                        fuel_values=model.fuel_values,
+                        power_values=model.power_values,
+                        energy_usage_adjustment_constant=model.energy_usage_adjustment_constant,
+                        energy_usage_adjustment_factor=model.energy_usage_adjustment_factor,
+                    )
+                    for start_time, model in generator_set_model.items()
+                }
+            ),
+        )
+
+        results = genset.evaluate(
+            expression_evaluator=variables,
+            power_requirement=TimeSeriesFloat(
+                values=[1, 2, 3, 4, 5, 6],
+                periods=variables.get_periods(),
+                unit=Unit.MEGA_WATT,
+            ),
+        )
+
+        # The genset will still report power rate
+        assert results.power == TimeSeriesStreamDayRate(
+            periods=variables.periods,
+            values=[1, 2, 3, 4, 5, 6],
+            unit=Unit.MEGA_WATT,
+        )
+
+        # But the fuel rate will only be valid for the first step. The rest is extrapolated.
+        assert results.energy_usage == TimeSeriesStreamDayRate(
+            periods=variables.periods,
+            values=[1, 2, 2, 2, 2, 2],
+            unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
+        )
+        assert results.is_valid == TimeSeriesBoolean(
+            periods=variables.periods,
+            values=[True, True, False, False, False, False],
+            unit=Unit.NONE,
+        )
+
+    def test_genset_late_startup(self, genset_test_helper, request):
+        time_vector = genset_test_helper.time_vector
+        variables = VariablesMap(time_vector=time_vector)
+
+        electricity2fuel = genset_test_helper.generator_fuel_energy_function("1000mw")
+
+        generator = genset_test_helper.genset_1000mw_late_start(request)
+        installation = genset_test_helper.installation(generator, request)
+        asset = genset_test_helper.asset(
+            installation=installation, facility_inputs=[electricity2fuel], fuel_types=[genset_test_helper.fuel()]
+        )
+        resources = {
+            electricity2fuel.name: genset_test_helper.generator_el2fuel_1000mw_resource(),
+        }
+        yaml_model = genset_test_helper.get_yaml_model(request, asset, resources)
+
+        energy_calculator = EnergyCalculator(energy_model=yaml_model, expression_evaluator=variables)
+        consumer_results = energy_calculator.evaluate_energy_usage()
 
 
 def test_genset_out_of_capacity(genset_2mw_dto, fuel_dto, energy_model_from_dto_factory):

--- a/tests/libecalc/core/consumers/test_genset.py
+++ b/tests/libecalc/core/consumers/test_genset.py
@@ -204,7 +204,7 @@ def genset_test_helper():
 
 
 class TestGenset:
-    def test_genset_out_of_capacity2(self, genset_test_helper, request):
+    def test_genset_out_of_capacity(self, genset_test_helper, request):
         """Testing a genset at capacity, at zero and above capacity.
 
         Note that extrapcorrection does not have any effect on the Genset itself - but may have an effect on the elconsumer.

--- a/tests/libecalc/core/consumers/test_genset.py
+++ b/tests/libecalc/core/consumers/test_genset.py
@@ -90,6 +90,27 @@ class GensetTestHelper:
 
         return yaml_model_factory(resource_stream=stream, resources=resources, frequency=frequency)
 
+    def get_results(self, yaml_model: YamlModel, variables: VariablesMap, component_name: str):
+        class LocalResult:
+            def __init__(self):
+                self.component_result = None
+                self.generator_set_result = None
+                self.consumer_results = None
+                self.energy_calculator = None
+                self.components = None
+
+        local_result = LocalResult()
+        local_result.energy_calculator = EnergyCalculator(energy_model=yaml_model, expression_evaluator=variables)
+        local_result.consumer_results = local_result.energy_calculator.evaluate_energy_usage()
+
+        graph = yaml_model.get_graph()
+        local_result.generator_set_result = local_result.consumer_results[component_name].component_result
+        local_result.components = [
+            local_result.consumer_results[successor].component_result
+            for successor in graph.get_successors(component_name)
+        ]
+        return local_result
+
     def generator_el2fuel_2mw_resource(self):
         return self.memory_resource_factory(
             data=[[0, 0.5, 1, 2], [0, 0.6, 1, 2]],
@@ -182,6 +203,8 @@ class GensetTestHelper:
             asset.facility_inputs = facility_inputs
         if fuel_types:
             asset.fuel_types = fuel_types
+        else:
+            asset.fuel_types = [self.fuel()]
 
         return asset.validate()
 
@@ -205,42 +228,34 @@ class TestGenset:
         asset = genset_test_helper.asset(
             installation=installation,
             facility_inputs=[genset_test_helper.generator_fuel_energy_function()],
-            fuel_types=[genset_test_helper.fuel()],
         )
         resources = {
             genset_test_helper.generator_fuel_energy_function().name: genset_test_helper.generator_el2fuel_2mw_resource(),
         }
         yaml_model = genset_test_helper.get_yaml_model(request, asset, resources)
 
-        energy_calculator = EnergyCalculator(energy_model=yaml_model, expression_evaluator=variables)
-        consumer_results = energy_calculator.evaluate_energy_usage()
-
-        graph = yaml_model.get_graph()
-        generator_set_result = consumer_results[generator.name].component_result
-        components = [
-            consumer_results[successor].component_result for successor in graph.get_successors(generator.name)
-        ]
+        results = genset_test_helper.get_results(yaml_model, variables, generator.name)
 
         # Note that this discrepancy between power rate and fuel rate will normally not happen, since the el-consumer
         # will also interpolate the same way as the genset does.
-        assert generator_set_result.power == TimeSeriesStreamDayRate(
+        assert results.generator_set_result.power == TimeSeriesStreamDayRate(
             periods=variables.periods,
             values=[1, 2, 10, 0, 0, 0],
             unit=Unit.MEGA_WATT,
         )
 
-        assert generator_set_result.is_valid == TimeSeriesBoolean(
+        assert results.generator_set_result.is_valid == TimeSeriesBoolean(
             periods=variables.periods,
             values=[True, True, False, True, True, True],
             unit=Unit.NONE,
         )
-        assert isinstance(components[0], GenericComponentResult)
+        assert isinstance(results.components[0], GenericComponentResult)
 
-        emission_results = energy_calculator.evaluate_emissions()
+        emission_results = results.energy_calculator.evaluate_emissions()
 
         genset_emissions = emission_results[generator.name]
         assert genset_emissions["co2"].rate.values == [0.001, 0.002, 0.002, 0, 0, 0]
-        assert generator_set_result.periods == variables.periods
+        assert results.generator_set_result.periods == variables.periods
 
     def test_genset_with_elconsumer_nan_results(self, genset_test_helper, request):
         """Testing what happens when the el-consumers has nan-values in power. -> Genset should not do anything."""
@@ -252,7 +267,6 @@ class TestGenset:
         asset = genset_test_helper.asset(
             installation=installation,
             facility_inputs=[genset_test_helper.generator_fuel_energy_function()],
-            fuel_types=[genset_test_helper.fuel()],
         )
         resources = {
             genset_test_helper.generator_fuel_energy_function().name: genset_test_helper.generator_el2fuel_2mw_resource(),
@@ -260,6 +274,7 @@ class TestGenset:
         yaml_model = genset_test_helper.get_yaml_model(request, asset, resources)
 
         generator_set_model = yaml_model.get_graph().get_node(generator.name).generator_set_model
+
         genset = Genset(
             id=generator.name,
             name=generator.name,
@@ -312,7 +327,6 @@ class TestGenset:
         asset = genset_test_helper.asset(
             installation=installation,
             facility_inputs=[genset_test_helper.generator_fuel_energy_function()],
-            fuel_types=[genset_test_helper.fuel()],
         )
         resources = {
             genset_test_helper.generator_fuel_energy_function().name: genset_test_helper.generator_el2fuel_2mw_resource(),
@@ -372,181 +386,30 @@ class TestGenset:
 
         generator = genset_test_helper.genset_1000mw_late_start(request)
         installation = genset_test_helper.installation(generator, request)
-        asset = genset_test_helper.asset(
-            installation=installation, facility_inputs=[electricity2fuel], fuel_types=[genset_test_helper.fuel()]
-        )
+        asset = genset_test_helper.asset(installation=installation, facility_inputs=[electricity2fuel])
         resources = {
             electricity2fuel.name: genset_test_helper.generator_el2fuel_1000mw_resource(),
         }
         yaml_model = genset_test_helper.get_yaml_model(request, asset, resources)
 
-        energy_calculator = EnergyCalculator(energy_model=yaml_model, expression_evaluator=variables)
-        consumer_results = energy_calculator.evaluate_energy_usage()
+        results = genset_test_helper.get_results(yaml_model, variables, generator.name)
 
-
-def test_genset_out_of_capacity(genset_2mw_dto, fuel_dto, energy_model_from_dto_factory):
-    """Testing a genset at capacity, at zero and above capacity.
-
-    Note that extrapcorrection does not have any effect on the Genset itself - but may have an effect on the elconsumer.
-    """
-    time_vector = pd.date_range(datetime(2020, 1, 1), datetime(2026, 1, 1), freq="YS").to_pydatetime().tolist()
-
-    variables = VariablesMap(time_vector=time_vector)
-    energy_calculator = EnergyCalculator(
-        energy_model=energy_model_from_dto_factory(genset_2mw_dto), expression_evaluator=variables
-    )
-    consumer_results = energy_calculator.evaluate_energy_usage()
-
-    graph = genset_2mw_dto.get_graph()
-    generator_set_result = consumer_results[genset_2mw_dto.id].component_result
-    components = [consumer_results[successor].component_result for successor in graph.get_successors(genset_2mw_dto.id)]
-
-    # Note that this discrepancy between power rate and fuel rate will normally not happen, since the el-consumer
-    # will also interpolate the same way as the genset does.
-    assert generator_set_result.power == TimeSeriesStreamDayRate(
-        periods=variables.periods,
-        values=[1, 2, 10, 0, 0, 0],
-        unit=Unit.MEGA_WATT,
-    )
-    assert generator_set_result.is_valid == TimeSeriesBoolean(
-        periods=variables.periods,
-        values=[True, True, False, True, True, True],
-        unit=Unit.NONE,
-    )
-    assert isinstance(components[0], GenericComponentResult)
-
-    emission_results = energy_calculator.evaluate_emissions()
-
-    genset_emissions = emission_results[genset_2mw_dto.id]
-    assert genset_emissions["co2"].rate.values == [0.001, 0.002, 0.002, 0, 0, 0]
-    assert generator_set_result.periods == variables.periods
-
-
-def test_genset_with_elconsumer_nan_results(genset_2mw_dto, fuel_dto):
-    """Testing what happens when the el-consumers has nan-values in power. -> Genset should not do anything."""
-    time_vector = pd.date_range(datetime(2020, 1, 1), datetime(2026, 1, 1), freq="YS").to_pydatetime().tolist()
-    genset = Genset(
-        id=genset_2mw_dto.id,
-        name=genset_2mw_dto.name,
-        temporal_generator_set_model=TemporalModel(
-            {
-                start_time: GeneratorModelSampled(
-                    fuel_values=model.fuel_values,
-                    power_values=model.power_values,
-                    energy_usage_adjustment_constant=model.energy_usage_adjustment_constant,
-                    energy_usage_adjustment_factor=model.energy_usage_adjustment_factor,
-                )
-                for start_time, model in genset_2mw_dto.generator_set_model.items()
-            }
-        ),
-    )
-    variables = VariablesMap(time_vector=time_vector)
-    results = genset.evaluate(
-        expression_evaluator=variables,
-        power_requirement=TimeSeriesFloat(
-            values=[np.nan, np.nan, 0.5, 0.5, np.nan, np.nan],
-            periods=variables.get_periods(),
+        assert results.generator_set_result.power == TimeSeriesStreamDayRate(
+            periods=variables.periods,
+            values=[1.0, 2.0, 10.0, 0.0, 0.0, 0.0],
             unit=Unit.MEGA_WATT,
-        ),
-    )
+        )
 
-    # The Genset is not supposed to handle NaN-values from the el-consumers.
-    np.testing.assert_equal(results.power.values, [np.nan, np.nan, 0.5, 0.5, np.nan, np.nan])
-    assert results.power.unit == Unit.MEGA_WATT
-    assert results.power.periods == variables.periods
-
-    # The resulting fuel rate will be zero and the result is invalid for the NaN periods.
-    assert results.energy_usage == TimeSeriesStreamDayRate(
-        periods=variables.periods,
-        values=[0, 0, 0.6, 0.6, 0.0, 0.0],
-        unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
-    )
-    assert results.is_valid == TimeSeriesBoolean(
-        periods=variables.periods,
-        values=[False, False, True, True, False, False],
-        unit=Unit.NONE,
-    )
-
-
-def test_genset_outside_capacity(genset_2mw_dto, fuel_dto):
-    """Testing what happens when the power rate is outside of genset capacity. -> Genset will extrapolate (forward fill)."""
-    time_vector = pd.date_range(datetime(2020, 1, 1), datetime(2026, 1, 1), freq="YS").to_pydatetime().tolist()
-    genset = Genset(
-        id=genset_2mw_dto.id,
-        name=genset_2mw_dto.name,
-        temporal_generator_set_model=TemporalModel(
-            {
-                start_time: GeneratorModelSampled(
-                    fuel_values=model.fuel_values,
-                    power_values=model.power_values,
-                    energy_usage_adjustment_constant=model.energy_usage_adjustment_constant,
-                    energy_usage_adjustment_factor=model.energy_usage_adjustment_factor,
-                )
-                for start_time, model in genset_2mw_dto.generator_set_model.items()
-            }
-        ),
-    )
-    variables = VariablesMap(time_vector=time_vector)
-    results = genset.evaluate(
-        expression_evaluator=variables,
-        power_requirement=TimeSeriesFloat(
-            values=[1, 2, 3, 4, 5, 6],
-            periods=variables.get_periods(),
-            unit=Unit.MEGA_WATT,
-        ),
-    )
-
-    # The genset will still report power rate
-    assert results.power == TimeSeriesStreamDayRate(
-        periods=variables.periods,
-        values=[1, 2, 3, 4, 5, 6],
-        unit=Unit.MEGA_WATT,
-    )
-
-    # But the fuel rate will only be valid for the first step. The rest is extrapolated.
-    assert results.energy_usage == TimeSeriesStreamDayRate(
-        periods=variables.periods,
-        values=[1, 2, 2, 2, 2, 2],
-        unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
-    )
-    assert results.is_valid == TimeSeriesBoolean(
-        periods=variables.periods,
-        values=[True, True, False, False, False, False],
-        unit=Unit.NONE,
-    )
-
-
-def test_genset_late_startup(genset_1000mw_late_startup_dto, fuel_dto, energy_model_from_dto_factory):
-    time_vector = pd.date_range(datetime(2020, 1, 1), datetime(2026, 1, 1), freq="YS").to_pydatetime().tolist()
-    variables = VariablesMap(time_vector=time_vector)
-    energy_calculator = EnergyCalculator(
-        energy_model=energy_model_from_dto_factory(genset_1000mw_late_startup_dto), expression_evaluator=variables
-    )
-    consumer_results = energy_calculator.evaluate_energy_usage()
-
-    graph = genset_1000mw_late_startup_dto.get_graph()
-    generator_set_result = consumer_results[genset_1000mw_late_startup_dto.id].component_result
-    components = [
-        consumer_results[successor].component_result
-        for successor in graph.get_successors(genset_1000mw_late_startup_dto.id)
-    ]
-
-    assert generator_set_result.power == TimeSeriesStreamDayRate(
-        periods=variables.periods,
-        values=[1.0, 2.0, 10.0, 0.0, 0.0, 0.0],
-        unit=Unit.MEGA_WATT,
-    )
-
-    # Note that the genset is not able to deliver the power rate demanded by the el-consumer(s) for the two
-    # first time-steps before the genset is activated in 2022.
-    assert generator_set_result.energy_usage == TimeSeriesStreamDayRate(
-        periods=variables.periods,
-        values=[0.0, 0.0, 10.0, 0.0, 0.0, 0.0],
-        unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
-    )
-    assert generator_set_result.is_valid == TimeSeriesBoolean(
-        periods=variables.periods,
-        values=[False, False, True, True, True, True],
-        unit=Unit.NONE,
-    )
-    np.testing.assert_equal(components[0].power.values, [1.0, 2.0, 10.0, 0.0, 0.0, 0.0])
+        # Note that the genset is not able to deliver the power rate demanded by the el-consumer(s) for the two
+        # first time-steps before the genset is activated in 2022.
+        assert results.generator_set_result.energy_usage == TimeSeriesStreamDayRate(
+            periods=variables.periods,
+            values=[0.0, 0.0, 10.0, 0.0, 0.0, 0.0],
+            unit=Unit.STANDARD_CUBIC_METER_PER_DAY,
+        )
+        assert results.generator_set_result.is_valid == TimeSeriesBoolean(
+            periods=variables.periods,
+            values=[False, False, True, True, True, True],
+            unit=Unit.NONE,
+        )
+        np.testing.assert_equal(results.components[0].power.values, [1.0, 2.0, 10.0, 0.0, 0.0, 0.0])

--- a/tests/libecalc/core/consumers/test_genset.py
+++ b/tests/libecalc/core/consumers/test_genset.py
@@ -50,17 +50,9 @@ class GensetTestHelper:
         self.d2021 = datetime(2021, 1, 1)
         self.d2022 = datetime(2022, 1, 1)
         self.d2023 = datetime(2023, 1, 1)
-        self.d2024 = datetime(2024, 1, 1)
-        self.d2025 = datetime(2025, 1, 1)
         self.d2026 = datetime(2026, 1, 1)
 
         self.p1900 = Period(self.d1900)
-        self.p2020 = Period(self.d2020, self.d2021)
-        self.p2021 = Period(self.d2021, self.d2022)
-        self.p2022 = Period(self.d2022, self.d2023)
-        self.p2023 = Period(self.d2023, self.d2024)
-        self.p2024 = Period(self.d2024, self.d2025)
-        self.p2025 = Period(self.d2025, self.d2026)
 
         self.time_vector = pd.date_range(self.d2020, self.d2026, freq="YS").to_pydatetime().tolist()
 
@@ -195,9 +187,7 @@ class GensetTestHelper:
         facility_inputs: list[YamlFacilityModelType] = None,
         fuel_types: list[YamlFuelType] = None,
     ):
-        asset = (
-            YamlAssetBuilder().with_installations([installation]).with_start(self.p2020.start).with_end(self.p2025.end)
-        )
+        asset = YamlAssetBuilder().with_installations([installation]).with_start(self.d2020).with_end(self.d2026)
 
         if facility_inputs:
             asset.facility_inputs = facility_inputs


### PR DESCRIPTION
## Why is this pull request needed?

Yaml builders should replace the dtos (data transfer objects) in the current tests for generator sets
## What does this pull request change?

- [x] Replace dtos with builders in tests for generator sets
- [x] Delete unused fixtures

## Issues related to this change:
https://github.com/equinor/ecalc-internal/issues/251