### PR TITLE
chore: remove pydantic validation from dto classes

### DIFF
--- a/src/libecalc/core/models/compressor/sampled/compressor_model_sampled.py
+++ b/src/libecalc/core/models/compressor/sampled/compressor_model_sampled.py
@@ -167,8 +167,15 @@ class CompressorModelSampled(CompressorModel):
         """
         # subtract an epsilon to make robust comparison.
         if rate is not None:
+            # Ensure rate is a NumPy array
+            rate = np.array(rate, dtype=np.float64)
             # To avoid bringing rate below zero.
             rate = np.where(rate > 0, rate - EPSILON, rate)
+        if suction_pressure is not None:
+            suction_pressure = np.array(suction_pressure, dtype=np.float64)
+
+        if discharge_pressure is not None:
+            discharge_pressure = np.array(discharge_pressure, dtype=np.float64)
 
         number_of_data_points = 0
         if rate is not None:

--- a/src/libecalc/core/models/model_input_validation.py
+++ b/src/libecalc/core/models/model_input_validation.py
@@ -29,12 +29,18 @@ def validate_model_input(
     NDArray[np.float64],
     list[ModelInputFailureStatus],
 ]:
+    # Ensure input is a NumPy array
+    rate = np.array(rate, dtype=np.float64)
+    suction_pressure = np.array(suction_pressure, dtype=np.float64)
+    discharge_pressure = np.array(discharge_pressure, dtype=np.float64)
+
     indices_to_validate = _find_indices_to_validate(rate=rate)
     validated_failure_status = [ModelInputFailureStatus.NO_FAILURE] * len(suction_pressure)
     validated_rate = rate.copy()
     validated_suction_pressure = suction_pressure.copy()
     validated_discharge_pressure = discharge_pressure.copy()
     if intermediate_pressure is not None:
+        intermediate_pressure = np.array(intermediate_pressure, dtype=np.float64)
         validated_intermediate_pressure = intermediate_pressure
     if len(indices_to_validate) >= 1:
         (
@@ -82,6 +88,7 @@ def _find_indices_to_validate(rate: NDArray[np.float64]) -> list[int]:
     For a 1D array, this means returning the indices where rate is positive.
     For a 2D array, this means returning the indices where at least one rate is positive (along 0-axis).
     """
+    rate = np.atleast_1d(rate)  # Ensure rate is at least 1D
     return np.where(np.any(rate != 0, axis=0) if np.ndim(rate) == 2 else rate != 0)[0].tolist()
 
 

--- a/src/libecalc/core/models/pump/pump.py
+++ b/src/libecalc/core/models/pump/pump.py
@@ -293,8 +293,8 @@ class PumpSingleSpeed(PumpModel):
         :param fluid_density:
         """
         # Ensure rate is a NumPy array
-        rate = np.array(rate, dtype=np.float64)
-        fluid_density = np.array(fluid_density, dtype=np.float64)
+        rate = np.asfarray(rate)
+        fluid_density = np.asfarray(fluid_density)
 
         # Ensure that the pump does not run when rate is <= 0.
         stream_day_rate = np.where(rate > 0, rate, 0)

--- a/src/libecalc/core/models/pump/pump.py
+++ b/src/libecalc/core/models/pump/pump.py
@@ -63,9 +63,13 @@ class PumpModel(BaseModel):
 
     @staticmethod
     def _calculate_head(
-        ps: NDArray[np.float64], pd: NDArray[np.float64], density: Union[NDArray[np.float64], float]
+        ps: Union[NDArray[np.float64], list[float]],
+        pd: Union[NDArray[np.float64], list[float]],
+        density: Union[NDArray[np.float64], float],
     ) -> NDArray[np.float64]:
         """:return: Head in joule per kg [J/kg]"""
+        ps = np.array(ps, dtype=np.float64)
+        pd = np.array(pd, dtype=np.float64)
         return np.array(Unit.BARA.to(Unit.PASCAL)(pd - ps) / density)
 
     @staticmethod
@@ -288,6 +292,10 @@ class PumpSingleSpeed(PumpModel):
         :param discharge_pressures:
         :param fluid_density:
         """
+        # Ensure rate is a NumPy array
+        rate = np.array(rate, dtype=np.float64)
+        fluid_density = np.array(fluid_density, dtype=np.float64)
+
         # Ensure that the pump does not run when rate is <= 0.
         stream_day_rate = np.where(rate > 0, rate, 0)
 

