### PR TITLE
chore: specify poetry version in ci

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.4
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.4
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/examples-ci.yml
+++ b/.github/workflows/examples-ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.4
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/lib-ci.yml
+++ b/.github/workflows/lib-ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.4
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
Poetry just released v2.0.0, which causes ci to break. Set it to v1.8.4 for now as that is the version we are currently using.