### PR TITLE
chore: invalidate negative fuel rates in direct consumer function

### DIFF
--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/consumer_function/direct_expression_consumer_function.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/consumer_function/direct_expression_consumer_function.py
@@ -99,9 +99,19 @@ class DirectExpressionConsumerFunction(ConsumerFunction):
             power_loss_factor_expression=self._power_loss_factor_expression,
         )
 
+        is_valid = np.asarray(energy_function_result.is_valid)
+
+        # Invalidate negative fuel rates after applying conditions.
+        # Direct consumers can use LOAD (electrical consumers) or FUELRATE (fuel consumers).
+        # Note: Negative load values can be valid in some cases (e.g., energy efficiency measures on generator sets),
+        # but negative fuel rates are always invalid.
+
+        if self.is_fuel_consumer:
+            is_valid[energy_usage < 0] = False
+
         consumer_function_result = ConsumerFunctionResult(
             periods=expression_evaluator.get_periods(),
-            is_valid=np.asarray(energy_function_result.is_valid),
+            is_valid=is_valid,
             energy_function_result=energy_function_result,
             condition=condition,
             energy_usage_before_power_loss_factor=np.asarray(energy_function_result.energy_usage),


### PR DESCRIPTION
equinor/ecalc-internal#354


## Why is this pull request needed?

This pull request addresses the issue of invalid negative fuel rates in the DirectExpressionConsumerFunction.evaluate method. Negative load values can be valid in some cases (e.g., energy efficiency measures on generator sets).
Negative fuel rates are always invalid.


## What does this pull request change?

The following changes have been made:  

- [ ] Updated the evaluate method to ensure that the is_valid array is set to False for any negative values in energy_usage after applying conditions.
- [ ] Added a comment to clarify the handling of negative fuel rates and loads
- [ ] Added tests


## Issues related to this change:
https://github.com/equinor/ecalc-internal/issues/354