--- a/src/libecalc/core/models/pump/pump.py
+++ b/src/libecalc/core/models/pump/pump.py
@@ -293,8 +293,8 @@ class PumpSingleSpeed(PumpModel):
         :param fluid_density:
         """
         # Ensure rate is a NumPy array
-        rate = np.asfarray(rate)
-        fluid_density = np.asfarray(fluid_density)
+        rate = np.asarray(rate, dtype=np.float64)
+        fluid_density = np.asarray(fluid_density, dtype=np.float64)
 
         # Ensure that the pump does not run when rate is <= 0.
         stream_day_rate = np.where(rate > 0, rate, 0)

--- a/src/libecalc/domain/infrastructure/__init__.py
+++ b/src/libecalc/domain/infrastructure/__init__.py
@@ -1,5 +1,4 @@
 from libecalc.domain.infrastructure.energy_components.asset.asset import Asset
-from libecalc.domain.infrastructure.energy_components.base.component_dto import BaseConsumer
 from libecalc.domain.infrastructure.energy_components.electricity_consumer.electricity_consumer import (
     ElectricityConsumer,
 )

--- a/src/libecalc/domain/infrastructure/energy_components/asset/asset.py
+++ b/src/libecalc/domain/infrastructure/energy_components/asset/asset.py
@@ -1,23 +1,19 @@
-from typing import Literal
-
 from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.common.component_type import ComponentType
 from libecalc.common.string.string_utils import generate_id
-from libecalc.domain.infrastructure.energy_components.base.component_dto import Component
 from libecalc.domain.infrastructure.energy_components.installation.installation import Installation
 from libecalc.dto.component_graph import ComponentGraph
 
 
-class Asset(Component, EnergyComponent):
+class Asset(EnergyComponent):
     def __init__(
         self,
         name: str,
         installations: list[Installation],
-        component_type: Literal[ComponentType.ASSET] = ComponentType.ASSET,
     ):
         self.name = name
         self.installations = installations
-        self.component_type = component_type
+        self.component_type = ComponentType.ASSET
 
     @property
     def id(self):

--- a/src/libecalc/domain/infrastructure/energy_components/asset/asset.py
+++ b/src/libecalc/domain/infrastructure/energy_components/asset/asset.py
@@ -1,7 +1,5 @@
 from typing import Literal
 
-from pydantic import Field
-
 from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.common.component_type import ComponentType
 from libecalc.common.string.string_utils import generate_id
@@ -12,14 +10,19 @@ from libecalc.dto.utils.validators import ComponentNameStr
 
 
 class Asset(Component, EnergyComponent):
+    def __init__(
+        self,
+        name: ComponentNameStr,
+        installations: list[Installation],
+        component_type: Literal[ComponentType.ASSET] = ComponentType.ASSET,
+    ):
+        self.name = name
+        self.installations = installations
+        self.component_type = component_type
+
     @property
     def id(self):
         return generate_id(self.name)
-
-    name: ComponentNameStr
-
-    installations: list[Installation] = Field(default_factory=list)
-    component_type: Literal[ComponentType.ASSET] = ComponentType.ASSET
 
     def is_fuel_consumer(self) -> bool:
         return True

--- a/src/libecalc/domain/infrastructure/energy_components/asset/asset.py
+++ b/src/libecalc/domain/infrastructure/energy_components/asset/asset.py
@@ -6,13 +6,12 @@ from libecalc.common.string.string_utils import generate_id
 from libecalc.domain.infrastructure.energy_components.base.component_dto import Component
 from libecalc.domain.infrastructure.energy_components.installation.installation import Installation
 from libecalc.dto.component_graph import ComponentGraph
-from libecalc.dto.utils.validators import ComponentNameStr
 
 
 class Asset(Component, EnergyComponent):
     def __init__(
         self,
-        name: ComponentNameStr,
+        name: str,
         installations: list[Installation],
         component_type: Literal[ComponentType.ASSET] = ComponentType.ASSET,
     ):

--- a/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional, Union
 
-from pydantic_core.core_schema import ValidationInfo
-
 from libecalc.application.energy.emitter import Emitter
 from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.common.component_type import ComponentType
@@ -60,7 +58,7 @@ class BaseEquipment(BaseComponent, ABC):
         max_usage_from_shore: Optional[Expression] = None,
     ):
         super().__init__(name, regularity)
-        self.user_defined_category = self.check_user_defined_category(user_defined_category)
+        self.user_defined_category = self.check_user_defined_category(user_defined_category, name)
         self.energy_usage_model = energy_usage_model
         self.component_type = component_type
         self.fuel = fuel
@@ -74,20 +72,15 @@ class BaseEquipment(BaseComponent, ABC):
         return generate_id(self.name)
 
     @classmethod
-    def check_user_defined_category(cls, user_defined_category, info: ValidationInfo = None):
+    def check_user_defined_category(cls, user_defined_category, name: str):
         """Provide which value and context to make it easier for user to correct wrt mandatory changes."""
         if isinstance(user_defined_category, dict) and len(user_defined_category.values()) > 0:
             user_defined_category = _convert_keys_in_dictionary_from_str_to_periods(user_defined_category)
             for user_category in user_defined_category.values():
                 if user_category not in list(ConsumerUserDefinedCategoryType):
-                    name_context_str = ""
-                    if (name := info.data.get("name")) is not None:
-                        name_context_str = f"with the name {name}"
-
                     raise ValueError(
-                        f"CATEGORY: {user_category} is not allowed for {cls.__name__} {name_context_str}. Valid categories are: {[(consumer_user_defined_category.value) for consumer_user_defined_category in ConsumerUserDefinedCategoryType]}"
+                        f"CATEGORY: {user_category} is not allowed for {cls.__name__} with name {name}. Valid categories are: {[(consumer_user_defined_category.value) for consumer_user_defined_category in ConsumerUserDefinedCategoryType]}"
                     )
-
         return user_defined_category
 
 

--- a/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import Optional
 
-from libecalc.application.energy.emitter import Emitter
-from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.common.component_type import ComponentType
 from libecalc.common.consumption_type import ConsumptionType
 from libecalc.common.string.string_utils import generate_id
@@ -55,20 +53,12 @@ class BaseEquipment(BaseComponent, ABC):
         component_type: ComponentType,
         energy_usage_model: Optional[dict[Period, Expression]] = None,
         fuel: Optional[dict[Period, FuelType]] = None,
-        generator_set_model: Optional[dict[Period, Union[BaseEquipment, Emitter, EnergyComponent]]] = None,
-        consumers: Optional[list[BaseEquipment]] = None,
-        cable_loss: Optional[Expression] = None,
-        max_usage_from_shore: Optional[Expression] = None,
     ):
         super().__init__(name, regularity)
         self.user_defined_category = user_defined_category
         self.energy_usage_model = energy_usage_model
         self.component_type = component_type
         self.fuel = fuel
-        self.generator_set_model = generator_set_model
-        self.consumers = consumers
-        self.cable_loss = cable_loss
-        self.max_usage_from_shore = max_usage_from_shore
 
     @property
     def id(self) -> str:

--- a/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
@@ -1,9 +1,12 @@
-from abc import ABC, abstractmethod
-from typing import Optional
+from __future__ import annotations
 
-from pydantic import ConfigDict, Field, field_validator
+from abc import ABC, abstractmethod
+from typing import Optional, Union
+
 from pydantic_core.core_schema import ValidationInfo
 
+from libecalc.application.energy.emitter import Emitter
+from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.common.component_type import ComponentType
 from libecalc.common.consumption_type import ConsumptionType
 from libecalc.common.string.string_utils import generate_id
@@ -11,7 +14,6 @@ from libecalc.common.time_utils import Period
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
 from libecalc.domain.infrastructure.energy_components.utils import _convert_keys_in_dictionary_from_str_to_periods
-from libecalc.dto.base import EcalcBaseModel
 from libecalc.dto.fuel_type import FuelType
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.dto.utils.validators import (
@@ -22,7 +24,7 @@ from libecalc.dto.utils.validators import (
 from libecalc.expression import Expression
 
 
-class Component(EcalcBaseModel, ABC):
+class Component(ABC):
     component_type: ComponentType
 
     @property
@@ -31,13 +33,11 @@ class Component(EcalcBaseModel, ABC):
 
 
 class BaseComponent(Component, ABC):
-    name: ComponentNameStr
+    def __init__(self, name: ComponentNameStr, regularity: dict[Period, Expression]):
+        self.name = name
+        self.regularity = self.check_regularity(regularity)
+        validate_temporal_model(self.regularity)
 
-    regularity: dict[Period, Expression]
-
-    _validate_base_temporal_model = field_validator("regularity")(validate_temporal_model)
-
-    @field_validator("regularity", mode="before")
     @classmethod
     def check_regularity(cls, regularity):
         if isinstance(regularity, dict) and len(regularity.values()) > 0:
@@ -46,14 +46,35 @@ class BaseComponent(Component, ABC):
 
 
 class BaseEquipment(BaseComponent, ABC):
-    user_defined_category: dict[Period, ConsumerUserDefinedCategoryType] = Field(..., validate_default=True)
+    def __init__(
+        self,
+        name: ComponentNameStr,
+        regularity: dict[Period, Expression],
+        user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
+        component_type: ComponentType,
+        energy_usage_model: Optional[dict[Period, Expression]] = None,
+        fuel: Optional[dict[Period, FuelType]] = None,
+        generator_set_model: Optional[dict[Period, Union[BaseEquipment, Emitter, EnergyComponent]]] = None,
+        consumers: Optional[list[BaseEquipment]] = None,
+        cable_loss: Optional[Expression] = None,
+        max_usage_from_shore: Optional[Expression] = None,
+    ):
+        super().__init__(name, regularity)
+        self.user_defined_category = self.check_user_defined_category(user_defined_category)
+        self.energy_usage_model = energy_usage_model
+        self.component_type = component_type
+        self.fuel = fuel
+        self.generator_set_model = generator_set_model
+        self.consumers = consumers
+        self.cable_loss = cable_loss
+        self.max_usage_from_shore = max_usage_from_shore
 
     @property
     def id(self) -> str:
         return generate_id(self.name)
 
-    @field_validator("user_defined_category", mode="before")
-    def check_user_defined_category(cls, user_defined_category, info: ValidationInfo):
+    @classmethod
+    def check_user_defined_category(cls, user_defined_category, info: ValidationInfo = None):
         """Provide which value and context to make it easier for user to correct wrt mandatory changes."""
         if isinstance(user_defined_category, dict) and len(user_defined_category.values()) > 0:
             user_defined_category = _convert_keys_in_dictionary_from_str_to_periods(user_defined_category)
@@ -73,34 +94,53 @@ class BaseEquipment(BaseComponent, ABC):
 class BaseConsumer(BaseEquipment, ABC):
     """Base class for all consumers."""
 
-    consumes: ConsumptionType
-    fuel: Optional[dict[Period, FuelType]] = None
+    def __init__(
+        self,
+        name: ComponentNameStr,
+        regularity: dict[Period, Expression],
+        consumes: ConsumptionType,
+        user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
+        component_type: ComponentType,
+        energy_usage_model: Optional[dict[Period, Expression]] = None,
+        fuel: Optional[dict[Period, FuelType]] = None,
+    ):
+        super().__init__(name, regularity, user_defined_category, component_type, energy_usage_model, fuel)
 
-    @field_validator("fuel", mode="before")
+        self.fuel = self.validate_fuel_exist(name=self.name, fuel=fuel, consumes=consumes)
+        self.consumes = consumes
+
     @classmethod
-    def validate_fuel_exist(cls, fuel, info: ValidationInfo):
+    def validate_fuel_exist(cls, name: str, fuel: Optional[dict[Period, FuelType]], consumes: ConsumptionType):
         """
         Make sure fuel is set if consumption type is FUEL.
         """
         if isinstance(fuel, dict) and len(fuel.values()) > 0:
             fuel = _convert_keys_in_dictionary_from_str_to_periods(fuel)
-        if info.data.get("consumes") == ConsumptionType.FUEL and (fuel is None or len(fuel) < 1):
-            msg = f"Missing fuel for fuel consumer '{info.data.get('name')}'"
+        if consumes == ConsumptionType.FUEL and (fuel is None or len(fuel) < 1):
+            msg = f"Missing fuel for fuel consumer '{name}'"
             raise ValueError(msg)
         return fuel
 
 
-class ExpressionTimeSeries(EcalcBaseModel):
-    value: ExpressionType
-    unit: Unit
-    type: Optional[RateType] = None
+class ExpressionTimeSeries:
+    def __init__(self, value: ExpressionType, unit: Unit, type: Optional[RateType] = None):
+        self.value = value
+        self.unit = unit
+        self.type = type
 
 
-class ExpressionStreamConditions(EcalcBaseModel):
-    rate: Optional[ExpressionTimeSeries] = None
-    pressure: Optional[ExpressionTimeSeries] = None
-    temperature: Optional[ExpressionTimeSeries] = None
-    fluid_density: Optional[ExpressionTimeSeries] = None
+class ExpressionStreamConditions:
+    def __init__(
+        self,
+        rate: Optional[ExpressionTimeSeries] = None,
+        pressure: Optional[ExpressionTimeSeries] = None,
+        temperature: Optional[ExpressionTimeSeries] = None,
+        fluid_density: Optional[ExpressionTimeSeries] = None,
+    ):
+        self.rate = rate
+        self.pressure = pressure
+        self.temperature = temperature
+        self.fluid_density = fluid_density
 
 
 ConsumerID = str
@@ -110,13 +150,13 @@ StreamID = str
 SystemStreamConditions = dict[ConsumerID, dict[StreamID, ExpressionStreamConditions]]
 
 
-class Crossover(EcalcBaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+class Crossover:
+    def __init__(self, from_component_id: str, to_component_id: str, stream_name: Optional[str] = None):
+        self.stream_name = stream_name
+        self.from_component_id = from_component_id
+        self.to_component_id = to_component_id
 
-    stream_name: Optional[str] = Field(None)
-    from_component_id: str
-    to_component_id: str
 
-
-class SystemComponentConditions(EcalcBaseModel):
-    crossover: list[Crossover]
+class SystemComponentConditions:
+    def __init__(self, crossover: list[Crossover]):
+        self.crossover = crossover

--- a/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
@@ -15,7 +15,6 @@ from libecalc.domain.infrastructure.energy_components.utils import _convert_keys
 from libecalc.dto.fuel_type import FuelType
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.dto.utils.validators import (
-    ComponentNameStr,
     ExpressionType,
     validate_temporal_model,
 )
@@ -31,7 +30,7 @@ class Component(ABC):
 
 
 class BaseComponent(Component, ABC):
-    def __init__(self, name: ComponentNameStr, regularity: dict[Period, Expression]):
+    def __init__(self, name: str, regularity: dict[Period, Expression]):
         self.name = name
         self.regularity = self.check_regularity(regularity)
         validate_temporal_model(self.regularity)
@@ -46,7 +45,7 @@ class BaseComponent(Component, ABC):
 class BaseEquipment(BaseComponent, ABC):
     def __init__(
         self,
-        name: ComponentNameStr,
+        name: str,
         regularity: dict[Period, Expression],
         user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
         component_type: ComponentType,
@@ -89,7 +88,7 @@ class BaseConsumer(BaseEquipment, ABC):
 
     def __init__(
         self,
-        name: ComponentNameStr,
+        name: str,
         regularity: dict[Period, Expression],
         consumes: ConsumptionType,
         user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],

--- a/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/base/component_dto.py
@@ -61,7 +61,7 @@ class BaseEquipment(BaseComponent, ABC):
         max_usage_from_shore: Optional[Expression] = None,
     ):
         super().__init__(name, regularity)
-        self.user_defined_category = self.check_user_defined_category(user_defined_category, name)
+        self.user_defined_category = user_defined_category
         self.energy_usage_model = energy_usage_model
         self.component_type = component_type
         self.fuel = fuel
@@ -73,31 +73,6 @@ class BaseEquipment(BaseComponent, ABC):
     @property
     def id(self) -> str:
         return generate_id(self.name)
-
-    @classmethod
-    def check_user_defined_category(
-        cls, user_defined_category, name: str
-    ):  # TODO: Check if this is needed. Should be handled in yaml validation
-        """Provide which value and context to make it easier for user to correct wrt mandatory changes."""
-
-        if isinstance(user_defined_category, dict) and len(user_defined_category.values()) > 0:
-            user_defined_category = _convert_keys_in_dictionary_from_str_to_periods(user_defined_category)
-            for user_category in user_defined_category.values():
-                if user_category not in list(ConsumerUserDefinedCategoryType):
-                    msg = (
-                        f"CATEGORY: {user_category} is not allowed for {cls.__name__}. Valid categories are: "
-                        f"{[(consumer_user_defined_category.value) for consumer_user_defined_category in ConsumerUserDefinedCategoryType]}"
-                    )
-
-                    raise ComponentValidationException(
-                        errors=[
-                            ModelValidationError(
-                                name=name,
-                                message=str(msg),
-                            )
-                        ]
-                    )
-        return user_defined_category
 
 
 class BaseConsumer(BaseEquipment, ABC):

--- a/src/libecalc/domain/infrastructure/energy_components/common.py
+++ b/src/libecalc/domain/infrastructure/energy_components/common.py
@@ -1,6 +1,4 @@
-from typing import Annotated, Literal, Optional, TypeVar, Union
-
-from pydantic import ConfigDict, Field
+from typing import Literal, Optional, TypeVar, Union
 
 from libecalc.common.component_type import ComponentType
 from libecalc.domain.infrastructure.energy_components.asset.asset import Asset
@@ -14,10 +12,9 @@ from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consume
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_dto import GeneratorSet
 from libecalc.domain.infrastructure.energy_components.installation.installation import Installation
 from libecalc.domain.infrastructure.energy_components.pump.component_dto import PumpComponent
-from libecalc.dto.base import EcalcBaseModel
 from libecalc.expression import Expression
 
-Consumer = Annotated[Union[FuelConsumer, ElectricityConsumer], Field(discriminator="consumes")]
+Consumer = Union[FuelConsumer, ElectricityConsumer]
 
 ComponentDTO = Union[
     Asset,
@@ -31,36 +28,46 @@ ComponentDTO = Union[
 ]
 
 
-class CompressorOperationalSettings(EcalcBaseModel):
-    rate: Expression
-    inlet_pressure: Expression
-    outlet_pressure: Expression
+class CompressorOperationalSettings:
+    def __init__(self, rate: Expression, inlet_pressure: Expression, outlet_pressure: Expression):
+        self.rate = rate
+        self.inlet_pressure = inlet_pressure
+        self.outlet_pressure = outlet_pressure
 
 
-class PumpOperationalSettings(EcalcBaseModel):
-    rate: Expression
-    inlet_pressure: Expression
-    outlet_pressure: Expression
-    fluid_density: Expression
+class PumpOperationalSettings:
+    def __init__(
+        self, rate: Expression, inlet_pressure: Expression, outlet_pressure: Expression, fluid_density: Expression
+    ):
+        self.rate = rate
+        self.inlet_pressure = inlet_pressure
+        self.outlet_pressure = outlet_pressure
+        self.fluid_density = fluid_density
 
 
-class Stream(EcalcBaseModel):
-    model_config = ConfigDict(populate_by_name=True)
-
-    stream_name: Optional[str] = Field(None)
-    from_component_id: str
-    to_component_id: str
+class Stream:
+    def __init__(self, from_component_id: str, to_component_id: str, stream_name: Optional[str] = None):
+        self.stream_name = stream_name
+        self.from_component_id = from_component_id
+        self.to_component_id = to_component_id
 
 
 ConsumerComponent = TypeVar("ConsumerComponent", bound=Union[CompressorComponent, PumpComponent])
 
 
 class TrainComponent(BaseConsumer):
-    component_type: Literal[ComponentType.TRAIN_V2] = Field(
-        ComponentType.TRAIN_V2,
-        title="TYPE",
-        description="The type of the component",
-        alias="TYPE",
-    )
-    stages: list[ConsumerComponent]
-    streams: list[Stream]
+    component_type: Literal[ComponentType.TRAIN_V2] = ComponentType.TRAIN_V2
+
+    def __init__(
+        self,
+        name: str,
+        regularity: dict,
+        consumes,
+        user_defined_category: dict,
+        component_type: ComponentType,
+        stages: list,
+        streams: list,
+    ):
+        super().__init__(name, regularity, consumes, user_defined_category, component_type)
+        self.stages = stages
+        self.streams = streams

--- a/src/libecalc/domain/infrastructure/energy_components/component_validation_error.py
+++ b/src/libecalc/domain/infrastructure/energy_components/component_validation_error.py
@@ -51,3 +51,13 @@ class ComponentValidationException(Exception):
 
     def errors(self) -> list[ModelValidationError]:
         return self._errors
+
+
+class ComponentDtoValidationError(Exception):
+    def __init__(self, errors: list[ModelValidationError]):
+        self.errors = errors
+        messages = [str(error) for error in errors]
+        super().__init__("\n".join(messages))
+
+    def error_count(self):
+        return len(self.errors)

--- a/src/libecalc/domain/infrastructure/energy_components/component_validation_error.py
+++ b/src/libecalc/domain/infrastructure/energy_components/component_validation_error.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import yaml
+
+from libecalc.presentation.yaml.file_context import FileContext
+from libecalc.presentation.yaml.validation_errors import Location
+
+
+@dataclass
+class ModelValidationError:
+    message: str
+    name: Optional[str] = None
+    location: Optional[Location] = None
+    data: Optional[dict] = None
+    file_context: Optional[FileContext] = None
+
+    @property
+    def yaml(self) -> Optional[str]:
+        if self.data is None:
+            return None
+
+        return yaml.dump(self.data, sort_keys=False).strip()
+
+    def error_message(self):
+        msg = ""
+        if self.file_context is not None:
+            msg += f"Object starting on line {self.file_context.start.line_number}\n"
+        yaml = self.yaml
+        if yaml is not None:
+            msg += "...\n"
+            msg += yaml
+            msg += "\n...\n\n"
+
+        if self.location is not None and not self.location.is_empty():
+            msg += f"Location: {self.location.as_dot_separated()}\n"
+
+        if self.name is not None:
+            msg += f"Name: {self.name}\n"
+
+        msg += f"Message: {self.message}\n"
+        return msg
+
+    def __str__(self):
+        return self.error_message()
+
+
+class ComponentValidationException(Exception):
+    def __init__(self, errors: list[ModelValidationError]):
+        self._errors = errors
+
+    def errors(self) -> list[ModelValidationError]:
+        return self._errors

--- a/src/libecalc/domain/infrastructure/energy_components/compressor/component_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/compressor/component_dto.py
@@ -1,16 +1,68 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.common.component_type import ComponentType
 from libecalc.common.consumption_type import ConsumptionType
+from libecalc.common.string.string_utils import generate_id
 from libecalc.common.time_utils import Period
-from libecalc.domain.infrastructure.energy_components.base.component_dto import BaseConsumer
-from libecalc.dto.models.compressor import CompressorModel
+from libecalc.domain.infrastructure.energy_components.component_validation_error import (
+    ComponentValidationException,
+    ModelValidationError,
+)
+from libecalc.domain.infrastructure.energy_components.utils import _convert_keys_in_dictionary_from_str_to_periods
+from libecalc.dto import FuelType
+from libecalc.dto.types import ConsumerUserDefinedCategoryType
+from libecalc.dto.utils.validators import validate_temporal_model
+from libecalc.expression import Expression
 
 
-class CompressorComponent(BaseConsumer, EnergyComponent):
+class CompressorComponent(EnergyComponent):
     component_type: Literal[ComponentType.COMPRESSOR] = ComponentType.COMPRESSOR
-    energy_usage_model: dict[Period, CompressorModel]
+
+    def __init__(
+        self,
+        name: str,
+        regularity: dict[Period, Expression],
+        consumes: ConsumptionType,
+        user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
+        energy_usage_model: Optional[dict[Period, Expression]] = None,
+        fuel: Optional[dict[Period, FuelType]] = None,
+        component_type: Optional[ComponentType] = ComponentType.COMPRESSOR,
+    ):
+        self.name = name
+        self.regularity = self.check_regularity(regularity)
+        validate_temporal_model(self.regularity)
+        self.user_defined_category = user_defined_category
+        self.energy_usage_model = energy_usage_model
+        self.fuel = self.validate_fuel_exist(name=self.name, fuel=fuel, consumes=consumes)
+        self.consumes = consumes
+        self.component_type = component_type
+
+    @property
+    def id(self) -> str:
+        return generate_id(self.name)
+
+    @staticmethod
+    def check_regularity(regularity):
+        if isinstance(regularity, dict) and len(regularity.values()) > 0:
+            regularity = _convert_keys_in_dictionary_from_str_to_periods(regularity)
+        return regularity
+
+    @staticmethod
+    def validate_fuel_exist(name: str, fuel: Optional[dict[Period, FuelType]], consumes: ConsumptionType):
+        if isinstance(fuel, dict) and len(fuel.values()) > 0:
+            fuel = _convert_keys_in_dictionary_from_str_to_periods(fuel)
+        if consumes == ConsumptionType.FUEL and (fuel is None or len(fuel) < 1):
+            msg = "Missing fuel for fuel consumer"
+            raise ComponentValidationException(
+                errors=[
+                    ModelValidationError(
+                        name=name,
+                        message=str(msg),
+                    )
+                ],
+            )
+        return fuel
 
     def is_fuel_consumer(self) -> bool:
         return self.consumes == ConsumptionType.FUEL

--- a/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
@@ -31,6 +31,10 @@ from libecalc.domain.infrastructure.energy_components.base.component_dto import 
     SystemComponentConditions,
     SystemStreamConditions,
 )
+from libecalc.domain.infrastructure.energy_components.component_validation_error import (
+    ComponentValidationException,
+    ModelValidationError,
+)
 from libecalc.domain.infrastructure.energy_components.compressor import Compressor
 from libecalc.domain.infrastructure.energy_components.compressor.component_dto import CompressorComponent
 from libecalc.domain.infrastructure.energy_components.consumer_system.consumer_system import (
@@ -261,7 +265,14 @@ def create_consumer(
             model_for_period = energy_usage_model
 
     if model_for_period is None:
-        raise ValueError(f"Could not find model for consumer {consumer.name} at timestep {period}")
+        raise ComponentValidationException(
+            errors=[
+                ModelValidationError(
+                    name=consumer.name,
+                    message=f"Could not find model at timestep {period}",
+                )
+            ]
+        )
 
     if consumer.component_type in {ComponentType.COMPRESSOR, ComponentType.COMPRESSOR_V2}:
         return Compressor(

--- a/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
@@ -1,8 +1,6 @@
 from collections import defaultdict
 from typing import Literal, Optional, Union
 
-from pydantic import Field
-
 from libecalc.application.energy.component_energy_context import ComponentEnergyContext
 from libecalc.application.energy.emitter import Emitter
 from libecalc.application.energy.energy_component import EnergyComponent
@@ -41,20 +39,36 @@ from libecalc.domain.infrastructure.energy_components.consumer_system.consumer_s
 from libecalc.domain.infrastructure.energy_components.fuel_model.fuel_model import FuelModel
 from libecalc.domain.infrastructure.energy_components.pump import Pump
 from libecalc.domain.infrastructure.energy_components.pump.component_dto import PumpComponent
+from libecalc.dto import FuelType
 from libecalc.dto.component_graph import ComponentGraph
+from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.expression import Expression
 
 
 class ConsumerSystem(BaseConsumer, Emitter, EnergyComponent):
-    component_type: Literal[ComponentType.CONSUMER_SYSTEM_V2] = Field(
-        ComponentType.CONSUMER_SYSTEM_V2,
-        title="TYPE",
-        description="The type of the component",
-    )
-
-    component_conditions: SystemComponentConditions
-    stream_conditions_priorities: Priorities[SystemStreamConditions]
-    consumers: Union[list[CompressorComponent], list[PumpComponent]]
+    def __init__(
+        self,
+        name: str,
+        user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
+        regularity: dict[Period, Expression],
+        consumes: ConsumptionType,
+        component_conditions: SystemComponentConditions,
+        stream_conditions_priorities: Priorities[SystemStreamConditions],
+        consumers: Union[list[CompressorComponent], list[PumpComponent]],
+        fuel: Optional[dict[Period, FuelType]] = None,
+        component_type: Literal[ComponentType.CONSUMER_SYSTEM_V2] = ComponentType.CONSUMER_SYSTEM_V2,
+    ):
+        super().__init__(
+            component_type=component_type,
+            name=name,
+            user_defined_category=user_defined_category,
+            regularity=regularity,
+            consumes=consumes,
+            fuel=fuel,
+        )
+        self.component_conditions = component_conditions
+        self.stream_conditions_priorities = stream_conditions_priorities
+        self.consumers = consumers
 
     def is_fuel_consumer(self) -> bool:
         return self.consumes == ConsumptionType.FUEL

--- a/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
@@ -207,34 +207,40 @@ class ConsumerSystem(BaseConsumer, Emitter, EnergyComponent):
                             periods=expression_evaluator.get_periods(),
                             values=list(
                                 expression_evaluator.evaluate(
-                                    Expression.setup_from_expression(stream_conditions.rate.value)
+                                    Expression.setup_from_expression(stream_conditions["rate"].value)
                                 )
                             ),
-                            unit=stream_conditions.rate.unit,
+                            unit=stream_conditions["rate"].unit,
                         )
-                        if stream_conditions.rate is not None
+                        if stream_conditions and "rate" in stream_conditions and stream_conditions["rate"] is not None
                         else None,
                         pressure=TimeSeriesFloat(
                             periods=expression_evaluator.get_periods(),
                             values=list(
                                 expression_evaluator.evaluate(
-                                    expression=Expression.setup_from_expression(stream_conditions.pressure.value)
+                                    expression=Expression.setup_from_expression(stream_conditions["pressure"].value)
                                 )
                             ),
-                            unit=stream_conditions.pressure.unit,
+                            unit=stream_conditions["pressure"].unit,
                         )
-                        if stream_conditions.pressure is not None
+                        if stream_conditions
+                        and "pressure" in stream_conditions
+                        and stream_conditions["pressure"] is not None
                         else None,
                         fluid_density=TimeSeriesFloat(
                             periods=expression_evaluator.get_periods(),
                             values=list(
                                 expression_evaluator.evaluate(
-                                    expression=Expression.setup_from_expression(stream_conditions.fluid_density.value)
+                                    expression=Expression.setup_from_expression(
+                                        stream_conditions["fluid_density"].value
+                                    )
                                 )
                             ),
-                            unit=stream_conditions.fluid_density.unit,
+                            unit=stream_conditions["fluid_density"].unit,
                         )
-                        if stream_conditions.fluid_density is not None
+                        if stream_conditions
+                        and "fluid_density" in stream_conditions
+                        and stream_conditions["fluid_density"] is not None
                         else None,
                     )
                     for stream_name, stream_conditions in streams_conditions.items()
@@ -257,14 +263,14 @@ def create_consumer(
     if model_for_period is None:
         raise ValueError(f"Could not find model for consumer {consumer.name} at timestep {period}")
 
-    if consumer.component_type == ComponentType.COMPRESSOR:
+    if consumer.component_type in {ComponentType.COMPRESSOR, ComponentType.COMPRESSOR_V2}:
         return Compressor(
             id=consumer.id,
             compressor_model=create_compressor_model(
                 compressor_model_dto=model_for_period,
             ),
         )
-    elif consumer.component_type == ComponentType.PUMP:
+    elif consumer.component_type in {ComponentType.PUMP, ComponentType.PUMP_V2}:
         return Pump(
             id=consumer.id,
             pump_model=create_pump_model(

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set.py
@@ -18,6 +18,10 @@ from libecalc.common.utils.rates import (
 from libecalc.common.variables import ExpressionEvaluator
 from libecalc.core.models.generator import GeneratorModelSampled
 from libecalc.core.result import GeneratorSetResult
+from libecalc.domain.infrastructure.energy_components.component_validation_error import (
+    ComponentValidationException,
+    ModelValidationError,
+)
 
 
 class Genset:
@@ -48,7 +52,14 @@ class Genset:
         assert power_requirement.unit == Unit.MEGA_WATT
 
         if not len(power_requirement) == len(expression_evaluator.get_periods()):
-            raise ValueError("length of power_requirement does not match the time vector.")
+            raise ComponentValidationException(
+                errors=[
+                    ModelValidationError(
+                        name=self.name,
+                        message="length of power_requirement does not match the time vector.",
+                    )
+                ]
+            )
 
         # Compute fuel consumption from power rate.
         fuel_rate = self.evaluate_fuel_rate(

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_dto.py
@@ -149,13 +149,23 @@ class GeneratorSet(Emitter, EnergyComponent):
             generator_set_model = _convert_keys_in_dictionary_from_str_to_periods(generator_set_model)
         return generator_set_model
 
-    @staticmethod
-    def check_fuel(fuel: dict[Period, FuelType]):
+    def check_fuel(self, fuel: dict[Period, FuelType]):
         """
