### PR TITLE
perf(libecalc): Increase performance of datetime-parsing

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/variables_mapper/time_series_collection_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/variables_mapper/time_series_collection_mapper.py
@@ -2,37 +2,77 @@ import re
 from datetime import datetime
 from typing import Union
 
-import pandas
+import pandas as pd
 
 from libecalc.common.errors.exceptions import InvalidResourceException
 from libecalc.presentation.yaml.resource import Resource
+from libecalc.presentation.yaml.validation_errors import ValidationError
 from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 
 
-def _parse_date(date_input: Union[int, str]) -> datetime:
+def parse_time_vector(date_input: list[int | str]) -> list[datetime]:
+    """Parse entire timeseries in a single format.
+
+    Args:
+        date_input: Dates in unknown format.
+
+    Returns:
+        Consistent dates.
+
+    Raises:
+        ValidationError:
+            If dates do not match any of the given patterns.
+            If dates are in an inconsistent format.
     """
-    Parse timeseries input:
+    date_patterns = {
+        # Only year supplied (YYYY e.g. 1996).
+        "YEAR_ONLY": r"\d{4}",
+        # ISO8601 date only e.g. '2024-01-31', '2024-12-01'.
+        "ISO8601_date": r"(\d{4})(\.|\/|-)(1[0-2]|0?[1-9])\2(3[01]|[12][0-9]|0?[1-9])",
+        # ISO8601 date and time e.g. '2024-01-31 13:37:59', '2024-12-01 23:59:59'.
+        "ISO8601_datetime": r"(\d{4})(\.|\/|-)(1[0-2]|0?[1-9])\2(3[01]|[12][0-9]|0?[1-9])((\s|T)(\d{2}:){2}\d{2})",
+        # European standard (day first) e.g. '31-01-2024', '1/12/2024', '01.12.2024'.
+        "EU_date": r"(3[01]|[12][0-9]|0?[1-9])(\.|\/|-)(1[0-2]|0?[1-9])\2(\d{4})",
+        # European date with time, e.g. e.g. '31-01-2024 13:37:59', '1/12/2024 10:30:00', '01.01.2024 13:37')
+        "EU_datetime": r"(3[01]|[12][0-9]|0?[1-9])(\.|\/|-)(1[0-2]|0?[1-9])\2(\d{4})((\s|T)(\d{2}):(\d{2})(:\d{2})?)",
+        "EU_optional_time": r"(3[01]|[12][0-9]|0?[1-9])(\.|\/|-)(1[0-2]|0?[1-9])\2(\d{4})((\s)(\d{2}):(\d{2})(:\d{2})?)?",
+        # US standard date (month first), e.g. '12-31-2024', '9/1/2024'.
+        "US_date": r"(1[0-2]|0?[1-9])(\.|\/|-)(3[01]|[12][0-9]|0?[1-9])\2(\d{4})",
+        # US standard date with time (e.g. '12-31-2024 01:37:59', '9.9.2024 1:13')
+        "US_datetime": r"(1[0-2]|0?[1-9])(\.|\/|-)(3[01]|[12][0-9]|0?[1-9])\2(\d{4})((\s|T)(\d{1,2}):(\d{2})(:\d{2})?)",
+        "US_optional_time": r"(1[0-2]|0?[1-9])(\.|\/|-)(3[01]|[12][0-9]|0?[1-9])\2(\d{4})((\s|T)(\d{1,2})\:(\d{2})(:\d{2})?)?",
+    }
+    # Replace '/', '\', '.', ':', and ',' with '-' for consistency.
+    check_dates: pd.Series = pd.Series(date_input).astype(str)
+    date_list: list[str] = check_dates.str.replace(r"/|\.", "-", regex=True).tolist()
 
