### PR TITLE
feat: manually control java process for neqsim

### DIFF
--- a/src/ecalc_cli/commands/run.py
+++ b/src/ecalc_cli/commands/run.py
@@ -16,6 +16,7 @@ from ecalc_cli.io.output import (
 )
 from ecalc_cli.logger import logger
 from ecalc_cli.types import DateFormat, Frequency
+from ecalc_neqsim_wrapper import NeqsimService
 from libecalc.application.energy_calculator import EnergyCalculator
 from libecalc.application.graph_result import GraphResult
 from libecalc.common.math.numbers import Numbers
@@ -110,87 +111,90 @@ def run(
     logger.info(f"eCalc™ simulation starting. Running {run_info}")
     validate_arguments(model_file=model_file, output_folder=output_folder)
 
-    configuration_service = FileConfigurationService(configuration_path=model_file)
-    resource_service = FileResourceService(working_directory=model_file.parent)
-    model = YamlModel(
-        configuration_service=configuration_service,
-        resource_service=resource_service,
-        output_frequency=frequency,
-    ).validate_for_run()
+    with NeqsimService():
+        configuration_service = FileConfigurationService(configuration_path=model_file)
+        resource_service = FileResourceService(working_directory=model_file.parent)
+        model = YamlModel(
+            configuration_service=configuration_service,
+            resource_service=resource_service,
+            output_frequency=frequency,
+        ).validate_for_run()
 
-    if (flow_diagram or ltp_export) and (model.start is None or model.end is None):
-        logger.warning(
-            "When using Flow Diagram or Long Term Prognosis export, START and END should be specified in YAML to make sure you get the intended period as output. See documentation for more information."
+        if (flow_diagram or ltp_export) and (model.start is None or model.end is None):
+            logger.warning(
+                "When using Flow Diagram or Long Term Prognosis export, START and END should be specified in YAML to make sure you get the intended period as output. See documentation for more information."
+            )
+
+        if flow_diagram:
+            write_flow_diagram(
+                energy_model=model,
+                output_folder=output_folder,
+                name_prefix=name_prefix,
+            )
+
+        energy_calculator = EnergyCalculator(energy_model=model, expression_evaluator=model.variables)
+        precision = 6
+        consumer_results = energy_calculator.evaluate_energy_usage()
+        emission_results = energy_calculator.evaluate_emissions()
+        results_core = GraphResult(
+            graph=model.get_graph(),
+            consumer_results=consumer_results,
+            variables_map=model.variables,
+            emission_results=emission_results,
         )
 
-    if flow_diagram:
-        write_flow_diagram(
-            energy_model=model,
-            output_folder=output_folder,
-            name_prefix=name_prefix,
-        )
+        run_info.end = datetime.now()
 
-    energy_calculator = EnergyCalculator(energy_model=model, expression_evaluator=model.variables)
-    precision = 6
-    consumer_results = energy_calculator.evaluate_energy_usage()
-    emission_results = energy_calculator.evaluate_emissions()
-    results_core = GraphResult(
-        graph=model.get_graph(),
-        consumer_results=consumer_results,
-        variables_map=model.variables,
-        emission_results=emission_results,
-    )
+        output_prefix: Path = output_folder / name_prefix
 
-    run_info.end = datetime.now()
+        results_dto = get_asset_result(results_core)
 
-    output_prefix: Path = output_folder / name_prefix
+        if (
+            frequency != libecalc.common.time_utils.Frequency.NONE
+        ):  # Not sure why this had to be changed from Frequency.NONE to libecalc.common.time_utils.Frequency.NONE
+            # Note: LTP can't use this resampled-result yet, because of differences in methodology.
+            results_resampled = Numbers.format_results_to_precision(
+                results_dto.resample(frequency), precision=precision
+            )
+        else:
+            results_resampled = results_dto.model_copy()
 
-    results_dto = get_asset_result(results_core)
+        if csv:
+            csv_data = get_result_output(
+                results=results_resampled,
+                output_format=OutputFormat.CSV,
+                simple_output=not detailed_output,
+                date_format_option=int(date_format_option.value),
+            )
+            write_output(output=csv_data, output_file=output_prefix.with_suffix(".csv"))
 
-    if (
-        frequency != libecalc.common.time_utils.Frequency.NONE
-    ):  # Not sure why this had to be changed from Frequency.NONE to libecalc.common.time_utils.Frequency.NONE
-        # Note: LTP can't use this resampled-result yet, because of differences in methodology.
-        results_resampled = Numbers.format_results_to_precision(results_dto.resample(frequency), precision=precision)
-    else:
-        results_resampled = results_dto.model_copy()
+        if json:
+            write_json(
+                results=results_resampled,
+                output_folder=output_folder,
+                name_prefix=name_prefix,
+                run_info=run_info,
+                date_format_option=int(date_format_option.value),
+                simple_output=not detailed_output,
+            )
 
-    if csv:
-        csv_data = get_result_output(
-            results=results_resampled,
-            output_format=OutputFormat.CSV,
-            simple_output=not detailed_output,
-            date_format_option=int(date_format_option.value),
-        )
-        write_output(output=csv_data, output_file=output_prefix.with_suffix(".csv"))
+        if ltp_export:
+            write_ltp_export(
+                results=results_core,
+                output_folder=output_folder,
+                frequency=frequency,  # Keep until alternative export option is in place (e.g. stp-export)
+                name_prefix=name_prefix,
+            )
 
-    if json:
-        write_json(
-            results=results_resampled,
-            output_folder=output_folder,
-            name_prefix=name_prefix,
-            run_info=run_info,
-            date_format_option=int(date_format_option.value),
-            simple_output=not detailed_output,
-        )
+        if stp_export:
+            write_stp_export(
+                results=results_core,
+                output_folder=output_folder,
+                frequency=frequency,  # Keep until alternative export option is in place (e.g. stp-export)
+                name_prefix=name_prefix,
+            )
 
-    if ltp_export:
-        write_ltp_export(
-            results=results_core,
-            output_folder=output_folder,
-            frequency=frequency,  # Keep until alternative export option is in place (e.g. stp-export)
-            name_prefix=name_prefix,
-        )
-
-    if stp_export:
-        write_stp_export(
-            results=results_core,
-            output_folder=output_folder,
-            frequency=frequency,  # Keep until alternative export option is in place (e.g. stp-export)
-            name_prefix=name_prefix,
-        )
-
-    logger.info(f"eCalc™ simulation successful. Duration: {run_info.end - run_info.start}")
+        logger.info(f"eCalc™ simulation successful. Duration: {run_info.end - run_info.start}")
 
 
 def validate_arguments(model_file: Path, output_folder: Path):

--- a/src/ecalc_cli/commands/selftest.py
+++ b/src/ecalc_cli/commands/selftest.py
@@ -1,6 +1,6 @@
 import libecalc.version
 from ecalc_cli.logger import logger
-from ecalc_neqsim_wrapper import start_server
+from ecalc_neqsim_wrapper import NeqsimService
 
 
 def selftest_java() -> bool:
@@ -11,9 +11,9 @@ def selftest_java() -> bool:
 
     """
     try:
-        start_server()
-        logger.debug("SUCCESS: Java seems to be correctly installed!")
-        return True
+        with NeqsimService():
+            logger.debug("SUCCESS: Java seems to be correctly installed!")
+            return True
     except Exception:
         logger.error(
             "Java does not seem to be installed. eCalc will currently not work since NeqSim depends on Java. Please install. See instructions in documentation."

--- a/src/ecalc_neqsim_wrapper/__init__.py
+++ b/src/ecalc_neqsim_wrapper/__init__.py
@@ -1,8 +1,4 @@
-from ecalc_neqsim_wrapper.java_service import start_server
-
-java_gateway = start_server()
-neqsim = java_gateway.jvm.neqsim
-
+from ecalc_neqsim_wrapper.java_service import NeqsimService
 from ecalc_neqsim_wrapper.thermo import NeqsimFluid
 
 

--- a/src/ecalc_neqsim_wrapper/java_service.py
+++ b/src/ecalc_neqsim_wrapper/java_service.py
@@ -1,27 +1,76 @@
+import logging
 import os
 from os import path
+from typing import Optional
 
 from py4j.java_gateway import JavaGateway
 
-gateway = None
-local_os_name = os.name
-colon = ":"
-if local_os_name == "nt":
-    colon = ";"
+_logger = logging.getLogger(__name__)
 
 
-def create_classpath(jars):
+# Java process started explicitly, should only be used 'on-demand', not on import
+_neqsim_service: Optional["NeqsimService"] = None
+
+
+_local_os_name = os.name
+_colon = ":"
+if _local_os_name == "nt":
+    _colon = ";"
+
+
+def _create_classpath(jars):
     """Create path to NeqSim .jar file"""
     resources_dir = path.dirname(__file__) + "/lib"
-    return colon.join([path.join(resources_dir, jar) for jar in jars])
+    return _colon.join([path.join(resources_dir, jar) for jar in jars])
 
 
-def start_server():
-    """Start JVM for NeqSim Wrapper"""
-    global gateway
+def _start_server(maximum_memory: str = "4G") -> JavaGateway:
+    """
+    Start JVM for NeqSim Wrapper
+    Returns: (int, Popen) port, process
+
+    """
     jars = ["NeqSim.jar"]
-    classpath = create_classpath(jars)
-    import logging
+    classpath = _create_classpath(jars)
 
     logging.getLogger("py4j").setLevel(logging.ERROR)
-    return JavaGateway.launch_gateway(classpath=classpath, die_on_exit=True, javaopts=["-Xmx4G"])
+    return JavaGateway.launch_gateway(classpath=classpath, die_on_exit=False, javaopts=[f"-Xmx{maximum_memory}"])
+
+
+class NeqsimService:
+    def __init__(self, maximum_memory: str = "4G"):
+        global _neqsim_service
+        self._gateway = _start_server(maximum_memory=maximum_memory)
+        _logger.info(
+            f"Started neqsim process with PID '{self._gateway.java_process.pid}' on port '{self._gateway.gateway_parameters.port}'"
+        )
+        _neqsim_service = self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.shutdown()
+
+    def get_neqsim_module(self):
+        return self._gateway.jvm.neqsim
+
+    def shutdown(self):
+        global _neqsim_service
+        _logger.info(
+            f"Killing neqsim process with PID '{self._gateway.java_process.pid}' on port '{self._gateway.gateway_parameters.port}'"
+        )
+        # Shutdown gateway, connections ++
+        try:
+            self._gateway.shutdown()
+        except Exception:
+            _logger.exception("Java gateway close failed")
+        finally:
+            _neqsim_service = None
+
+
+def get_neqsim_service():
+    try:
+        return _neqsim_service
+    except LookupError as e:
+        raise ValueError("Java gateway must be set up") from e

--- a/src/ecalc_neqsim_wrapper/mappings.py
+++ b/src/ecalc_neqsim_wrapper/mappings.py
@@ -1,26 +1,9 @@
 from __future__ import annotations
 
-from enum import Enum
-
-from ecalc_neqsim_wrapper import neqsim
 from libecalc.common.errors.exceptions import EcalcError
-from libecalc.common.fluid import EoSModel, FluidComposition
+from libecalc.common.fluid import FluidComposition
 from libecalc.common.logger import logger
 
-
-class NeqsimEoSModelType(Enum):
-    SRK = neqsim.thermo.system.SystemSrkEos
-    PR = neqsim.thermo.system.SystemPrEos
-    GERG_SRK = neqsim.thermo.system.SystemSrkEos
-    GERG_PR = neqsim.thermo.system.SystemPrEos
-
-
-_map_eos_model_to_neqsim = {
-    EoSModel.SRK: NeqsimEoSModelType.SRK,
-    EoSModel.PR: NeqsimEoSModelType.PR,
-    EoSModel.GERG_SRK: NeqsimEoSModelType.GERG_SRK,
-    EoSModel.GERG_PR: NeqsimEoSModelType.GERG_PR,
-}
 _map_fluid_component_to_neqsim = {
     "water": "water",
     "nitrogen": "nitrogen",
@@ -62,10 +45,3 @@ def map_fluid_composition_to_neqsim(fluid_composition: FluidComposition) -> dict
         raise EcalcError(title="Failed to create NeqSim fluid", message=msg)
 
     return component_dict
-
-
-def map_eos_model_to_neqsim(ecalc_eos_model: EoSModel) -> NeqsimEoSModelType:
-    try:
-        return _map_eos_model_to_neqsim[ecalc_eos_model]
-    except KeyError as e:
-        raise EcalcError(title="Failed to create NeqSim fluid", message=str(e)) from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from typing import Optional, cast
 import pytest
 import yaml
 
+from ecalc_neqsim_wrapper import NeqsimService
 from libecalc.common.math.numbers import Numbers
 from libecalc.common.time_utils import Frequency
 from libecalc.examples import advanced, drogon, simple
@@ -272,3 +273,9 @@ def energy_model_from_dto_factory():
         return DTOEnergyModel(component)
 
     return create_energy_model
+
+
+@pytest.fixture(autouse=True)
+def with_neqsim_service():
+    with NeqsimService() as neqsim:
+        yield neqsim

--- a/tests/ecalc_neqsim_wrapper/conftest.py
+++ b/tests/ecalc_neqsim_wrapper/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ecalc_neqsim_wrapper import NeqsimService
 from ecalc_neqsim_wrapper.thermo import NeqsimFluid
 from libecalc.common.fluid import EoSModel, FluidComposition
 
@@ -32,6 +33,12 @@ MEDIUM_MW_19P4_COMPOSITION = FluidComposition(
 LIGHT_FLUID_COMPOSITION = FluidComposition(
     methane=10.0, ethane=1.0, propane=0.1, n_hexane=10.1
 )  # Heptane not used in eCalc, only care about C1-C6
+
+
+@pytest.fixture(autouse=True)
+def with_neqsim_service():
+    with NeqsimService() as neqsim_service:
+        yield neqsim_service
 
 
 @pytest.fixture

--- a/tests/ecalc_neqsim_wrapper/unit_tests/test_java_service.py
+++ b/tests/ecalc_neqsim_wrapper/unit_tests/test_java_service.py
@@ -1,13 +1,18 @@
-from ecalc_neqsim_wrapper import neqsim
+import pytest
 
 
-def test_py4j_service():
+@pytest.fixture
+def neqsim_module(with_neqsim_service):
+    yield with_neqsim_service.get_neqsim_module()
+
+
+def test_py4j_service(neqsim_module):
     """Testing the most simple case to ensure that the java service is running and working."""
-    thermo_system = neqsim.thermo.system.SystemSrkEos(280.0, 10.0)
+    thermo_system = neqsim_module.thermo.system.SystemSrkEos(280.0, 10.0)
     thermo_system.addComponent("methane", 10.0)
     thermo_system.addComponent("water", 4.0)
 
-    thermo_dynamic_operations = neqsim.thermodynamicoperations.ThermodynamicOperations(thermo_system)
+    thermo_dynamic_operations = neqsim_module.thermodynamicoperations.ThermodynamicOperations(thermo_system)
     thermo_dynamic_operations.TPflash()
 
     gas_enthalpy = thermo_system.getPhase(0).getEnthalpy()


### PR DESCRIPTION
When starting a new java-process we also need to clear the NeqsimFluid cache, since the py4j/java-connection is stored within the cached objects (JavaObject from py4j).