-        Make sure that temporal models are converted to Period objects if they are strings
+        Make sure that temporal models are converted to Period objects if they are strings,
+        and that fuel is set
         """
         if isinstance(fuel, dict) and len(fuel.values()) > 0:
             fuel = _convert_keys_in_dictionary_from_str_to_periods(fuel)
+        if self.is_fuel_consumer() and (fuel is None or len(fuel) < 1):
+            msg = "Missing fuel for generator set"
+            raise ComponentValidationException(
+                errors=[
+                    ModelValidationError(
+                        name=self.name,
+                        message=str(msg),
+                    )
+                ],
+            )
         return fuel
 
     def check_consumers(self):

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_dto.py
@@ -52,8 +52,7 @@ class GeneratorSet(BaseEquipment, Emitter, EnergyComponent):
             name,
             regularity,
             user_defined_category,
-            ComponentType.GENERATOR_SET,
-            generator_set_model=generator_set_model,
+            component_type,
             fuel=fuel,
         )
         self.generator_set_model = self.check_generator_set_model(generator_set_model)

--- a/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
+++ b/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
@@ -5,10 +5,6 @@ from libecalc.common.component_type import ComponentType
 from libecalc.common.string.string_utils import generate_id
 from libecalc.common.time_utils import Period
 from libecalc.domain.infrastructure.energy_components.base.component_dto import BaseComponent
-from libecalc.domain.infrastructure.energy_components.component_validation_error import (
-    ComponentValidationException,
-    ModelValidationError,
-)
 from libecalc.domain.infrastructure.energy_components.consumer_system.consumer_system_dto import ConsumerSystem
 from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consumer import FuelConsumer
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_dto import GeneratorSet
@@ -19,7 +15,6 @@ from libecalc.dto.utils.validators import (
     validate_temporal_model,
 )
 from libecalc.expression import Expression
-from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlVentingEmitter,
 )
@@ -76,22 +71,6 @@ class Installation(BaseComponent, EnergyComponent):
     def convert_expression_installation(self, data):
         # Implement the conversion logic here
         return convert_expression(data)
-
-    def check_fuel_consumers_or_venting_emitters_exist(self):
-        try:
-            if self.fuel_consumers or self.venting_emitters:
-                return self
-        except AttributeError:
-            raise ComponentValidationException(
-                errors=[
-                    ModelValidationError(
-                        name=self.name,
-                        message=f"Keywords are missing:\n It is required to specify at least one of the keywords "
-                        f"{EcalcYamlKeywords.fuel_consumers}, {EcalcYamlKeywords.generator_sets} or "
-                        f"{EcalcYamlKeywords.installation_venting_emitters} in the model.",
-                    )
-                ]
-            ) from None
 
     def get_graph(self) -> ComponentGraph:
         graph = ComponentGraph()

--- a/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
+++ b/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
@@ -4,7 +4,6 @@ from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.common.component_type import ComponentType
 from libecalc.common.string.string_utils import generate_id
 from libecalc.common.time_utils import Period
-from libecalc.domain.infrastructure.energy_components.base.component_dto import BaseComponent
 from libecalc.domain.infrastructure.energy_components.consumer_system.consumer_system_dto import ConsumerSystem
 from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consumer import FuelConsumer
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_dto import GeneratorSet
@@ -20,7 +19,7 @@ from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import 
 )
 
 
-class Installation(BaseComponent, EnergyComponent):
+class Installation(EnergyComponent):
     def __init__(
         self,
         name: str,
@@ -30,7 +29,7 @@ class Installation(BaseComponent, EnergyComponent):
         venting_emitters: Optional[list[YamlVentingEmitter]] = None,
         user_defined_category: Optional[InstallationUserDefinedCategoryType] = None,
     ):
-        super().__init__(name, regularity)
+        self.name = name
         self.hydrocarbon_export = self.convert_expression_installation(hydrocarbon_export)
         self.regularity = self.convert_expression_installation(regularity)
         self.fuel_consumers = fuel_consumers

--- a/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
+++ b/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
@@ -1,7 +1,5 @@
 from typing import Optional, Union
 
-from pydantic_core.core_schema import ValidationInfo
-
 from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.common.component_type import ComponentType
 from libecalc.common.string.string_utils import generate_id
@@ -75,16 +73,12 @@ class Installation(BaseComponent, EnergyComponent):
         # Implement the conversion logic here
         return convert_expression(data)
 
-    def check_user_defined_category(cls, user_defined_category, info: ValidationInfo = None):
+    def check_user_defined_category(self, user_defined_category):
         # Provide which value and context to make it easier for user to correct wrt mandatory changes.
         if user_defined_category is not None:
             if user_defined_category not in list(InstallationUserDefinedCategoryType):
-                name_context_str = ""
-                if (name := info.data.get("name")) is not None:
-                    name_context_str = f"with the name {name}"
-
                 raise ValueError(
-                    f"CATEGORY: {user_defined_category} is not allowed for {cls.__name__} {name_context_str}. Valid categories are: {[str(installation_user_defined_category.value) for installation_user_defined_category in InstallationUserDefinedCategoryType]}"
+                    f"CATEGORY: {user_defined_category} is not allowed for Installation with name {self.name}. Valid categories are: {[str(installation_user_defined_category.value) for installation_user_defined_category in InstallationUserDefinedCategoryType]}"
                 )
 
         return user_defined_category

--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/component.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/component.py
@@ -26,7 +26,6 @@ from libecalc.core.result.results import (
     GenericComponentResult,
     PumpResult,
 )
-from libecalc.domain.infrastructure.energy_components.base import BaseConsumer
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function import (
     ConsumerFunction,
     ConsumerFunctionResult,
@@ -56,7 +55,7 @@ ConsumerOrSystemFunctionResult = Union[ConsumerSystemConsumerFunctionResult, Con
 ConsumerResult = Union[ConsumerSystemResult, PumpResult, CompressorResult]
 
 
-class Consumer(BaseConsumer):
+class Consumer:
     def __init__(
         self,
         id: str,

--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/consumer_function/results.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/consumer_function/results.py
@@ -11,6 +11,10 @@ from numpy.typing import NDArray
 from libecalc.common.logger import logger
 from libecalc.common.time_utils import Periods
 from libecalc.core.models.results.base import EnergyFunctionResult
+from libecalc.domain.infrastructure.energy_components.component_validation_error import (
+    ComponentValidationException,
+    ModelValidationError,
+)
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.types import (
     ConsumerFunctionType,
 )
@@ -94,7 +98,14 @@ class ConsumerFunctionResult(ConsumerFunctionResultBase):
         if not isinstance(self, type(other)):
             msg = "Mixing CONSUMER_SYSTEM with non-CONSUMER_SYSTEM is no longer supported."
             logger.warning(msg)
-            raise ValueError(msg)
+            raise ComponentValidationException(
+                errors=[
+                    ModelValidationError(
+                        name=self.__repr_name__(),
+                        message=msg,
+                    )
+                ]
+            )
 
         for attribute, values in self.__dict__.items():
             other_values = other.__getattribute__(attribute)

--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/operational_setting.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/operational_setting.py
@@ -5,16 +5,14 @@ from typing import Any, Optional
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import BaseModel, ConfigDict, model_validator
 
 from libecalc.common.errors.exceptions import EcalcError, IncompatibleDataError
 from libecalc.common.logger import logger
 from libecalc.common.utils.rates import Rates
-from libecalc.core.utils.array_type import PydanticNDArray
 from libecalc.expression import Expression
 
 
-class ConsumerSystemOperationalSettingExpressions(BaseModel):
+class ConsumerSystemOperationalSettingExpressions:
     """Each index of a setting is aligned with a consumer. The first consumer has rate self.rates[0], etc.
 
     cross_overs: Defines what consumer to send exceeding rates to (Warning! index starts at 1!).
