### PR TITLE
fix: issue with empty optional keywords

### DIFF
--- a/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
@@ -45,11 +45,6 @@ class YamlValidator(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def all_resource_names(self) -> list[str]:
-        pass
-
-    @property
-    @abc.abstractmethod
     def variables(self) -> dict[str, YamlVariable]:
         pass
 

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import ConfigDict, Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 
@@ -30,20 +28,20 @@ class YamlAsset(YamlBase):
         title="Asset",
     )
 
-    time_series: Optional[list[YamlTimeSeriesCollection]] = Field(
-        None,
+    time_series: list[YamlTimeSeriesCollection] = Field(
+        default_factory=list,
         title="TIME_SERIES",
         description="Defines the inputs for time dependent variables, or 'reservoir variables'."
         "\n\n$ECALC_DOCS_KEYWORDS_URL/TIME_SERIES",
     )
-    facility_inputs: Optional[list[YamlFacilityModel]] = Field(
-        None,
+    facility_inputs: list[YamlFacilityModel] = Field(
+        default_factory=list,
         title="FACILITY_INPUTS",
         description="Defines input files which characterize various facility elements."
         "\n\n$ECALC_DOCS_KEYWORDS_URL/FACILITY_INPUTS",
     )
-    models: Optional[list[YamlConsumerModel]] = Field(
-        None,
+    models: list[YamlConsumerModel] = Field(
+        default_factory=list,
         title="MODELS",
         description="Defines input files which characterize various facility elements."
         "\n\n$ECALC_DOCS_KEYWORDS_URL/MODELS",
@@ -55,7 +53,7 @@ class YamlAsset(YamlBase):
         "\n\n$ECALC_DOCS_KEYWORDS_URL/FUEL_TYPES",
     )
     variables: YamlVariables = Field(
-        None,
+        default_factory=dict,  # type: ignore
         title="VARIABLES",
         description="Defines variables used in an energy usage model by means of expressions or constants."
         "\n\n$ECALC_DOCS_KEYWORDS_URL/VARIABLES",


### PR DESCRIPTION
If specifying only a keyword without the data for an optional keyword in
the yaml we would not get a validation error. I.e. the json-schema did
not capture the error. In addition, the validation context setup did not
account for None in the data, expecting either unset or some data (not
None). This caused a type error since we then tried to use None as a
list.

Adding only `MODELS:` to the yaml would reproduce the error. Removing
`MODELS:` or adding an empty list `MODELS: []` would make it valid.