-    - Integer gets interpreted as year
-    - Starting with YYYY.xx.xx, then we assume ISO 8601
-    - Other than that, we assume a day-first format (e.g. Norwegian: DD.MM.YYYY)
-    """
-    # Columns with integers as dates are interpreted as year
-    if isinstance(date_input, int):
-        return datetime(date_input, 1, 1)
+    if check_dates.str.fullmatch(date_patterns["YEAR_ONLY"]).all():
+        return pd.to_datetime(date_list, format="%Y", errors="raise").to_pydatetime().tolist()
+    if check_dates.str.fullmatch(date_patterns["ISO8601_datetime"]).all():
+        return pd.to_datetime(date_list, format="ISO8601", errors="raise").to_pydatetime().tolist()
+    if check_dates.str.fullmatch(date_patterns["ISO8601_date"]).all():
+        return pd.to_datetime(date_list, format="ISO8601", errors="raise").to_pydatetime().tolist()
+    if check_dates.str.fullmatch(date_patterns["EU_datetime"]).all():
+        return pd.to_datetime(date_list, dayfirst=True, errors="raise").to_pydatetime().tolist()
+    if check_dates.str.fullmatch(date_patterns["EU_date"]).all():
+        return pd.to_datetime(date_list, dayfirst=True, errors="raise").to_pydatetime().tolist()
+    if check_dates.str.fullmatch(date_patterns["US_datetime"]).all():
+        return pd.to_datetime(date_list, format="%m-%d-%Y %H:%M:%S", errors="raise").to_pydatetime().tolist()
+    if check_dates.str.fullmatch(date_patterns["US_date"]).all():
+        return pd.to_datetime(date_list, format="%m-%d-%Y", errors="raise").to_pydatetime().tolist()
 
-    date_split = re.split(r"\D+", date_input)
-    if len(date_split[0]) == 4:
-        return pandas.to_datetime(date_input).to_pydatetime()
-    else:
-        return pandas.to_datetime(date_input, dayfirst=True).to_pydatetime()
+    if check_dates.str.contains(r"(am|pm|AM|PM)$", regex=True).any():
+        raise ValidationError("AM/PM are not supported in dates, only 24 hour clock is valid.")
+    if check_dates.str.fullmatch(date_patterns["EU_optional_time"]).all():
+        raise ValidationError("A mix of only dates and dates with time is not valid, ensure dates are consistent.")
+    if check_dates.str.fullmatch(date_patterns["US_optional_time"]).all():
+        raise ValidationError("A mix of only dates and dates with time is not valid, ensure dates are consistent.")
+    raise ValidationError(
+        "The provided date doesn't match any of the accepted date formats, or contains inconsistently formatted dates."
+    )
 
 
-def parse_time_vector(time_vector: list[Union[int, str]]) -> list[datetime]:
-    return [_parse_date(date_input) for date_input in time_vector]
-
-
-def parse_time_series_from_resource(resource: Resource):
+def parse_time_series_from_resource(resource: Resource) -> tuple[list[datetime], list[str]]:
     time_series_resource_headers = resource.get_headers()
 
     if len(time_series_resource_headers) == 0:

--- a/tests/libecalc/input/mappers/variables_mapper/test_timeseries.py
+++ b/tests/libecalc/input/mappers/variables_mapper/test_timeseries.py
@@ -56,7 +56,7 @@ class TestTimeSeries:
         "typ_enum, extrapolate, influence_time_vector, interpolation_type, extrapolate_result",
         parameterized_valid_timeseries_data,
     )
-    def test_valid_minimal_timeserie_different_types(
+    def test_valid_minimal_timeseries_different_types(
         self,
         typ_enum,
         extrapolate,
@@ -409,6 +409,121 @@ Validation error
         ]
 
     @pytest.mark.parametrize(
+        "dates, expected",
+        [
+            pytest.param(
+                [2012, 2013, 2014],
+                [datetime(2012, 1, 1), datetime(2013, 1, 1), datetime(2014, 1, 1)],
+                id="integer year only"
+            ),
+            pytest.param(
+                [2012, "2013", 2014],
+                [datetime(2012, 1, 1), datetime(2013, 1, 1), datetime(2014, 1, 1)],
+                id="integer and string year mix"
+            ),
+            pytest.param(
+                ["2012", "2013", "2014"],
+                [datetime(2012, 1, 1), datetime(2013, 1, 1), datetime(2014, 1, 1)],
+                id="string year only"
+            ),
+            pytest.param(
+                ["1970.01.01", "1980.02.20", "2000.10.01"],
+                [datetime(1970, 1, 1), datetime(1980, 2, 20), datetime(2000, 10, 1)],
+                id="ISO-8601 date only"
+            ),
+            pytest.param(
+                ["1970.01.01 10:10:10", "1980.02.20 11:10:01", "2000.10.01 10:20:30"],
+                [datetime(1970, 1, 1, 10, 10, 10), datetime(1980, 2, 20, 11, 10, 1), datetime(2000, 10, 1, 10, 20, 30)],
+                id="ISO-8601 datetime"
+            ),
+            pytest.param(
+                ["1.01.1970", "20.02.1980", "01.10.2000"],
+                [datetime(1970, 1, 1), datetime(1980, 2, 20), datetime(2000, 10, 1)],
+                id="eu style date"
+            ),
+            pytest.param(
+                ["21.01.1970 10:00:00", "12.02.1980 11:10:10", "1.12.2000 11:12:13"],
+                [datetime(1970, 1, 21, 10, 0, 0), datetime(1980, 2, 12, 11, 10, 10), datetime(2000, 12, 1, 11, 12, 13)],
+                id="eu style datetime"
+            ),
+            pytest.param(
+                ["01.21.1970", "02.02.1980", "01.10.2000"],
+                [datetime(1970, 1, 21), datetime(1980, 2, 2), datetime(2000, 1, 10)],
+                id="us style date"
+            ),
+            pytest.param(
+                ["01.21.1970 10:00:00", "02.02.1980 23:23:23", "01.10.2000 11:12:13"],
+                [datetime(1970, 1, 21, 10, 0, 0), datetime(1980, 2, 2, 23, 23, 23), datetime(2000, 1, 10, 11, 12, 13)],
+                id="us style datetime"
+            ),
+            pytest.param(
+                ["21-01-1970 23:59", "12-02-1980 11:10", "1-12-2000 11:12"],
+                [datetime(1970, 1, 21, 23, 59, 0), datetime(1980, 2, 12, 11, 10, 0),
+                 datetime(2000, 12, 1, 11, 12, 0)],
+                id="eu style datetime, without seconds"
+            ),
+        ]
+    )
+    def test_timeseries_valid_datetime_types(self, dates: list[str | int], expected: list[datetime]):
+        filename = "sim1.csv"
+        resource = MemoryResource(headers=["DATE", "HEADER1"], data=[dates, [1, 2, 3]])
+        time_series_collection = TimeSeriesCollection.from_yaml(
+            resource=resource,
+            yaml_collection=TypeAdapter(YamlTimeSeriesCollection).validate_python(
+                _create_timeseries_data(typ="DEFAULT", name="SIM1", file=filename)
+            )
+        )
+        assert time_series_collection.get_time_vector() == expected
+
+    @pytest.mark.parametrize(
+        "dates, expected_exception_text",
+        [
+            pytest.param(
+                ["2012.01.01", "2013.01.01", "2014"],
+                "The provided date doesn't match any of the accepted date formats",
+                id="string year and some dates"
+            ),
+            pytest.param(
+                ["13.01.1970", "1.13.1980", "01.01.2000"],
+                "The provided date doesn't match any of the accepted date formats",
+                id="mix of eu and us style date"
+            ),
+            pytest.param(
+                ["13.01.1970 10:10:10", "01.10.1980", "01.01.2000 10:11:12"],
+                "A mix of only dates and dates with time is not valid",
+                id="mix of date and datetime"
+            ),
+            pytest.param(
+                ["13.01.1970 10:10:10", "1.13.1980", "01.01.2000 10:11:12"],
+                "The provided date doesn't match any of the accepted date formats",
+                id="mix of eu and us style date, with time"
+            ),
+            pytest.param(
+                ["21.01.1970 10:00:00", "12.02.1980", "1.12.2000 11:12:13"],
+                "A mix of only dates and dates with time is not valid",
+                id="eu style mix of date and time"
+            ),
+            pytest.param(
+                ["01.21.1970 10:00:00 AM", "02.02.1980 11:10:10pm", "01.10.2000 11:12:13 AM"],
+                "AM/PM are not supported in dates",
+                id="us style datetime, am/pm"
+            ),
+
+        ]
+    )
+    def test_timeseries_invalid_datetime_types(self, dates: list[str | int], expected_exception_text: str):
+        filename = "sim1.csv"
+        resource = MemoryResource(headers=["DATE", "HEADER1"], data=[dates, [1, 2, 3]])
+        with pytest.raises(ValidationError) as e:
+            TimeSeriesCollection.from_yaml(
+                resource=resource,
+                yaml_collection=TypeAdapter(YamlTimeSeriesCollection).validate_python(
+                    _create_timeseries_data(typ="DEFAULT", name="SIM1", file=filename)
+                )
+            )
+        assert expected_exception_text in str(e.value)
+
+    @pytest.mark.parametrize(
         "header",
         ["COLUMN;1", "1", "*A", "~ABC", "A?A", "A)A", "A£", "A $", "C*", "A!A"],
     )
@@ -438,8 +553,8 @@ Validation error
         error_message = str(ve.value)
         assert "SIM1" in error_message
         assert (
-            "The time series resource header contains illegal characters. Allowed characters are: ^[A-Za-z][A-Za-z0-9_.,\\-\\s#+:\\/]*$"
-            in error_message
+                "The time series resource header contains illegal characters. Allowed characters are: ^[A-Za-z][A-Za-z0-9_.,\\-\\s#+:\\/]*$"
+                in error_message
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