@@ -28,17 +26,25 @@ class ConsumerSystemOperationalSettingExpressions(BaseModel):
     Note that circular references is not possible.
     """
 
-    rates: list[Expression]
-    suction_pressures: list[Expression]
-    discharge_pressures: list[Expression]
-    cross_overs: Optional[list[int]] = None
-    fluid_densities: Optional[list[Expression]] = None
+    def __init__(
+        self,
+        rates: list[Expression],
+        suction_pressures: list[Expression],
+        discharge_pressures: list[Expression],
+        cross_overs: Optional[list[int]] = None,
+        fluid_densities: Optional[list[Expression]] = None,
+    ):
+        self.rates = rates
+        self.suction_pressures = suction_pressures
+        self.discharge_pressures = discharge_pressures
+        self.cross_overs = cross_overs
+        self.fluid_densities = fluid_densities
+        self.check_list_length()
 
     @property
     def number_of_consumers(self):
         return len(self.rates)
 
-    @model_validator(mode="after")
     def check_list_length(self):
         def _log_error(field: str, field_values: list[Any], n_rates) -> None:
             msg = (
@@ -68,20 +74,36 @@ class CompressorSystemOperationalSettingExpressions(ConsumerSystemOperationalSet
 
 
 class PumpSystemOperationalSettingExpressions(ConsumerSystemOperationalSettingExpressions):
-    fluid_densities: list[Expression]
+    def __init__(
+        self,
+        rates: list[Expression],
+        suction_pressures: list[Expression],
+        fluid_densities: list[Expression],
+        discharge_pressures: list[Expression],
+        cross_overs: Optional[list[int]] = None,
+    ):
+        super().__init__(rates, suction_pressures, discharge_pressures, cross_overs)
+        self.fluid_densities = fluid_densities
 
 
-class ConsumerSystemOperationalSetting(BaseModel):
+class ConsumerSystemOperationalSetting:
     """Warning! The methods below are fragile to changes in attribute names and types."""
 
-    rates: list[PydanticNDArray]
-    suction_pressures: list[PydanticNDArray]
-    discharge_pressures: list[PydanticNDArray]
-    cross_overs: Optional[list[int]] = None
-    fluid_densities: Optional[list[PydanticNDArray]] = None
-    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+    def __init__(
+        self,
+        rates: list[NDArray[np.float64]],
+        suction_pressures: list[NDArray[np.float64]],
+        discharge_pressures: list[NDArray[np.float64]],
+        cross_overs: Optional[list[int]] = None,
+        fluid_densities: Optional[list[NDArray[np.float64]]] = None,
+    ):
+        self.rates = rates
+        self.suction_pressures = suction_pressures
+        self.discharge_pressures = discharge_pressures
+        self.cross_overs = cross_overs
+        self.fluid_densities = fluid_densities
+        self.check_list_length()
 
-    @model_validator(mode="after")
     def check_list_length(self):
         def _log_error(field: str, field_values: list[Any], n_rates: int) -> None:
             error_message = (
@@ -142,9 +164,25 @@ class ConsumerSystemOperationalSetting(BaseModel):
         data.update({"rates": rates_after_cross_over})
         return self.__class__(**data)
 
+    def model_copy(self, update: dict) -> ConsumerSystemOperationalSetting:
+        """Create a copy of the current model with updates."""
+        new_model = deepcopy(self)
+        for key, value in update.items():
+            setattr(new_model, key, value)
+        return new_model
+
 
 class CompressorSystemOperationalSetting(ConsumerSystemOperationalSetting): ...
 
 
 class PumpSystemOperationalSetting(ConsumerSystemOperationalSetting):
-    fluid_densities: list[PydanticNDArray]
+    def __init__(
+        self,
+        rates: list[NDArray[np.float64]],
+        suction_pressures: list[NDArray[np.float64]],
+        discharge_pressures: list[NDArray[np.float64]],
+        fluid_densities: list[NDArray[np.float64]],
+        cross_overs: Optional[list[int]] = None,
+    ):
+        super().__init__(rates, suction_pressures, discharge_pressures, cross_overs, fluid_densities)
+        self.fluid_densities = fluid_densities

--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/results.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/results.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal, Optional, Union
+from typing import Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import BaseModel, ConfigDict
 
 from libecalc.common.logger import logger
 from libecalc.common.time_utils import Periods
-from libecalc.core.models.results import CompressorTrainResult, PumpModelResult
+from libecalc.core.models.results import CompressorTrainResult, EnergyFunctionResult, PumpModelResult
 from libecalc.core.result.results import ConsumerModelResult
-from libecalc.core.utils.array_type import PydanticNDArray
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.results import (
     ConsumerFunctionResultBase,
 )
@@ -23,16 +21,17 @@ from libecalc.domain.infrastructure.energy_components.legacy_consumer.system.ope
 )
 
 
-class ConsumerSystemComponentResult(BaseModel):
-    name: str
-    consumer_model_result: Union[PumpModelResult, CompressorTrainResult]
+class ConsumerSystemComponentResult:
+    def __init__(self, name: str, consumer_model_result: Union[PumpModelResult, CompressorTrainResult]):
+        self.name = name
+        self.consumer_model_result = consumer_model_result
 
     @property
     def energy_usage(self) -> list[Optional[float]]:
         return self.consumer_model_result.energy_usage
 
     @property
-    def power(self) -> PydanticNDArray:
+    def power(self) -> NDArray:
         if self.consumer_model_result.power is not None:
             return np.asarray(self.consumer_model_result.power)
         else:
@@ -44,7 +43,8 @@ class ConsumerSystemComponentResult(BaseModel):
 
 
 class PumpResult(ConsumerSystemComponentResult):
-    consumer_model_result: PumpModelResult
+    def __init__(self, name: str, consumer_model_result: PumpModelResult):
+        super().__init__(name, consumer_model_result)
 
     @property
     def fluid_density(self):
@@ -52,15 +52,16 @@ class PumpResult(ConsumerSystemComponentResult):
 
 
 class CompressorResult(ConsumerSystemComponentResult):
-    consumer_model_result: Union[ConsumerModelResult, CompressorTrainResult]
+    def __init__(self, name: str, consumer_model_result: Union[ConsumerModelResult, CompressorTrainResult]):
+        super().__init__(name, consumer_model_result)
 
 
-class ConsumerSystemOperationalSettingResult(BaseModel):
-    consumer_results: list[ConsumerSystemComponentResult]
-    model_config = ConfigDict(frozen=True)
+class ConsumerSystemOperationalSettingResult:
+    def __init__(self, consumer_results: list[ConsumerSystemComponentResult]):
+        self.consumer_results = consumer_results
 
     @property
-    def total_energy_usage(self) -> PydanticNDArray:
+    def total_energy_usage(self) -> NDArray:
         total_energy_usage = np.sum(
             [np.asarray(result.energy_usage) for result in self.consumer_results],
             axis=0,
@@ -68,7 +69,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
         return np.array(total_energy_usage)
 
     @property
-    def total_power(self) -> PydanticNDArray:
+    def total_power(self) -> NDArray:
         total_power = np.sum(
             [np.asarray(result.power) for result in self.consumer_results],
             axis=0,
@@ -76,7 +77,7 @@ class ConsumerSystemOperationalSettingResult(BaseModel):
         return np.array(total_power)
 
     @property
-    def indices_outside_capacity(self) -> PydanticNDArray:
+    def indices_outside_capacity(self) -> NDArray:
         invalid_indices = np.full_like(self.total_energy_usage, fill_value=0)
 
         for result in self.consumer_results:
@@ -110,15 +111,39 @@ class ConsumerSystemConsumerFunctionResult(ConsumerFunctionResultBase):
     data for the energy usage of each consumer in the system in this operational setting.
     """
 
