### PR TITLE
Create stream and fluid domain with thermodynamic adapter

### DIFF
--- a/src/ecalc_neqsim_wrapper/thermo.py
+++ b/src/ecalc_neqsim_wrapper/thermo.py
@@ -12,10 +12,7 @@ from pydantic import BaseModel
 from ecalc_neqsim_wrapper.components import COMPONENTS
 from ecalc_neqsim_wrapper.exceptions import NeqsimPhaseError
 from ecalc_neqsim_wrapper.java_service import get_neqsim_service
-from ecalc_neqsim_wrapper.mappings import (
-    _map_fluid_component_from_neqsim,
-    map_fluid_composition_to_neqsim,
-)
+from ecalc_neqsim_wrapper.mappings import _map_fluid_component_from_neqsim, map_fluid_composition_to_neqsim
 from libecalc.common.decorators.capturer import Capturer
 from libecalc.common.fluid import EoSModel, FluidComposition
 from libecalc.common.logger import logger
@@ -271,6 +268,15 @@ class NeqsimFluid:
     @property
     def pressure_bara(self) -> float:
         return self._thermodynamic_system.getPressure("bara")
+
+    @property
+    def vapor_fraction_molar(self) -> float:
+        if self._thermodynamic_system.hasPhaseType("gas"):
+            phaseNumber = self._thermodynamic_system.getPhaseNumberOfPhase("gas")
+            gasFractionc = self._thermodynamic_system.getMoleFraction(phaseNumber)
+            return gasFractionc
+        else:
+            return 0.0
 
     @staticmethod
     def _tp_flash(thermodynamic_system: ThermodynamicSystem, use_gerg: bool) -> ThermodynamicSystem:

--- a/src/libecalc/common/fluid.py
+++ b/src/libecalc/common/fluid.py
@@ -29,6 +29,19 @@ class FluidComposition(EcalcBaseModel):
     n_pentane: float = Field(0.0, ge=0.0)
     n_hexane: float = Field(0.0, ge=0.0)
 
+    def normalized(self) -> FluidComposition:
+        """
+        Returns a new FluidComposition instance with each component normalized so that
+        the sum of all components equals 1.
+        """
+        # Using model_dump() for Pydantic v2
+        data = self.model_dump()
+        total = sum(data.values())
+        if total == 0:
+            raise ValueError("Total composition is 0; cannot normalize.")
+        normalized_data = {key: value / total for key, value in data.items()}
+        return self.__class__(**normalized_data)
+
 
 class FluidModel(EcalcBaseModel):
     eos_model: EoSModel

--- a/src/libecalc/domain/process/core/stream/__init__.py
+++ b/src/libecalc/domain/process/core/stream/__init__.py
@@ -1,0 +1,5 @@
+from libecalc.domain.process.core.stream.conditions import ProcessConditions
+from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.stream import Stream
+
+__all__ = ["Stream", "Fluid", "ProcessConditions"]

--- a/src/libecalc/domain/process/core/stream/conditions.py
+++ b/src/libecalc/domain/process/core/stream/conditions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from libecalc.common.units import UnitConstants
+from libecalc.common.units import Unit, UnitConstants
 
 
 @dataclass(frozen=True)
@@ -28,22 +28,22 @@ class ProcessConditions:
     @property
     def temperature_celsius(self) -> float:
         """Get temperature in Celsius."""
-        return self.temperature - 273.15
+        return Unit.KELVIN.to(Unit.CELSIUS)(self.temperature)
 
     @property
     def pressure_pascal(self) -> float:
         """Get pressure in Pascal."""
-        return self.pressure * 1e5
+        return Unit.BARA.to(Unit.PASCAL)(self.pressure)
 
     @property
     def pressure_atm(self) -> float:
         """Get pressure in atmospheres."""
-        return self.pressure / 1.01325
+        return self.pressure / UnitConstants.STANDARD_PRESSURE_BARA
 
     @classmethod
     def from_celsius(cls, temperature_celsius: float, pressure: float) -> ProcessConditions:
         """Create instance with temperature specified in Celsius."""
-        return cls(temperature=temperature_celsius + 273.15, pressure=pressure)
+        return cls(temperature=Unit.CELSIUS.to(Unit.KELVIN)(temperature_celsius), pressure=pressure)
 
     @classmethod
     def standard_conditions(cls) -> ProcessConditions:

--- a/src/libecalc/domain/process/core/stream/conditions.py
+++ b/src/libecalc/domain/process/core/stream/conditions.py
@@ -15,40 +15,40 @@ class ProcessConditions:
         pressure: Pressure in bara (absolute bar)
     """
 
-    temperature: float
-    pressure: float
+    temperature_kelvin: float
+    pressure_bara: float
 
     def __post_init__(self):
         """Validate conditions"""
-        if self.temperature <= 0:
-            raise ValueError(f"Temperature must be positive, got {self.temperature}")
-        if self.pressure <= 0:
-            raise ValueError(f"Pressure must be positive, got {self.pressure}")
+        if self.temperature_kelvin <= 0:
+            raise ValueError(f"Temperature must be positive, got {self.temperature_kelvin}")
+        if self.pressure_bara <= 0:
+            raise ValueError(f"Pressure must be positive, got {self.pressure_bara}")
 
     @property
     def temperature_celsius(self) -> float:
         """Get temperature in Celsius."""
-        return Unit.KELVIN.to(Unit.CELSIUS)(self.temperature)
+        return Unit.KELVIN.to(Unit.CELSIUS)(self.temperature_kelvin)
 
     @property
     def pressure_pascal(self) -> float:
         """Get pressure in Pascal."""
-        return Unit.BARA.to(Unit.PASCAL)(self.pressure)
+        return Unit.BARA.to(Unit.PASCAL)(self.pressure_bara)
 
     @property
     def pressure_atm(self) -> float:
         """Get pressure in atmospheres."""
-        return self.pressure / UnitConstants.STANDARD_PRESSURE_BARA
+        return self.pressure_bara / UnitConstants.STANDARD_PRESSURE_BARA
 
     @classmethod
-    def from_celsius(cls, temperature_celsius: float, pressure: float) -> ProcessConditions:
+    def from_celsius(cls, temperature_celsius: float, pressure_bara: float) -> ProcessConditions:
         """Create instance with temperature specified in Celsius."""
-        return cls(temperature=Unit.CELSIUS.to(Unit.KELVIN)(temperature_celsius), pressure=pressure)
+        return cls(temperature_kelvin=Unit.CELSIUS.to(Unit.KELVIN)(temperature_celsius), pressure_bara=pressure_bara)
 
     @classmethod
     def standard_conditions(cls) -> ProcessConditions:
         """Create instance with standard conditions."""
         return cls(
-            temperature=UnitConstants.STANDARD_TEMPERATURE_KELVIN,
-            pressure=UnitConstants.STANDARD_PRESSURE_BARA,
+            temperature_kelvin=UnitConstants.STANDARD_TEMPERATURE_KELVIN,
+            pressure_bara=UnitConstants.STANDARD_PRESSURE_BARA,
         )

--- a/src/libecalc/domain/process/core/stream/conditions.py
+++ b/src/libecalc/domain/process/core/stream/conditions.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from libecalc.common.units import UnitConstants
+
+
+@dataclass(frozen=True)
+class ProcessConditions:
+    """
+    Represents the physical conditions of a process stream.
+
+    Attributes:
+        temperature: Temperature in Kelvin
+        pressure: Pressure in bara (absolute bar)
+    """
+
+    temperature: float
+    pressure: float
+
+    def __post_init__(self):
+        """Validate conditions"""
+        if self.temperature <= 0:
+            raise ValueError(f"Temperature must be positive, got {self.temperature}")
+        if self.pressure <= 0:
+            raise ValueError(f"Pressure must be positive, got {self.pressure}")
+
+    @property
+    def temperature_celsius(self) -> float:
+        """Get temperature in Celsius."""
+        return self.temperature - 273.15
+
+    @property
+    def pressure_pascal(self) -> float:
+        """Get pressure in Pascal."""
+        return self.pressure * 1e5
+
+    @property
+    def pressure_atm(self) -> float:
+        """Get pressure in atmospheres."""
+        return self.pressure / 1.01325
+
+    @classmethod
+    def from_celsius(cls, temperature_celsius: float, pressure: float) -> ProcessConditions:
+        """Create instance with temperature specified in Celsius."""
+        return cls(temperature=temperature_celsius + 273.15, pressure=pressure)
+
+    @classmethod
+    def standard_conditions(cls) -> ProcessConditions:
+        """Create instance with standard conditions."""
+        return cls(
+            temperature=UnitConstants.STANDARD_TEMPERATURE_KELVIN,
+            pressure=UnitConstants.STANDARD_PRESSURE_BARA,
+        )

--- a/src/libecalc/domain/process/core/stream/exceptions.py
+++ b/src/libecalc/domain/process/core/stream/exceptions.py
@@ -1,0 +1,11 @@
+class InvalidStreamException(Exception):
+    """Base exception for invalid stream operations."""
+
+    pass
+
+
+class NegativeMassRateException(InvalidStreamException):
+    """Exception raised for negative mass rate in a stream."""
+
+    def __init__(self, mass_rate: float):
+        super().__init__(f"Mass rate must be non-negative, got {mass_rate}")

--- a/src/libecalc/domain/process/core/stream/fluid.py
+++ b/src/libecalc/domain/process/core/stream/fluid.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Literal, Optional, Protocol
+from typing import Literal, Protocol
 
 from libecalc.common.fluid import EoSModel, FluidComposition
 
@@ -63,9 +63,9 @@ class Fluid:
 
     # Instance variables
     composition: FluidComposition
-    eos_model: Optional[EoSModel] = None
+    eos_model: EoSModel | None = None
     _engine_type: ThermodynamicEngineType = "neqsim"  # Default to NeqSim
-    _thermodynamic_engine: Optional[ThermodynamicEngine] = None  # Will be initialized in __post_init__
+    _thermodynamic_engine: ThermodynamicEngine | None = None  # Will be initialized in __post_init__
 
     def __post_init__(self):
         """Initialize the thermodynamic engine if not provided"""
@@ -101,6 +101,6 @@ class Fluid:
         return self._thermodynamic_engine
 
     @classmethod
-    def with_neqsim_engine(cls, composition: FluidComposition, eos_model: Optional[EoSModel] = None) -> Fluid:
+    def with_neqsim_engine(cls, composition: FluidComposition, eos_model: EoSModel | None = None) -> Fluid:
         """Create a fluid instance that uses the NeqSim engine"""
         return cls(composition=composition, eos_model=eos_model, _engine_type="neqsim")

--- a/src/libecalc/domain/process/core/stream/fluid.py
+++ b/src/libecalc/domain/process/core/stream/fluid.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Literal, Optional, Protocol
+
+from libecalc.common.fluid import EoSModel, FluidComposition
+
+
+class ThermodynamicEngine(Protocol):
+    """Protocol defining the interface for thermodynamic calculations"""
+
+    def get_density(self, fluid: Fluid, pressure: float, temperature: float) -> float:
+        """Get density at given conditions [kg/m³]"""
+        ...
+
+    def get_enthalpy(self, fluid: Fluid, pressure: float, temperature: float) -> float:
+        """Get specific enthalpy at given conditions [kJ/kg]"""
+        ...
+
+    def get_z(self, fluid: Fluid, pressure: float, temperature: float) -> float:
+        """Get compressibility factor (Z) at given conditions [-]"""
+        ...
+
+    def get_kappa(self, fluid: Fluid, pressure: float, temperature: float) -> float:
+        """Get heat capacity ratio (kappa) at given conditions [-]"""
+        ...
+
+    def get_standard_density_gas_phase_after_flash(self, fluid: Fluid) -> float:
+        """Get gas phase density at standard conditions after TP flash and liquid removal [kg/m³]"""
+        ...
+
+    def get_vapor_fraction_molar(self, fluid: Fluid, pressure: float, temperature: float) -> float:
+        """Get molar gas fraction at given conditions (0.0-1.0)"""
+        ...
+
+    def get_molar_mass(self, fluid: Fluid) -> float:
+        """Get molar mass [kg/kmol]"""
+        ...
+
+
+# Define a type for supported thermodynamic engines
+ThermodynamicEngineType = Literal["neqsim"]
+
+
+@dataclass(frozen=True)
+class Fluid:
+    """
+    Represents a fluid with composition and properties.
+
+    This class abstracts away the specific implementation of thermodynamic
+    calculations, allowing for different backends (NeqSim, explicit correlations, etc).
+
+    There are two ways to create a Fluid instance:
+    1. Using the default constructor: Fluid(composition=...)
+       - creates a fluid with NeqSim engine (default)
+    2. Using the factory method: Fluid.with_neqsim_engine(composition=...)
+       - explicitly creates a fluid with NeqSim engine
+    """
+
+    # Class variables
+    DEFAULT_EOS_MODEL = EoSModel.SRK
+
+    # Instance variables
+    composition: FluidComposition
+    eos_model: Optional[EoSModel] = None
+    _engine_type: ThermodynamicEngineType = "neqsim"  # Default to NeqSim
+    _thermodynamic_engine: Optional[ThermodynamicEngine] = None  # Will be initialized in __post_init__
+
+    def __post_init__(self):
+        """Initialize the thermodynamic engine if not provided"""
+        # If engine is already provided, we don't need to create one
+        if self._thermodynamic_engine is not None:
+            return
+
+        # Import adapters here to avoid circular import at runtime
+        from libecalc.domain.process.core.stream.thermo_adapters import NeqSimThermodynamicAdapter
+
+        # Use object.__setattr__ since this is a frozen dataclass
+        if self._engine_type == "neqsim":
+            # For NeqSim, we require an EoS model
+            if self.eos_model is None:
+                # Default to SRK if not specified
+                object.__setattr__(self, "eos_model", self.DEFAULT_EOS_MODEL)
+            engine = NeqSimThermodynamicAdapter()
+        else:
+            # Fallback to NeqSim if unknown engine type
+            if self.eos_model is None:
+                object.__setattr__(self, "eos_model", self.DEFAULT_EOS_MODEL)
+            engine = NeqSimThermodynamicAdapter()
+
+        object.__setattr__(self, "_thermodynamic_engine", engine)
+
+    @cached_property
+    def molar_mass(self) -> float:
+        """Get molar mass of fluid [kg/mol]"""
+        return self._get_thermodynamic_engine().get_molar_mass(self)
+
+    def _get_thermodynamic_engine(self) -> ThermodynamicEngine:
+        """Get the thermodynamic engine for this fluid"""
+        return self._thermodynamic_engine
+
+    @classmethod
+    def with_neqsim_engine(cls, composition: FluidComposition, eos_model: Optional[EoSModel] = None) -> Fluid:
+        """Create a fluid instance that uses the NeqSim engine"""
+        return cls(composition=composition, eos_model=eos_model, _engine_type="neqsim")

--- a/src/libecalc/domain/process/core/stream/fluid.py
+++ b/src/libecalc/domain/process/core/stream/fluid.py
@@ -10,32 +10,32 @@ from libecalc.common.fluid import EoSModel, FluidComposition
 class ThermodynamicEngine(Protocol):
     """Protocol defining the interface for thermodynamic calculations"""
 
-    def get_density(self, fluid: Fluid, pressure: float, temperature: float) -> float:
+    def get_density(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
         """Get density at given conditions [kg/m³]"""
         ...
 
-    def get_enthalpy(self, fluid: Fluid, pressure: float, temperature: float) -> float:
+    def get_enthalpy(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
         """Get specific enthalpy at given conditions [kJ/kg]"""
         ...
 
-    def get_z(self, fluid: Fluid, pressure: float, temperature: float) -> float:
-        """Get compressibility factor (Z) at given conditions [-]"""
+    def get_z(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
+        """Get compressibility factor at given conditions [-]"""
         ...
 
-    def get_kappa(self, fluid: Fluid, pressure: float, temperature: float) -> float:
-        """Get heat capacity ratio (kappa) at given conditions [-]"""
+    def get_kappa(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
+        """Get isentropic exponent at given conditions [-]"""
         ...
 
     def get_standard_density_gas_phase_after_flash(self, fluid: Fluid) -> float:
-        """Get gas phase density at standard conditions after TP flash and liquid removal [kg/m³]"""
+        """Get gas phase density at standard conditions after TP flash [kg/Sm³]"""
         ...
 
-    def get_vapor_fraction_molar(self, fluid: Fluid, pressure: float, temperature: float) -> float:
-        """Get molar gas fraction at given conditions (0.0-1.0)"""
+    def get_vapor_fraction_molar(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
+        """Get molar vapor fraction at given conditions [0-1]"""
         ...
 
     def get_molar_mass(self, fluid: Fluid) -> float:
-        """Get molar mass [kg/kmol]"""
+        """Get molar mass of the fluid [kg/mol]"""
         ...
 
 

--- a/src/libecalc/domain/process/core/stream/fluid_factory.py
+++ b/src/libecalc/domain/process/core/stream/fluid_factory.py
@@ -1,0 +1,11 @@
+from libecalc.common.fluid import EoSModel, FluidComposition
+from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.thermo_adapters import NeqSimThermodynamicAdapter
+
+
+def create_fluid_with_neqsim_engine(composition: FluidComposition, eos_model: EoSModel | None = None) -> Fluid:
+    """Create a fluid instance that uses the NeqSim engine"""
+    if eos_model is None:
+        eos_model = EoSModel.SRK  # Default to SRK if not specified
+    engine = NeqSimThermodynamicAdapter()
+    return Fluid(composition=composition, eos_model=eos_model, _thermodynamic_engine=engine)

--- a/src/libecalc/domain/process/core/stream/mixing.py
+++ b/src/libecalc/domain/process/core/stream/mixing.py
@@ -15,7 +15,7 @@ class SimplifiedStreamMixing:
 
     This mixing strategy performs a simplified mixing calculation without requiring
     thermodynamic equilibrium calculations. The approach uses:
-    - The first stream's temperature (assumes inlet streams have similar temperatures)
+    - The mass-weighted average temperature of all streams
     - The lowest pressure among all streams for the resulting mixture
     - Component-wise molar balance for composition calculation
     - No thermodynamic equilibrium calculations
@@ -43,7 +43,10 @@ class SimplifiedStreamMixing:
         if total_mass_rate == 0:
             raise ValueError("Total mass rate cannot be zero")
 
-        reference_temperature = streams[0].conditions.temperature
+        # Calculate mass-weighted average temperature
+        reference_temperature = (
+            sum(stream.mass_rate * stream.conditions.temperature for stream in streams) / total_mass_rate
+        )
 
         reference_pressure = min(stream.conditions.pressure for stream in streams)
 

--- a/src/libecalc/domain/process/core/stream/mixing.py
+++ b/src/libecalc/domain/process/core/stream/mixing.py
@@ -47,10 +47,10 @@ class SimplifiedStreamMixing:
             raise ValueError("Total mass rate cannot be zero")
 
         # Calculate mass-weighted average temperature
-        reference_temperature = sum(s.mass_rate * s.conditions.temperature for s in streams) / total_mass_rate
+        reference_temperature = sum(s.mass_rate * s.conditions.temperature_kelvin for s in streams) / total_mass_rate
 
         # Lowest pressure among all streams
-        reference_pressure = min(s.conditions.pressure for s in streams)
+        reference_pressure = min(s.conditions.pressure_bara for s in streams)
 
         # All streams must share the same EoS
         reference_eos_model = streams[0].fluid.eos_model
@@ -90,6 +90,6 @@ class SimplifiedStreamMixing:
 
         return Stream(
             fluid=result_fluid,
-            conditions=ProcessConditions(temperature=reference_temperature, pressure=reference_pressure),
+            conditions=ProcessConditions(temperature_kelvin=reference_temperature, pressure_bara=reference_pressure),
             mass_rate=total_mass_rate,
         )

--- a/src/libecalc/domain/process/core/stream/mixing.py
+++ b/src/libecalc/domain/process/core/stream/mixing.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING
+
+from typing_extensions import Protocol
 
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
 from libecalc.domain.process.core.stream.fluid import Fluid, FluidComposition, ThermodynamicEngine
-
-if TYPE_CHECKING:
-    from libecalc.domain.process.core.stream.stream import Stream
+from libecalc.domain.process.core.stream.stream import Stream
 
 
-class SimplifiedStreamMixing:
+class StreamMixingStrategy(Protocol):
+    """Protocol for stream mixing strategies"""
+
+    def mix_streams(self, streams: list[Stream], engine: ThermodynamicEngine | None = None) -> Stream:
+        """Mix multiple streams into a single resultant stream"""
+        ...
+
+
+class SimplifiedStreamMixing(StreamMixingStrategy):
     """Implementation of simplified mixing using component-wise molar balance.
 
     This mixing strategy performs a simplified mixing calculation without requiring

