### PR TITLE
chore: remove pydantic from domain process dto

### DIFF
--- a/src/libecalc/domain/process/core/compressor/factory.py
+++ b/src/libecalc/domain/process/core/compressor/factory.py
@@ -27,7 +27,7 @@ from libecalc.domain.process.core.compressor.train.variable_speed_compressor_tra
     VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures,
 )
 from libecalc.domain.process.core.turbine import TurbineModel
-from libecalc.domain.process.dto import CompressorModel as CompressorModelDTO
+from libecalc.domain.process.dto import CompressorModelTypes as CompressorModelDTO
 from libecalc.domain.process.dto import (
     CompressorSampled,
     CompressorTrainSimplifiedWithKnownStages,

--- a/src/libecalc/domain/process/core/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/domain/process/core/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Optional, cast
 
 import numpy as np
@@ -1159,8 +1160,8 @@ def split_train_on_stage_number(
     :param stage_number:
     :return:
     """
-    first_part_data_transfer_object = compressor_train.data_transfer_object.model_copy()
-    last_part_data_transfer_object = compressor_train.data_transfer_object.model_copy()
+    first_part_data_transfer_object = deepcopy(compressor_train.data_transfer_object)
+    last_part_data_transfer_object = deepcopy(compressor_train.data_transfer_object)
     first_part_data_transfer_object.stages = first_part_data_transfer_object.stages[:stage_number]
     last_part_data_transfer_object.stages = last_part_data_transfer_object.stages[stage_number:]
     first_part_data_transfer_object.pressure_control = pressure_control_first_part

--- a/src/libecalc/domain/process/dto/__init__.py
+++ b/src/libecalc/domain/process/dto/__init__.py
@@ -5,7 +5,7 @@ from pydantic import Field
 from libecalc.domain.process.dto.compressor import (
     CompressorChart,
     CompressorConsumerFunction,
-    CompressorModel,
+    CompressorModelTypes,
     CompressorSampled,
     CompressorStage,
     CompressorTrainSimplifiedWithKnownStages,

--- a/src/libecalc/domain/process/dto/base.py
+++ b/src/libecalc/domain/process/dto/base.py
@@ -1,26 +1,21 @@
 from typing import Optional
 
-from pydantic import ConfigDict, field_validator
-
 from libecalc.common.consumer_type import ConsumerType
 from libecalc.common.energy_usage_type import EnergyUsageType
-from libecalc.dto.base import EcalcBaseModel
 from libecalc.dto.utils.validators import convert_expression
 from libecalc.expression import Expression
 
 
-class ConsumerFunction(EcalcBaseModel):
-    typ: ConsumerType
-    energy_usage_type: EnergyUsageType
-    condition: Optional[Expression] = None
-
-    _convert_condition_to_expression = field_validator("condition", mode="before")(convert_expression)
-    model_config = ConfigDict(use_enum_values=True)
+class ConsumerFunction:
+    def __init__(self, typ: ConsumerType, energy_usage_type: EnergyUsageType, condition: Optional[Expression] = None):
+        self.typ = typ
+        self.energy_usage_type = energy_usage_type
+        self.condition = convert_expression(condition)
 
 
-class EnergyModel(EcalcBaseModel):
+class EnergyModel:
     """Generic/template/protocol. Only for sub classing, not direct use."""
 
-    energy_usage_adjustment_constant: float
-    energy_usage_adjustment_factor: float
-    model_config = ConfigDict(use_enum_values=True)
+    def __init__(self, energy_usage_adjustment_constant: float, energy_usage_adjustment_factor: float):
+        self.energy_usage_adjustment_constant = energy_usage_adjustment_constant
+        self.energy_usage_adjustment_factor = energy_usage_adjustment_factor

--- a/src/libecalc/domain/process/dto/chart.py
+++ b/src/libecalc/domain/process/dto/chart.py
@@ -1,18 +1,56 @@
 from typing import Literal
 
-from pydantic import Field
-
 from libecalc.common.chart_type import ChartType
-from libecalc.dto.base import EcalcBaseModel
 
 
-class GenericChartFromDesignPoint(EcalcBaseModel):
+class GenericChartFromDesignPoint:
     typ: Literal[ChartType.GENERIC_FROM_DESIGN_POINT] = ChartType.GENERIC_FROM_DESIGN_POINT
-    polytropic_efficiency_fraction: float = Field(..., gt=0, le=1)
-    design_rate_actual_m3_per_hour: float = Field(..., ge=0)
-    design_polytropic_head_J_per_kg: float = Field(..., ge=0)
+
+    def __init__(
+        self,
+        polytropic_efficiency_fraction: float,
+        design_rate_actual_m3_per_hour: float,
+        design_polytropic_head_J_per_kg: float,
+    ):
+        self.polytropic_efficiency_fraction = polytropic_efficiency_fraction
+        self.design_rate_actual_m3_per_hour = design_rate_actual_m3_per_hour
+        self.design_polytropic_head_J_per_kg = design_polytropic_head_J_per_kg
+        self._validate_polytropic_efficiency_fraction()
+        self._validate_design_rate_actual_m3_per_hour()
+        self._validate_design_polytropic_head_J_per_kg()
+
+    def _validate_polytropic_efficiency_fraction(self):
+        if not isinstance(self.polytropic_efficiency_fraction, int | float):
+            raise ValueError("polytropic_efficiency_fraction must be a number")
+
+        if not (0 < self.polytropic_efficiency_fraction <= 1):
+            raise ValueError("polytropic_efficiency_fraction must be greater than 0 and less than or equal to 1")
+
+    def _validate_design_rate_actual_m3_per_hour(self):
+        if not isinstance(self.design_rate_actual_m3_per_hour, int | float):
+            raise ValueError("design_rate_actual_m3_per_hour must be a number")
+
+        if self.design_rate_actual_m3_per_hour < 0:
+            raise ValueError("design_rate_actual_m3_per_hour must be greater than or equal to 0")
+
+    def _validate_design_polytropic_head_J_per_kg(self):
+        if not isinstance(self.design_polytropic_head_J_per_kg, int | float):
+            raise ValueError("design_polytropic_head_J_per_kg must be a number")
+
+        if self.design_polytropic_head_J_per_kg < 0:
+            raise ValueError("design_polytropic_head_J_per_kg must be greater than or equal to 0")
 
 
-class GenericChartFromInput(EcalcBaseModel):
+class GenericChartFromInput:
     typ: Literal[ChartType.GENERIC_FROM_INPUT] = ChartType.GENERIC_FROM_INPUT
-    polytropic_efficiency_fraction: float = Field(..., gt=0, le=1)
+
+    def __init__(self, polytropic_efficiency_fraction: float):
+        self.polytropic_efficiency_fraction = polytropic_efficiency_fraction
+        self._validate_polytropic_efficiency_fraction()
+
+    def _validate_polytropic_efficiency_fraction(self):
+        if not isinstance(self.polytropic_efficiency_fraction, int | float):
+            raise ValueError("polytropic_efficiency_fraction must be a number")
+
+        if not (0 < self.polytropic_efficiency_fraction <= 1):
+            raise ValueError("polytropic_efficiency_fraction must be greater than 0 and less than or equal to 1")

--- a/src/libecalc/domain/process/dto/compressor/__init__.py
+++ b/src/libecalc/domain/process/dto/compressor/__init__.py
@@ -1,6 +1,4 @@
-from typing import Union
-
-from .base import CompressorConsumerFunction, CompressorWithTurbine
+from .base import CompressorConsumerFunction, CompressorModelTypes, CompressorWithTurbine
 from .chart import CompressorChart
 from .sampled import CompressorSampled
 from .stage import (
@@ -15,13 +13,3 @@ from .train import (
     VariableSpeedCompressorTrain,
     VariableSpeedCompressorTrainMultipleStreamsAndPressures,
 )
-
-CompressorModel = Union[
-    CompressorSampled,
-    CompressorTrainSimplifiedWithUnknownStages,
-    CompressorTrainSimplifiedWithKnownStages,
-    CompressorWithTurbine,
-    VariableSpeedCompressorTrain,
-    SingleSpeedCompressorTrain,
-    VariableSpeedCompressorTrainMultipleStreamsAndPressures,
-]

--- a/src/libecalc/domain/process/dto/compressor/base.py
+++ b/src/libecalc/domain/process/dto/compressor/base.py
@@ -1,10 +1,8 @@
 from typing import Literal, Optional, Union
 
-from pydantic import Field, field_validator
-
 from libecalc.common.consumer_type import ConsumerType
 from libecalc.common.energy_model_type import EnergyModelType
-from libecalc.domain.process.dto.base import ConsumerFunction, EnergyModel
+from libecalc.domain.process.dto.base import ConsumerFunction, EnergyModel, EnergyUsageType
 from libecalc.domain.process.dto.compressor.sampled import CompressorSampled
 from libecalc.domain.process.dto.compressor.train import (
     CompressorTrainSimplifiedWithKnownStages,
@@ -20,18 +18,27 @@ from libecalc.expression import Expression
 
 class CompressorWithTurbine(EnergyModel):
     typ: Literal[EnergyModelType.COMPRESSOR_WITH_TURBINE] = EnergyModelType.COMPRESSOR_WITH_TURBINE
-    compressor_train: Union[
-        CompressorSampled,
-        CompressorTrainSimplifiedWithKnownStages,
-        CompressorTrainSimplifiedWithUnknownStages,
-        SingleSpeedCompressorTrain,
-        VariableSpeedCompressorTrain,
-        VariableSpeedCompressorTrainMultipleStreamsAndPressures,
-    ] = Field(..., discriminator="typ")
-    turbine: Turbine
+
+    def __init__(
+        self,
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+        compressor_train: Union[
+            CompressorSampled,
+            CompressorTrainSimplifiedWithKnownStages,
+            CompressorTrainSimplifiedWithUnknownStages,
+            SingleSpeedCompressorTrain,
+            VariableSpeedCompressorTrain,
+            VariableSpeedCompressorTrainMultipleStreamsAndPressures,
+        ],
+        turbine: Turbine,
+    ):
+        super().__init__(energy_usage_adjustment_constant, energy_usage_adjustment_factor)
+        self.compressor_train = compressor_train
+        self.turbine = turbine
 
 
-CompressorModel = Union[
+CompressorModelTypes = Union[
     CompressorSampled,
     CompressorTrainSimplifiedWithUnknownStages,
     CompressorTrainSimplifiedWithKnownStages,
@@ -44,24 +51,25 @@ CompressorModel = Union[
 
 class CompressorConsumerFunction(ConsumerFunction):
     typ: Literal[ConsumerType.COMPRESSOR] = ConsumerType.COMPRESSOR
-    power_loss_factor: Optional[Expression] = None
-    model: CompressorModel = Field(..., discriminator="typ")
-    rate_standard_m3_day: Union[Expression, list[Expression]]
-    suction_pressure: Optional[Expression] = None
-    discharge_pressure: Optional[Expression] = None
-    interstage_control_pressure: Optional[Expression] = None
     # Todo: add pressure_control_first_part, pressure_control_last_part and stage_number_interstage_pressure
     # TODO: validate power loss factor wrt energy usage type
     # validate energy function has the same energy_usage_type
 
-    _convert_expressions = field_validator(
-        "suction_pressure",
-        "discharge_pressure",
-        "power_loss_factor",
-        "interstage_control_pressure",
-        mode="before",
-    )(convert_expression)
-    _convert_rate_expressions = field_validator(
-        "rate_standard_m3_day",
-        mode="before",
-    )(convert_expressions)
+    def __init__(
+        self,
+        energy_usage_type: EnergyUsageType,
+        model: CompressorModelTypes,
+        rate_standard_m3_day: Union[Expression, list[Expression]],
+        condition: Optional[Expression] = None,
+        power_loss_factor: Optional[Expression] = None,
+        suction_pressure: Optional[Expression] = None,
+        discharge_pressure: Optional[Expression] = None,
+        interstage_control_pressure: Optional[Expression] = None,
+    ):
+        super().__init__(typ=self.typ, energy_usage_type=energy_usage_type, condition=condition)
+        self.model = model
+        self.rate_standard_m3_day = convert_expressions(rate_standard_m3_day)
+        self.power_loss_factor = convert_expression(power_loss_factor)
+        self.suction_pressure = convert_expression(suction_pressure)
+        self.discharge_pressure = convert_expression(discharge_pressure)
+        self.interstage_control_pressure = convert_expression(interstage_control_pressure)

--- a/src/libecalc/domain/process/dto/compressor/sampled.py
+++ b/src/libecalc/domain/process/dto/compressor/sampled.py
@@ -1,6 +1,4 @@
-from typing import Annotated, Literal, Optional
-
-from pydantic import Field, model_validator
+from typing import Literal, Optional
 
 from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.common.energy_usage_type import EnergyUsageType
@@ -10,14 +8,36 @@ from libecalc.domain.process.dto.base import EnergyModel
 class CompressorSampled(EnergyModel):
     typ: Literal[EnergyModelType.COMPRESSOR_SAMPLED] = EnergyModelType.COMPRESSOR_SAMPLED
     energy_usage_type: EnergyUsageType
-    energy_usage_values: list[Annotated[float, Field(ge=0)]]
-    rate_values: Optional[list[Annotated[float, Field(ge=0)]]] = None
-    suction_pressure_values: Optional[list[Annotated[float, Field(ge=0)]]] = None
-    discharge_pressure_values: Optional[list[Annotated[float, Field(ge=0)]]] = None
-    power_interpolation_values: Optional[list[Annotated[float, Field(ge=0)]]] = None
+    energy_usage_values: list[float]
+    rate_values: Optional[list[float]] = None
+    suction_pressure_values: Optional[list[float]] = None
+    discharge_pressure_values: Optional[list[float]] = None
+    power_interpolation_values: Optional[list[float]] = None
+
+    def __init__(
+        self,
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+        energy_usage_type: EnergyUsageType,
+        energy_usage_values: list[float],
+        rate_values: Optional[list[float]] = None,
+        suction_pressure_values: Optional[list[float]] = None,
+        discharge_pressure_values: Optional[list[float]] = None,
+        power_interpolation_values: Optional[list[float]] = None,
+    ):
+        super().__init__(energy_usage_adjustment_constant, energy_usage_adjustment_factor)
+        self.energy_usage_type = energy_usage_type
+        self.energy_usage_values = energy_usage_values
+        self.rate_values = rate_values
+        self.suction_pressure_values = suction_pressure_values
+        self.discharge_pressure_values = discharge_pressure_values
+        self.power_interpolation_values = power_interpolation_values
+
+        self.validate_minimum_one_variable()
+        self.validate_equal_list_lengths()
+        self.validate_non_negative_values()
 
     # skip_on_failure required if not pre=True, we don't need validation of lengths if other validations fails
-    @model_validator(mode="after")
     def validate_equal_list_lengths(self):
         number_of_data_points = len(self.energy_usage_values)
         for variable_name in (
@@ -33,15 +53,22 @@ class CompressorSampled(EnergyModel):
                         f"{variable_name} has wrong number of points. "
                         f"Should have {number_of_data_points} (equal to number of energy usage value points)"
                     )
-        return self
 
-    @model_validator(mode="before")
-    def validate_minimum_one_variable(cls, values):
-        rate_not_given = "rate_values" not in values
-        suction_pressure_not_given = "suction_pressure_values" not in values
-        discharge_pressure_not_given = "discharge_pressure_values" not in values
-        if rate_not_given and suction_pressure_not_given and discharge_pressure_not_given:
+    def validate_minimum_one_variable(self):
+        if not self.rate_values and not self.suction_pressure_values and not self.discharge_pressure_values:
             raise ValueError(
                 "Need at least one variable for CompressorTrainSampled (rate, suction_pressure or discharge_pressure)"
             )
-        return values
+
+    def validate_non_negative_values(self):
+        for variable_name in (
+            "energy_usage_values",
+            "rate_values",
+            "suction_pressure_values",
+            "discharge_pressure_values",
+            "power_interpolation_values",
+        ):
+            variable = getattr(self, variable_name)
+            if variable is not None:
+                if any(value < 0 for value in variable):
+                    raise ValueError(f"All values in {variable_name} must be greater than or equal to 0")

--- a/src/libecalc/domain/process/dto/compressor/stage.py
+++ b/src/libecalc/domain/process/dto/compressor/stage.py
@@ -1,32 +1,65 @@
-from typing import Annotated, Optional
-
-from pydantic import Field
+from typing import Optional
 
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
 from libecalc.common.serializable_chart import VariableSpeedChartDTO
 from libecalc.domain.process.dto.compressor.chart import CompressorChart
-from libecalc.dto.base import EcalcBaseModel
 
 
-class CompressorStage(EcalcBaseModel):
-    compressor_chart: CompressorChart
-    inlet_temperature_kelvin: Annotated[float, Field(ge=0)]
-    pressure_drop_before_stage: Annotated[float, Field(ge=0)]
-    remove_liquid_after_cooling: bool
-    control_margin: Annotated[float, Field(ge=0, le=1)] = 0.0  # Todo: this probably belong to the chart, not the stage.
+class CompressorStage:
+    def __init__(
+        self,
+        compressor_chart: CompressorChart,
+        inlet_temperature_kelvin: float,
+        pressure_drop_before_stage: float,
+        remove_liquid_after_cooling: bool,
+        control_margin: float = 0.0,
+    ):
+        if inlet_temperature_kelvin < 0:
+            raise ValueError("inlet_temperature_kelvin must be greater than or equal to 0")
+        if pressure_drop_before_stage < 0:
+            raise ValueError("pressure_drop_before_stage must be greater than or equal to 0")
+        if not (0 <= control_margin <= 1):
+            raise ValueError("control_margin must be between 0 and 1")
+
+        self.compressor_chart = compressor_chart
+        self.inlet_temperature_kelvin = inlet_temperature_kelvin
+        self.pressure_drop_before_stage = pressure_drop_before_stage
+        self.remove_liquid_after_cooling = remove_liquid_after_cooling
+        self.control_margin = control_margin
 
 
-class InterstagePressureControl(EcalcBaseModel):
-    upstream_pressure_control: FixedSpeedPressureControl
-    downstream_pressure_control: FixedSpeedPressureControl
+class InterstagePressureControl:
+    def __init__(
+        self,
+        upstream_pressure_control: FixedSpeedPressureControl,
+        downstream_pressure_control: FixedSpeedPressureControl,
+    ):
+        self.upstream_pressure_control = upstream_pressure_control
+        self.downstream_pressure_control = downstream_pressure_control
 
 
 class MultipleStreamsCompressorStage(CompressorStage):
     """Special case for multiple streams model."""
 
-    compressor_chart: VariableSpeedChartDTO
-    stream_reference: Optional[list[str]] = None
-    interstage_pressure_control: Optional[InterstagePressureControl] = None
+    def __init__(
+        self,
+        compressor_chart: VariableSpeedChartDTO,
+        inlet_temperature_kelvin: float,
+        pressure_drop_before_stage: float,
+        remove_liquid_after_cooling: bool,
+        stream_reference: Optional[list[str]] = None,
+        interstage_pressure_control: Optional[InterstagePressureControl] = None,
+        control_margin: float = 0.0,
+    ):
+        super().__init__(
+            compressor_chart=compressor_chart,
+            inlet_temperature_kelvin=inlet_temperature_kelvin,
+            pressure_drop_before_stage=pressure_drop_before_stage,
+            remove_liquid_after_cooling=remove_liquid_after_cooling,
+            control_margin=control_margin,
+        )
+        self.stream_reference = stream_reference
+        self.interstage_pressure_control = interstage_pressure_control
 
     @property
     def has_control_pressure(self):

--- a/src/libecalc/domain/process/dto/compressor/train.py
+++ b/src/libecalc/domain/process/dto/compressor/train.py
@@ -1,6 +1,4 @@
-from typing import Annotated, Literal, Optional
-
-from pydantic import Field, field_validator
+from typing import Literal, Optional
 
 from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
@@ -19,10 +17,29 @@ from libecalc.domain.process.dto.compressor.stage import (
 class CompressorTrain(EnergyModel):
     typ: EnergyModelType
     stages: list[CompressorStage]
-    fluid_model: FluidModel
+    fluid_model: Optional[FluidModel] = None
     calculate_max_rate: bool = False
     maximum_power: Optional[float] = None
-    pressure_control: FixedSpeedPressureControl
+    pressure_control: Optional[FixedSpeedPressureControl] = None
+
+    def __init__(
+        self,
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+        typ: EnergyModelType,
+        stages: list[CompressorStage],
+        fluid_model: Optional[FluidModel] = None,
+        pressure_control: Optional[FixedSpeedPressureControl] = None,
+        calculate_max_rate: bool = False,
+        maximum_power: Optional[float] = None,
+    ):
+        super().__init__(energy_usage_adjustment_constant, energy_usage_adjustment_factor)
+        self.typ = typ
+        self.stages = stages
+        self.fluid_model = fluid_model
+        self.calculate_max_rate = calculate_max_rate
+        self.maximum_power = maximum_power
+        self.pressure_control = pressure_control
 
 
 class CompressorTrainSimplifiedWithKnownStages(CompressorTrain):
@@ -33,9 +50,28 @@ class CompressorTrainSimplifiedWithKnownStages(CompressorTrain):
     # Not in use:
     pressure_control: Optional[FixedSpeedPressureControl] = None  # Not relevant for simplified trains.
 
-    @field_validator("stages")
-    @classmethod
-    def _validate_stages(cls, stages):
+    def __init__(
+        self,
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+        stages: list[CompressorStage],
+        fluid_model: FluidModel,
+        calculate_max_rate: bool = False,
+        maximum_power: Optional[float] = None,
+    ):
+        super().__init__(
+            energy_usage_adjustment_constant=energy_usage_adjustment_constant,
+            energy_usage_adjustment_factor=energy_usage_adjustment_factor,
+            typ=self.typ,
+            stages=stages,
+            fluid_model=fluid_model,
+            pressure_control=self.pressure_control,
+            calculate_max_rate=calculate_max_rate,
+            maximum_power=maximum_power,
+        )
+
+    @staticmethod
+    def _validate_stages(stages):
         for stage in stages:
             if isinstance(stage.compressor_chart, SingleSpeedChartDTO):
                 raise ValueError(
@@ -54,21 +90,40 @@ class CompressorTrainSimplifiedWithUnknownStages(CompressorTrain):
         EnergyModelType.COMPRESSOR_TRAIN_SIMPLIFIED_WITH_UNKNOWN_STAGES
     )
     stage: CompressorStage
-    maximum_pressure_ratio_per_stage: Annotated[float, Field(ge=0)]
+    maximum_pressure_ratio_per_stage: float
 
     # Not in use:
     stages: list[CompressorStage] = []  # Not relevant since the stage is Unknown
     pressure_control: Optional[FixedSpeedPressureControl] = None  # Not relevant for simplified trains.
 
-    @field_validator("stage")
-    @classmethod
-    def _validate_stages(cls, stage):
-        if isinstance(stage.compressor_chart, SingleSpeedChartDTO):
-            raise ValueError(
-                "Simplified Compressor Train does not support Single Speed Compressor Chart."
-                f" Given type was {type(stage.compressor_chart)}"
-            )
-        return stage
+    def __init__(
+        self,
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+        fluid_model: FluidModel,
+        stage: CompressorStage,
+        maximum_pressure_ratio_per_stage: float,
+        calculate_max_rate: bool = False,
+        maximum_power: Optional[float] = None,
+    ):
+        super().__init__(
+            energy_usage_adjustment_constant,
+            energy_usage_adjustment_factor,
+            self.typ,
+            stages=self.stages,
+            fluid_model=fluid_model,
+            pressure_control=self.pressure_control,
+            calculate_max_rate=calculate_max_rate,
+            maximum_power=maximum_power,
+        )
+        self.stage = stage
+        self.maximum_pressure_ratio_per_stage = maximum_pressure_ratio_per_stage
+        self.fluid_model = fluid_model
+        self._validate_maximum_pressure_ratio_per_stage()
+
+    def _validate_maximum_pressure_ratio_per_stage(self):
+        if self.maximum_pressure_ratio_per_stage < 0:
+            raise ValueError("maximum_pressure_ratio_per_stage must be greater than or equal to 0")
 
 
 class SingleSpeedCompressorTrain(CompressorTrain):
@@ -77,18 +132,45 @@ class SingleSpeedCompressorTrain(CompressorTrain):
     typ: Literal[EnergyModelType.SINGLE_SPEED_COMPRESSOR_TRAIN_COMMON_SHAFT] = (
         EnergyModelType.SINGLE_SPEED_COMPRESSOR_TRAIN_COMMON_SHAFT
     )
-    maximum_discharge_pressure: Optional[Annotated[float, Field(ge=0)]] = None
+    maximum_discharge_pressure: Optional[float] = None
 
-    @field_validator("stages")
-    @classmethod
-    def _validate_stages(cls, stages):
+    def __init__(
+        self,
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+        stages: list[CompressorStage],
+        fluid_model: Optional[FluidModel] = None,
+        pressure_control: Optional[FixedSpeedPressureControl] = None,
+        calculate_max_rate: bool = False,
+        maximum_power: Optional[float] = None,
+        maximum_discharge_pressure: Optional[float] = None,
+    ):
+        super().__init__(
+            energy_usage_adjustment_constant=energy_usage_adjustment_constant,
+            energy_usage_adjustment_factor=energy_usage_adjustment_factor,
+            typ=self.typ,
+            stages=stages,
+            fluid_model=fluid_model,
+            pressure_control=pressure_control,
+            calculate_max_rate=calculate_max_rate,
+            maximum_power=maximum_power,
+        )
+        self.maximum_discharge_pressure = maximum_discharge_pressure
+        self._validate_maximum_discharge_pressure()
+        self._validate_stages(stages)
+
+    def _validate_maximum_discharge_pressure(self):
+        if self.maximum_discharge_pressure is not None and self.maximum_discharge_pressure < 0:
+            raise ValueError("maximum_discharge_pressure must be greater than or equal to 0")
+
+    @staticmethod
+    def _validate_stages(stages):
         for stage in stages:
             if not isinstance(stage.compressor_chart, SingleSpeedChartDTO):
                 raise ValueError(
                     "Single Speed Compressor train only accepts Single Speed Compressor Charts."
                     f" Given type was {type(stage.compressor_chart)}"
                 )
-        return stages
 
 
 class VariableSpeedCompressorTrain(CompressorTrain):
@@ -96,9 +178,30 @@ class VariableSpeedCompressorTrain(CompressorTrain):
         EnergyModelType.VARIABLE_SPEED_COMPRESSOR_TRAIN_COMMON_SHAFT
     )
 
-    @field_validator("stages")
-    @classmethod
-    def _validate_stages(cls, stages):
+    def __init__(
+        self,
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+        stages: list[CompressorStage],
+        fluid_model: Optional[FluidModel] = None,
+        pressure_control: Optional[FixedSpeedPressureControl] = None,
+        calculate_max_rate: bool = False,
+        maximum_power: Optional[float] = None,
+    ):
+        super().__init__(
+            energy_usage_adjustment_constant=energy_usage_adjustment_constant,
+            energy_usage_adjustment_factor=energy_usage_adjustment_factor,
+            typ=self.typ,
+            stages=stages,
+            fluid_model=fluid_model,
+            pressure_control=pressure_control,
+            calculate_max_rate=calculate_max_rate,
+            maximum_power=maximum_power,
+        )
+        self._validate_stages(stages)
+
+    @staticmethod
+    def _validate_stages(stages):
         min_speed_per_stage = []
         max_speed_per_stage = []
         for stage in stages:
@@ -115,7 +218,6 @@ class VariableSpeedCompressorTrain(CompressorTrain):
                 f" Stage {min_speed_per_stage.index(max(min_speed_per_stage)) + 1}'s minimum speed is higher"
                 f" than max speed of stage {max_speed_per_stage.index(min(max_speed_per_stage)) + 1}"
             )
-        return stages
 
 
 class VariableSpeedCompressorTrainMultipleStreamsAndPressures(CompressorTrain):
@@ -138,9 +240,35 @@ class VariableSpeedCompressorTrainMultipleStreamsAndPressures(CompressorTrain):
     # Not in use:
     fluid_model: Optional[FluidModel] = None  # Not relevant. set by the individual stream.
 
-    @field_validator("stages")
-    @classmethod
-    def _validate_stages(cls, stages):
+    def __init__(
+        self,
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+        streams: list[MultipleStreamsAndPressureStream],
+        stages: list[MultipleStreamsCompressorStage],
+        calculate_max_rate: bool = False,
+        maximum_power: Optional[float] = None,
+        pressure_control: Optional[FixedSpeedPressureControl] = None,
+    ):
+        super().__init__(
+            energy_usage_adjustment_constant,
+            energy_usage_adjustment_factor,
+            self.typ,
+            stages,
+            fluid_model=self.fluid_model,
+            pressure_control=None,
+            calculate_max_rate=calculate_max_rate,
+            maximum_power=maximum_power,
+        )
+        self.streams = streams
+        self.stages = stages
+        if pressure_control and not isinstance(pressure_control, FixedSpeedPressureControl):
+            raise TypeError(f"pressure_control must be of type FixedSpeedPressureControl, got {type(pressure_control)}")
+        self.pressure_control = pressure_control
+        self._validate_stages(stages)
+
+    @staticmethod
+    def _validate_stages(stages):
         if sum([stage.has_control_pressure for stage in stages]) > 1:
             raise ValueError("Only one interstage pressure should be defined for a compressor train")
         min_speed_per_stage = []
@@ -159,7 +287,6 @@ class VariableSpeedCompressorTrainMultipleStreamsAndPressures(CompressorTrain):
                 f" Stage {min_speed_per_stage.index(max(min_speed_per_stage)) + 1}'s minimum speed is higher"
                 f" than max speed of stage {max_speed_per_stage.index(min(max_speed_per_stage)) + 1}"
             )
-        return stages
 
     @property
     def has_interstage_pressure(self):

--- a/src/libecalc/domain/process/dto/consumer_system.py
+++ b/src/libecalc/domain/process/dto/consumer_system.py
@@ -1,96 +1,175 @@
 from typing import Literal, Optional
 
-from pydantic import Field, field_validator
-
 from libecalc.common.chart_type import ChartType
 from libecalc.common.consumer_type import ConsumerType
 from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.logger import logger
 from libecalc.domain.process.dto.base import ConsumerFunction
-from libecalc.domain.process.dto.compressor import CompressorModel
+from libecalc.domain.process.dto.compressor import CompressorModelTypes
 from libecalc.domain.process.dto.compressor.train import (
     CompressorTrainSimplifiedWithKnownStages,
     CompressorTrainSimplifiedWithUnknownStages,
 )
 from libecalc.domain.process.pump.pump import PumpModelDTO
-from libecalc.dto.base import EcalcBaseModel
 from libecalc.dto.utils.validators import convert_expression, convert_expressions
 from libecalc.expression import Expression
 
 
-class CompressorSystemCompressor(EcalcBaseModel):
-    name: str
-    compressor_train: CompressorModel = Field(..., discriminator="typ")
+class CompressorSystemCompressor:
+    def __init__(self, name: str, compressor_train: CompressorModelTypes):
+        self.name = name
+        self.compressor_train = compressor_train
 
 
-class SystemOperationalSetting(EcalcBaseModel):
-    rate_fractions: Optional[list[Expression]] = None
-    rates: Optional[list[Expression]] = None
-    suction_pressure: Optional[Expression] = None
-    suction_pressures: Optional[list[Expression]] = None
-    discharge_pressure: Optional[Expression] = None
-    discharge_pressures: Optional[list[Expression]] = None
-    crossover: Optional[list[int]] = None
-
-    _convert_expression_lists = field_validator(
-        "rate_fractions",
-        "rates",
-        "suction_pressures",
-        "discharge_pressures",
-        mode="before",
-    )(convert_expressions)
-    _convert_expression = field_validator("suction_pressure", "discharge_pressure", mode="before")(convert_expression)
+class SystemOperationalSetting:
+    def __init__(
+        self,
+        rate_fractions: Optional[list[Expression]] = None,
+        rates: Optional[list[Expression]] = None,
+        suction_pressure: Optional[Expression] = None,
+        suction_pressures: Optional[list[Expression]] = None,
+        discharge_pressure: Optional[Expression] = None,
+        discharge_pressures: Optional[list[Expression]] = None,
+        crossover: Optional[list[int]] = None,
+    ):
+        self.rate_fractions = convert_expressions(rate_fractions)
+        self.rates = convert_expressions(rates)
+        self.suction_pressure = convert_expression(suction_pressure)
+        self.suction_pressures = convert_expressions(suction_pressures)
+        self.discharge_pressure = convert_expression(discharge_pressure)
+        self.discharge_pressures = convert_expressions(discharge_pressures)
+        self.crossover = crossover
 
 
 class PumpSystemOperationalSetting(SystemOperationalSetting):
-    fluid_densities: Optional[list[Expression]] = None
+    def __init__(
+        self,
+        rate_fractions: Optional[list[Expression]] = None,
+        rates: Optional[list[Expression]] = None,
+        suction_pressure: Optional[Expression] = None,
+        suction_pressures: Optional[list[Expression]] = None,
+        discharge_pressure: Optional[Expression] = None,
+        discharge_pressures: Optional[list[Expression]] = None,
+        crossover: Optional[list[int]] = None,
+        fluid_densities: Optional[list[Expression]] = None,
+    ):
+        super().__init__(
+            rate_fractions,
+            rates,
+            suction_pressure,
+            suction_pressures,
+            discharge_pressure,
+            discharge_pressures,
+            crossover,
+        )
+        self.fluid_densities = convert_expressions(fluid_densities)
 
-    _convert_expression_lists = field_validator(
-        "fluid_densities",
-        mode="before",
-    )(convert_expressions)
+    def __eq__(self, other):
+        if not isinstance(other, PumpSystemOperationalSetting):
+            return False
+        return (
+            self.rate_fractions == other.rate_fractions
+            and self.rates == other.rates
+            and self.suction_pressure == other.suction_pressure
+            and self.suction_pressures == other.suction_pressures
+            and self.discharge_pressure == other.discharge_pressure
+            and self.discharge_pressures == other.discharge_pressures
+            and self.crossover == other.crossover
+            and self.fluid_densities == other.fluid_densities
+        )
 
 
-class PumpSystemPump(EcalcBaseModel):
-    name: str
-    pump_model: PumpModelDTO
+class PumpSystemPump:
+    def __init__(self, name: str, pump_model: PumpModelDTO):
+        self.name = name
+        self.pump_model = pump_model
+
+    def __eq__(self, other):
+        if not isinstance(other, PumpSystemPump):
+            return False
+        return self.name == other.name and self.pump_model == other.pump_model
 
 
 class PumpSystemConsumerFunction(ConsumerFunction):
     typ: Literal[ConsumerType.PUMP_SYSTEM] = ConsumerType.PUMP_SYSTEM
     energy_usage_type: EnergyUsageType = EnergyUsageType.POWER
-    power_loss_factor: Optional[Expression] = None
-    pumps: list[PumpSystemPump]
-    fluid_density: Expression
-    total_system_rate: Optional[Expression] = None
-    operational_settings: list[PumpSystemOperationalSetting]
 
-    _convert_expression = field_validator("fluid_density", "total_system_rate", "power_loss_factor", mode="before")(
-        convert_expression
-    )
+    def __init__(
+        self,
+        condition: Optional[Expression] = None,
+        power_loss_factor: Optional[Expression] = None,
+        pumps: list[PumpSystemPump] = None,
+        fluid_density: Expression = None,
+        total_system_rate: Optional[Expression] = None,
+        operational_settings: list[PumpSystemOperationalSetting] = None,
+    ):
+        super().__init__(self.typ, self.energy_usage_type, condition)
+        self.power_loss_factor = convert_expression(power_loss_factor)
+        self.pumps = pumps
+        self.fluid_density = convert_expression(fluid_density)
+        self.total_system_rate = convert_expression(total_system_rate)
+        self.operational_settings = operational_settings
+
+    def __eq__(self, other):
+        if not isinstance(other, PumpSystemConsumerFunction):
+            return False
+        return (
+            self.typ == other.typ
+            and self.energy_usage_type == other.energy_usage_type
+            and self.power_loss_factor == other.power_loss_factor
+            and self.condition == other.condition
+            and self.pumps == other.pumps
+            and self.fluid_density == other.fluid_density
+            and self.total_system_rate == other.total_system_rate
+            and self.operational_settings == other.operational_settings
+        )
 
 
 class CompressorSystemOperationalSetting(SystemOperationalSetting):
-    pass
+    def __init__(
+        self,
+        rate_fractions: Optional[list[Expression]] = None,
+        rates: Optional[list[Expression]] = None,
+        suction_pressure: Optional[Expression] = None,
+        suction_pressures: Optional[list[Expression]] = None,
+        discharge_pressure: Optional[Expression] = None,
+        discharge_pressures: Optional[list[Expression]] = None,
+        crossover: Optional[list[int]] = None,
+    ):
+        super().__init__(
+            rate_fractions,
+            rates,
+            suction_pressure,
+            suction_pressures,
+            discharge_pressure,
+            discharge_pressures,
+            crossover,
+        )
 
 
 class CompressorSystemConsumerFunction(ConsumerFunction):
     typ: Literal[ConsumerType.COMPRESSOR_SYSTEM] = ConsumerType.COMPRESSOR_SYSTEM
-    power_loss_factor: Optional[Expression] = None
-    compressors: list[CompressorSystemCompressor]
-    total_system_rate: Optional[Expression] = None
-    operational_settings: list[CompressorSystemOperationalSetting]
 
-    _convert_total_system_rate_to_expression = field_validator("total_system_rate", "power_loss_factor", mode="before")(
-        convert_expression
-    )
+    def __init__(
+        self,
+        energy_usage_type: EnergyUsageType,
+        condition: Optional[Expression] = None,
+        power_loss_factor: Optional[Expression] = None,
+        compressors: list[CompressorSystemCompressor] = None,
+        total_system_rate: Optional[Expression] = None,
+        operational_settings: list[CompressorSystemOperationalSetting] = None,
+    ):
+        super().__init__(self.typ, energy_usage_type, condition)
+        self.power_loss_factor = convert_expression(power_loss_factor)
+        self.compressors = compressors
+        self.total_system_rate = convert_expression(total_system_rate)
+        self.operational_settings = operational_settings
 
-    @field_validator("compressors")
-    @classmethod
+    @staticmethod
     def check_for_generic_from_input_compressor_chart_in_simplified_train_compressor_system(
-        cls, v: list[CompressorSystemCompressor]
+        compressors: list[CompressorSystemCompressor],
     ) -> list[CompressorSystemCompressor]:
-        for compressor_system_compressor in v:
+        for compressor_system_compressor in compressors:
             compressor_train = compressor_system_compressor.compressor_train
             if isinstance(compressor_train, CompressorTrainSimplifiedWithKnownStages):
                 for i, stage in enumerate(compressor_train.stages):
@@ -111,4 +190,4 @@ class CompressorSystemConsumerFunction(ConsumerFunction):
                         f" to define a design point yourself instead of letting an algorithm find one based on"
                         f" changing rates!"
                     )
-        return v
+        return compressors

--- a/src/libecalc/domain/process/dto/direct.py
+++ b/src/libecalc/domain/process/dto/direct.py
@@ -1,8 +1,7 @@
-from typing import Literal, Optional, Self
-
-from pydantic import field_validator, model_validator
+from typing import Literal, Optional
 
 from libecalc.common.consumer_type import ConsumerType
+from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.utils.rates import RateType
 from libecalc.domain.process.dto.base import ConsumerFunction
 from libecalc.dto.utils.validators import convert_expression
@@ -11,17 +10,38 @@ from libecalc.expression import Expression
 
 class DirectConsumerFunction(ConsumerFunction):
     typ: Literal[ConsumerType.DIRECT] = ConsumerType.DIRECT
-    fuel_rate: Optional[Expression] = None
-    load: Optional[Expression] = None
-    power_loss_factor: Optional[Expression] = None
-    consumption_rate_type: RateType = RateType.STREAM_DAY
 
-    _convert_expressions = field_validator("fuel_rate", "load", "power_loss_factor", mode="before")(convert_expression)
+    def __init__(
+        self,
+        energy_usage_type: EnergyUsageType,
+        condition: Optional[Expression] = None,
+        fuel_rate: Optional[Expression] = None,
+        load: Optional[Expression] = None,
+        power_loss_factor: Optional[Expression] = None,
+        consumption_rate_type: RateType = RateType.STREAM_DAY,
+    ):
+        super().__init__(self.typ, energy_usage_type, condition)
+        self.fuel_rate = convert_expression(fuel_rate)
+        self.load = convert_expression(load)
+        self.power_loss_factor = convert_expression(power_loss_factor)
+        self.consumption_rate_type = consumption_rate_type
+        self.validate_either_load_or_fuel_rate()
 
-    @model_validator(mode="after")
-    def validate_either_load_or_fuel_rate(self) -> Self:
-        has_fuel_rate = getattr(self, "fuel_rate", None) is not None
-        has_load = getattr(self, "load", None) is not None
-        if (has_fuel_rate and not has_load) or (not has_fuel_rate and has_load):
-            return self
-        raise ValueError(f"Either 'fuel_rate' or 'load' should be specified for '{ConsumerType.DIRECT}' models.")
+    def validate_either_load_or_fuel_rate(self):
+        has_fuel_rate = self.fuel_rate is not None
+        has_load = self.load is not None
+        if not ((has_fuel_rate and not has_load) or (not has_fuel_rate and has_load)):
+            raise ValueError(f"Either 'fuel_rate' or 'load' should be specified for '{ConsumerType.DIRECT}' models.")
+
+    def __eq__(self, other):
+        if not isinstance(other, DirectConsumerFunction):
+            return False
+        return (
+            self.typ == other.typ
+            and self.energy_usage_type == other.energy_usage_type
+            and self.condition == other.condition
+            and self.fuel_rate == other.fuel_rate
+            and self.load == other.load
+            and self.power_loss_factor == other.power_loss_factor
+            and self.consumption_rate_type == other.consumption_rate_type
+        )

--- a/src/libecalc/domain/process/dto/generator_set.py
+++ b/src/libecalc/domain/process/dto/generator_set.py
@@ -1,7 +1,5 @@
 from typing import Literal
 
-from pydantic import field_validator
-
 from libecalc.common.energy_model_type import EnergyModelType
 
 from .sampled import EnergyModelSampled
@@ -10,20 +8,29 @@ from .sampled import EnergyModelSampled
 class GeneratorSetSampled(EnergyModelSampled):
     typ: Literal[EnergyModelType.GENERATOR_SET_SAMPLED] = EnergyModelType.GENERATOR_SET_SAMPLED
 
-    @field_validator("headers")
-    @classmethod
-    def validate_headers(cls, headers: list[str]) -> list[str]:
-        is_valid_headers = len(headers) == 2 and "FUEL" in headers and "POWER" in headers
+    def __init__(
+        self,
+        headers: list[str],
+        data: list[list[float]],
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+    ):
+        super().__init__(headers, data, energy_usage_adjustment_constant, energy_usage_adjustment_factor)
+        self.validate_headers()
+        self.validate_data()
+
+    def validate_headers(self):
+        is_valid_headers = len(self.headers) == 2 and "FUEL" in self.headers and "POWER" in self.headers
         if not is_valid_headers:
             raise ValueError("Sampled generator set data should have a 'FUEL' and 'POWER' header")
-        return headers
 
-    @field_validator("data")
-    @classmethod
-    def validate_data(cls, data: list[list[float]]) -> list[list[float]]:
-        if len({len(lst) for lst in data}) > 1:
-            raise ValueError("Sampled generator set data should have equal number of datapoints for FUEL and POWER.")
-        return data
+    def validate_data(self):
+        lengths = [len(lst) for lst in self.data]
+        if len(set(lengths)) > 1:
+            problematic_vectors = [(i, len(lst)) for i, lst in enumerate(self.data)]
+            raise ValueError(
+                f"Sampled generator set data should have equal number of datapoints for FUEL and POWER. Found lengths: {problematic_vectors}"
+            )
 
     @property
     def fuel_values(self) -> list[float]:
@@ -32,3 +39,14 @@ class GeneratorSetSampled(EnergyModelSampled):
     @property
     def power_values(self) -> list[float]:
         return self.data[self.headers.index("POWER")]
+
+    def __eq__(self, other):
+        if not isinstance(other, GeneratorSetSampled):
+            return False
+        return (
+            self.typ == other.typ
+            and self.headers == other.headers
+            and self.data == other.data
+            and self.energy_usage_adjustment_constant == other.energy_usage_adjustment_constant
+            and self.energy_usage_adjustment_factor == other.energy_usage_adjustment_factor
+        )

--- a/src/libecalc/domain/process/dto/sampled.py
+++ b/src/libecalc/domain/process/dto/sampled.py
@@ -2,7 +2,29 @@ from libecalc.domain.process.dto.base import EnergyModel
 
 
 class EnergyModelSampled(EnergyModel):
-    headers: list[str]
-    data: list[list[float]]
-    # TODO: validate number of headers equals number of vectors
-    # validate all vectors (in data) have equal length
+    def __init__(
+        self,
+        headers: list[str],
+        data: list[list[float]],
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+    ):
+        super().__init__(energy_usage_adjustment_constant, energy_usage_adjustment_factor)
+        self.headers = headers
+        self.data = data
+        self.validate_headers()
+        self.validate_data()
+
+    def validate_headers(self):
+        # Ensure the number of headers equals the number of vectors
+        if len(self.headers) != len(self.data):
+            raise ValueError(
+                f"The number of headers ({len(self.headers)}) must equal the number of data vectors ({len(self.data)})"
+            )
+
+    def validate_data(self):
+        # Ensure all vectors in data have equal length
+        lengths = [len(lst) for lst in self.data]
+        if len(set(lengths)) > 1:
+            problematic_vectors = [(i, len(lst)) for i, lst in enumerate(self.data)]
+            raise ValueError(f"All vectors in data must have equal length. Found lengths: {problematic_vectors}")

--- a/src/libecalc/domain/process/dto/tabulated.py
+++ b/src/libecalc/domain/process/dto/tabulated.py
@@ -1,12 +1,10 @@
 from typing import Literal, Optional
 
-from pydantic import field_validator
-
 from libecalc.common.consumer_type import ConsumerType
 from libecalc.common.energy_model_type import EnergyModelType
+from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.domain.process.dto.base import ConsumerFunction
 from libecalc.domain.process.dto.sampled import EnergyModelSampled
-from libecalc.dto.base import EcalcBaseModel
 from libecalc.dto.utils.validators import convert_expression
 from libecalc.expression import Expression
 
@@ -14,26 +12,50 @@ from libecalc.expression import Expression
 class TabulatedData(EnergyModelSampled):
     typ: Literal[EnergyModelType.TABULATED] = EnergyModelType.TABULATED
 
-    @field_validator("headers")
-    @classmethod
-    def validate_headers(cls, headers: list[str]) -> list[str]:
-        is_valid_headers = len(headers) > 0 and "FUEL" in headers or "POWER" in headers
+    def __init__(
+        self,
+        headers: list[str],
+        data: list[list[float]],
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+    ):
+        super().__init__(headers, data, energy_usage_adjustment_constant, energy_usage_adjustment_factor)
+        self.validate_headers()
+        self.validate_data()
+
+    def validate_headers(self):
+        is_valid_headers = len(self.headers) > 0 and ("FUEL" in self.headers or "POWER" in self.headers)
         if not is_valid_headers:
             raise ValueError("TABULAR facility input type data must have a 'FUEL' or 'POWER' header")
-        return headers
+
+    def validate_data(self):
+        lengths = [len(lst) for lst in self.data]
+        if len(set(lengths)) > 1:
+            problematic_vectors = [(i, len(lst)) for i, lst in enumerate(self.data)]
+            raise ValueError(
+                f"TABULAR facility input type data should have equal number of datapoints for all headers. Found lengths: {problematic_vectors}"
+            )
 
 
-class Variables(EcalcBaseModel):
-    name: str
-    expression: Expression
-
-    _convert_variable_expression = field_validator("expression", mode="before")(convert_expression)
+class Variables:
+    def __init__(self, name: str, expression: Expression):
+        self.name = name
+        self.expression = convert_expression(expression)
 
 
 class TabulatedConsumerFunction(ConsumerFunction):
     typ: Literal[ConsumerType.TABULATED] = ConsumerType.TABULATED
-    power_loss_factor: Optional[Expression] = None
-    model: TabulatedData
-    variables: list[Variables]
 
-    _convert_to_expression = field_validator("power_loss_factor", mode="before")(convert_expression)
+    def __init__(
+        self,
+        model: TabulatedData,
+        energy_usage_type: EnergyUsageType,
+        variables: list[Variables],
+        power_loss_factor: Optional[Expression] = None,
+        condition: Optional[Expression] = None,
+    ):
+        super().__init__(ConsumerType.TABULATED, energy_usage_type, power_loss_factor)
+        self.model = model
+        self.variables = variables
+        self.power_loss_factor = convert_expression(power_loss_factor) if power_loss_factor else None
+        self.condition = convert_expression(condition) if condition else None

--- a/src/libecalc/domain/process/dto/turbine.py
+++ b/src/libecalc/domain/process/dto/turbine.py
@@ -1,6 +1,4 @@
-from typing import Annotated, Literal, Self
-
-from pydantic import Field, model_validator
+from typing import Literal
 
 from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.domain.process.dto.base import EnergyModel
@@ -8,19 +6,24 @@ from libecalc.domain.process.dto.base import EnergyModel
 
 class Turbine(EnergyModel):
     typ: Literal[EnergyModelType.TURBINE] = EnergyModelType.TURBINE
-    lower_heating_value: Annotated[float, Field(ge=0)]
-    turbine_loads: list[Annotated[float, Field(ge=0)]]
-    turbine_efficiency_fractions: list[float]
 
-    @model_validator(mode="after")
-    def validate_loads_and_efficiency_factors(self) -> Self:
-        turbine_loads, turbine_efficiencies = (
-            self.turbine_loads,
-            self.turbine_efficiency_fractions,
-        )
-        if len(turbine_loads) != len(turbine_efficiencies):
+    def __init__(
+        self,
+        lower_heating_value: float,
+        turbine_loads: list[float],
+        turbine_efficiency_fractions: list[float],
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+    ):
+        super().__init__(energy_usage_adjustment_constant, energy_usage_adjustment_factor)
+        self.lower_heating_value = lower_heating_value
+        self.turbine_loads = turbine_loads
+        self.turbine_efficiency_fractions = turbine_efficiency_fractions
+        self.validate_loads_and_efficiency_factors()
+
+    def validate_loads_and_efficiency_factors(self):
+        if len(self.turbine_loads) != len(self.turbine_efficiency_fractions):
             raise ValueError("Need equal number of load and efficiency values for turbine model")
 
-        if not all(0 <= x <= 1 for x in turbine_efficiencies):
+        if not all(0 <= x <= 1 for x in self.turbine_efficiency_fractions):
             raise ValueError("Turbine efficiency fraction should be a number between 0 and 1")
-        return self

--- a/src/libecalc/domain/process/pump/pump_consumer_function.py
+++ b/src/libecalc/domain/process/pump/pump_consumer_function.py
@@ -1,7 +1,5 @@
 from typing import Literal, Optional
 
-from pydantic import field_validator
-
 from libecalc.common.consumer_type import ConsumerType
 from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.domain.process.dto.base import ConsumerFunction
@@ -13,18 +11,21 @@ from libecalc.expression import Expression
 class PumpConsumerFunction(ConsumerFunction):
     typ: Literal[ConsumerType.PUMP] = ConsumerType.PUMP
     energy_usage_type: EnergyUsageType = EnergyUsageType.POWER
-    power_loss_factor: Optional[Expression] = None
-    model: PumpModelDTO
-    rate_standard_m3_day: Expression
-    suction_pressure: Expression
-    discharge_pressure: Expression
-    fluid_density: Expression
 
-    _convert_pump_expressions = field_validator(
-        "rate_standard_m3_day",
-        "suction_pressure",
-        "discharge_pressure",
-        "fluid_density",
-        "power_loss_factor",
-        mode="before",
-    )(convert_expression)
+    def __init__(
+        self,
+        model: PumpModelDTO,
+        rate_standard_m3_day: Expression,
+        suction_pressure: Expression,
+        discharge_pressure: Expression,
+        fluid_density: Expression,
+        power_loss_factor: Optional[Expression] = None,
+        condition: Optional[Expression] = None,
+    ):
+        super().__init__(typ=self.typ, energy_usage_type=self.energy_usage_type, condition=condition)
+        self.model = model
+        self.rate_standard_m3_day = convert_expression(rate_standard_m3_day)
+        self.suction_pressure = convert_expression(suction_pressure)
+        self.discharge_pressure = convert_expression(discharge_pressure)
+        self.fluid_density = convert_expression(fluid_density)
+        self.power_loss_factor = convert_expression(power_loss_factor)

--- a/src/libecalc/presentation/yaml/domain/reference_service.py
+++ b/src/libecalc/presentation/yaml/domain/reference_service.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from typing import Protocol
 
-from libecalc.domain.process.dto import CompressorModel, GeneratorSetSampled, TabulatedData
+from libecalc.domain.process.dto import CompressorModelTypes, GeneratorSetSampled, TabulatedData
 from libecalc.domain.process.pump.pump import PumpModelDTO
 from libecalc.dto import FuelType
 
@@ -20,7 +20,7 @@ class ReferenceService(Protocol):
 
     def get_generator_set_model(self, reference: str) -> GeneratorSetSampled: ...
 
-    def get_compressor_model(self, reference: str) -> CompressorModel: ...
+    def get_compressor_model(self, reference: str) -> CompressorModelTypes: ...
 
     def get_pump_model(self, reference: str) -> PumpModelDTO: ...
 

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -6,7 +6,7 @@ from libecalc.common.time_utils import Period, define_time_model_for_period
 from libecalc.common.utils.rates import RateType
 from libecalc.domain.process.dto import (
     CompressorConsumerFunction,
-    CompressorModel,
+    CompressorModelTypes,
     CompressorSystemCompressor,
     CompressorSystemConsumerFunction,
     CompressorSystemOperationalSetting,
@@ -64,7 +64,7 @@ def _all_equal(items: set) -> bool:
 
 
 def _get_compressor_train_energy_usage_type(
-    compressor_train: CompressorModel,
+    compressor_train: CompressorModelTypes,
 ) -> EnergyUsageType:
     typ = compressor_train.typ
 

--- a/src/libecalc/presentation/yaml/mappers/energy_model_factory.py
+++ b/src/libecalc/presentation/yaml/mappers/energy_model_factory.py
@@ -1,0 +1,22 @@
+from typing import Union
+
+from libecalc.common.energy_model_type import EnergyModelType
+from libecalc.domain.process.dto import CompressorSampled as CompressorTrainSampledDTO
+from libecalc.domain.process.dto import GeneratorSetSampled, TabulatedData
+
+EnergyModelUnionType = Union[GeneratorSetSampled, TabulatedData, CompressorTrainSampledDTO]
+
+
+class EnergyModelFactory:
+    @staticmethod
+    def create(typ: EnergyModelType, model_data: dict) -> EnergyModelUnionType:
+        model_data = {key: value for key, value in model_data.items() if key != "typ"}
+
+        if typ == EnergyModelType.GENERATOR_SET_SAMPLED:
+            return GeneratorSetSampled(**model_data)
+        elif typ == EnergyModelType.TABULATED:
+            return TabulatedData(**model_data)
+        elif typ == EnergyModelType.COMPRESSOR_SAMPLED:
+            return CompressorTrainSampledDTO(**model_data)
+        else:
+            raise ValueError(f"Unsupported EnergyModelType: {typ}")

--- a/src/libecalc/presentation/yaml/mappers/facility_input.py
+++ b/src/libecalc/presentation/yaml/mappers/facility_input.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union
 
-from pydantic import TypeAdapter, ValidationError
+from pydantic import ValidationError
 
 from libecalc.common.chart_type import ChartType
 from libecalc.common.energy_model_type import EnergyModelType
@@ -10,6 +10,7 @@ from libecalc.common.serializable_chart import ChartCurveDTO, SingleSpeedChartDT
 from libecalc.domain.process.dto import CompressorSampled as CompressorTrainSampledDTO
 from libecalc.domain.process.dto import EnergyModel, GeneratorSetSampled, TabulatedData
 from libecalc.domain.process.pump.pump import PumpModelDTO
+from libecalc.presentation.yaml.mappers.energy_model_factory import EnergyModelFactory
 from libecalc.presentation.yaml.mappers.utils import (
     YAML_UNIT_MAPPING,
     chart_curves_as_resource_to_dto_format,
@@ -187,7 +188,7 @@ def _default_facility_to_dto_model_data(
         "energy_usage_adjustment_factor": _get_adjustment_factor(data=facility_data),
     }
 
-    return TypeAdapter(EnergyModelUnionType).validate_python(model_data)
+    return EnergyModelFactory.create(typ, model_data)
 
 
 facility_input_to_dto_map = {

--- a/src/libecalc/presentation/yaml/yaml_entities.py
+++ b/src/libecalc/presentation/yaml/yaml_entities.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import TextIO, Union, get_args
 
 from libecalc.common.errors.exceptions import ColumnNotFoundException, HeaderNotFoundException
-from libecalc.domain.process.dto import CompressorModel, EnergyModel, GeneratorSetSampled, TabulatedData
+from libecalc.domain.process.dto import CompressorModelTypes, EnergyModel, GeneratorSetSampled, TabulatedData
 from libecalc.domain.process.pump.pump import PumpModelDTO
 from libecalc.dto import FuelType
 from libecalc.presentation.yaml.domain.reference_service import InvalidReferenceException, ReferenceService
@@ -60,9 +60,9 @@ class References(ReferenceService):
             raise InvalidReferenceException("generator set model", reference)
         return model
 
-    def get_compressor_model(self, reference: str) -> CompressorModel:
+    def get_compressor_model(self, reference: str) -> CompressorModelTypes:
         model = self._get_model_reference(reference, "compressor model")
-        if not isinstance(model, get_args(CompressorModel)):
+        if not isinstance(model, get_args(CompressorModelTypes)):
             raise InvalidReferenceException("compressor model", reference)
         return model  # noqa
 

--- a/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import numpy as np
 import pytest
 from numpy.typing import NDArray
@@ -321,21 +323,21 @@ def test_compressor_train_simplified_known_stages_generic_chart(
         ],
         rtol=1e-3,
     )
-    simple_compressor_train_model_extra_generic_stage_from_data = CompressorTrainSimplifiedKnownStages(
-        simplified_compressor_train_with_known_stages_dto.model_copy(
-            update={
-                "stages": simplified_compressor_train_with_known_stages_dto.stages
-                + [
-                    dto.CompressorStage(
-                        inlet_temperature_kelvin=303.15,
-                        compressor_chart=dto.GenericChartFromInput(polytropic_efficiency_fraction=0.75),
-                        remove_liquid_after_cooling=True,
-                        pressure_drop_before_stage=0,
-                        control_margin=0,
-                    )
-                ]
-            }
+    compressor_dto_copy = deepcopy(simplified_compressor_train_with_known_stages_dto)
+
+    # Update stages in copy to add a stage with a generic chart
+    compressor_dto_copy.stages += [
+        dto.CompressorStage(
+            inlet_temperature_kelvin=303.15,
+            compressor_chart=dto.GenericChartFromInput(polytropic_efficiency_fraction=0.75),
+            remove_liquid_after_cooling=True,
+            pressure_drop_before_stage=0,
+            control_margin=0,
         )
+    ]
+    # Create the CompressorTrainSimplifiedKnownStages object with the updated DTO
+    simple_compressor_train_model_extra_generic_stage_from_data = CompressorTrainSimplifiedKnownStages(
+        data_transfer_object=compressor_dto_copy
     )
 
     pressure_ratios_per_stage = simple_compressor_train_model.calculate_pressure_ratios_per_stage(
@@ -353,27 +355,29 @@ def test_compressor_train_simplified_known_stages_generic_chart(
         maximum_rates_extra_stage_chart_from_data,
     )
 
+    compressor_dto_copy = deepcopy(simplified_compressor_train_with_known_stages_dto)
+
+    # Update the stages
+    compressor_dto_copy.stages = [
+        dto.CompressorStage(
+            inlet_temperature_kelvin=303.15,
+            compressor_chart=dto.GenericChartFromInput(polytropic_efficiency_fraction=0.75),
+            remove_liquid_after_cooling=True,
+            pressure_drop_before_stage=0,
+            control_margin=0,
+        ),
+        dto.CompressorStage(
+            inlet_temperature_kelvin=313.15,
+            compressor_chart=dto.GenericChartFromInput(polytropic_efficiency_fraction=0.75),
+            remove_liquid_after_cooling=True,
+            pressure_drop_before_stage=0,
+            control_margin=0,
+        ),
+    ]
+
+    # Create the CompressorTrainSimplifiedKnownStages object with the updated DTO
     simple_compressor_train_model_only_generic_chart_from_data = CompressorTrainSimplifiedKnownStages(
-        simplified_compressor_train_with_known_stages_dto.model_copy(
-            update={
-                "stages": [
-                    dto.CompressorStage(
-                        inlet_temperature_kelvin=303.15,
-                        compressor_chart=dto.GenericChartFromInput(polytropic_efficiency_fraction=0.75),
-                        remove_liquid_after_cooling=True,
-                        pressure_drop_before_stage=0,
-                        control_margin=0,
-                    ),
-                    dto.CompressorStage(
-                        inlet_temperature_kelvin=313.15,
-                        compressor_chart=dto.GenericChartFromInput(polytropic_efficiency_fraction=0.75),
-                        remove_liquid_after_cooling=True,
-                        pressure_drop_before_stage=0,
-                        control_margin=0,
-                    ),
-                ]
-            }
-        )
+        data_transfer_object=compressor_dto_copy
     )
 
     max_standard_rate = simple_compressor_train_model_only_generic_chart_from_data.get_max_standard_rate(

--- a/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import numpy as np
 import pytest
 
@@ -18,11 +20,9 @@ def variable_speed_compressor_train_one_compressor(
     variable_speed_compressor_train_dto, variable_speed_compressor_train_stage_dto
 ) -> VariableSpeedCompressorTrainCommonShaft:
     """Train with only one compressor, and standard medium fluid, no liquid off take."""
-    return VariableSpeedCompressorTrainCommonShaft(
-        data_transfer_object=variable_speed_compressor_train_dto.model_copy(
-            update={"stages": [variable_speed_compressor_train_stage_dto]}
-        )
-    )
+    dto_copy = deepcopy(variable_speed_compressor_train_dto)
+    dto_copy.stages = [variable_speed_compressor_train_stage_dto]
+    return VariableSpeedCompressorTrainCommonShaft(data_transfer_object=dto_copy)
 
 
 @pytest.fixture
@@ -30,14 +30,11 @@ def variable_speed_compressor_train_one_compressor_maximum_power(
     variable_speed_compressor_train_dto, variable_speed_compressor_train_stage_dto
 ) -> VariableSpeedCompressorTrainCommonShaft:
     """Train with only one compressor, and standard medium fluid, no liquid off take."""
-    return VariableSpeedCompressorTrainCommonShaft(
-        data_transfer_object=variable_speed_compressor_train_dto.model_copy(
-            update={
-                "stages": [variable_speed_compressor_train_stage_dto],
-                "maximum_power": 7.0,
-            }
-        )
-    )
+    dto_copy = deepcopy(variable_speed_compressor_train_dto)
+    dto_copy.stages = [variable_speed_compressor_train_stage_dto]
+    dto_copy.maximum_power = 7.0
+
+    return VariableSpeedCompressorTrainCommonShaft(data_transfer_object=dto_copy)
 
 
 @pytest.fixture
@@ -45,11 +42,11 @@ def variable_speed_compressor_train_one_compressor_no_pressure_control(
     variable_speed_compressor_train_dto, variable_speed_compressor_train_stage_dto
 ) -> VariableSpeedCompressorTrainCommonShaft:
     """Train with only one compressor, and standard medium fluid, no liquid off take."""
-    return VariableSpeedCompressorTrainCommonShaft(
-        data_transfer_object=variable_speed_compressor_train_dto.model_copy(
-            update={"stages": [variable_speed_compressor_train_stage_dto], "pressure_control": None}
-        )
-    )
+    dto_copy = deepcopy(variable_speed_compressor_train_dto)
+    dto_copy.stages = [variable_speed_compressor_train_stage_dto]
+    dto_copy.pressure_control = None
+
+    return VariableSpeedCompressorTrainCommonShaft(data_transfer_object=dto_copy)
 
 
 @pytest.fixture
@@ -57,14 +54,11 @@ def variable_speed_compressor_train_one_compressor_asv_rate(
     variable_speed_compressor_train_dto, variable_speed_compressor_train_stage_dto
 ) -> VariableSpeedCompressorTrainCommonShaft:
     """Train with only one compressor, and standard medium fluid, no liquid off take."""
-    return VariableSpeedCompressorTrainCommonShaft(
-        data_transfer_object=variable_speed_compressor_train_dto.model_copy(
-            update={
-                "stages": [variable_speed_compressor_train_stage_dto],
-                "pressure_control": FixedSpeedPressureControl.INDIVIDUAL_ASV_RATE,
-            }
-        )
-    )
+    dto_copy = deepcopy(variable_speed_compressor_train_dto)
+    dto_copy.stages = [variable_speed_compressor_train_stage_dto]
+    dto_copy.pressure_control = FixedSpeedPressureControl.INDIVIDUAL_ASV_RATE
+
+    return VariableSpeedCompressorTrainCommonShaft(data_transfer_object=dto_copy)
 
 
 @pytest.fixture
@@ -72,11 +66,10 @@ def variable_speed_compressor_train_two_compressors(
     variable_speed_compressor_train_dto, variable_speed_compressor_train_stage_dto
 ) -> VariableSpeedCompressorTrainCommonShaft:
     """Train with only two compressors, and standard medium fluid, no liquid off take."""
-    return VariableSpeedCompressorTrainCommonShaft(
-        data_transfer_object=variable_speed_compressor_train_dto.model_copy(
-            update={"stages": [variable_speed_compressor_train_stage_dto] * 2}
-        )
-    )
+    dto_copy = deepcopy(variable_speed_compressor_train_dto)
+    dto_copy.stages = [variable_speed_compressor_train_stage_dto] * 2
+
+    return VariableSpeedCompressorTrainCommonShaft(data_transfer_object=dto_copy)
 
 
 class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:

--- a/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
@@ -1,3 +1,6 @@
+from copy import deepcopy
+from typing import cast
+
 import numpy as np
 import pytest
 
@@ -32,11 +35,10 @@ def variable_speed_compressor_train_one_compressor(
     variable_speed_compressor_train_dto, variable_speed_compressor_train_stage_dto
 ) -> VariableSpeedCompressorTrainCommonShaft:
     """Train with only one compressor, and standard medium fluid, no liquid off take."""
-    return VariableSpeedCompressorTrainCommonShaft(
-        data_transfer_object=variable_speed_compressor_train_dto.model_copy(
-            update={"stages": [variable_speed_compressor_train_stage_dto]}
-        )
-    )
+    copied_dto = deepcopy(variable_speed_compressor_train_dto)
+    copied_dto.stages = [variable_speed_compressor_train_stage_dto]
+
+    return VariableSpeedCompressorTrainCommonShaft(data_transfer_object=copied_dto)
 
 
 @pytest.fixture
@@ -44,11 +46,10 @@ def variable_speed_compressor_train_two_compressors(
     variable_speed_compressor_train_dto, variable_speed_compressor_train_stage_dto
 ) -> VariableSpeedCompressorTrainCommonShaft:
     """Train with only two compressors, and standard medium fluid, no liquid off take."""
-    return VariableSpeedCompressorTrainCommonShaft(
-        data_transfer_object=variable_speed_compressor_train_dto.model_copy(
-            update={"stages": [variable_speed_compressor_train_stage_dto] * 2}
-        )
-    )
+    dto_copy = deepcopy(variable_speed_compressor_train_dto)
+    dto_copy.stages = [variable_speed_compressor_train_stage_dto] * 2
+
+    return VariableSpeedCompressorTrainCommonShaft(data_transfer_object=dto_copy)
 
 
 @pytest.fixture
@@ -56,14 +57,11 @@ def variable_speed_compressor_train_two_compressors_downstream_choke(
     variable_speed_compressor_train_dto, variable_speed_compressor_train_stage_dto
 ) -> VariableSpeedCompressorTrainCommonShaft:
     """Train with two compressors, and standard medium fluid, no liquid off take."""
-    return VariableSpeedCompressorTrainCommonShaft(
-        data_transfer_object=variable_speed_compressor_train_dto.model_copy(
-            update={
-                "stages": [variable_speed_compressor_train_stage_dto] * 2,
-                "pressure_control": libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
-            }
-        )
-    )
+    dto_copy = deepcopy(variable_speed_compressor_train_dto)
+    dto_copy.stages = [variable_speed_compressor_train_stage_dto] * 2
+    dto_copy.pressure_control = libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE
+
+    return VariableSpeedCompressorTrainCommonShaft(data_transfer_object=dto_copy)
 
 
 @pytest.fixture
@@ -71,14 +69,13 @@ def variable_speed_compressor_train_two_compressors_individual_asv_pressure(
     variable_speed_compressor_train_dto, variable_speed_compressor_train_stage_dto
 ) -> VariableSpeedCompressorTrainCommonShaft:
     """Train with two compressors, and standard medium fluid, no liquid off take."""
-    return VariableSpeedCompressorTrainCommonShaft(
-        data_transfer_object=variable_speed_compressor_train_dto.model_copy(
-            update={
-                "stages": [variable_speed_compressor_train_stage_dto] * 2,
-                "pressure_control": libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.INDIVIDUAL_ASV_PRESSURE,
-            }
-        )
+    dto_copy = deepcopy(variable_speed_compressor_train_dto)
+    dto_copy.stages = [variable_speed_compressor_train_stage_dto] * 2
+    dto_copy.pressure_control = (
+        libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.INDIVIDUAL_ASV_PRESSURE
     )
+
+    return VariableSpeedCompressorTrainCommonShaft(data_transfer_object=dto_copy)
 
 
 @pytest.fixture
@@ -98,7 +95,7 @@ def mock_variable_speed_compressor_train_multiple_streams_and_pressures(
         pressure_drop_before_stage=0,
         control_margin=0,
     )
-    stage1 = stage2.model_copy()
+    stage1 = deepcopy(stage2)
     stage1.stream_reference = "inlet"
     return dto.VariableSpeedCompressorTrainMultipleStreamsAndPressures(
         streams=[stream],
@@ -119,15 +116,15 @@ def variable_speed_compressor_train_one_compressor_one_stream(
     """Train with only one compressor, and standard medium fluid, no liquid off take,
     using multiple streams and pressures class.
     """
+    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
+    dto_copy.stages = cast(list[dto.MultipleStreamsCompressorStage], [variable_speed_compressor_train_stage_dto])
     return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=[
             FluidStreamObjectForMultipleStreams(
                 fluid=FluidStream(medium_fluid), is_inlet_stream=True, connected_to_stage_no=0
             )
         ],
-        data_transfer_object=mock_variable_speed_compressor_train_multiple_streams_and_pressures.model_copy(
-            update={"stages": [variable_speed_compressor_train_stage_dto]}
-        ),
+        data_transfer_object=dto_copy,
     )
 
 
@@ -140,18 +137,17 @@ def variable_speed_compressor_train_one_compressor_one_stream_downstream_choke(
     """Train with only one compressor, and standard medium fluid, no liquid off take,
     using multiple streams and pressures class.
     """
+    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
+    dto_copy.stages = cast(list[dto.MultipleStreamsCompressorStage], [variable_speed_compressor_train_stage_dto])
+    dto_copy.pressure_control = libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE
+
     return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=[
             FluidStreamObjectForMultipleStreams(
                 fluid=FluidStream(medium_fluid), is_inlet_stream=True, connected_to_stage_no=0
             )
         ],
-        data_transfer_object=mock_variable_speed_compressor_train_multiple_streams_and_pressures.model_copy(
-            update={
-                "stages": [variable_speed_compressor_train_stage_dto],
-                "pressure_control": libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
-            }
-        ),
+        data_transfer_object=dto_copy,
     )
 
 
@@ -169,14 +165,13 @@ def variable_speed_compressor_train_two_compressors_one_stream_downstream_choke(
             connected_to_stage_no=0,
         ),
     ]
+    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
+    dto_copy.stages = cast(list[dto.MultipleStreamsCompressorStage], [variable_speed_compressor_train_stage_dto] * 2)
+    dto_copy.pressure_control = libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE
+
     return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=fluid_streams,
-        data_transfer_object=mock_variable_speed_compressor_train_multiple_streams_and_pressures.model_copy(
-            update={
-                "stages": [variable_speed_compressor_train_stage_dto] * 2,
-                "pressure_control": libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
-            }
-        ),
+        data_transfer_object=dto_copy,
     )
 
 
@@ -194,14 +189,15 @@ def variable_speed_compressor_train_two_compressors_one_stream_individual_asv_pr
             connected_to_stage_no=0,
         ),
     ]
+    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
+    dto_copy.stages = cast(list[dto.MultipleStreamsCompressorStage], [variable_speed_compressor_train_stage_dto] * 2)
+    dto_copy.pressure_control = (
+        libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.INDIVIDUAL_ASV_PRESSURE
+    )
+
     return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=fluid_streams,
-        data_transfer_object=mock_variable_speed_compressor_train_multiple_streams_and_pressures.model_copy(
-            update={
-                "stages": [variable_speed_compressor_train_stage_dto] * 2,
-                "pressure_control": libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.INDIVIDUAL_ASV_PRESSURE,
-            }
-        ),
+        data_transfer_object=dto_copy,
     )
 
 
@@ -224,11 +220,12 @@ def variable_speed_compressor_train_two_compressors_two_streams(
             connected_to_stage_no=1,
         ),
     ]
+    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
+    dto_copy.stages = cast(list[dto.MultipleStreamsCompressorStage], [variable_speed_compressor_train_stage_dto] * 2)
+
     return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=fluid_streams,
-        data_transfer_object=mock_variable_speed_compressor_train_multiple_streams_and_pressures.model_copy(
-            update={"stages": [variable_speed_compressor_train_stage_dto] * 2}
-        ),
+        data_transfer_object=dto_copy,
     )
 
 
@@ -256,14 +253,13 @@ def variable_speed_compressor_train_two_compressors_ingoning_and_outgoing_stream
             connected_to_stage_no=1,
         ),
     ]
+    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
+    dto_copy.stages = cast(list[dto.MultipleStreamsCompressorStage], [variable_speed_compressor_train_stage_dto] * 2)
+    dto_copy.pressure_control = libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE
+
     return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=fluid_streams,
-        data_transfer_object=mock_variable_speed_compressor_train_multiple_streams_and_pressures.model_copy(
-            update={
-                "stages": [variable_speed_compressor_train_stage_dto] * 2,
-                "pressure_control": libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
-            }
-        ),
+        data_transfer_object=dto_copy,
     )
 
 

--- a/tests/libecalc/dto/test_energy_model.py
+++ b/tests/libecalc/dto/test_energy_model.py
@@ -20,7 +20,7 @@ class TestTurbine:
         )
 
     def test_unequal_load_and_efficiency_lengths(self):
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises(ValueError) as e:
             dto.Turbine(
                 lower_heating_value=38,
                 turbine_loads=[0, 2.352, 4.589, 6.853, 9.125, 11.399, 13.673, 15.947, 18.223, 20.496],
@@ -100,22 +100,22 @@ class TestGenericFromDesignPointCompressorChart:
         )
 
     def test_invalid_polytropic_efficiency(self):
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises(ValueError) as e:
             dto.GenericChartFromDesignPoint(
                 polytropic_efficiency_fraction=1.8,
                 design_rate_actual_m3_per_hour=7500.0,
                 design_polytropic_head_J_per_kg=55000,
             )
-        assert "Input should be less than or equal to 1" in str(e.value)
+        assert "polytropic_efficiency_fraction must be greater than 0 and less than or equal to 1" in str(e.value)
 
     def test_invalid_design_rate(self):
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises(ValueError) as e:
             dto.GenericChartFromDesignPoint(
                 polytropic_efficiency_fraction=0.8,
                 design_rate_actual_m3_per_hour="invalid_design_rate",
                 design_polytropic_head_J_per_kg=55000,
             )
-        assert "Input should be a valid number, unable to parse string as a number" in str(e.value)
+        assert "design_rate_actual_m3_per_hour must be a number" in str(e.value)
 
 
 class TestGenericFromInputCompressorChart:
@@ -123,9 +123,9 @@ class TestGenericFromInputCompressorChart:
         dto.GenericChartFromInput(polytropic_efficiency_fraction=0.8)
 
     def test_invalid(self):
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises(ValueError) as e:
             dto.GenericChartFromInput(polytropic_efficiency_fraction="str")
-        assert "Input should be a valid number, unable to parse string as a number" in str(e.value)
+        assert "polytropic_efficiency_fraction must be a number" in str(e.value)
 
 
 class TestCompressorSystemEnergyUsageModel:
@@ -268,7 +268,7 @@ class TestSingleSpeedCompressorTrain:
 
     def test_invalid_chart(self):
         """Single speed does not support variable speed charts."""
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError):
             dto.SingleSpeedCompressorTrain(
                 fluid_model=FluidModel(
                     eos_model=libecalc.common.fluid.EoSModel.PR,
@@ -342,7 +342,7 @@ class TestVariableSpeedCompressorTrain:
 
     def test_incompatible_stages(self):
         with pytest.raises(
-            ValidationError,
+            ValueError,
             match=r".*Variable speed compressors in compressor train have incompatible compressor charts.*",
         ):
             dto.VariableSpeedCompressorTrain(

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -43,7 +43,7 @@ class TestGeneratorSetSampled:
         assert generator_set_sampled.data == [[0, 0], [1, 2], [2, 4], [3, 6]]
 
     def test_invalid_headers(self):
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             dto.GeneratorSetSampled(
                 headers=["FUEL", "POWAH"],
                 data=[[0, 0], [1, 2], [2, 4], [3, 6]],

--- a/tests/libecalc/input/mappers/test_energy_usage_model.py
+++ b/tests/libecalc/input/mappers/test_energy_usage_model.py
@@ -71,7 +71,6 @@ pump_system = (
       DISCHARGE_PRESSURE: 200
     """,
     dto.PumpSystemConsumerFunction(
-        energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.POWER,
         condition=Expression.setup_from_expression(value="SIM1;WATER_PROD >0"),
         pumps=[
             dto.PumpSystemPump(


### PR DESCRIPTION
## Why is this pull request needed?

Part of libecalc refactoring and code improvements.

## What does this pull request change?

- Remove pydantic from libecalc.domain.process.dto (previously named models in main dto folder)
- Update affected classes and methods
- Update tests and fixtures