-    typ: Literal[ConsumerFunctionType.SYSTEM] = ConsumerFunctionType.SYSTEM  # type: ignore[valid-type]
-
-    operational_setting_used: PydanticNDArray  # integers in the range of number of operational settings
-    operational_settings: list[list[ConsumerSystemOperationalSetting]]
-    operational_settings_results: list[list[ConsumerSystemOperationalSettingResult]]
-    consumer_results: list[list[ConsumerSystemComponentResult]]
-    cross_over_used: Optional[PydanticNDArray] = (
-        None  # 0 or 1 whether cross over is used for this result (1=True, 0=False)
-    )
+    def __init__(
+        self,
+        operational_setting_used: NDArray,
+        operational_settings: list[list[ConsumerSystemOperationalSetting]],
+        operational_settings_results: list[list[ConsumerSystemOperationalSettingResult]],
+        consumer_results: list[list[ConsumerSystemComponentResult]],
+        cross_over_used: Optional[NDArray] = None,
+        # 0 or 1 whether cross over is used for this result (1=True, 0=False)
+        periods: Periods = None,
+        is_valid: NDArray = None,
+        energy_usage: NDArray = None,
+        energy_usage_before_power_loss_factor: Optional[NDArray] = None,
+        condition: Optional[NDArray] = None,
+        power_loss_factor: Optional[NDArray] = None,
+        energy_function_result: Optional[Union[EnergyFunctionResult, list[EnergyFunctionResult]]] = None,
+        power: Optional[NDArray] = None,
+    ):
+        super().__init__(
+            typ=ConsumerFunctionType.SYSTEM,
+            periods=periods,
+            is_valid=is_valid,
+            energy_usage=energy_usage,
+            energy_usage_before_power_loss_factor=energy_usage_before_power_loss_factor,
+            condition=condition,
+            power_loss_factor=power_loss_factor,
+            energy_function_result=energy_function_result,
+            power=power,
+        )
+        self.operational_setting_used = operational_setting_used
+        self.operational_settings = operational_settings
+        self.operational_settings_results = operational_settings_results
+        self.consumer_results = consumer_results
+        self.cross_over_used = cross_over_used
 
     def extend(self, other) -> ConsumerSystemConsumerFunctionResult:
         if not isinstance(self, type(other)):

--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/results.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/results.py
@@ -10,6 +10,10 @@ from libecalc.common.logger import logger
 from libecalc.common.time_utils import Periods
 from libecalc.core.models.results import CompressorTrainResult, EnergyFunctionResult, PumpModelResult
 from libecalc.core.result.results import ConsumerModelResult
+from libecalc.domain.infrastructure.energy_components.component_validation_error import (
+    ComponentValidationException,
+    ModelValidationError,
+)
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.results import (
     ConsumerFunctionResultBase,
 )
@@ -147,9 +151,16 @@ class ConsumerSystemConsumerFunctionResult(ConsumerFunctionResultBase):
 
     def extend(self, other) -> ConsumerSystemConsumerFunctionResult:
         if not isinstance(self, type(other)):
-            msg = f"{self.__repr_name__()} Mixing CONSUMER_SYSTEM with non-CONSUMER_SYSTEM is no longer supported."
+            msg = "Mixing CONSUMER_SYSTEM with non-CONSUMER_SYSTEM is no longer supported."
             logger.warning(msg)
-            raise ValueError(msg)
+            raise ComponentValidationException(
+                errors=[
+                    ModelValidationError(
+                        name=self.__repr_name__(),
+                        message=msg,
+                    )
+                ]
+            )
 
         for attribute, values in self.__dict__.items():
             other_values = other.__getattribute__(attribute)

--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/types.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/types.py
@@ -1,12 +1,10 @@
 from typing import Union
 
-from pydantic import BaseModel, ConfigDict
-
 from libecalc.core.models.compressor.base import CompressorModel
 from libecalc.core.models.pump import PumpModel
 
 
-class ConsumerSystemComponent(BaseModel):
-    name: str
-    facility_model: Union[PumpModel, CompressorModel]
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+class ConsumerSystemComponent:
+    def __init__(self, name: str, facility_model: Union[PumpModel, CompressorModel]):
+        self.name = name
+        self.facility_model = facility_model

--- a/src/libecalc/domain/infrastructure/energy_components/pump/component_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/pump/component_dto.py
@@ -1,16 +1,60 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.common.component_type import ComponentType
 from libecalc.common.consumption_type import ConsumptionType
+from libecalc.common.string.string_utils import generate_id
 from libecalc.common.time_utils import Period
-from libecalc.domain.infrastructure.energy_components.base.component_dto import BaseConsumer
+from libecalc.domain.infrastructure.energy_components.component_validation_error import (
+    ComponentValidationException,
+    ModelValidationError,
+)
+from libecalc.domain.infrastructure.energy_components.utils import _convert_keys_in_dictionary_from_str_to_periods
+from libecalc.dto import FuelType
 from libecalc.dto.models.pump import PumpModel
+from libecalc.dto.types import ConsumerUserDefinedCategoryType
+from libecalc.dto.utils.validators import validate_temporal_model
+from libecalc.expression import Expression
 
 
-class PumpComponent(BaseConsumer, EnergyComponent):
+class PumpComponent(EnergyComponent):
     component_type: Literal[ComponentType.PUMP] = ComponentType.PUMP
     energy_usage_model: dict[Period, PumpModel]
+
+    def __init__(
+        self,
+        name: str,
+        regularity: dict[Period, Expression],
+        user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
+        component_type: ComponentType,
+        energy_usage_model: dict[Period, PumpModel],
+        consumes: Literal[ConsumptionType.FUEL, ConsumptionType.ELECTRICITY],
+        fuel: Optional[dict[Period, FuelType]] = None,
+    ):
+        self.name = name
+        self.regularity = self.check_regularity(regularity)
+        validate_temporal_model(self.regularity)
+        self.user_defined_category = user_defined_category
+        self.component_type = component_type
+        self.energy_usage_model = self.check_energy_usage_model(energy_usage_model)
+        self.fuel = self.validate_fuel_exist(name=self.name, fuel=fuel, consumes=consumes)
+        self.consumes = consumes
+
+    @property
+    def id(self) -> str:
+        return generate_id(self.name)
+
+    @staticmethod
+    def check_regularity(regularity: dict[Period, Expression]):
+        if isinstance(regularity, dict) and len(regularity.values()) > 0:
+            regularity = _convert_keys_in_dictionary_from_str_to_periods(regularity)
+        return regularity
+
+    @staticmethod
+    def check_energy_usage_model(energy_usage_model: dict[Period, PumpModel]):
+        if isinstance(energy_usage_model, dict) and len(energy_usage_model.values()) > 0:
+            energy_usage_model = _convert_keys_in_dictionary_from_str_to_periods(energy_usage_model)
+        return energy_usage_model
 
     def is_fuel_consumer(self) -> bool:
         return self.consumes == ConsumptionType.FUEL
@@ -29,3 +73,22 @@ class PumpComponent(BaseConsumer, EnergyComponent):
 
     def get_name(self) -> str:
         return self.name
+
+    @classmethod
+    def validate_fuel_exist(cls, name: str, fuel: Optional[dict[Period, FuelType]], consumes: ConsumptionType):
+        """
+        Make sure fuel is set if consumption type is FUEL.
+        """
+        if isinstance(fuel, dict) and len(fuel.values()) > 0:
+            fuel = _convert_keys_in_dictionary_from_str_to_periods(fuel)
+        if consumes == ConsumptionType.FUEL and (fuel is None or len(fuel) < 1):
+            msg = "Missing fuel for fuel consumer"
+            raise ComponentValidationException(
+                errors=[
+                    ModelValidationError(
+                        name=name,
+                        message=str(msg),
+                    )
+                ],
+            )
+        return fuel

--- a/src/libecalc/domain/infrastructure/energy_components/utils.py
+++ b/src/libecalc/domain/infrastructure/energy_components/utils.py
@@ -3,13 +3,23 @@ from typing import Any, Union
 
 from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.time_utils import Period
+from libecalc.domain.infrastructure.energy_components.component_validation_error import (
+    ComponentValidationException,
+    ModelValidationError,
+)
 from libecalc.dto.models import ConsumerFunction
 
 
 def check_model_energy_usage_type(model_data: dict[Period, ConsumerFunction], energy_type: EnergyUsageType):
     for model in model_data.values():
         if model.energy_usage_type != energy_type:
-            raise ValueError(f"Model does not consume {energy_type.value}")
+            raise ComponentValidationException(
+                errors=[
+                    ModelValidationError(
+                        message=f"Model does not consume {energy_type.value}",
+                    )
+                ]
+            )
     return model_data
 
 

--- a/src/libecalc/presentation/yaml/ltp_validation.py
+++ b/src/libecalc/presentation/yaml/ltp_validation.py
@@ -22,7 +22,7 @@ def validate_generator_set_power_from_shore(
 
         if isinstance(category, ConsumerUserDefinedCategoryType):
             if category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
-                message = f"{feedback_text} for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for {category}."
+                message = f"{feedback_text} for the category {ConsumerUserDefinedCategoryType.POWER_FROM_SHORE.value}, not for {category.value}."
                 raise ValueError(message)
         else:
             if ConsumerUserDefinedCategoryType.POWER_FROM_SHORE not in category.values():

--- a/src/libecalc/presentation/yaml/ltp_validation.py
+++ b/src/libecalc/presentation/yaml/ltp_validation.py
@@ -9,17 +9,16 @@ from libecalc.dto.utils.validators import ExpressionType
 def validate_generator_set_power_from_shore(
     cable_loss: ExpressionType,
     max_usage_from_shore: ExpressionType,
-    model_fields: dict,
     category: Union[dict, ConsumerUserDefinedCategoryType],
 ):
     if cable_loss is not None or max_usage_from_shore is not None:
-        feedback_text = (
-            f"{model_fields['cable_loss'].title} and " f"{model_fields['max_usage_from_shore'].title} are only valid"
-        )
+        CABLE_LOSS = "CABLE_LOSS"
+        MAX_USAGE_FROM_SHORE = "MAX_USAGE_FROM_SHORE"
+        feedback_text = f"{CABLE_LOSS} and " f"{MAX_USAGE_FROM_SHORE} are only valid"
         if cable_loss is None:
-            feedback_text = f"{model_fields['max_usage_from_shore'].title} is only valid"
+            feedback_text = f"{MAX_USAGE_FROM_SHORE} is only valid"
         if max_usage_from_shore is None:
-            feedback_text = f"{model_fields['cable_loss'].title} is only valid"
+            feedback_text = f"{CABLE_LOSS} is only valid"
 
         if isinstance(category, ConsumerUserDefinedCategoryType):
             if category is not ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:

--- a/src/libecalc/presentation/yaml/mappers/component_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/component_mapper.py
@@ -228,7 +228,7 @@ class GeneratorSetMapper:
                 user_defined_category=user_defined_category,
                 cable_loss=cable_loss,
                 max_usage_from_shore=max_usage_from_shore,
-                component_type=ComponentType.GENERATOR_SET,  # TODO: Check if this is correct. Why isn´t component_type set for YamlGeneratorSet?
+                component_type=ComponentType.GENERATOR_SET,
             )
         except ValidationError as e:
             raise DtoValidationError(data=data.model_dump(), validation_error=e) from e

--- a/src/libecalc/presentation/yaml/mappers/component_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/component_mapper.py
@@ -152,6 +152,7 @@ class ConsumerMapper:
                     fuel=fuel,
                     energy_usage_model=energy_usage_model,
                     component_type=_get_component_type(energy_usage_model),
+                    consumes=consumes,
                 )
             except ValidationError as e:
                 raise DtoValidationError(data=data.model_dump(), validation_error=e) from e
@@ -166,6 +167,7 @@ class ConsumerMapper:
                     ),
                     energy_usage_model=energy_usage_model,
                     component_type=_get_component_type(energy_usage_model),
+                    consumes=consumes,
                 )
             except ValidationError as e:
                 raise DtoValidationError(data=data.model_dump(), validation_error=e) from e
@@ -226,6 +228,7 @@ class GeneratorSetMapper:
                 user_defined_category=user_defined_category,
                 cable_loss=cable_loss,
                 max_usage_from_shore=max_usage_from_shore,
+                component_type=ComponentType.GENERATOR_SET,  # TODO: Check if this is correct. Why isn´t component_type set for YamlGeneratorSet?
             )
         except ValidationError as e:
             raise DtoValidationError(data=data.model_dump(), validation_error=e) from e

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -9,7 +9,6 @@ from libecalc.application.energy.energy_model import EnergyModel
 from libecalc.common.time_utils import Frequency, Period
 from libecalc.common.variables import ExpressionEvaluator, VariablesMap
 from libecalc.domain.infrastructure.energy_components.component_validation_error import (
-    ComponentDtoValidationError,
     ComponentValidationException,
 )
 from libecalc.dto import ResultOptions