--- a/src/libecalc/domain/process/core/stream/mixing.py
+++ b/src/libecalc/domain/process/core/stream/mixing.py
@@ -4,10 +4,9 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
-from libecalc.domain.process.core.stream.fluid import Fluid, FluidComposition
+from libecalc.domain.process.core.stream.fluid import Fluid, FluidComposition, ThermodynamicEngine
 
 if TYPE_CHECKING:
-    from libecalc.domain.process.core.stream.fluid import ThermodynamicEngine
     from libecalc.domain.process.core.stream.stream import Stream
 
 
@@ -60,7 +59,7 @@ class SimplifiedStreamMixing:
                     f"Cannot mix streams with different EoS models: " f"{reference_eos_model} vs {s.fluid.eos_model}"
                 )
 
-        # Choose the engine for the resulting fluid
+        # Choose the thermodynamic engine for the resulting fluid
         # If none is given, use the first stream's engine
         if engine is None:
             engine = streams[0].fluid._thermodynamic_engine

--- a/src/libecalc/domain/process/core/stream/mixing.py
+++ b/src/libecalc/domain/process/core/stream/mixing.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from libecalc.domain.process.core.stream.conditions import ProcessConditions
+from libecalc.domain.process.core.stream.fluid import Fluid, FluidComposition
+
+if TYPE_CHECKING:
+    from libecalc.domain.process.core.stream.stream import Stream
+
+
+class SimplifiedStreamMixing:
+    """Implementation of simplified mixing using component-wise molar balance.
+
+    This mixing strategy performs a simplified mixing calculation without requiring
+    thermodynamic equilibrium calculations. The approach uses:
+    - The first stream's temperature (assumes inlet streams have similar temperatures)
+    - The lowest pressure among all streams for the resulting mixture
+    - Component-wise molar balance for composition calculation
+    - No thermodynamic equilibrium calculations
+
+    Note: This method is most appropriate when mixing streams with similar temperatures.
+    """
+
+    def mix_streams(self, streams: list[Stream]) -> Stream:
+        """Mix multiple streams using component-wise molar balance.
+
+        Args:
+            streams: List of streams to mix
+
+        Returns:
+            A new Stream instance representing the mixed stream
+
+        Raises:
+            ValueError: If streams list is empty or if total mass rate is zero
+            ValueError: If streams have different EoS models
+        """
+        if not streams:
+            raise ValueError("Cannot mix empty list of streams")
+
+        total_mass_rate = sum(stream.mass_rate for stream in streams)
+        if total_mass_rate == 0:
+            raise ValueError("Total mass rate cannot be zero")
+
+        reference_temperature = streams[0].conditions.temperature
+
+        reference_pressure = min(stream.conditions.pressure for stream in streams)
+
+        # For simplicity, use the EoS model from the first stream
+        reference_eos_model = streams[0].fluid.eos_model
+
+        for stream in streams[1:]:
+            if stream.fluid.eos_model != reference_eos_model:
+                raise ValueError(
+                    f"Cannot mix streams with different EoS models: "
+                    f"{reference_eos_model} vs {stream.fluid.eos_model}"
+                )
+
+        stream_total_molar_rates_list = []
+        for stream in streams:
+            stream_total_molar_rate = stream.mass_rate / stream.fluid.molar_mass
+            stream_total_molar_rates_list.append(stream_total_molar_rate)
+
+        mix_total_molar_rate = sum(stream_total_molar_rates_list)
+
+        mix_component_molar_rate_dict: defaultdict[str, float] = defaultdict(float)
+
+        # Sum molar flow of each component across all streams
+        for stream, stream_total_molar_rate in zip(streams, stream_total_molar_rates_list):
+            for component, stream_component_mole_fraction in stream.fluid.composition.model_dump().items():
+                stream_component_molar_rate = stream_total_molar_rate * stream_component_mole_fraction
+                mix_component_molar_rate_dict[component] += stream_component_molar_rate
+
+        # Convert to final mole fractions
+        mix_composition_dict = {
+            component: mix_comp_molar_rate / mix_total_molar_rate
+            for component, mix_comp_molar_rate in mix_component_molar_rate_dict.items()
+        }
+
+        mix_composition = FluidComposition.model_validate(mix_composition_dict)
+
+        result_fluid = Fluid(composition=mix_composition, eos_model=reference_eos_model)
+
+        # Import here to avoid circular import
+        from libecalc.domain.process.core.stream.stream import Stream
+
+        return Stream(
+            fluid=result_fluid,
+            conditions=ProcessConditions(temperature=reference_temperature, pressure=reference_pressure),
+            mass_rate=total_mass_rate,
+        )

