### PR TITLE
fix: delta profile when 2 result sets have different periods

### DIFF
--- a/src/libecalc/common/time_utils.py
+++ b/src/libecalc/common/time_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Any, Optional, Self, Union
@@ -160,7 +161,7 @@ class Periods:
 
         return Periods(periods=periods)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Period]:
         return self.periods.__iter__()
 
     def get_period(self, period: Period) -> Optional[Period]:


### PR DESCRIPTION
due to opposite check of what it was supposed to, ie. check that
we only include periods that are given in the common period vector,
but instead there was a check that the separate result had a
period that was not in the common period vector.

Resolves equinor/ecalc-internal#298