@@ -112,10 +111,8 @@ class YamlModel(EnergyModel):
             references=self._get_reference_service(),
             target_period=self.period,
         )
-        try:
-            return model_mapper.from_yaml_to_dto(configuration=self._configuration)
-        except ComponentValidationException as e:
-            raise ComponentDtoValidationError(errors=e.errors()) from e
+
+        return model_mapper.from_yaml_to_dto(configuration=self._configuration)
 
     @property
     def period(self) -> Period:
@@ -218,5 +215,5 @@ class YamlModel(EnergyModel):
             # Validate and create the graph used for evaluating the energy model
             self.get_graph()
             return self
-        except DtoValidationError as e:
+        except (DtoValidationError, ComponentValidationException) as e:
             raise ModelValidationException(errors=e.errors()) from e

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -8,6 +8,10 @@ from libecalc.application.energy.energy_component import EnergyComponent
 from libecalc.application.energy.energy_model import EnergyModel
 from libecalc.common.time_utils import Frequency, Period
 from libecalc.common.variables import ExpressionEvaluator, VariablesMap
+from libecalc.domain.infrastructure.energy_components.component_validation_error import (
+    ComponentDtoValidationError,
+    ComponentValidationException,
+)
 from libecalc.dto import ResultOptions
 from libecalc.dto.component_graph import ComponentGraph
 from libecalc.expression import Expression
@@ -20,7 +24,11 @@ from libecalc.presentation.yaml.mappers.variables_mapper import map_yaml_to_vari
 from libecalc.presentation.yaml.mappers.variables_mapper.get_global_time_vector import get_global_time_vector
 from libecalc.presentation.yaml.model_validation_exception import ModelValidationException
 from libecalc.presentation.yaml.resource_service import ResourceService
-from libecalc.presentation.yaml.validation_errors import DtoValidationError, Location, ModelValidationError
+from libecalc.presentation.yaml.validation_errors import (
+    DtoValidationError,
+    Location,
+    ModelValidationError,
+)
 from libecalc.presentation.yaml.yaml_models.exceptions import DuplicateKeyError, YamlError
 from libecalc.presentation.yaml.yaml_models.yaml_model import YamlValidator
 from libecalc.presentation.yaml.yaml_validation_context import (
@@ -104,7 +112,10 @@ class YamlModel(EnergyModel):
             references=self._get_reference_service(),
             target_period=self.period,
         )
-        return model_mapper.from_yaml_to_dto(configuration=self._configuration)
+        try:
+            return model_mapper.from_yaml_to_dto(configuration=self._configuration)
+        except ComponentValidationException as e:
+            raise ComponentDtoValidationError(errors=e.errors()) from e
 
     @property
     def period(self) -> Period:

--- a/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
@@ -96,7 +96,6 @@ class PyYamlYamlModel(YamlValidator, YamlConfiguration):
         internal_datamodel = PyYamlYamlModel.read_yaml(
             main_yaml=main_yaml, resources=resources, base_dir=base_dir, enable_include=enable_include
         )
-
         self = cls(internal_datamodel=internal_datamodel, name=main_yaml.name, instantiated_through_read=True)
         return self
 

--- a/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
@@ -446,16 +446,19 @@ class PyYamlYamlModel(YamlValidator, YamlConfiguration):
                 installation_obj = TypeAdapter(YamlInstallation).validate_python(installation)
 
                 # Validate and convert stream_conditions_priorities within the nested structure (remove when solved problem with nested validation)
-                for generator_set in installation_obj.generator_sets:
-                    for consumer in generator_set.consumers:
-                        print(f"Accessing consumer {consumer.name}")
-                        if isinstance(consumer, YamlConsumerSystem) and hasattr(
-                            consumer, "stream_conditions_priorities"
-                        ):
-                            consumer.stream_conditions_priorities = TypeAdapter(YamlPriorities).validate_python(
-                                consumer.stream_conditions_priorities
-                            )
-                            print(f"Stream conditions priorities: {consumer.stream_conditions_priorities.__str__()}")
+                if installation_obj.generator_sets is not None:
+                    for generator_set in installation_obj.generator_sets:
+                        for consumer in generator_set.consumers:
+                            print(f"Accessing consumer {consumer.name}")
+                            if isinstance(consumer, YamlConsumerSystem) and hasattr(
+                                consumer, "stream_conditions_priorities"
+                            ):
+                                consumer.stream_conditions_priorities = TypeAdapter(YamlPriorities).validate_python(
+                                    consumer.stream_conditions_priorities
+                                )
+                                print(
+                                    f"Stream conditions priorities: {consumer.stream_conditions_priorities.__str__()}"
+                                )
 
                 installations.append(installation_obj)
             except PydanticValidationError as e:

--- a/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
@@ -40,10 +40,6 @@ from libecalc.presentation.yaml.yaml_models.exceptions import (
     YamlError,
 )
 from libecalc.presentation.yaml.yaml_models.yaml_model import YamlConfiguration, YamlValidator
-from libecalc.presentation.yaml.yaml_types.components.system.yaml_consumer_system import (
-    YamlConsumerSystem,
-    YamlPriorities,
-)
 from libecalc.presentation.yaml.yaml_types.components.yaml_asset import YamlAsset
 from libecalc.presentation.yaml.yaml_types.components.yaml_installation import YamlInstallation
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import (
@@ -439,30 +435,11 @@ class PyYamlYamlModel(YamlValidator, YamlConfiguration):
 
     @property
     def installations(self) -> Iterable[YamlInstallation]:
-        print("Accessing installations property")
         installations = []
         for installation in self._internal_datamodel.get(EcalcYamlKeywords.installations, []):
             try:
-                installation_obj = TypeAdapter(YamlInstallation).validate_python(installation)
-
-                # Validate and convert stream_conditions_priorities within the nested structure (remove when solved problem with nested validation)
-                if installation_obj.generator_sets is not None:
-                    for generator_set in installation_obj.generator_sets:
-                        for consumer in generator_set.consumers:
-                            print(f"Accessing consumer {consumer.name}")
-                            if isinstance(consumer, YamlConsumerSystem) and hasattr(
-                                consumer, "stream_conditions_priorities"
-                            ):
-                                consumer.stream_conditions_priorities = TypeAdapter(YamlPriorities).validate_python(
-                                    consumer.stream_conditions_priorities
-                                )
-                                print(
-                                    f"Stream conditions priorities: {consumer.stream_conditions_priorities.__str__()}"
-                                )
-
-                installations.append(installation_obj)
-            except PydanticValidationError as e:
-                print(f"Validation error: {e}")
+                installations.append(TypeAdapter(YamlInstallation).validate_python(installation))
+            except PydanticValidationError:
                 pass
         return installations
 

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_compressor.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_compressor.py
@@ -55,4 +55,5 @@ class YamlCompressor(YamlConsumerBase):
                     self.energy_usage_model, target_period=target_period
                 ).items()
             },
+            component_type=self.component_type,
         )

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
@@ -73,7 +73,6 @@ class YamlGeneratorSet(YamlBase):
         _check_power_from_shore_attributes = validate_generator_set_power_from_shore(
             cable_loss=self.cable_loss,
             max_usage_from_shore=self.max_usage_from_shore,
-            model_fields=self.model_fields,
             category=self.category,
         )
         return self

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_pump.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_pump.py
@@ -52,4 +52,5 @@ class YamlPump(YamlConsumerBase):
                     self.energy_usage_model, target_period=target_period
                 ).items()
             },
+            component_type=self.component_type,
         )

--- a/tests/libecalc/core/consumers/conftest.py
+++ b/tests/libecalc/core/consumers/conftest.py
@@ -115,6 +115,7 @@ def genset_2mw_dto(fuel_dto, direct_el_consumer, generator_set_sampled_model_2mw
         },
         consumers=[direct_el_consumer],
         regularity={Period(datetime(1900, 1, 1)): Expression.setup_from_expression(1)},
+        component_type=ComponentType.GENERATOR_SET,
     )
 
 
@@ -129,4 +130,5 @@ def genset_1000mw_late_startup_dto(fuel_dto, direct_el_consumer, generator_set_s
         },
         consumers=[direct_el_consumer],
         regularity={Period(datetime(1900, 1, 1)): Expression.setup_from_expression(1)},
+        component_type=ComponentType.GENERATOR_SET,
     )

--- a/tests/libecalc/core/consumers/system/test_operational_setting.py
+++ b/tests/libecalc/core/consumers/system/test_operational_setting.py
@@ -23,7 +23,6 @@ def test_consumer_system_operational_settings_expression():
     assert operational_settings_expression.number_of_consumers == number_of_consumers
 
 
-@patch.multiple(ConsumerSystemOperationalSetting, __abstractmethods__=set())
 class TestConsumerSystemOperationalSetting:
     def test_operational_setting(self):
         operational_settings = ConsumerSystemOperationalSetting(

--- a/tests/libecalc/core/consumers/system/test_system_utils.py
+++ b/tests/libecalc/core/consumers/system/test_system_utils.py
@@ -329,9 +329,9 @@ def test_assemble_operational_setting_from_model_result_list():
         operational_settings=operational_settings, setting_number_used_per_timestep=setting_number_used_per_timestep
     )
 
-    assert np.array(result.rates[0]).tolist() == [0, 31, 22, 13, 4]
-    assert np.array(result.rates[1]).tolist() == [0, 31, 22, 13, 4]
-    assert np.array(result.suction_pressures[0]).tolist() == [0, 31, 22, 13, 4]
-    assert np.array(result.suction_pressures[1]).tolist() == [0, 31, 22, 13, 4]
-    assert np.array(result.discharge_pressures[0]).tolist() == [0, 31, 22, 13, 4]
-    assert np.array(result.discharge_pressures[1]).tolist() == [0, 31, 22, 13, 4]
+    assert result.rates[0] == [0, 31, 22, 13, 4]
+    assert result.rates[1] == [0, 31, 22, 13, 4]
+    assert result.suction_pressures[0] == [0, 31, 22, 13, 4]
+    assert result.suction_pressures[1] == [0, 31, 22, 13, 4]
+    assert result.discharge_pressures[0] == [0, 31, 22, 13, 4]
+    assert result.discharge_pressures[1] == [0, 31, 22, 13, 4]

--- a/tests/libecalc/core/consumers/system/test_system_utils.py
+++ b/tests/libecalc/core/consumers/system/test_system_utils.py
@@ -329,9 +329,9 @@ def test_assemble_operational_setting_from_model_result_list():
         operational_settings=operational_settings, setting_number_used_per_timestep=setting_number_used_per_timestep
     )
 
-    assert result.rates[0].tolist() == [0, 31, 22, 13, 4]
-    assert result.rates[1].tolist() == [0, 31, 22, 13, 4]
-    assert result.suction_pressures[0].tolist() == [0, 31, 22, 13, 4]
-    assert result.suction_pressures[1].tolist() == [0, 31, 22, 13, 4]
-    assert result.discharge_pressures[0].tolist() == [0, 31, 22, 13, 4]
-    assert result.discharge_pressures[1].tolist() == [0, 31, 22, 13, 4]
+    assert np.array(result.rates[0]).tolist() == [0, 31, 22, 13, 4]
+    assert np.array(result.rates[1]).tolist() == [0, 31, 22, 13, 4]
+    assert np.array(result.suction_pressures[0]).tolist() == [0, 31, 22, 13, 4]
+    assert np.array(result.suction_pressures[1]).tolist() == [0, 31, 22, 13, 4]
+    assert np.array(result.discharge_pressures[0]).tolist() == [0, 31, 22, 13, 4]
+    assert np.array(result.discharge_pressures[1]).tolist() == [0, 31, 22, 13, 4]

--- a/tests/libecalc/core/models/chart/test_chart_curve.py
+++ b/tests/libecalc/core/models/chart/test_chart_curve.py
@@ -180,7 +180,7 @@ def test_interpolation_functions():
     assert not (np.asarray(chart_curve.rate_head_and_efficiency_at_minimum_rate) - [336.0, 1778.7, 0.4717]).any()
     assert not (np.asarray(chart_curve.rate_head_and_efficiency_at_maximum_rate) - [1028, 1460.6, 0.7193]).any()
     assert chart_curve.efficiency_as_function_of_rate(708) == 0.6683
-    assert chart_curve.efficiency_as_function_of_rate(456.5) == 0.546
+    assert np.round(chart_curve.efficiency_as_function_of_rate(456.5), 3) == 0.546
     assert chart_curve.get_distance_and_efficiency_from_closest_point_on_curve(577, 1718.7) == (0.0, 0.6203)
     np.testing.assert_approx_equal(
         chart_curve.get_distance_and_efficiency_from_closest_point_on_curve(400, 1600)[0], 157.9450

--- a/tests/libecalc/dto/test_electricity_consumer.py
+++ b/tests/libecalc/dto/test_electricity_consumer.py
@@ -13,7 +13,7 @@ from libecalc.expression import Expression
 
 class TestElectricityConsumer:
     def test_invalid_energy_usage(self):
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises(ValueError) as e:
             ElectricityConsumer(
                 name="Test",
                 component_type=ComponentType.GENERIC,

--- a/tests/libecalc/dto/test_electricity_consumer.py
+++ b/tests/libecalc/dto/test_electricity_consumer.py
@@ -1,19 +1,19 @@
 from datetime import datetime
 
 import pytest
-from pydantic import ValidationError
 
 from libecalc import dto
 from libecalc.domain.infrastructure import ElectricityConsumer
 from libecalc.common.component_type import ComponentType
 from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.time_utils import Period
+from libecalc.domain.infrastructure.energy_components.component_validation_error import ComponentValidationException
 from libecalc.expression import Expression
 
 
 class TestElectricityConsumer:
     def test_invalid_energy_usage(self):
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ComponentValidationException) as e:
             ElectricityConsumer(
                 name="Test",
                 component_type=ComponentType.GENERIC,
@@ -25,7 +25,7 @@ class TestElectricityConsumer:
                 },
                 regularity={Period(datetime(1900, 1, 1)): Expression.setup_from_expression(1)},
             )