--- a/src/libecalc/domain/process/core/stream/stream.py
+++ b/src/libecalc/domain/process/core/stream/stream.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import ClassVar, Protocol
+
+from libecalc.common.units import UnitConstants
+from libecalc.domain.process.core.stream.conditions import ProcessConditions
+from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.mixing import SimplifiedStreamMixing
+
+
+class StreamMixingStrategy(Protocol):
+    """Protocol for stream mixing strategies"""
+
+    def mix_streams(self, streams: list[Stream]) -> Stream:
+        """Mix multiple streams into a single resultant stream"""
+        ...
+
+
+@dataclass
+class Stream:
+    """
+    Represents a fluid stream with its properties and conditions.
+
+    This class consolidates the functionality from various existing stream
+    implementations in the system.
+
+    Attributes:
+        fluid: Fluid object containing composition and EoS model
+        conditions: Process conditions (temperature and pressure)
+        mass_rate: Mass flow rate [kg/h]
+        name: Optional identifier for the stream
+    """
+
+    fluid: Fluid
+    conditions: ProcessConditions
+    mass_rate: float
+
+    # Default mixing strategy (class variable)
+    _stream_mixing_strategy: ClassVar[StreamMixingStrategy] = SimplifiedStreamMixing()
+
+    def __post_init__(self):
+        """Validate stream properties"""
+        if self.mass_rate < 0:
+            raise ValueError(f"Mass rate must be non-negative, got {self.mass_rate}")
+
+    @property
+    def temperature(self) -> float:
+        """Get stream temperature [K]."""
+        return self.conditions.temperature
+
+    @property
+    def pressure(self) -> float:
+        """Get stream pressure [bara]."""
+        return self.conditions.pressure
+
+    @cached_property
+    def density(self) -> float:
+        """Get density [kg/m³]."""
+        return self._get_thermodynamic_engine().get_density(self.fluid, self.pressure, self.temperature)
+
+    @cached_property
+    def molar_mass(self) -> float:
+        """Get molar mass of the fluid [kg/kmol]."""
+        return self._get_thermodynamic_engine().get_molar_mass(self.fluid)
+
+    @cached_property
+    def standard_density_gas_phase_after_flash(self) -> float:
+        """Get gas phase density at standard conditions after TP flash and liquid removal [kg/m³]."""
+        return self._get_thermodynamic_engine().get_standard_density_gas_phase_after_flash(self.fluid)
+
+    @cached_property
+    def enthalpy(self) -> float:
+        """Get specific enthalpy [J/kg]."""
+        return self._get_thermodynamic_engine().get_enthalpy(self.fluid, self.pressure, self.temperature)
+
+    @cached_property
+    def z(self) -> float:
+        """Get compressibility factor [-]."""
+        return self._get_thermodynamic_engine().get_z(self.fluid, self.pressure, self.temperature)
+
+    @cached_property
+    def kappa(self) -> float:
+        """Get isentropic exponent [-]."""
+        return self._get_thermodynamic_engine().get_kappa(self.fluid, self.pressure, self.temperature)
+
+    @cached_property
+    def volumetric_rate(self) -> float:
+        """Calculate volumetric flow rate [m³/s]."""
+        return self.mass_rate / self.density
+
+    @cached_property
+    def standard_rate(self) -> float:
+        """Calculate standard volumetric flow rate [Sm³/day]."""
+        return self.mass_rate / self.standard_density_gas_phase_after_flash * UnitConstants.HOURS_PER_DAY
+
+    def create_stream_with_new_conditions(self, new_conditions: ProcessConditions) -> Stream:
+        """Create a new stream with modified conditions.
+
+        Args:
+            new_conditions: New process conditions to apply
+
+        Returns:
+            A new Stream instance with the modified conditions
+        """
+        return Stream(
+            fluid=self.fluid,
+            conditions=new_conditions,
+            mass_rate=self.mass_rate,
+        )
+
+    def create_stream_with_new_pressure_and_temperature(self, new_pressure: float, new_temperature: float) -> Stream:
+        """Create a new stream with modified pressure and temperature.
+
+        Args:
+            new_pressure: New pressure [bara]
+            new_temperature: New temperature [K]
+
+        Returns:
+            A new Stream instance with the modified pressure and temperature
+        """
+        return self.create_stream_with_new_conditions(
+            ProcessConditions(pressure=new_pressure, temperature=new_temperature)
+        )
+
+    def create_stream_with_new_pressure_and_enthalpy_change(
+        self, new_pressure: float, enthalpy_change: float
+    ) -> Stream:
+        """Create a new stream with modified pressure and changed enthalpy.
+        TODO: This is a temporary method with only the
+
+        This simulates a PH-flash operation.
+
+        Args:
+            new_pressure: Target pressure [bara]
+            enthalpy_change: Change in specific enthalpy [J/kg]
+
+        Returns:
+            A new Stream instance with the modified pressure and resulting temperature
+        """
+        from ecalc_neqsim_wrapper.thermo import NeqsimFluid
+
+        neqsim_fluid = NeqsimFluid.create_thermo_system(
+            composition=self.fluid.composition,
+            temperature_kelvin=self.temperature,
+            pressure_bara=self.pressure,
+            eos_model=self.fluid.eos_model,
+        )
+
+        # Use NeqSim's PH flash to get the new state
+        neqsim_fluid = neqsim_fluid.set_new_pressure_and_enthalpy(
+            new_pressure=new_pressure,
+            new_enthalpy_joule_per_kg=neqsim_fluid.enthalpy_joule_per_kg + enthalpy_change,
+            remove_liquid=True,
+        )
+
+        # Return a new stream with the calculated temperature
+        return self.create_stream_with_new_pressure_and_temperature(
+            new_pressure=new_pressure, new_temperature=neqsim_fluid.temperature_kelvin
+        )
+
+    @classmethod
+    def mix(cls, streams: list[Stream]) -> Stream:
+        """Mix multiple streams into one.
+
+        Args:
+            streams: List of streams to mix, see MixingStrategy for more details
+
+        Returns:
+            A new Stream instance representing the mixed stream
+        """
+        return cls._stream_mixing_strategy.mix_streams(streams)
+
+    def _get_thermodynamic_engine(self):
+        """Get the thermodynamic engine from the fluid."""
+        return self.fluid._get_thermodynamic_engine()
+
+    @classmethod
+    def from_standard_rate(
+        cls,
+        fluid: Fluid,
+        conditions: ProcessConditions,
+        standard_rate: float,  # Sm³/day
+    ) -> Stream:
+        """Create a stream from standard volumetric flow rate instead of mass rate.
+
+        Args:
+            fluid: Fluid object containing composition and EoS model
+            conditions: Process conditions (temperature and pressure)
+            standard_rate: Volumetric flow rate at standard conditions [Sm³/day]
+
+        Returns:
+            A new Stream instance with mass rate calculated from standard rate
+        """
+        # Create a temporary fluid to get standard density
+        standard_density = fluid._get_thermodynamic_engine().get_standard_density_gas_phase_after_flash(fluid)
+
+        # Convert standard rate to mass rate
+        mass_rate = standard_rate * standard_density / UnitConstants.HOURS_PER_DAY
+
+        return cls(fluid=fluid, conditions=conditions, mass_rate=mass_rate)

--- a/src/libecalc/domain/process/core/stream/stream.py
+++ b/src/libecalc/domain/process/core/stream/stream.py
@@ -7,14 +7,14 @@ from typing import Protocol
 from libecalc.common.units import UnitConstants
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
 from libecalc.domain.process.core.stream.exceptions import NegativeMassRateException
-from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.fluid import Fluid, ThermodynamicEngine
 from libecalc.domain.process.core.stream.mixing import SimplifiedStreamMixing
 
 
 class StreamMixingStrategy(Protocol):
     """Protocol for stream mixing strategies"""
 
-    def mix_streams(self, streams: list[Stream]) -> Stream:
+    def mix_streams(self, streams: list[Stream], engine: ThermodynamicEngine | None = None) -> Stream:
         """Mix multiple streams into a single resultant stream"""
         ...
 

--- a/src/libecalc/domain/process/core/stream/stream.py
+++ b/src/libecalc/domain/process/core/stream/stream.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Protocol
 
 from libecalc.common.units import UnitConstants
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
+from libecalc.domain.process.core.stream.exceptions import NegativeMassRateException
 from libecalc.domain.process.core.stream.fluid import Fluid
 from libecalc.domain.process.core.stream.mixing import SimplifiedStreamMixing
 
@@ -43,7 +44,7 @@ class Stream:
     def __post_init__(self):
         """Validate stream properties"""
         if self.mass_rate < 0:
-            raise ValueError(f"Mass rate must be non-negative, got {self.mass_rate}")
+            raise NegativeMassRateException(self.mass_rate)
 
     @property
     def temperature(self) -> float:

--- a/src/libecalc/domain/process/core/stream/stream.py
+++ b/src/libecalc/domain/process/core/stream/stream.py
@@ -58,7 +58,9 @@ class Stream:
     @cached_property
     def density(self) -> float:
         """Get density [kg/m³]."""
-        return self._get_thermodynamic_engine().get_density(self.fluid, self.pressure, self.temperature)
+        return self._get_thermodynamic_engine().get_density(
+            self.fluid, pressure=self.pressure, temperature=self.temperature
+        )
 
     @cached_property
     def molar_mass(self) -> float:
@@ -73,17 +75,21 @@ class Stream:
     @cached_property
     def enthalpy(self) -> float:
         """Get specific enthalpy [J/kg]."""
-        return self._get_thermodynamic_engine().get_enthalpy(self.fluid, self.pressure, self.temperature)
+        return self._get_thermodynamic_engine().get_enthalpy(
+            self.fluid, pressure=self.pressure, temperature=self.temperature
+        )
 
     @cached_property
     def z(self) -> float:
         """Get compressibility factor [-]."""
-        return self._get_thermodynamic_engine().get_z(self.fluid, self.pressure, self.temperature)
+        return self._get_thermodynamic_engine().get_z(self.fluid, pressure=self.pressure, temperature=self.temperature)
 
     @cached_property
     def kappa(self) -> float:
         """Get isentropic exponent [-]."""
-        return self._get_thermodynamic_engine().get_kappa(self.fluid, self.pressure, self.temperature)
+        return self._get_thermodynamic_engine().get_kappa(
+            self.fluid, pressure=self.pressure, temperature=self.temperature
+        )
 
     @cached_property
     def volumetric_rate(self) -> float:
