### PR TITLE
refactor: store results in fuel and electricity components

### DIFF
--- a/src/libecalc/domain/infrastructure/emitters/venting_emitter.py
+++ b/src/libecalc/domain/infrastructure/emitters/venting_emitter.py
@@ -140,9 +140,6 @@ class VentingEmitter(Emitter, EnergyComponent):
     def is_container(self) -> bool:
         return False
 
-    def get_emission_results(self) -> Optional[dict[str, EmissionResult]]:
-        return self.emission_results
-
 
 class DirectVentingEmitter(VentingEmitter):
     def __init__(self, emissions: list[VentingEmission], **kwargs):

--- a/src/libecalc/domain/infrastructure/emitters/venting_emitter.py
+++ b/src/libecalc/domain/infrastructure/emitters/venting_emitter.py
@@ -72,6 +72,7 @@ class VentingEmitter(Emitter, EnergyComponent):
         self.user_defined_category = user_defined_category
         self.emitter_type = emitter_type
         self._regularity = regularity
+        self.emission_results: Optional[dict[str, EmissionResult]] = None
 
     @property
     def id(self) -> str:
@@ -96,7 +97,8 @@ class VentingEmitter(Emitter, EnergyComponent):
                 rate=emission_rate,
             )
             venting_emitter_results[emission_name] = emission_result
-        return venting_emitter_results
+        self.emission_results = venting_emitter_results
+        return self.emission_results
 
     def get_emissions(self) -> dict[str, TimeSeriesStreamDayRate]:
         raise NotImplementedError("Subclasses should implement this method")
@@ -137,6 +139,9 @@ class VentingEmitter(Emitter, EnergyComponent):
 
     def is_container(self) -> bool:
         return False
+
+    def get_emission_results(self) -> Optional[dict[str, EmissionResult]]:
+        return self.emission_results
 
 
 class DirectVentingEmitter(VentingEmitter):

--- a/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
@@ -275,12 +275,6 @@ class ConsumerSystem(Emitter, EnergyComponent):
                 ]
         return dict(parsed_priorities)
 
-    def get_consumer_results(self) -> dict[str, EcalcModelResult]:
-        return self.consumer_results
-
-    def get_emission_results(self) -> Optional[dict[str, EmissionResult]]:
-        return self.emission_results
-
 
 def create_consumer(
     consumer: Union[CompressorComponent, PumpComponent],

--- a/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/consumer_system/consumer_system_dto.py
@@ -74,6 +74,8 @@ class ConsumerSystem(Emitter, EnergyComponent):
         self.fuel = self.validate_fuel_exist(name=self.name, fuel=fuel, consumes=consumes)
         self.component_type = component_type
         self.consumers = consumers
+        self.consumer_results: dict[str, EcalcModelResult] = {}
+        self.emission_results: Optional[dict[str, EmissionResult]] = None
 
     @property
     def id(self) -> str:
@@ -192,7 +194,8 @@ class ConsumerSystem(Emitter, EnergyComponent):
                 models=[],
             )
 
-        return consumer_results
+        self.consumer_results = consumer_results
+        return self.consumer_results
 
     def evaluate_emissions(
         self,
@@ -206,10 +209,11 @@ class ConsumerSystem(Emitter, EnergyComponent):
 
             assert fuel_usage is not None
 
-            return fuel_model.evaluate_emissions(
+            self.emission_results = fuel_model.evaluate_emissions(
                 fuel_rate=fuel_usage.values,
                 expression_evaluator=self.expression_evaluator,
             )
+        return self.emission_results
 
     def get_graph(self) -> ComponentGraph:
         graph = ComponentGraph()
@@ -270,6 +274,12 @@ class ConsumerSystem(Emitter, EnergyComponent):
                     for stream_name, stream_conditions in streams_conditions.items()
                 ]
         return dict(parsed_priorities)
+
+    def get_consumer_results(self) -> dict[str, EcalcModelResult]:
+        return self.consumer_results
+
+    def get_emission_results(self) -> Optional[dict[str, EmissionResult]]:
+        return self.emission_results
 
 
 def create_consumer(

--- a/src/libecalc/domain/infrastructure/energy_components/electricity_consumer/electricity_consumer.py
+++ b/src/libecalc/domain/infrastructure/energy_components/electricity_consumer/electricity_consumer.py
@@ -50,6 +50,7 @@ class ElectricityConsumer(EnergyComponent):
         self.expression_evaluator = expression_evaluator
         self.consumes = consumes
         self.component_type = component_type
+        self.consumer_results: dict[str, EcalcModelResult] = {}
 
     @property
     def id(self) -> str:
@@ -80,7 +81,6 @@ class ElectricityConsumer(EnergyComponent):
         return self.name
 
     def evaluate_energy_usage(self, context: ComponentEnergyContext) -> dict[str, EcalcModelResult]:
-        consumer_results: dict[str, EcalcModelResult] = {}
         consumer = ConsumerEnergyComponent(
             id=self.id,
             name=self.name,
@@ -94,9 +94,9 @@ class ElectricityConsumer(EnergyComponent):
                 }
             ),
         )