-        assert "Model does not consume POWER" in str(e.value)
+        assert "Model does not consume POWER" in str(e.value.errors()[0])
 
     def test_valid_electricity_consumer(self):
         # Should not raise ValidationError

--- a/tests/libecalc/dto/test_fuel_consumer.py
+++ b/tests/libecalc/dto/test_fuel_consumer.py
@@ -10,6 +10,7 @@ from libecalc.domain.infrastructure import FuelConsumer, Installation
 from libecalc.common.component_type import ComponentType
 from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.time_utils import Period
+from libecalc.domain.infrastructure.energy_components.component_validation_error import ComponentValidationException
 from libecalc.expression import Expression
 
 regularity = {Period(datetime(2000, 1, 1)): Expression.setup_from_expression(1)}
@@ -93,7 +94,7 @@ def get_fuel_consumer(
 
 class TestFuelConsumer:
     def test_missing_fuel(self):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ComponentValidationException) as exc_info:
             FuelConsumer(
                 name="test",
                 fuel={},
@@ -107,4 +108,4 @@ class TestFuelConsumer:
                 regularity=regularity,
                 user_defined_category="category",
             )
-        assert "Missing fuel for fuel consumer 'test'" in str(exc_info.value)
+        assert "Name: test\nMessage: Missing fuel for fuel consumer" in str(exc_info.value.errors()[0])

--- a/tests/libecalc/dto/test_fuel_consumer.py
+++ b/tests/libecalc/dto/test_fuel_consumer.py
@@ -2,7 +2,10 @@ from datetime import datetime
 from io import StringIO
 
 import pytest
+from yaml import YAMLError
 
+from libecalc.presentation.yaml.validation_errors import DtoValidationError, DataValidationError, ValidationError
+from libecalc.presentation.yaml.yaml_models.exceptions import DuplicateKeyError, YamlError
 import libecalc.dto.fuel_type
 import libecalc.dto.types
 from ecalc_cli.types import Frequency
@@ -18,8 +21,10 @@ from libecalc.domain.infrastructure.energy_components.component_validation_error
     ComponentDtoValidationError,
 )
 from libecalc.expression import Expression
+from libecalc.presentation.yaml.model_validation_exception import ModelValidationException
 from libecalc.presentation.yaml.yaml_entities import ResourceStream
 from libecalc.presentation.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
+from libecalc.presentation.yaml.yaml_types.components.yaml_asset import YamlAsset
 from libecalc.testing.yaml_builder import YamlAssetBuilder, YamlInstallationBuilder, YamlFuelConsumerBuilder
 
 regularity = {Period(datetime(2000, 1, 1)): Expression.setup_from_expression(1)}
@@ -101,56 +106,84 @@ def get_fuel_consumer(
     )
 
 
-class TestFuelConsumer:
-    def test_missing_fuel(self):
-        with pytest.raises(ComponentValidationException) as exc_info:
-            FuelConsumer(
-                name="test",
-                fuel={},
-                component_type=ComponentType.GENERIC,
-                energy_usage_model={
-                    Period(datetime(2000, 1, 1)): dto.DirectConsumerFunction(
-                        fuel_rate=Expression.setup_from_expression(1),
-                        energy_usage_type=EnergyUsageType.FUEL,
-                    )
-                },
-                regularity=regularity,
-                user_defined_category="category",
-            )
-        assert "Name: test\nMessage: Missing fuel for fuel consumer" in str(exc_info.value.errors()[0])
+class TestFuelConsumerHelper:
+    def __init__(self):
+        self.time_vector = [datetime(2027, 1, 1), datetime(2028, 1, 1), datetime(2029, 1, 1)]
+        self.defined_fuel = "fuel"
 
-    def test_blank_fuel_name_and_missing_fuel(self, yaml_model_factory, request):
-        time_vector = [datetime(2027, 1, 1), datetime(2028, 1, 1), datetime(2029, 1, 1)]
-        variables = VariablesMap(time_vector=time_vector, variables={})
-
-        fuel_consumer = YamlFuelConsumerBuilder().with_test_data().validate()
-
-        # Setting fuel reference name to blank
-        fuel_consumer.fuel = ""
+    def get_stream(self, consumer_fuel: str, installation_fuel: str = ""):
+        fuel_reference = consumer_fuel
+        fuel_consumer = YamlFuelConsumerBuilder().with_test_data().with_fuel(fuel_reference).validate()
 
         installation = (
-            YamlInstallationBuilder().with_name("Installation 1").with_fuel_consumers([fuel_consumer])
+            YamlInstallationBuilder()
+            .with_name("Installation 1")
+            .with_fuel(installation_fuel)
+            .with_fuel_consumers([fuel_consumer])
         ).validate()
 
-        # No fuel is set for the asset (means None)
         asset = (
-            YamlAssetBuilder().with_installations([installation]).with_start(time_vector[0]).with_end(time_vector[-1])
+            YamlAssetBuilder()
+            .with_test_data()
+            .with_installations([installation])
+            .with_start(self.time_vector[0])
+            .with_end(self.time_vector[-1])
         ).validate()
 
-        yaml_model_factory = request.getfixturevalue("yaml_model_factory")
+        # Set the name of defined fuel type for the asset
+        asset.fuel_types[0].name = self.defined_fuel
+
         asset_dict = asset.model_dump(
             serialize_as_any=True,
             mode="json",
             exclude_unset=True,
             by_alias=True,
         )
-
         yaml_string = PyYamlYamlModel.dump_yaml(yaml_dict=asset_dict)
-        stream = ResourceStream(name="", stream=StringIO(yaml_string))
+        return ResourceStream(name="", stream=StringIO(yaml_string))
 
-        asset_yaml = yaml_model_factory(resource_stream=stream, resources={}, frequency=Frequency.YEAR)
-        energy_calculator = EnergyCalculator(energy_model=asset_yaml, expression_evaluator=variables)
 
-        with pytest.raises(ComponentDtoValidationError) as exc_info:
-            energy_calculator.evaluate_energy_usage()
-        assert "Name: flare\nMessage: Missing fuel for fuel consumer" in str(exc_info.value.errors[0])
+@pytest.fixture()
+def test_fuel_consumer_helper():
+    return TestFuelConsumerHelper()
+
+
+class TestFuelConsumer:
+    def test_blank_fuel_reference(self, yaml_model_factory, test_fuel_consumer_helper):
+        """
+        Check scenarios with blank fuel reference.
+        The asset has one correctly defined fuel type, named 'fuel'.
+        """
+
+        # Blank fuel reference in installation and in consumer
+        asset_stream = test_fuel_consumer_helper.get_stream(installation_fuel="", consumer_fuel="")
+
+        with pytest.raises(DataValidationError) as exc_info:
+            yaml_model_factory(resource_stream=asset_stream, resources={}, frequency=Frequency.YEAR).validate_for_run()
+
+        assert "Invalid fuel reference ''. Available references: fuel" in str(exc_info.value)
+
+        # Correct fuel reference in installation and blank in consumer.
+        # The installation fuel should propagate to the consumer, hence model should validate.
+        asset_stream = test_fuel_consumer_helper.get_stream(
+            installation_fuel=test_fuel_consumer_helper.defined_fuel, consumer_fuel=""
+        )
+
+        yaml_model_factory(resource_stream=asset_stream, resources={}, frequency=Frequency.YEAR).validate_for_run()
+
+    def test_wrong_fuel_reference(self, request, yaml_model_factory, test_fuel_consumer_helper):
+        """
+        Check wrong fuel reference.
+        The asset has one correctly defined fuel type, named 'fuel'.
+
+        A wrong fuel reference can be caused by misspelling or by using a reference that is not defined in the asset FUEL_TYPES.
+        """
+
+        asset_stream = test_fuel_consumer_helper.get_stream(
+            installation_fuel="wrong_fuel_name", consumer_fuel="wrong_fuel_name"
+        )
+
+        with pytest.raises(DataValidationError) as exc_info:
+            yaml_model_factory(resource_stream=asset_stream, resources={}, frequency=Frequency.YEAR).validate_for_run()
+
+        assert "Invalid fuel reference 'wrong_fuel_name'. Available references: fuel" in str(exc_info.value)