@@ -128,7 +134,7 @@ class Stream:
         self, new_pressure: float, enthalpy_change: float
     ) -> Stream:
         """Create a new stream with modified pressure and changed enthalpy.
-        TODO: This is a temporary method with only the
+        TODO: This is a temporary method with only the NeqSim backend.
 
         This simulates a PH-flash operation.
 

--- a/src/libecalc/domain/process/core/stream/stream.py
+++ b/src/libecalc/domain/process/core/stream/stream.py
@@ -48,12 +48,12 @@ class Stream:
     @property
     def temperature(self) -> float:
         """Get stream temperature [K]."""
-        return self.conditions.temperature
+        return self.conditions.temperature_kelvin
 
     @property
     def pressure(self) -> float:
         """Get stream pressure [bara]."""
-        return self.conditions.pressure
+        return self.conditions.pressure_bara
 
     @cached_property
     def density(self) -> float:
@@ -127,7 +127,7 @@ class Stream:
             A new Stream instance with the modified pressure and temperature
         """
         return self.create_stream_with_new_conditions(
-            ProcessConditions(pressure=new_pressure, temperature=new_temperature)
+            ProcessConditions(pressure_bara=new_pressure, temperature_kelvin=new_temperature)
         )
 
     def create_stream_with_new_pressure_and_enthalpy_change(

--- a/src/libecalc/domain/process/core/stream/stream.py
+++ b/src/libecalc/domain/process/core/stream/stream.py
@@ -2,21 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Protocol
 
 from libecalc.common.units import UnitConstants
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
 from libecalc.domain.process.core.stream.exceptions import NegativeMassRateException
-from libecalc.domain.process.core.stream.fluid import Fluid, ThermodynamicEngine
-from libecalc.domain.process.core.stream.mixing import SimplifiedStreamMixing
-
-
-class StreamMixingStrategy(Protocol):
-    """Protocol for stream mixing strategies"""
-
-    def mix_streams(self, streams: list[Stream], engine: ThermodynamicEngine | None = None) -> Stream:
-        """Mix multiple streams into a single resultant stream"""
-        ...
+from libecalc.domain.process.core.stream.fluid import Fluid
 
 
 @dataclass(frozen=True)
@@ -31,15 +21,11 @@ class Stream:
         fluid: Fluid object containing composition and EoS model
         conditions: Process conditions (temperature and pressure)
         mass_rate: Mass flow rate [kg/h]
-        name: Optional identifier for the stream
     """
 
     fluid: Fluid
     conditions: ProcessConditions
     mass_rate: float
-
-    # Setting default mixing strategy
-    _stream_mixing_strategy: StreamMixingStrategy = SimplifiedStreamMixing()
 
     def __post_init__(self):
         """Validate stream properties"""
@@ -166,18 +152,6 @@ class Stream:
         return self.create_stream_with_new_pressure_and_temperature(
             new_pressure=new_pressure, new_temperature=neqsim_fluid.temperature_kelvin
         )
-
-    @classmethod
-    def mix(cls, streams: list[Stream]) -> Stream:
-        """Mix multiple streams into one.
-
-        Args:
-            streams: List of streams to mix, see MixingStrategy for more details
-
-        Returns:
-            A new Stream instance representing the mixed stream
-        """
-        return cls._stream_mixing_strategy.mix_streams(streams)
 
     def _get_thermodynamic_engine(self):
         """Get the thermodynamic engine from the fluid."""

--- a/src/libecalc/domain/process/core/stream/stream.py
+++ b/src/libecalc/domain/process/core/stream/stream.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import cached_property
-from typing import ClassVar, Protocol
+from typing import Protocol
 
 from libecalc.common.units import UnitConstants
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
@@ -19,7 +19,7 @@ class StreamMixingStrategy(Protocol):
         ...
 
 
-@dataclass
+@dataclass(frozen=True)
 class Stream:
     """
     Represents a fluid stream with its properties and conditions.
@@ -38,8 +38,8 @@ class Stream:
     conditions: ProcessConditions
     mass_rate: float
 
-    # Default mixing strategy (class variable)
-    _stream_mixing_strategy: ClassVar[StreamMixingStrategy] = SimplifiedStreamMixing()
+    # Setting default mixing strategy
+    _stream_mixing_strategy: StreamMixingStrategy = SimplifiedStreamMixing()
 
     def __post_init__(self):
         """Validate stream properties"""

--- a/src/libecalc/domain/process/core/stream/thermo_adapters.py
+++ b/src/libecalc/domain/process/core/stream/thermo_adapters.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ecalc_neqsim_wrapper.thermo import NeqsimFluid
+from libecalc.domain.process.core.stream.conditions import ProcessConditions
+from libecalc.domain.process.core.stream.fluid import ThermodynamicEngine
+
+# Only import Fluid for type checking to avoid circular import
+if TYPE_CHECKING:
+    from libecalc.domain.process.core.stream.fluid import Fluid
+
+
+class NeqSimThermodynamicAdapter(ThermodynamicEngine):
+    """
+    Adapter for NeqSim thermodynamic calculations.
+
+    This adapter translates between our domain model and NeqSim, using the ecalc_neqsim_wrapper
+    to interface with the NeqSim Java service.
+
+    Units are standardized as follows:
+    - Pressure: bara
+    - Temperature: Kelvin
+    - Density: kg/m³
+    - Enthalpy: kJ/kg
+    - Molar mass: kg/mol
+    """
+
+    def _create_neqsim_fluid(self, fluid: Fluid, *, pressure: float, temperature: float) -> NeqsimFluid:
+        """
+        Create a NeqSim fluid from our domain model.
+
+        Args:
+            fluid: Our domain fluid model
+            pressure: Pressure in bara
+            temperature: Temperature in Kelvin
+
+        Returns:
+            NeqSim fluid object
+        """
+        return NeqsimFluid.create_thermo_system(
+            composition=fluid.composition,
+            temperature_kelvin=temperature,
+            pressure_bara=pressure,
+            eos_model=fluid.eos_model,
+        )
+
+    def get_density(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
+        """
+        Get density of the gas phase at given conditions.
+
+        Returns:
+            Density in kg/Am³
+        """
+        neqsim_fluid = self._create_neqsim_fluid(fluid, pressure=pressure, temperature=temperature)
+        return neqsim_fluid.density
+
+    def get_enthalpy(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
+        """
+        Get specific enthalpy at given conditions relative to reference conditions.
+
+        Returns:
+            Specific enthalpy in J/kg
+        """
+        neqsim_fluid = self._create_neqsim_fluid(fluid, pressure=pressure, temperature=temperature)
+        return neqsim_fluid.enthalpy_joule_per_kg
+
+    def get_z(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
+        """
+        Get compressibility factor (Z) at given conditions (gas phase)
+
+        Returns:
+            Z-factor (dimensionless)
+        """
+        neqsim_fluid = self._create_neqsim_fluid(fluid, pressure=pressure, temperature=temperature)
+        return neqsim_fluid.z
+
+    def get_kappa(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
+        """
+        Get heat capacity ratio (kappa) at given conditions.
+
+        Returns:
+            Kappa (isentropic exponent, dimensionless)
+        """
+        neqsim_fluid = self._create_neqsim_fluid(fluid, pressure=pressure, temperature=temperature)
+        return neqsim_fluid.kappa
+
+    def get_molar_mass(self, fluid: Fluid) -> float:
+        """
+        Get molar mass of the fluid.
+
+        Returns:
+            Molar mass in kg/mol
+        """
+        # Create at standard conditions, since molar mass is composition-dependent only
+        standard_conditions = ProcessConditions.standard_conditions()
+        neqsim_fluid = self._create_neqsim_fluid(
+            fluid,
+            pressure=standard_conditions.pressure,
+            temperature=standard_conditions.temperature,
+        )
+        return neqsim_fluid.molar_mass
+
+    def get_standard_density_gas_phase_after_flash(self, fluid: Fluid) -> float:
+        """
+        Get gas phase density at standard conditions after TP flash and liquid removal of potential liquid phase.
+
+        Returns:
+            Gas phase density in kg/Sm³
+        """
+        # Create fluid at standard conditions
+        standard_conditions = ProcessConditions.standard_conditions()
+        neqsim_fluid_at_standard_conditions = NeqsimFluid.create_thermo_system(
+            composition=fluid.composition,
+            temperature_kelvin=standard_conditions.temperature,
+            pressure_bara=standard_conditions.pressure,
+            eos_model=fluid.eos_model,
+        )
+
+        # TP flash is already performed during create_thermo_system
+        # Remove liquid phase to ensure we have only gas phase
+        liquid_removed_fluid = neqsim_fluid_at_standard_conditions.set_new_pressure_and_temperature(
+            new_pressure_bara=standard_conditions.pressure,
+            new_temperature_kelvin=standard_conditions.temperature,
+            remove_liquid=True,
+        )
+
+        return liquid_removed_fluid.density
+
+    def get_vapor_fraction_molar(self, fluid: Fluid, *, pressure: float, temperature: float) -> float:
+        """
+        Get molar gas fraction at given conditions.
+
+        Returns:
+            Gas fraction as a value between 0.0 and 1.0
+        """
+        neqsim_fluid = self._create_neqsim_fluid(fluid, pressure=pressure, temperature=temperature)
+        return neqsim_fluid.vapor_fraction_molar

--- a/src/libecalc/domain/process/core/stream/thermo_adapters.py
+++ b/src/libecalc/domain/process/core/stream/thermo_adapters.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from ecalc_neqsim_wrapper.thermo import NeqsimFluid
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
-from libecalc.domain.process.core.stream.fluid import ThermodynamicEngine
-
-# Only import Fluid for type checking to avoid circular import
-if TYPE_CHECKING:
-    from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.fluid import Fluid, ThermodynamicEngine
 
 
 class NeqSimThermodynamicAdapter(ThermodynamicEngine):

--- a/src/libecalc/domain/process/core/stream/thermo_adapters.py
+++ b/src/libecalc/domain/process/core/stream/thermo_adapters.py
@@ -90,8 +90,8 @@ class NeqSimThermodynamicAdapter(ThermodynamicEngine):
         standard_conditions = ProcessConditions.standard_conditions()
         neqsim_fluid = self._create_neqsim_fluid(
             fluid,
-            pressure=standard_conditions.pressure,
-            temperature=standard_conditions.temperature,
+            pressure=standard_conditions.pressure_bara,
+            temperature=standard_conditions.temperature_kelvin,
         )
         return neqsim_fluid.molar_mass
 
@@ -106,16 +106,16 @@ class NeqSimThermodynamicAdapter(ThermodynamicEngine):
         standard_conditions = ProcessConditions.standard_conditions()
         neqsim_fluid_at_standard_conditions = NeqsimFluid.create_thermo_system(
             composition=fluid.composition,
-            temperature_kelvin=standard_conditions.temperature,
-            pressure_bara=standard_conditions.pressure,
+            temperature_kelvin=standard_conditions.temperature_kelvin,
+            pressure_bara=standard_conditions.pressure_bara,
             eos_model=fluid.eos_model,
         )
 
         # TP flash is already performed during create_thermo_system
         # Remove liquid phase to ensure we have only gas phase
         liquid_removed_fluid = neqsim_fluid_at_standard_conditions.set_new_pressure_and_temperature(
-            new_pressure_bara=standard_conditions.pressure,
-            new_temperature_kelvin=standard_conditions.temperature,
+            new_pressure_bara=standard_conditions.pressure_bara,
+            new_temperature_kelvin=standard_conditions.temperature_kelvin,
             remove_liquid=True,
         )
 

--- a/src/libecalc/domain/process/core/stream/thermo_constants.py
+++ b/src/libecalc/domain/process/core/stream/thermo_constants.py
@@ -1,0 +1,51 @@
+"""
+Constants and properties used in thermodynamic calculations.
+"""
+
+from pydantic import BaseModel, Field
+
+from libecalc.common.fluid import FluidComposition
+
+
+class ComponentProperties(BaseModel):
+    """Properties for a single component including critical properties and molecular weight."""
+
+    critical_temperature_k: float = Field(..., alias="Tc")  # K
+    critical_pressure_bara: float = Field(..., alias="Pc")  # bara
+    acentric_factor: float = Field(..., alias="omega")
+    molecular_weight_kg_per_mol: float
+
+
+class ThermodynamicConstants:
+    """Constants used in thermodynamic calculations."""
+
+    # Gas constant
+    R_J_PER_MOL_K = 8.31446261815324  # J/(mol·K)
+
+    # Component properties combining critical properties and molecular weights
+    COMPONENTS: dict[str, ComponentProperties] = {
+        "water": ComponentProperties(Tc=647.3, Pc=221.2, omega=0.344, molecular_weight_kg_per_mol=0.01801534),
+        "nitrogen": ComponentProperties(Tc=126.2, Pc=33.9, omega=0.039, molecular_weight_kg_per_mol=0.02801340),
+        "CO2": ComponentProperties(Tc=304.1, Pc=73.8, omega=0.239, molecular_weight_kg_per_mol=0.04400995),
+        "methane": ComponentProperties(Tc=190.4, Pc=46.0, omega=0.011, molecular_weight_kg_per_mol=0.01604246),
+        "ethane": ComponentProperties(Tc=305.4, Pc=48.8, omega=0.099, molecular_weight_kg_per_mol=0.03006904),
+        "propane": ComponentProperties(Tc=369.8, Pc=42.5, omega=0.153, molecular_weight_kg_per_mol=0.04409562),
+        "i_butane": ComponentProperties(Tc=408.2, Pc=36.5, omega=0.183, molecular_weight_kg_per_mol=0.05812220),
+        "n_butane": ComponentProperties(Tc=425.2, Pc=38.0, omega=0.199, molecular_weight_kg_per_mol=0.05812220),
+        "i_pentane": ComponentProperties(Tc=460.4, Pc=33.9, omega=0.227, molecular_weight_kg_per_mol=0.07214878),
+        "n_pentane": ComponentProperties(Tc=469.7, Pc=33.7, omega=0.251, molecular_weight_kg_per_mol=0.07214878),
+        "n_hexane": ComponentProperties(Tc=507.5, Pc=30.1, omega=0.299, molecular_weight_kg_per_mol=0.08617536),
+    }
+
+    @classmethod
+    def validate_components(cls):
+        """Validate that all components defined in FluidComposition have their properties defined."""
+        fluid_composition_fields = set(FluidComposition.model_fields.keys())
+        missing_components = fluid_composition_fields - cls.COMPONENTS.keys()
+        if missing_components:
+            raise ValueError(f"Missing component properties for: {missing_components}")
+        return True
+
+
+# Validate components at module import time
+ThermodynamicConstants.validate_components()

--- a/tests/libecalc/common/test_fluid_common.py
+++ b/tests/libecalc/common/test_fluid_common.py
@@ -1,0 +1,27 @@
+import pytest
+
+from libecalc.common.fluid import FluidComposition
+
+
+def test_fluid_composition_normalized():
+    # Dynamically build a dictionary with each field set to 1.0,
+    # so the test is agnostic to the number and names of components.
+    init_data = {field: 1.0 for field in FluidComposition.model_fields}
+    composition = FluidComposition(**init_data)
+
+    normalized_composition = composition.normalized()
+    data = normalized_composition.model_dump()
+    total = sum(data.values())
+
+    # Check that the total sum is 1 (within a tolerance)
+    assert pytest.approx(total, rel=1e-4) == 1.0
+
+    # Check that each normalized value is between 0 and 1
+    for value in data.values():
+        assert 0.0 <= value <= 1.0
+
+
+def test_fluid_composition_normalized_zero_total():
+    composition = FluidComposition()
+    with pytest.raises(ValueError, match="Total composition is 0; cannot normalize."):
+        composition.normalized()

--- a/tests/libecalc/domain/core/stream/conftest.py
+++ b/tests/libecalc/domain/core/stream/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from libecalc.common.fluid import FluidComposition
+
+
+@pytest.fixture
+def medium_composition() -> FluidComposition:
+    """Create a medium gas composition (19.4 kg/kmol) for testing.
+    This matches the predefined MEDIUM_MW_19P4 composition."""
+    return FluidComposition(
+        nitrogen=0.74373,
+        CO2=2.415619,
+        methane=85.60145,
+        ethane=6.707826,
+        propane=2.611471,
+        i_butane=0.45077,
+        n_butane=0.691702,
+        i_pentane=0.210714,
+        n_pentane=0.197937,
+        n_hexane=0.368786,
+    )

--- a/tests/libecalc/domain/core/stream/conftest.py
+++ b/tests/libecalc/domain/core/stream/conftest.py
@@ -19,3 +19,21 @@ def medium_composition() -> FluidComposition:
         n_pentane=0.197937,
         n_hexane=0.368786,
     )
+
+
+@pytest.fixture
+def ultra_rich_composition() -> FluidComposition:
+    """Create an ultra rich gas composition (24.6 kg/kmol) for testing.
+    This matches the predefined ULTRA_RICH_MW_24P6 composition."""
+    return FluidComposition(
+        nitrogen=3.433045573,
+        CO2=0.341296928,
+        methane=62.50752861,
+        ethane=15.64946798,
+        propane=13.2202369,
+        i_butane=1.606103192,
+        n_butane=2.479421803,
+        i_pentane=0.351335073,
+        n_pentane=0.291106204,
+        n_hexane=0.120457739,
+    )

--- a/tests/libecalc/domain/core/stream/test_conditions.py
+++ b/tests/libecalc/domain/core/stream/test_conditions.py
@@ -8,11 +8,11 @@ class TestProcessConditions:
 
     def test_init_and_properties(self):
         """Test initialization and basic property conversions."""
-        conditions = ProcessConditions(temperature=300.0, pressure=10.0)
+        conditions = ProcessConditions(temperature_kelvin=300.0, pressure_bara=10.0)
 
         # Test direct attributes
-        assert conditions.temperature == 300.0
-        assert conditions.pressure == 10.0
+        assert conditions.temperature_kelvin == 300.0
+        assert conditions.pressure_bara == 10.0
 
         # Test one conversion property
         assert conditions.temperature_celsius == pytest.approx(26.85)
@@ -22,5 +22,5 @@ class TestProcessConditions:
         conditions = ProcessConditions.standard_conditions()
 
         # Standard conditions should be 15°C (288.15K) and 1.01325 bara
-        assert conditions.temperature == pytest.approx(288.15)
-        assert conditions.pressure == pytest.approx(1.01325)
+        assert conditions.temperature_kelvin == pytest.approx(288.15)
+        assert conditions.pressure_bara == pytest.approx(1.01325)

--- a/tests/libecalc/domain/core/stream/test_conditions.py
+++ b/tests/libecalc/domain/core/stream/test_conditions.py
@@ -1,0 +1,26 @@
+import pytest
+
+from libecalc.domain.process.core.stream.conditions import ProcessConditions
+
+
+class TestProcessConditions:
+    """Test suite for the ProcessConditions class."""
+
+    def test_init_and_properties(self):
+        """Test initialization and basic property conversions."""
+        conditions = ProcessConditions(temperature=300.0, pressure=10.0)
+
+        # Test direct attributes
+        assert conditions.temperature == 300.0
+        assert conditions.pressure == 10.0
+
+        # Test one conversion property
+        assert conditions.temperature_celsius == pytest.approx(26.85)
+
+    def test_standard_conditions(self):
+        """Test the standard_conditions factory method."""
+        conditions = ProcessConditions.standard_conditions()
+
+        # Standard conditions should be 15°C (288.15K) and 1.01325 bara
+        assert conditions.temperature == pytest.approx(288.15)
+        assert conditions.pressure == pytest.approx(1.01325)

--- a/tests/libecalc/domain/core/stream/test_fluid.py
+++ b/tests/libecalc/domain/core/stream/test_fluid.py
@@ -1,9 +1,9 @@
 from dataclasses import FrozenInstanceError
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
-from libecalc.common.fluid import EoSModel, FluidComposition
+from libecalc.common.fluid import EoSModel
 from libecalc.domain.process.core.stream.fluid import Fluid
 
 
@@ -11,73 +11,31 @@ from libecalc.domain.process.core.stream.fluid import Fluid
 def mock_thermodynamic_engine():
     """Create a mock thermodynamic engine for testing."""
     mock_engine = Mock()
-    mock_engine.get_molar_mass.return_value = 0.016  # Methane-like molar mass (kg/mol)
+    mock_engine.get_molar_mass.return_value = 0.016  # e.g., methane-like
     return mock_engine
 
 
 class TestFluid:
-    """Test suite for the Fluid class."""
-
-    def test_init_default(self, medium_composition):
-        """Test that a Fluid can be initialized with default settings."""
-        fluid = Fluid(composition=medium_composition)
-
-        # Verify default values
-        assert fluid.composition == medium_composition
-        assert fluid.eos_model == EoSModel.SRK
-        assert fluid._engine_type == "neqsim"
-        assert fluid._thermodynamic_engine is not None
-
-    def test_with_neqsim_engine_factory(self, medium_composition):
-        """Test the factory method for creating a Fluid with NeqSim engine."""
-        fluid = Fluid.with_neqsim_engine(composition=medium_composition)
-
-        # Verify factory method sets correct values
-        assert fluid.composition == medium_composition
-        assert fluid.eos_model == EoSModel.SRK
-        assert fluid._engine_type == "neqsim"
-        assert fluid._thermodynamic_engine is not None
-
-    def test_custom_eos_model(self, medium_composition):
-        """Test that a Fluid can be initialized with a custom EoS model."""
-        fluid = Fluid(composition=medium_composition, eos_model=EoSModel.PR)
-
-        # Verify custom EoS model
-        assert fluid.eos_model == EoSModel.PR
-
-    @patch("libecalc.domain.process.core.stream.thermo_adapters.NeqSimThermodynamicAdapter")
-    def test_thermodynamic_engine_initialization(self, mock_adapter_class, medium_composition):
-        """Test that the thermodynamic engine is properly initialized."""
-        mock_adapter = Mock()
-        mock_adapter_class.return_value = mock_adapter
-
-        fluid = Fluid(composition=medium_composition)
-
-        # Verify the mock adapter was used
-        assert fluid._thermodynamic_engine is mock_adapter
-
-    def test_custom_thermodynamic_engine_and_molar_mass(self, medium_composition, mock_thermodynamic_engine):
-        """Test that:
-        1. A custom thermodynamic engine can be provided during initialization
-        2. The molar_mass property correctly calls get_molar_mass on the engine
+    def test_init_requires_engine(self, medium_composition, mock_thermodynamic_engine):
         """
-        # Create fluid with a pre-configured engine (passed during initialization)
-        fluid = Fluid(composition=medium_composition, _thermodynamic_engine=mock_thermodynamic_engine)
-
-        # Verify the engine was used directly without creating a new one
+        Since Fluid no longer creates a default engine,
+        we must supply one at init time. This test verifies that.
+        """
+        fluid = Fluid(
+            composition=medium_composition, eos_model=EoSModel.PR, _thermodynamic_engine=mock_thermodynamic_engine
+        )
+        assert fluid.composition == medium_composition
+        assert fluid.eos_model == EoSModel.PR
         assert fluid._thermodynamic_engine == mock_thermodynamic_engine
 
-        # Call the molar_mass property
-        molar_mass = fluid.molar_mass
-
-        # Verify the property correctly calls get_molar_mass on the engine
+    def test_molar_mass_calls_engine(self, medium_composition, mock_thermodynamic_engine):
+        """The Fluid should delegate molar_mass calculation to the supplied engine."""
+        fluid = Fluid(composition=medium_composition, _thermodynamic_engine=mock_thermodynamic_engine)
+        assert fluid.molar_mass == 0.016
         mock_thermodynamic_engine.get_molar_mass.assert_called_once_with(fluid)
-        assert molar_mass == 0.016  # The mocked return value
 
-    def test_fluid_frozen_dataclass(self, medium_composition):
-        """Test that Fluid is a frozen dataclass that cannot be modified after creation."""
-        fluid = Fluid(composition=medium_composition)
-
-        # Attempting to modify the fluid should raise an exception
+    def test_fluid_frozen_dataclass(self, medium_composition, mock_thermodynamic_engine):
+        """Verify that Fluid is a frozen dataclass."""
+        fluid = Fluid(composition=medium_composition, _thermodynamic_engine=mock_thermodynamic_engine)
         with pytest.raises(FrozenInstanceError):
-            fluid.composition = FluidComposition(methane=90.0, ethane=10.0)
+            fluid.eos_model = EoSModel.PR  # Attempt to mutate

--- a/tests/libecalc/domain/core/stream/test_fluid.py
+++ b/tests/libecalc/domain/core/stream/test_fluid.py
@@ -1,0 +1,83 @@
+from dataclasses import FrozenInstanceError
+from unittest.mock import Mock, patch
+
+import pytest
+
+from libecalc.common.fluid import EoSModel, FluidComposition
+from libecalc.domain.process.core.stream.fluid import Fluid
+
+
+@pytest.fixture
+def mock_thermodynamic_engine():
+    """Create a mock thermodynamic engine for testing."""
+    mock_engine = Mock()
+    mock_engine.get_molar_mass.return_value = 0.016  # Methane-like molar mass (kg/mol)
+    return mock_engine
+
+
+class TestFluid:
+    """Test suite for the Fluid class."""
+
+    def test_init_default(self, medium_composition):
+        """Test that a Fluid can be initialized with default settings."""
+        fluid = Fluid(composition=medium_composition)
+
+        # Verify default values
+        assert fluid.composition == medium_composition
+        assert fluid.eos_model == EoSModel.SRK
+        assert fluid._engine_type == "neqsim"
+        assert fluid._thermodynamic_engine is not None
+
+    def test_with_neqsim_engine_factory(self, medium_composition):
+        """Test the factory method for creating a Fluid with NeqSim engine."""
+        fluid = Fluid.with_neqsim_engine(composition=medium_composition)
+
+        # Verify factory method sets correct values
+        assert fluid.composition == medium_composition
+        assert fluid.eos_model == EoSModel.SRK
+        assert fluid._engine_type == "neqsim"
+        assert fluid._thermodynamic_engine is not None
+
+    def test_custom_eos_model(self, medium_composition):
+        """Test that a Fluid can be initialized with a custom EoS model."""
+        fluid = Fluid(composition=medium_composition, eos_model=EoSModel.PR)
+
+        # Verify custom EoS model
+        assert fluid.eos_model == EoSModel.PR
+
+    @patch("libecalc.domain.process.core.stream.thermo_adapters.NeqSimThermodynamicAdapter")
+    def test_thermodynamic_engine_initialization(self, mock_adapter_class, medium_composition):
+        """Test that the thermodynamic engine is properly initialized."""
+        mock_adapter = Mock()
+        mock_adapter_class.return_value = mock_adapter
+
+        fluid = Fluid(composition=medium_composition)
+
+        # Verify the mock adapter was used
+        assert fluid._thermodynamic_engine is mock_adapter
+
+    def test_custom_thermodynamic_engine_and_molar_mass(self, medium_composition, mock_thermodynamic_engine):
+        """Test that:
+        1. A custom thermodynamic engine can be provided during initialization
+        2. The molar_mass property correctly calls get_molar_mass on the engine
+        """
+        # Create fluid with a pre-configured engine (passed during initialization)
+        fluid = Fluid(composition=medium_composition, _thermodynamic_engine=mock_thermodynamic_engine)
+
+        # Verify the engine was used directly without creating a new one
+        assert fluid._thermodynamic_engine == mock_thermodynamic_engine
+
+        # Call the molar_mass property
+        molar_mass = fluid.molar_mass
+
+        # Verify the property correctly calls get_molar_mass on the engine
+        mock_thermodynamic_engine.get_molar_mass.assert_called_once_with(fluid)
+        assert molar_mass == 0.016  # The mocked return value
+
+    def test_fluid_frozen_dataclass(self, medium_composition):
+        """Test that Fluid is a frozen dataclass that cannot be modified after creation."""
+        fluid = Fluid(composition=medium_composition)
+
+        # Attempting to modify the fluid should raise an exception
+        with pytest.raises(FrozenInstanceError):
+            fluid.composition = FluidComposition(methane=90.0, ethane=10.0)

--- a/tests/libecalc/domain/core/stream/test_fluid_factory.py
+++ b/tests/libecalc/domain/core/stream/test_fluid_factory.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from libecalc.common.fluid import EoSModel
+from libecalc.domain.process.core.stream.fluid_factory import create_fluid_with_neqsim_engine
+from libecalc.domain.process.core.stream.thermo_adapters import NeqSimThermodynamicAdapter
+
+
+def test_create_fluid_with_neqsim_engine(medium_composition):
+    """Ensure factory creates a Fluid with a NeqSim engine and default EoS if not specified."""
+
+    with patch.object(NeqSimThermodynamicAdapter, "__init__", return_value=None) as mock_adapter_init:
+        fluid = create_fluid_with_neqsim_engine(medium_composition)
+
+        # Check the adapter was instantiated
+        mock_adapter_init.assert_called_once()
+
+    assert fluid.composition == medium_composition
+    assert fluid.eos_model == EoSModel.SRK  # default if not provided
+    assert fluid.molar_mass  # calls the adapter behind the scenes
+    # There's no fluid._engine_type or fluid._thermodynamic_engine == None anymore
+
+
+def test_create_fluid_with_neqsim_engine_custom_eos(medium_composition):
+    """Check the factory respects a custom EoS if provided."""
+    fluid = create_fluid_with_neqsim_engine(medium_composition, eos_model=EoSModel.PR)
+
+    assert fluid.eos_model == EoSModel.PR

--- a/tests/libecalc/domain/core/stream/test_mixing.py
+++ b/tests/libecalc/domain/core/stream/test_mixing.py
@@ -1,8 +1,11 @@
+from unittest.mock import Mock
+
 import pytest
 
 from libecalc.common.fluid import EoSModel
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
-from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.fluid import Fluid, ThermodynamicEngine
+from libecalc.domain.process.core.stream.fluid_factory import create_fluid_with_neqsim_engine
 from libecalc.domain.process.core.stream.mixing import SimplifiedStreamMixing
 from libecalc.domain.process.core.stream.stream import Stream
 
@@ -20,8 +23,8 @@ class TestSimplifiedStreamMixing:
         eos_model = EoSModel.SRK
 
         # Create fluid objects
-        medium_fluid = Fluid(composition=medium_composition, eos_model=eos_model)
-        ultra_rich_fluid = Fluid(composition=ultra_rich_composition, eos_model=eos_model)
+        medium_fluid = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=eos_model)
+        ultra_rich_fluid = create_fluid_with_neqsim_engine(composition=ultra_rich_composition, eos_model=eos_model)
 
         # Create stream objects
         conditions = ProcessConditions(temperature=temperature, pressure=pressure)
@@ -55,9 +58,8 @@ class TestSimplifiedStreamMixing:
 
     def test_mix_streams_with_different_conditions(self, medium_composition):
         """Test mixing streams with different pressure and temperature conditions."""
-        # Create two streams with the same composition but different conditions
         eos_model = EoSModel.SRK
-        fluid = Fluid(composition=medium_composition, eos_model=eos_model)
+        fluid = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=eos_model)
 
         # Stream 1: High pressure, low temperature
         conditions1 = ProcessConditions(temperature=300.0, pressure=20.0)
@@ -71,10 +73,11 @@ class TestSimplifiedStreamMixing:
         mixing_strategy = SimplifiedStreamMixing()
         mixed_stream = mixing_strategy.mix_streams([stream1, stream2])
 
-        # Verify the mixed stream uses the simplifications mass-weighted average temperature and lowest pressure
+        # Verify the mixed stream uses the simplified mass-weighted average temperature and lowest pressure
         expected_temperature = (
             stream1.mass_rate * stream1.conditions.temperature + stream2.mass_rate * stream2.conditions.temperature
         ) / (stream1.mass_rate + stream2.mass_rate)
+
         assert mixed_stream.conditions.temperature == expected_temperature
         assert mixed_stream.conditions.pressure == stream2.conditions.pressure
         assert mixed_stream.mass_rate == stream1.mass_rate + stream2.mass_rate
@@ -82,8 +85,8 @@ class TestSimplifiedStreamMixing:
     def test_mix_streams_with_different_eos_models(self, medium_composition):
         """Test mixing streams with different EoS models raises ValueError."""
         # Create two streams with different EoS models
-        fluid1 = Fluid(composition=medium_composition, eos_model=EoSModel.SRK)
-        fluid2 = Fluid(composition=medium_composition, eos_model=EoSModel.PR)
+        fluid1 = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=EoSModel.SRK)
+        fluid2 = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=EoSModel.PR)
 
         conditions = ProcessConditions(temperature=300.0, pressure=15.0)
         stream1 = Stream(fluid=fluid1, conditions=conditions, mass_rate=500.0)
@@ -93,3 +96,37 @@ class TestSimplifiedStreamMixing:
 
         with pytest.raises(ValueError, match="Cannot mix streams with different EoS models"):
             mixing_strategy.mix_streams([stream1, stream2])
+
+    def test_mix_streams_engine_override(self, medium_composition):
+        """
+        Verify that if no engine is provided, the result inherits from the first stream;
+        if a custom engine is provided, it is used for the mixed Fluid.
+        """
+        # We'll mock out the engine references to confirm which one the new fluid picks
+        mock_engine_first = Mock(spec=ThermodynamicEngine)
+        mock_engine_second = Mock(spec=ThermodynamicEngine)
+
+        # Ensure get_molar_mass returns a numeric value
+        mock_engine_first.get_molar_mass.return_value = 0.018
+        mock_engine_second.get_molar_mass.return_value = 0.018
+
+        # Create two fluids with the same EoS model but different engine objects
+        eos_model = EoSModel.SRK
+        fluid1 = Fluid(composition=medium_composition, eos_model=eos_model, _thermodynamic_engine=mock_engine_first)
+        fluid2 = Fluid(composition=medium_composition, eos_model=eos_model, _thermodynamic_engine=mock_engine_second)
+
+        conditions = ProcessConditions(temperature=300.0, pressure=20.0)
+        stream1 = Stream(fluid=fluid1, conditions=conditions, mass_rate=100.0)
+        stream2 = Stream(fluid=fluid2, conditions=conditions, mass_rate=100.0)
+
+        mixing_strategy = SimplifiedStreamMixing()
+
+        # Case 1: No engine override => inherits engine from the first stream
+        mixed_stream_inherited = mixing_strategy.mix_streams([stream1, stream2])
+        assert mixed_stream_inherited.fluid._thermodynamic_engine is mock_engine_first
+
+        # Case 2: Provide a custom engine
+        custom_engine = Mock(spec=ThermodynamicEngine)
+        custom_engine.get_molar_mass.return_value = 0.018  # Must also return a float
+        mixed_stream_custom = mixing_strategy.mix_streams([stream1, stream2], engine=custom_engine)
+        assert mixed_stream_custom.fluid._thermodynamic_engine is custom_engine

--- a/tests/libecalc/domain/core/stream/test_mixing.py
+++ b/tests/libecalc/domain/core/stream/test_mixing.py
@@ -71,9 +71,12 @@ class TestSimplifiedStreamMixing:
         mixing_strategy = SimplifiedStreamMixing()
         mixed_stream = mixing_strategy.mix_streams([stream1, stream2])
 
-        # Verify the mixed stream uses the first stream's temperature and lowest pressure
-        assert mixed_stream.temperature == stream1.temperature
-        assert mixed_stream.pressure == stream2.pressure
+        # Verify the mixed stream uses the simplifications mass-weighted average temperature and lowest pressure
+        expected_temperature = (
+            stream1.mass_rate * stream1.conditions.temperature + stream2.mass_rate * stream2.conditions.temperature
+        ) / (stream1.mass_rate + stream2.mass_rate)
+        assert mixed_stream.conditions.temperature == expected_temperature
+        assert mixed_stream.conditions.pressure == stream2.conditions.pressure
         assert mixed_stream.mass_rate == stream1.mass_rate + stream2.mass_rate
 
     def test_mix_streams_with_different_eos_models(self, medium_composition):

--- a/tests/libecalc/domain/core/stream/test_mixing.py
+++ b/tests/libecalc/domain/core/stream/test_mixing.py
@@ -34,16 +34,16 @@ class TestSimplifiedStreamMixing:
 
         # Expected values from mixing medium (30%) and ultra rich (70%) compositions
         expected_values = {
-            "nitrogen": 2.487276589996555,
-            "CO2": 1.0707871730843908,
-            "methane": 70.62911715314632,
-            "ethane": 12.504902973680636,
-            "propane": 9.489383653583825,
-            "i_butane": 1.1997997038567125,
-            "n_butane": 1.8507228295685063,
-            "i_pentane": 0.3018819517169132,
-            "n_pentane": 0.2583407880707626,
-            "n_hexane": 0.20778894297432215,
+            "nitrogen": 0.024873,
+            "CO2": 0.010708,
+            "methane": 0.706291,
+            "ethane": 0.125049,
+            "propane": 0.094894,
+            "i_butane": 0.011998,
+            "n_butane": 0.018507,
+            "i_pentane": 0.003019,
+            "n_pentane": 0.002583,
+            "n_hexane": 0.002078,
             "water": 0.0,
         }
 
@@ -51,7 +51,7 @@ class TestSimplifiedStreamMixing:
         mixed_composition = mixed_stream.fluid.composition
         for component, expected_value in expected_values.items():
             actual_value = getattr(mixed_composition, component)
-            assert actual_value == pytest.approx(expected_value, abs=1e-10)
+            assert actual_value == pytest.approx(expected_value, abs=1e-5)
 
     def test_mix_streams_with_different_conditions(self, medium_composition):
         """Test mixing streams with different pressure and temperature conditions."""

--- a/tests/libecalc/domain/core/stream/test_mixing.py
+++ b/tests/libecalc/domain/core/stream/test_mixing.py
@@ -27,7 +27,7 @@ class TestSimplifiedStreamMixing:
         ultra_rich_fluid = create_fluid_with_neqsim_engine(composition=ultra_rich_composition, eos_model=eos_model)
 
         # Create stream objects
-        conditions = ProcessConditions(temperature=temperature, pressure=pressure)
+        conditions = ProcessConditions(temperature_kelvin=temperature, pressure_bara=pressure)
         medium_stream = Stream(fluid=medium_fluid, conditions=conditions, mass_rate=mass_rate_medium)
         ultra_rich_stream = Stream(fluid=ultra_rich_fluid, conditions=conditions, mass_rate=mass_rate_ultra_rich)
 
@@ -62,11 +62,11 @@ class TestSimplifiedStreamMixing:
         fluid = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=eos_model)
 
         # Stream 1: High pressure, low temperature
-        conditions1 = ProcessConditions(temperature=300.0, pressure=20.0)
+        conditions1 = ProcessConditions(temperature_kelvin=300.0, pressure_bara=20.0)
         stream1 = Stream(fluid=fluid, conditions=conditions1, mass_rate=500.0)
 
         # Stream 2: Low pressure, high temperature
-        conditions2 = ProcessConditions(temperature=350.0, pressure=10.0)
+        conditions2 = ProcessConditions(temperature_kelvin=350.0, pressure_bara=10.0)
         stream2 = Stream(fluid=fluid, conditions=conditions2, mass_rate=500.0)
 
         # Mix streams
@@ -75,11 +75,12 @@ class TestSimplifiedStreamMixing:
 
         # Verify the mixed stream uses the simplified mass-weighted average temperature and lowest pressure
         expected_temperature = (
-            stream1.mass_rate * stream1.conditions.temperature + stream2.mass_rate * stream2.conditions.temperature
+            stream1.mass_rate * stream1.conditions.temperature_kelvin
+            + stream2.mass_rate * stream2.conditions.temperature_kelvin
         ) / (stream1.mass_rate + stream2.mass_rate)
 
-        assert mixed_stream.conditions.temperature == expected_temperature
-        assert mixed_stream.conditions.pressure == stream2.conditions.pressure
+        assert mixed_stream.conditions.temperature_kelvin == expected_temperature
+        assert mixed_stream.conditions.pressure_bara == stream2.conditions.pressure_bara
         assert mixed_stream.mass_rate == stream1.mass_rate + stream2.mass_rate
 
     def test_mix_streams_with_different_eos_models(self, medium_composition):
@@ -88,7 +89,7 @@ class TestSimplifiedStreamMixing:
         fluid1 = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=EoSModel.SRK)
         fluid2 = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=EoSModel.PR)
 
-        conditions = ProcessConditions(temperature=300.0, pressure=15.0)
+        conditions = ProcessConditions(temperature_kelvin=300.0, pressure_bara=15.0)
         stream1 = Stream(fluid=fluid1, conditions=conditions, mass_rate=500.0)
         stream2 = Stream(fluid=fluid2, conditions=conditions, mass_rate=500.0)
 
@@ -115,7 +116,7 @@ class TestSimplifiedStreamMixing:
         fluid1 = Fluid(composition=medium_composition, eos_model=eos_model, _thermodynamic_engine=mock_engine_first)
         fluid2 = Fluid(composition=medium_composition, eos_model=eos_model, _thermodynamic_engine=mock_engine_second)
 
-        conditions = ProcessConditions(temperature=300.0, pressure=20.0)
+        conditions = ProcessConditions(temperature_kelvin=300.0, pressure_bara=20.0)
         stream1 = Stream(fluid=fluid1, conditions=conditions, mass_rate=100.0)
         stream2 = Stream(fluid=fluid2, conditions=conditions, mass_rate=100.0)
 

--- a/tests/libecalc/domain/core/stream/test_mixing.py
+++ b/tests/libecalc/domain/core/stream/test_mixing.py
@@ -1,0 +1,92 @@
+import pytest
+
+from libecalc.common.fluid import EoSModel
+from libecalc.domain.process.core.stream.conditions import ProcessConditions
+from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.mixing import SimplifiedStreamMixing
+from libecalc.domain.process.core.stream.stream import Stream
+
+
+class TestSimplifiedStreamMixing:
+    """Test suite for the SimplifiedStreamMixing class."""
+
+    def test_mix_medium_and_ultra_rich_compositions(self, medium_composition, ultra_rich_composition):
+        """Test mixing medium and ultra rich compositions using SimplifiedStreamMixing."""
+        # Define stream properties
+        mass_rate_medium = 300.0  # kg/h
+        mass_rate_ultra_rich = 700.0  # kg/h
+        pressure = 15.0  # bara
+        temperature = 310.0  # K
+        eos_model = EoSModel.SRK
+
+        # Create fluid objects
+        medium_fluid = Fluid(composition=medium_composition, eos_model=eos_model)
+        ultra_rich_fluid = Fluid(composition=ultra_rich_composition, eos_model=eos_model)
+
+        # Create stream objects
+        conditions = ProcessConditions(temperature=temperature, pressure=pressure)
+        medium_stream = Stream(fluid=medium_fluid, conditions=conditions, mass_rate=mass_rate_medium)
+        ultra_rich_stream = Stream(fluid=ultra_rich_fluid, conditions=conditions, mass_rate=mass_rate_ultra_rich)
+
+        # Mix streams using SimplifiedStreamMixing strategy
+        mixing_strategy = SimplifiedStreamMixing()
+        mixed_stream = mixing_strategy.mix_streams([medium_stream, ultra_rich_stream])
+
+        # Expected values from mixing medium (30%) and ultra rich (70%) compositions
+        expected_values = {
+            "nitrogen": 2.487276589996555,
+            "CO2": 1.0707871730843908,
+            "methane": 70.62911715314632,
+            "ethane": 12.504902973680636,
+            "propane": 9.489383653583825,
+            "i_butane": 1.1997997038567125,
+            "n_butane": 1.8507228295685063,
+            "i_pentane": 0.3018819517169132,
+            "n_pentane": 0.2583407880707626,
+            "n_hexane": 0.20778894297432215,
+            "water": 0.0,
+        }
+
+        # Verify mixed composition matches expected values
+        mixed_composition = mixed_stream.fluid.composition
+        for component, expected_value in expected_values.items():
+            actual_value = getattr(mixed_composition, component)
+            assert actual_value == pytest.approx(expected_value, abs=1e-10)
+
+    def test_mix_streams_with_different_conditions(self, medium_composition):
+        """Test mixing streams with different pressure and temperature conditions."""
+        # Create two streams with the same composition but different conditions
+        eos_model = EoSModel.SRK
+        fluid = Fluid(composition=medium_composition, eos_model=eos_model)
+
+        # Stream 1: High pressure, low temperature
+        conditions1 = ProcessConditions(temperature=300.0, pressure=20.0)
+        stream1 = Stream(fluid=fluid, conditions=conditions1, mass_rate=500.0)
+
+        # Stream 2: Low pressure, high temperature
+        conditions2 = ProcessConditions(temperature=350.0, pressure=10.0)
+        stream2 = Stream(fluid=fluid, conditions=conditions2, mass_rate=500.0)
+
+        # Mix streams
+        mixing_strategy = SimplifiedStreamMixing()
+        mixed_stream = mixing_strategy.mix_streams([stream1, stream2])
+
+        # Verify the mixed stream uses the first stream's temperature and lowest pressure
+        assert mixed_stream.temperature == stream1.temperature
+        assert mixed_stream.pressure == stream2.pressure
+        assert mixed_stream.mass_rate == stream1.mass_rate + stream2.mass_rate
+
+    def test_mix_streams_with_different_eos_models(self, medium_composition):
+        """Test mixing streams with different EoS models raises ValueError."""
+        # Create two streams with different EoS models
+        fluid1 = Fluid(composition=medium_composition, eos_model=EoSModel.SRK)
+        fluid2 = Fluid(composition=medium_composition, eos_model=EoSModel.PR)
+
+        conditions = ProcessConditions(temperature=300.0, pressure=15.0)
+        stream1 = Stream(fluid=fluid1, conditions=conditions, mass_rate=500.0)
+        stream2 = Stream(fluid=fluid2, conditions=conditions, mass_rate=500.0)
+
+        mixing_strategy = SimplifiedStreamMixing()
+
+        with pytest.raises(ValueError, match="Cannot mix streams with different EoS models"):
+            mixing_strategy.mix_streams([stream1, stream2])

--- a/tests/libecalc/domain/core/stream/test_stream.py
+++ b/tests/libecalc/domain/core/stream/test_stream.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -52,21 +52,6 @@ class TestStream:
         assert new_stream.temperature == 350.0
         assert new_stream.pressure == 15.0
         assert new_stream.fluid is basic_stream.fluid
-
-    @patch("libecalc.domain.process.core.stream.stream.Stream._stream_mixing_strategy")
-    def test_mix(self, mock_mixing_strategy, basic_stream):
-        """Test the static mix method."""
-        streams = [basic_stream, basic_stream]  # Just mix the same stream for simplicity
-
-        # Configure the mock
-        mock_result = Mock(spec=Stream)
-        mock_mixing_strategy.mix_streams.return_value = mock_result
-
-        result = Stream.mix(streams)
-
-        # Verify mixing strategy was called
-        mock_mixing_strategy.mix_streams.assert_called_once_with(streams)
-        assert result is mock_result
 
     def test_negative_mass_rate_exception(self, mock_fluid):
         """Test that NegativeMassRateException is raised for negative mass rate."""

--- a/tests/libecalc/domain/core/stream/test_stream.py
+++ b/tests/libecalc/domain/core/stream/test_stream.py
@@ -61,7 +61,6 @@ class TestStream:
         mock_result = Mock(spec=Stream)
         mock_mixing_strategy.mix_streams.return_value = mock_result
 
-        # Call the mix method
         result = Stream.mix(streams)
 
         # Verify mixing strategy was called

--- a/tests/libecalc/domain/core/stream/test_stream.py
+++ b/tests/libecalc/domain/core/stream/test_stream.py
@@ -4,6 +4,7 @@ import pytest
 
 from libecalc.common.fluid import EoSModel
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
+from libecalc.domain.process.core.stream.exceptions import NegativeMassRateException
 from libecalc.domain.process.core.stream.fluid_factory import create_fluid_with_neqsim_engine
 from libecalc.domain.process.core.stream.stream import Stream
 
@@ -66,3 +67,9 @@ class TestStream:
         # Verify mixing strategy was called
         mock_mixing_strategy.mix_streams.assert_called_once_with(streams)
         assert result is mock_result
+
+    def test_negative_mass_rate_exception(self, mock_fluid):
+        """Test that NegativeMassRateException is raised for negative mass rate."""
+        conditions = ProcessConditions(temperature_kelvin=310.0, pressure_bara=20.0)
+        with pytest.raises(NegativeMassRateException):
+            Stream(fluid=mock_fluid, conditions=conditions, mass_rate=-100.0)

--- a/tests/libecalc/domain/core/stream/test_stream.py
+++ b/tests/libecalc/domain/core/stream/test_stream.py
@@ -1,0 +1,69 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from libecalc.common.fluid import EoSModel
+from libecalc.domain.process.core.stream.conditions import ProcessConditions
+from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.stream import Stream
+
+
+@pytest.fixture
+def mock_fluid():
+    """Create a mock fluid for testing."""
+    fluid = Mock(spec=Fluid)
+    return fluid
+
+
+@pytest.fixture
+def basic_stream(medium_composition):
+    """Create a basic stream for testing."""
+    eos_model = EoSModel.SRK
+    fluid = Fluid(composition=medium_composition, eos_model=eos_model)
+    conditions = ProcessConditions(temperature=300.0, pressure=10.0)
+    return Stream(fluid=fluid, conditions=conditions, mass_rate=1000.0)
+
+
+class TestStream:
+    """Test suite for the Stream class."""
+
+    def test_init_and_basic_properties(self, mock_fluid):
+        """Test initialization and basic property accessors."""
+        conditions = ProcessConditions(temperature=310.0, pressure=20.0)
+        stream = Stream(fluid=mock_fluid, conditions=conditions, mass_rate=100.0)
+
+        # Verify basic attributes
+        assert stream.fluid is mock_fluid
+        assert stream.conditions is conditions
+        assert stream.mass_rate == 100.0
+
+        # Verify property accessors
+        assert stream.temperature == 310.0
+        assert stream.pressure == 20.0
+
+    def test_create_stream_with_new_conditions(self, basic_stream):
+        """Test creating a new stream with modified conditions."""
+        new_conditions = ProcessConditions(temperature=350.0, pressure=15.0)
+
+        new_stream = basic_stream.create_stream_with_new_conditions(new_conditions)
+
+        # Verify new stream has the new conditions but same fluid
+        assert new_stream.temperature == 350.0
+        assert new_stream.pressure == 15.0
+        assert new_stream.fluid is basic_stream.fluid
+
+    @patch("libecalc.domain.process.core.stream.stream.Stream._stream_mixing_strategy")
+    def test_mix(self, mock_mixing_strategy, basic_stream):
+        """Test the static mix method."""
+        streams = [basic_stream, basic_stream]  # Just mix the same stream for simplicity
+
+        # Configure the mock
+        mock_result = Mock(spec=Stream)
+        mock_mixing_strategy.mix_streams.return_value = mock_result
+
+        # Call the mix method
+        result = Stream.mix(streams)
+
+        # Verify mixing strategy was called
+        mock_mixing_strategy.mix_streams.assert_called_once_with(streams)
+        assert result is mock_result

--- a/tests/libecalc/domain/core/stream/test_stream.py
+++ b/tests/libecalc/domain/core/stream/test_stream.py
@@ -20,7 +20,7 @@ def basic_stream(medium_composition):
     """Create a basic stream for testing."""
     eos_model = EoSModel.SRK
     fluid = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=eos_model)
-    conditions = ProcessConditions(temperature=300.0, pressure=10.0)
+    conditions = ProcessConditions(temperature_kelvin=300.0, pressure_bara=10.0)
     return Stream(fluid=fluid, conditions=conditions, mass_rate=1000.0)
 
 
@@ -29,7 +29,7 @@ class TestStream:
 
     def test_init_and_basic_properties(self, mock_fluid):
         """Test initialization and basic property accessors."""
-        conditions = ProcessConditions(temperature=310.0, pressure=20.0)
+        conditions = ProcessConditions(temperature_kelvin=310.0, pressure_bara=20.0)
         stream = Stream(fluid=mock_fluid, conditions=conditions, mass_rate=100.0)
 
         # Verify basic attributes
@@ -43,7 +43,7 @@ class TestStream:
 
     def test_create_stream_with_new_conditions(self, basic_stream):
         """Test creating a new stream with modified conditions."""
-        new_conditions = ProcessConditions(temperature=350.0, pressure=15.0)
+        new_conditions = ProcessConditions(temperature_kelvin=350.0, pressure_bara=15.0)
 
         new_stream = basic_stream.create_stream_with_new_conditions(new_conditions)
 

--- a/tests/libecalc/domain/core/stream/test_stream.py
+++ b/tests/libecalc/domain/core/stream/test_stream.py
@@ -4,14 +4,14 @@ import pytest
 
 from libecalc.common.fluid import EoSModel
 from libecalc.domain.process.core.stream.conditions import ProcessConditions
-from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.fluid_factory import create_fluid_with_neqsim_engine
 from libecalc.domain.process.core.stream.stream import Stream
 
 
 @pytest.fixture
 def mock_fluid():
     """Create a mock fluid for testing."""
-    fluid = Mock(spec=Fluid)
+    fluid = Mock(spec=create_fluid_with_neqsim_engine)
     return fluid
 
 
@@ -19,7 +19,7 @@ def mock_fluid():
 def basic_stream(medium_composition):
     """Create a basic stream for testing."""
     eos_model = EoSModel.SRK
-    fluid = Fluid(composition=medium_composition, eos_model=eos_model)
+    fluid = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=eos_model)
     conditions = ProcessConditions(temperature=300.0, pressure=10.0)
     return Stream(fluid=fluid, conditions=conditions, mass_rate=1000.0)
 

--- a/tests/libecalc/domain/core/stream/test_thermo_adapters.py
+++ b/tests/libecalc/domain/core/stream/test_thermo_adapters.py
@@ -4,14 +4,14 @@ import pytest
 
 from ecalc_neqsim_wrapper.thermo import NeqsimFluid
 from libecalc.common.fluid import EoSModel
-from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.fluid_factory import create_fluid_with_neqsim_engine
 from libecalc.domain.process.core.stream.thermo_adapters import NeqSimThermodynamicAdapter
 
 
 @pytest.fixture
 def mock_fluid():
     """Create a mocked domain Fluid for testing."""
-    fluid = Mock(spec=Fluid)
+    fluid = Mock(spec=create_fluid_with_neqsim_engine)
     fluid.composition = Mock()
     fluid.eos_model = EoSModel.SRK
     return fluid
@@ -95,7 +95,7 @@ class TestNeqSimThermodynamicAdapterIntegration:
         3. Verifying expected values at specific conditions
         """
         # Arrange
-        fluid = Fluid(composition=medium_composition, eos_model=EoSModel.SRK)
+        fluid = create_fluid_with_neqsim_engine(composition=medium_composition, eos_model=EoSModel.SRK)
         adapter = NeqSimThermodynamicAdapter()
         pressure = 50.0
         temperature = 400.0

--- a/tests/libecalc/domain/core/stream/test_thermo_adapters.py
+++ b/tests/libecalc/domain/core/stream/test_thermo_adapters.py
@@ -1,0 +1,141 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ecalc_neqsim_wrapper.thermo import NeqsimFluid
+from libecalc.common.fluid import EoSModel
+from libecalc.domain.process.core.stream.fluid import Fluid
+from libecalc.domain.process.core.stream.thermo_adapters import NeqSimThermodynamicAdapter
+
+
+@pytest.fixture
+def mock_fluid():
+    """Create a mocked domain Fluid for testing."""
+    fluid = Mock(spec=Fluid)
+    fluid.composition = Mock()
+    fluid.eos_model = EoSModel.SRK
+    return fluid
+
+
+@pytest.fixture
+def mock_neqsim_fluid():
+    """Create a mocked NeqsimFluid for testing."""
+    mock_fluid = Mock(spec=NeqsimFluid)
+    mock_fluid.density = 50.0
+    mock_fluid.enthalpy_joule_per_kg = 500000.0
+    mock_fluid.z = 0.95
+    mock_fluid.kappa = 1.3
+    mock_fluid.molar_mass = 0.016  # Methane-like
+    mock_fluid.set_new_pressure_and_temperature.return_value = mock_fluid
+    mock_fluid.vapor_fraction_molar = 1.0
+    return mock_fluid
+
+
+class TestNeqSimThermodynamicAdapterUnit:
+    """Unit tests for the NeqSimThermodynamicAdapter."""
+
+    @patch("libecalc.domain.process.core.stream.thermo_adapters.NeqSimThermodynamicAdapter._create_neqsim_fluid")
+    @patch("libecalc.domain.process.core.stream.thermo_adapters.NeqsimFluid")
+    def test_all_properties(self, mock_neqsim_fluid_class, mock_create_neqsim_fluid, mock_fluid, mock_neqsim_fluid):
+        """Test that all adapter methods correctly delegate to NeqsimFluid and return expected values."""
+        # Arrange
+        mock_create_neqsim_fluid.return_value = mock_neqsim_fluid
+        mock_neqsim_fluid_class.create_thermo_system.return_value = mock_neqsim_fluid
+        mock_neqsim_fluid.set_new_pressure_and_temperature.return_value = mock_neqsim_fluid
+
+        adapter = NeqSimThermodynamicAdapter()
+        pressure = 10.0
+        temperature = 300.0
+
+        # Act & Assert for each property
+        # Density
+        density = adapter.get_density(mock_fluid, pressure=pressure, temperature=temperature)
+        assert density == 50.0
+        mock_create_neqsim_fluid.assert_called_with(mock_fluid, pressure=pressure, temperature=temperature)
+
+        # Enthalpy
+        enthalpy = adapter.get_enthalpy(mock_fluid, pressure=pressure, temperature=temperature)
+        assert enthalpy == 500000.0
+        mock_create_neqsim_fluid.assert_called_with(mock_fluid, pressure=pressure, temperature=temperature)
+
+        # Z-factor
+        z = adapter.get_z(mock_fluid, pressure=pressure, temperature=temperature)
+        assert z == 0.95
+        mock_create_neqsim_fluid.assert_called_with(mock_fluid, pressure=pressure, temperature=temperature)
+
+        # Kappa
+        kappa = adapter.get_kappa(mock_fluid, pressure=pressure, temperature=temperature)
+        assert kappa == 1.3
+        mock_create_neqsim_fluid.assert_called_with(mock_fluid, pressure=pressure, temperature=temperature)
+
+        # Molar mass (uses _create_neqsim_fluid with standard conditions)
+        molar_mass = adapter.get_molar_mass(mock_fluid)
+        assert molar_mass == 0.016
+        mock_create_neqsim_fluid.assert_called_with(mock_fluid, pressure=1.01325, temperature=288.15)
+
+        # Standard density (uses set_new_pressure_and_temperature)
+        std_density = adapter.get_standard_density_gas_phase_after_flash(mock_fluid)
+        assert std_density == 50.0  # Uses the same density property
+        mock_neqsim_fluid_class.create_thermo_system.assert_called()
+
+        # Vapor fraction
+        vapor_fraction = adapter.get_vapor_fraction_molar(mock_fluid, pressure=pressure, temperature=temperature)
+        assert vapor_fraction == 1.0
+
+
+class TestNeqSimThermodynamicAdapterIntegration:
+    """Integration tests for the NeqSimThermodynamicAdapter."""
+
+    def test_thermodynamic_properties_at_specified_conditions(self, medium_composition):
+        """Test the full thermodynamic property calculation pipeline.
+
+        This test covers:
+        1. Creating a NeqsimFluid from domain model
+        2. Getting all properties via the adapter's interface
+        3. Verifying expected values at specific conditions
+        """
+        # Arrange
+        fluid = Fluid(composition=medium_composition, eos_model=EoSModel.SRK)
+        adapter = NeqSimThermodynamicAdapter()
+        pressure = 50.0
+        temperature = 400.0
+
+        # First test the direct creation of NeqsimFluid
+        neqsim_fluid = adapter._create_neqsim_fluid(fluid, pressure=pressure, temperature=temperature)
+        assert isinstance(neqsim_fluid, NeqsimFluid), "Should create a valid NeqsimFluid instance"
+
+        # Get direct raw property values for comparison
+        direct_density = neqsim_fluid.density
+        direct_enthalpy = neqsim_fluid.enthalpy_joule_per_kg
+        direct_z = neqsim_fluid.z
+        direct_kappa = neqsim_fluid.kappa
+        direct_molar_mass = neqsim_fluid.molar_mass
+        direct_vapor_fraction = neqsim_fluid.vapor_fraction_molar
+
+        # Act - now get all properties through the adapter interface
+        density = adapter.get_density(fluid, pressure=pressure, temperature=temperature)
+        enthalpy = adapter.get_enthalpy(fluid, pressure=pressure, temperature=temperature)
+        z = adapter.get_z(fluid, pressure=pressure, temperature=temperature)
+        kappa = adapter.get_kappa(fluid, pressure=pressure, temperature=temperature)
+        molar_mass = adapter.get_molar_mass(fluid)
+        std_density = adapter.get_standard_density_gas_phase_after_flash(fluid)
+        vapor_fraction = adapter.get_vapor_fraction_molar(fluid, pressure=pressure, temperature=temperature)
+
+        # Assert expected values match for both direct and adapter-mediated properties
+        assert density == pytest.approx(direct_density), "Adapter should return same density as direct access"
+        assert enthalpy == pytest.approx(direct_enthalpy), "Adapter should return same enthalpy as direct access"
+        assert z == pytest.approx(direct_z), "Adapter should return same z-factor as direct access"
+        assert kappa == pytest.approx(direct_kappa), "Adapter should return same kappa as direct access"
+        assert molar_mass == pytest.approx(direct_molar_mass), "Adapter should return same molar mass as direct access"
+        assert vapor_fraction == pytest.approx(
+            direct_vapor_fraction
+        ), "Adapter should return same vapor fraction as direct access"
+
+        # Assert expected values at 50 bara and 400K from reference data
+        assert density == pytest.approx(30.15, abs=0.5)  # kg/m3
+        assert enthalpy == pytest.approx(239226, abs=5000)  # J/kg
+        assert z == pytest.approx(0.972, abs=0.02)  # dimensionless
+        assert kappa == pytest.approx(1.20, abs=0.1)  # dimensionless
+        assert molar_mass == pytest.approx(0.0194, abs=0.001)  # kg/mol
+        assert std_density == pytest.approx(0.825, abs=0.02)  # kg/m3
+        assert vapor_fraction == pytest.approx(1.0, abs=0.01)  # dimensionless

--- a/tests/libecalc/domain/core/stream/test_thermo_constants.py
+++ b/tests/libecalc/domain/core/stream/test_thermo_constants.py
@@ -1,0 +1,16 @@
+from libecalc.domain.process.core.stream.thermo_constants import ThermodynamicConstants
+
+
+class TestThermodynamicConstants:
+    """Minimal test suite for ThermodynamicConstants."""
+
+    def test_validate_components(self):
+        """Test that component validation runs without errors.
+
+        This test simply verifies that the component definitions are structurally valid.
+        """
+        # Should run without raising exceptions
+        ThermodynamicConstants.validate_components()
+
+        # If we reach here, the validation passed
+        assert True


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

To create centralized domain entity around fluid and stream and to create a thermodynamic adapter for future modifications of thermodynamic engine or simplifications and optimizations related to thermodynamic calculations.

## What does this pull request change?

- Centralizes domain entities for fluid and stream processing by defining dedicated classes for process conditions, fluid, and stream.
- Implements the NeqSim thermodynamic adapter to encapsulate interactions with the NeqSim Java service, paving the way for future modifications/optimizations or changing thermo engine more easily.
- Introduces a simplified stream mixing strategy with molar balance with simplifications similar to the ones used earlier in the neqsim fluid mix method, but a little enhanced by assuming outlet set to lowest inlet pressure and a simplified mass weighted temperature instead of setting equal to one of the streams (not requiring thermodynamic equilibrium calculations)
- Enhances fluid composition handling by adding a normalization method to `FluidComposition`, ensuring mole fractions always sum to 1 and making the logic agnostic to changes in component names or count.
- Testing across the new domain entities, mixing strategies, and thermodynamic adapter to ensure robustness and maintainability.


## Issues related to this change:

refs.:
?
