### PR TITLE
fix: error message when variables are unsolvable

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/variables_mapper/variables_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/variables_mapper/variables_mapper.py
@@ -12,6 +12,11 @@ from libecalc.presentation.yaml.yaml_types.yaml_variable import (
 )
 
 
+class InvalidVariablesException(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
 @dataclass
 class VariableProcessor:
     reference_id: str
@@ -87,7 +92,7 @@ def _evaluate_variables(variables: dict[str, YamlVariable], variables_map: Varia
             }
         )
         unsolvable_variables = sorted([variable.reference_id for variable in variables_to_process])
-        raise ValueError(
+        raise InvalidVariablesException(
             f"Could not evaluate all variables, unable to resolve references in {', '.join(unsolvable_variables)}. "
             f"Missing references are {', '.join(missing_references)}"
         )

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -19,6 +19,7 @@ from libecalc.presentation.yaml.mappers.component_mapper import EcalcModelMapper
 from libecalc.presentation.yaml.mappers.create_references import create_references
 from libecalc.presentation.yaml.mappers.variables_mapper import map_yaml_to_variables
 from libecalc.presentation.yaml.mappers.variables_mapper.get_global_time_vector import get_global_time_vector
+from libecalc.presentation.yaml.mappers.variables_mapper.variables_mapper import InvalidVariablesException
 from libecalc.presentation.yaml.model_validation_exception import ModelValidationException
 from libecalc.presentation.yaml.resource_service import ResourceService
 from libecalc.presentation.yaml.validation_errors import (
@@ -26,6 +27,7 @@ from libecalc.presentation.yaml.validation_errors import (
     Location,
     ModelValidationError,
 )
+from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
 from libecalc.presentation.yaml.yaml_models.exceptions import DuplicateKeyError, YamlError
 from libecalc.presentation.yaml.yaml_models.yaml_model import YamlValidator
 from libecalc.presentation.yaml.yaml_validation_context import (
@@ -208,5 +210,18 @@ class YamlModel(EnergyModel):
             # Validate and create the graph used for evaluating the energy model
             self.get_graph()
             return self
+        except InvalidVariablesException as e:
+            # TODO: Variables are evaluated when setting up ExpressionEvaluator. This seems unnecessary.
+            #  We could evaluate when needed instead.
+            raise ModelValidationException(
+                errors=[
+                    ModelValidationError(
+                        location=Location(keys=[EcalcYamlKeywords.variables]),
+                        message=str(e),
+                        data=None,
+                        file_context=None,
+                    )
+                ],
+            ) from e
         except (DtoValidationError, ComponentValidationException) as e:
             raise ModelValidationException(errors=e.errors()) from e

--- a/tests/libecalc/input/mappers/variables_mapper/test_variables_mapper.py
+++ b/tests/libecalc/input/mappers/variables_mapper/test_variables_mapper.py
@@ -6,6 +6,7 @@ from libecalc.common.time_utils import Periods
 from libecalc.common.variables import VariablesMap
 from libecalc.expression import Expression
 from libecalc.presentation.yaml.mappers.variables_mapper.variables_mapper import (
+    InvalidVariablesException,
     VariableProcessor,
     _evaluate_variables,
 )
@@ -14,7 +15,7 @@ from libecalc.presentation.yaml.yaml_types.yaml_variable import YamlSingleVariab
 
 class TestEvaluateVariables:
     def test_unsolvable(self):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(InvalidVariablesException) as exc_info:
             _evaluate_variables(
                 variables={
                     "test_id": YamlSingleVariable(value=Expression.setup_from_expression("SIM1;TEST")),


### PR DESCRIPTION
Catch the error and convert it to an expected error.

Further improvement could be to evaluate variables when needed, but it
would still be nice if we could make sure we _can_ solve in
validating.