--- a/tests/libecalc/dto/test_fuel_consumer.py
+++ b/tests/libecalc/dto/test_fuel_consumer.py
@@ -93,7 +93,7 @@ def get_fuel_consumer(
 
 class TestFuelConsumer:
     def test_missing_fuel(self):
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             FuelConsumer(
                 name="test",
                 fuel={},

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -15,7 +15,6 @@ from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.time_utils import Period
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.expression import Expression
-from libecalc.presentation.yaml.yaml_types.components.yaml_generator_set import YamlGeneratorSet
 from libecalc.testing.yaml_builder import YamlGeneratorSetBuilder
 
 

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -236,40 +236,6 @@ class TestGeneratorSet:
                 component_type=ComponentType.GENERATOR_SET,
             )
 
-    def test_power_from_shore_wrong_category(self):
-        """
-        Check that CABLE_LOSS and MAX_USAGE_FROM_SHORE are only allowed if generator set category is POWER-FROM-SHORE
-        This validation is done in the yaml layer.
-        """
-
-        # Check for CABLE_LOSS
-        with pytest.raises(ValueError) as exc_info:
-            YamlGeneratorSetBuilder().with_test_data().with_category("BOILER").with_cable_loss(0).validate()
-
-        assert ("CABLE_LOSS is only valid for the category POWER-FROM-SHORE, not for BOILER") in str(exc_info.value)
-
-        # Check for MAX_USAGE_FROM_SHORE
-        with pytest.raises(ValueError) as exc_info:
-            YamlGeneratorSetBuilder().with_test_data().with_category("BOILER").with_max_usage_from_shore(20).validate()
-
-        assert ("MAX_USAGE_FROM_SHORE is only valid for the category POWER-FROM-SHORE, not for BOILER") in str(
-            exc_info.value
-        )
-
-        # Check for CABLE_LOSS and MAX_USAGE_FROM_SHORE
-        with pytest.raises(ValueError) as exc_info:
-            (
-                YamlGeneratorSetBuilder()
-                .with_test_data()
-                .with_category("BOILER")
-                .with_cable_loss(0)
-                .with_max_usage_from_shore(20)
-            ).validate()
-
-        assert (
-            "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, not for BOILER"
-        ) in str(exc_info.value)
-
     def test_missing_installation_fuel(self, yaml_model_factory, test_generator_set_helper):
         """
         Check scenario where FUEL is not entered as a keyword in installation.

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -24,7 +24,6 @@ from libecalc.testing.yaml_builder import (
     YamlGeneratorSetBuilder,
     YamlAssetBuilder,
     YamlInstallationBuilder,
-    YamlFuelConsumerBuilder,
     YamlElectricity2fuelBuilder,
 )
 

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from io import StringIO
+from typing import Union
 
 import pytest
 from pydantic import ValidationError
@@ -12,10 +14,19 @@ from libecalc.common.component_type import ComponentType
 from libecalc.common.consumption_type import ConsumptionType
 from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.common.energy_usage_type import EnergyUsageType
-from libecalc.common.time_utils import Period
+from libecalc.common.time_utils import Period, Frequency
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.expression import Expression
-from libecalc.testing.yaml_builder import YamlGeneratorSetBuilder
+from libecalc.presentation.yaml.model_validation_exception import ModelValidationException
+from libecalc.presentation.yaml.yaml_entities import ResourceStream, MemoryResource
+from libecalc.presentation.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
+from libecalc.testing.yaml_builder import (
+    YamlGeneratorSetBuilder,
+    YamlAssetBuilder,
+    YamlInstallationBuilder,
+    YamlFuelConsumerBuilder,
+    YamlElectricity2fuelBuilder,
+)
 
 
 class TestGeneratorSetSampled:
@@ -39,6 +50,127 @@ class TestGeneratorSetSampled:
                 energy_usage_adjustment_factor=1.0,
             )
         assert "Sampled generator set data should have a 'FUEL' and 'POWER' header" in str(exc_info.value)
+
+
+class TestGeneratorSetHelper:
+    def __init__(self):
+        self.time_vector = [datetime(2027, 1, 1), datetime(2028, 1, 1), datetime(2029, 1, 1)]
+        self.defined_fuel = "fuel"
+
+    class ReturnValue:
+        def __init__(self, resource_stream: ResourceStream, resources: dict):
+            self.resource_stream = resource_stream
+            self.resources = resources
+
+    @staticmethod
+    def memory_resource_factory(data: list[list[Union[float, int, str]]], headers: list[str]) -> MemoryResource:
+        return MemoryResource(
+            data=data,
+            headers=headers,
+        )
+
+    def generator_electricity2fuel_resource(self):
+        return self.memory_resource_factory(
+            data=[
+                [
+                    0,
+                    0.1,
+                    10,
+                    11,
+                    12,
+                    14,
+                    15,
+                    16,
+                    17,
+                    17.1,
+                    18.5,
+                    20,
+                    20.5,
+                    20.6,
+                    24,
+                    28,
+                    30,
+                    32,
+                    34,
+                    36,
+                    38,
+                    40,
+                    41,
+                    410,
+                ],
+                [
+                    0,
+                    75803.4,
+                    75803.4,
+                    80759.1,
+                    85714.8,
+                    95744,
+                    100728.8,
+                    105676.9,
+                    110598.4,
+                    136263.4,
+                    143260,
+                    151004.1,
+                    153736.5,
+                    154084.7,
+                    171429.6,
+                    191488,
+                    201457.5,
+                    211353.8,
+                    221196.9,
+                    231054,
+                    241049.3,
+                    251374.6,
+                    256839.4,
+                    2568394,
+                ],
+            ],  # float and int with equal value should count as equal.
+            headers=[
+                "POWER",
+                "FUEL",
+            ],
+        )
+
+    def get_data(self, consumer_fuel: str, installation_fuel: str = None):
+        fuel_reference = consumer_fuel
+        el2fuel = YamlElectricity2fuelBuilder().with_test_data().validate()
+        generator_set = YamlGeneratorSetBuilder().with_test_data().with_fuel(fuel_reference).validate()
+        installation = (
+            YamlInstallationBuilder()
+            .with_name("Installation 1")
+            .with_fuel(installation_fuel)
+            .with_generator_sets([generator_set])
+        ).validate()
+
+        asset = (
+            YamlAssetBuilder()
+            .with_test_data()
+            .with_installations([installation])
+            .with_facility_inputs([el2fuel])
+            .with_start(self.time_vector[0])
+            .with_end(self.time_vector[-1])
+        ).validate()
+
+        # Set the name of defined fuel type for the asset
+        asset.fuel_types[0].name = self.defined_fuel
+
+        asset_dict = asset.model_dump(
+            serialize_as_any=True,
+            mode="json",
+            exclude_unset=True,
+            by_alias=True,
+        )
+        yaml_string = PyYamlYamlModel.dump_yaml(yaml_dict=asset_dict)
+
+        resources = {el2fuel.name: self.generator_electricity2fuel_resource()}
+        return self.ReturnValue(
+            resource_stream=ResourceStream(name="yaml_file_location", stream=StringIO(yaml_string)), resources=resources
+        )
+
+
+@pytest.fixture()
+def test_generator_set_helper():
+    return TestGeneratorSetHelper()
 
 
 class TestGeneratorSet:
@@ -137,3 +269,22 @@ class TestGeneratorSet:
         assert (
             "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, not for BOILER"
         ) in str(exc_info.value)
+
+    def test_missing_installation_fuel(self, yaml_model_factory, test_generator_set_helper):
+        """
+        Check scenario where FUEL is not entered as a keyword in installation.
+        In addition, the generator set has an empty fuel reference.
+
+        The error should be handled in the infrastructure layer (dto).
+        """
+
+        asset_data = test_generator_set_helper.get_data(installation_fuel=None, consumer_fuel="")
+
+        with pytest.raises(ModelValidationException) as exc_info:
+            yaml_model_factory(
+                resource_stream=asset_data.resource_stream, resources=asset_data.resources, frequency=Frequency.YEAR
+            ).validate_for_run()
+
+        assert "Validation error\n\n\tName: DefaultGeneratorSet\n\tMessage: Missing fuel for generator set\n" in str(
+            exc_info.value
+        )

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 import libecalc.dto.fuel_type
 from libecalc import dto
 from libecalc.domain.infrastructure import GeneratorSet, FuelConsumer
+from libecalc.domain.infrastructure.energy_components.component_validation_error import ComponentValidationException
 from libecalc.dto.models import GeneratorSetSampled
 from libecalc.common.component_type import ComponentType
 from libecalc.common.consumption_type import ConsumptionType
@@ -90,7 +91,7 @@ class TestGeneratorSet:
             regularity={Period(datetime(2000, 1, 1)): Expression.setup_from_expression(1)},
             user_defined_category={Period(datetime(2000, 1, 1)): ConsumerUserDefinedCategoryType.MISCELLANEOUS},
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ComponentValidationException):
             GeneratorSet(
                 name="Test",
                 user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.MISCELLANEOUS},

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -60,6 +60,7 @@ class TestGeneratorSet:
                     emissions=[],
                 )
             },
+            component_type=ComponentType.GENERATOR_SET,
         )
         assert generator_set_dto.generator_set_model == {
             Period(datetime(1900, 1, 1)): dto.GeneratorSetSampled(
@@ -89,7 +90,7 @@ class TestGeneratorSet:
             regularity={Period(datetime(2000, 1, 1)): Expression.setup_from_expression(1)},
             user_defined_category={Period(datetime(2000, 1, 1)): ConsumerUserDefinedCategoryType.MISCELLANEOUS},
         )
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError):
             GeneratorSet(
                 name="Test",
                 user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.MISCELLANEOUS},
@@ -97,6 +98,7 @@ class TestGeneratorSet:
                 regularity={},
                 consumers=[fuel_consumer],
                 fuel={},
+                component_type=ComponentType.GENERATOR_SET,
             )
 
     def test_power_from_shore_wrong_category(self):
@@ -114,6 +116,7 @@ class TestGeneratorSet:
                 consumers=[],
                 fuel={},
                 cable_loss=0,
+                component_type=ComponentType.GENERATOR_SET,
             )
 
         assert ("CABLE_LOSS is only valid for the category POWER-FROM-SHORE, not for BOILER") in str(exc_info.value)
@@ -128,6 +131,7 @@ class TestGeneratorSet:
                 consumers=[],
                 fuel={},
                 max_usage_from_shore=20,
+                component_type=ComponentType.GENERATOR_SET,
             )
 
         assert ("MAX_USAGE_FROM_SHORE is only valid for the category POWER-FROM-SHORE, not for BOILER") in str(
@@ -144,6 +148,7 @@ class TestGeneratorSet:
                 fuel={},
                 max_usage_from_shore=20,
                 cable_loss=0,
+                component_type=ComponentType.GENERATOR_SET,
             )
 
         assert (

--- a/tests/libecalc/presentation/yaml/yaml_types/components/test_fuel_consumer.py
+++ b/tests/libecalc/presentation/yaml/yaml_types/components/test_fuel_consumer.py
@@ -3,8 +3,8 @@ from io import StringIO
 
 import pytest
 
+from libecalc.presentation.yaml.validation_errors import DataValidationError
 from ecalc_cli.types import Frequency
-from libecalc.presentation.yaml.model_validation_exception import ModelValidationException
 from libecalc.presentation.yaml.yaml_entities import ResourceStream
 from libecalc.presentation.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
 from libecalc.testing.yaml_builder import YamlAssetBuilder, YamlInstallationBuilder, YamlFuelConsumerBuilder
@@ -53,17 +53,41 @@ def test_fuel_consumer_helper():
 
 
 class TestFuelConsumer:
-    def test_no_fuel_installation_and_blank_reference_consumer(self, yaml_model_factory, test_fuel_consumer_helper):
+    def test_blank_fuel_reference(self, yaml_model_factory, test_fuel_consumer_helper):
         """
-        Check scenario where FUEL is not entered as a keyword in installation.
-        In addition, the consumer has a blank fuel reference.
-
-        The error should be handled in the infrastructure layer (dto).
+        Check scenarios with blank fuel reference.
+        The asset has one correctly defined fuel type, named 'fuel'.
         """
 
-        asset_stream = test_fuel_consumer_helper.get_stream(installation_fuel=None, consumer_fuel="")
+        # Blank fuel reference in installation and in consumer
+        asset_stream = test_fuel_consumer_helper.get_stream(installation_fuel="", consumer_fuel="")
 
-        with pytest.raises(ModelValidationException) as exc_info:
+        with pytest.raises(DataValidationError) as exc_info:
             yaml_model_factory(resource_stream=asset_stream, resources={}, frequency=Frequency.YEAR).validate_for_run()
 
-        assert "Validation error\n\n\tName: flare\n\tMessage: Missing fuel for fuel consumer\n" in str(exc_info.value)
+        assert "Invalid fuel reference ''. Available references: fuel" in str(exc_info.value)
+
+        # Correct fuel reference in installation and blank in consumer.
+        # The installation fuel should propagate to the consumer, hence model should validate.
+        asset_stream = test_fuel_consumer_helper.get_stream(
+            installation_fuel=test_fuel_consumer_helper.defined_fuel, consumer_fuel=""
+        )
+
+        yaml_model_factory(resource_stream=asset_stream, resources={}, frequency=Frequency.YEAR).validate_for_run()
+
+    def test_wrong_fuel_reference(self, request, yaml_model_factory, test_fuel_consumer_helper):
+        """
+        Check wrong fuel reference.
+        The asset has one correctly defined fuel type, named 'fuel'.
+
+        A wrong fuel reference can be caused by misspelling or by using a reference that is not defined in the asset FUEL_TYPES.
+        """
+
+        asset_stream = test_fuel_consumer_helper.get_stream(
+            installation_fuel="wrong_fuel_name", consumer_fuel="wrong_fuel_name"
+        )
+
+        with pytest.raises(DataValidationError) as exc_info:
+            yaml_model_factory(resource_stream=asset_stream, resources={}, frequency=Frequency.YEAR).validate_for_run()
+
+        assert "Invalid fuel reference 'wrong_fuel_name'. Available references: fuel" in str(exc_info.value)

--- a/tests/libecalc/presentation/yaml/yaml_types/components/test_generator_set.py
+++ b/tests/libecalc/presentation/yaml/yaml_types/components/test_generator_set.py
@@ -1,0 +1,39 @@
+import pytest
+
+from libecalc.testing.yaml_builder import YamlGeneratorSetBuilder
+
+
+class TestGeneratorSet:
+    def test_power_from_shore_wrong_category(self):
+        """
+        Check that CABLE_LOSS and MAX_USAGE_FROM_SHORE are only allowed if generator set category is POWER-FROM-SHORE
+        This validation is done in the yaml layer.
+        """
+
+        # Check for CABLE_LOSS
+        with pytest.raises(ValueError) as exc_info:
+            YamlGeneratorSetBuilder().with_test_data().with_category("BOILER").with_cable_loss(0).validate()
+
+        assert ("CABLE_LOSS is only valid for the category POWER-FROM-SHORE, not for BOILER") in str(exc_info.value)
+
+        # Check for MAX_USAGE_FROM_SHORE
+        with pytest.raises(ValueError) as exc_info:
+            YamlGeneratorSetBuilder().with_test_data().with_category("BOILER").with_max_usage_from_shore(20).validate()
+
+        assert ("MAX_USAGE_FROM_SHORE is only valid for the category POWER-FROM-SHORE, not for BOILER") in str(
+            exc_info.value
+        )
+
+        # Check for CABLE_LOSS and MAX_USAGE_FROM_SHORE
+        with pytest.raises(ValueError) as exc_info:
+            (
+                YamlGeneratorSetBuilder()
+                .with_test_data()
+                .with_category("BOILER")
+                .with_cable_loss(0)
+                .with_max_usage_from_shore(20)
+            ).validate()
+
+        assert (
+            "CABLE_LOSS and MAX_USAGE_FROM_SHORE are only valid for the category POWER-FROM-SHORE, not for BOILER"
+        ) in str(exc_info.value)


### PR DESCRIPTION
equinor/ecalc-internal#291

## Why is this pull request needed?

Pydantic validation is taken care of in the Yaml classes now. It is not needed in the dto classes, here we need more flexibility.

## What does this pull request change?
Remove inheritance from EcalcBaseModel (Pydantic) in Component base class. Remove: field_validators, Field definitions, ConfigDict import and usage. Remove Pydantic specific imports and replace with standard Python types if necessary. In libecalc/domain/infracstructure/energy_components/ this is done for:

- [x] base/component_dto.py
- [x] consumer_system/consumer_system_dto.py
- [x] electricity_consumer/electricity_consumer.py
- [x] generator_set_dto.py
- [x] installation/installation.py
- [x] asset/asset.py
- [x] legacy_consumer: All files in directory

In addition the following changes are done:
- [x] Implemented a new ComponentValidationException for energy components
- [x] Remove some redundant validation from dto layer (in GeneratorSet and Installation)
- [x] Remove redundant validation of user defined category in dto layer
- [x] Update affected tests: Use yaml classes instead of dtos, as validation is done here only (after removing redundant validation in dto)
- [x] Remove Component, BaseComponent, BaseEquipment and BaseConsumer from base/component_dto, and transfered functionality and parameters to individual energy components. Reduce complexity and improve readability.
- [x] Add test to check that new `ComponentValidationException` is catched in YamlModel.dto. 