-        consumer_results[self.id] = consumer.evaluate(expression_evaluator=self.expression_evaluator)
+        self.consumer_results[self.id] = consumer.evaluate(expression_evaluator=self.expression_evaluator)
 
-        return consumer_results
+        return self.consumer_results
 
     @staticmethod
     def check_energy_usage_model(energy_usage_model: dict[Period, ElectricEnergyUsageModel]):
@@ -114,3 +114,6 @@ class ElectricityConsumer(EnergyComponent):
     @staticmethod
     def _check_model_energy_usage(energy_usage_model: dict[Period, ElectricEnergyUsageModel]):
         check_model_energy_usage_type(energy_usage_model, EnergyUsageType.POWER)
+
+    def get_consumer_results(self) -> dict[str, EcalcModelResult]:
+        return self.consumer_results

--- a/src/libecalc/domain/infrastructure/energy_components/electricity_consumer/electricity_consumer.py
+++ b/src/libecalc/domain/infrastructure/energy_components/electricity_consumer/electricity_consumer.py
@@ -114,6 +114,3 @@ class ElectricityConsumer(EnergyComponent):
     @staticmethod
     def _check_model_energy_usage(energy_usage_model: dict[Period, ElectricEnergyUsageModel]):
         check_model_energy_usage_type(energy_usage_model, EnergyUsageType.POWER)
-
-    def get_consumer_results(self) -> dict[str, EcalcModelResult]:
-        return self.consumer_results

--- a/src/libecalc/domain/infrastructure/energy_components/fuel_consumer/fuel_consumer.py
+++ b/src/libecalc/domain/infrastructure/energy_components/fuel_consumer/fuel_consumer.py
@@ -163,9 +163,3 @@ class FuelConsumer(Emitter, EnergyComponent):
                 ],
             )
         return fuel
-
-    def get_consumer_results(self) -> dict[str, EcalcModelResult]:
-        return self.consumer_results
-
-    def get_emission_results(self) -> Optional[dict[str, EmissionResult]]:
-        return self.emission_results

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_dto.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_dto.py
@@ -195,9 +195,3 @@ class GeneratorSet(Emitter, EnergyComponent):
             graph.add_edge(self.id, electricity_consumer.id)
 
         return graph
-
-    def get_consumer_results(self) -> dict[str, EcalcModelResult]:
-        return self.consumer_results
-
-    def get_emission_results(self) -> Optional[dict[str, EmissionResult]]:
-        return self.emission_results

--- a/tests/libecalc/integration/test_all_consumer_with_time_slots_models.py
+++ b/tests/libecalc/integration/test_all_consumer_with_time_slots_models.py
@@ -244,7 +244,6 @@ def test_all_consumer_with_time_slots_models_results(
     ecalc_model = consumer_with_time_slots_models_dto.ecalc_model
     variables = consumer_with_time_slots_models_dto.variables
 
-    variables_dummy = VariablesMap(time_vector=[datetime(1900, 1, 1)])
     graph = ecalc_model.get_graph()
     energy_calculator = EnergyCalculator(
         energy_model=energy_model_from_dto_factory(ecalc_model), expression_evaluator=variables


### PR DESCRIPTION
## Why is this pull request needed?

This PR is part of a larger refactoring of results. It will not implement any functional changes, but is part of a preparation with the objective to allow individual components to be queried directly for their results, simplifying the retrieval process.

## What does this pull request change?

- [x] Modify the evaluate_energy_usage method in the component classes to store results within the respective components for: `FuelConsumer`, `ElectricityConsumer`, `GeneratorSet` and `ConsumerSystem` in the domain layer
- [x] Modify the evaluate_emissions method in the component classes to store results within the respective components.


## Issues related to this change:
https://github.com/equinor/ecalc-internal/issues/505