### PR TITLE
chore: remove pydantic from domain process core compressor

### DIFF
--- a/src/libecalc/domain/component_validation_error.py
+++ b/src/libecalc/domain/component_validation_error.py
@@ -99,6 +99,14 @@ class ProcessTurbineEfficiencyValidationException(DomainValidationException):
     pass
 
 
+class ProcessCompressorEfficiencyValidationException(DomainValidationException):
+    pass
+
+
+class ProcessFluidModelValidationException(DomainValidationException):
+    pass
+
+
 class ComponentDtoValidationError(Exception):
     def __init__(self, errors: list[ModelValidationError]):
         self.errors = errors

--- a/src/libecalc/domain/process/core/compressor/train/chart/types.py
+++ b/src/libecalc/domain/process/core/compressor/train/chart/types.py
@@ -1,16 +1,17 @@
-from pydantic import BaseModel, ConfigDict
-
 from libecalc.domain.process.core.chart.chart_area_flag import ChartAreaFlag
 
 
-class CompressorChartHeadEfficiencyResultSinglePoint(BaseModel):
-    polytropic_head: float
-    polytropic_efficiency: float
-    chart_area_flag: ChartAreaFlag
-    is_valid: bool
+class CompressorChartHeadEfficiencyResultSinglePoint:
+    def __init__(
+        self, polytropic_head: float, polytropic_efficiency: float, chart_area_flag: ChartAreaFlag, is_valid: bool
+    ):
+        self.polytropic_head = polytropic_head
+        self.polytropic_efficiency = polytropic_efficiency
+        self.chart_area_flag = chart_area_flag
+        self.is_valid = is_valid
 
 
-class CompressorChartResult(BaseModel):
+class CompressorChartResult:
     """asv_corrected_rates: Rates [Am3/h] corrected for Anti Surge Valve.
     choke_corrected_heads: Heads [J/kg] when corrected for Choke
     rate_has_recirc: Rate [Am3/h] when recirculating
@@ -20,14 +21,23 @@ class CompressorChartResult(BaseModel):
     exceeds_capacity:
     """
 
-    asv_corrected_rates: list[float]
-    choke_corrected_heads: list[float]
-    rate_has_recirc: list[bool]
-    pressure_is_choked: list[bool]
-    rate_exceeds_maximum: list[bool]
-    head_exceeds_maximum: list[bool]
-    exceeds_capacity: list[bool]
-    model_config = ConfigDict(extra="forbid")
+    def __init__(
+        self,
+        asv_corrected_rates: list[float],
+        choke_corrected_heads: list[float],
+        rate_has_recirc: list[bool],
+        pressure_is_choked: list[bool],
+        rate_exceeds_maximum: list[bool],
+        head_exceeds_maximum: list[bool],
+        exceeds_capacity: list[bool],
+    ):
+        self.asv_corrected_rates = asv_corrected_rates
+        self.choke_corrected_heads = choke_corrected_heads
+        self.rate_has_recirc = rate_has_recirc
+        self.pressure_is_choked = pressure_is_choked
+        self.rate_exceeds_maximum = rate_exceeds_maximum
+        self.head_exceeds_maximum = head_exceeds_maximum
+        self.exceeds_capacity = exceeds_capacity
 
     @property
     def any_points_below_stone_wall(self):

--- a/src/libecalc/domain/process/core/compressor/train/stage.py
+++ b/src/libecalc/domain/process/core/compressor/train/stage.py
@@ -1,7 +1,3 @@
-from typing import Annotated
-
-from pydantic import BaseModel, ConfigDict, Field, model_validator
-
 from libecalc.common.errors.exceptions import IllegalStateException
 from libecalc.common.fluid import FluidStream as FluidStreamDTO
 from libecalc.common.logger import logger
@@ -20,17 +16,23 @@ from libecalc.domain.process.core.compressor.train.utils.common import (
 )
 
 
-class CompressorTrainStage(BaseModel):
+class CompressorTrainStage:
     """inlet_temperature_kelvin [K].
 
     Note: Used in both Single and Variable Speed compressor process modelling.
     """
 
-    compressor_chart: SingleSpeedCompressorChart | VariableSpeedCompressorChart
-    inlet_temperature_kelvin: float
-    remove_liquid_after_cooling: bool
-    pressure_drop_ahead_of_stage: float | None = None
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    def __init__(
+        self,
+        compressor_chart: SingleSpeedCompressorChart | VariableSpeedCompressorChart,
+        inlet_temperature_kelvin: float,
+        remove_liquid_after_cooling: bool,
+        pressure_drop_ahead_of_stage: float | None = None,
+    ):
+        self.compressor_chart = compressor_chart
+        self.inlet_temperature_kelvin = inlet_temperature_kelvin
+        self.remove_liquid_after_cooling = remove_liquid_after_cooling
+        self.pressure_drop_ahead_of_stage = pressure_drop_ahead_of_stage
 
     def evaluate(
         self,
@@ -201,13 +203,32 @@ class UndefinedCompressorStage(CompressorTrainStage):
     Artifact of the 'Generic from Input' chart.
     """
 
-    polytropic_efficiency: Annotated[float, Field(gt=0, le=1)]
+    def __init__(
+        self,
+        polytropic_efficiency: float,
+        compressor_chart: VariableSpeedCompressorChart = None,  # Not in use. Not relevant when undefined.
+        inlet_temperature_kelvin: float = 0.0,
+        remove_liquid_after_cooling: bool = False,
+        pressure_drop_ahead_of_stage: float | None = None,
+    ):
+        self.validate_predefined_chart(compressor_chart, polytropic_efficiency)
+        self.validate_polytropic_efficiency(polytropic_efficiency)
+        super().__init__(
+            compressor_chart=compressor_chart,
+            inlet_temperature_kelvin=inlet_temperature_kelvin,
+            remove_liquid_after_cooling=remove_liquid_after_cooling,
+            pressure_drop_ahead_of_stage=pressure_drop_ahead_of_stage,
+        )
+        self.polytropic_efficiency = polytropic_efficiency
 
-    # Not in use:
-    compressor_chart: VariableSpeedCompressorChart = None  # Not relevant when undefined.
-
-    @model_validator(mode="before")
-    def validate_predefined_chart(cls, v: dict):
-        if v.get("compressor_chart") is None and v.get("polytropic_efficiency") is None:
+    @staticmethod
+    def validate_predefined_chart(compressor_chart, polytropic_efficiency):
+        if compressor_chart is None and polytropic_efficiency is None:
             raise ValueError("Stage with non-predefined compressor chart needs to have polytropic_efficiency")
-        return v
+
+    @staticmethod
+    def validate_polytropic_efficiency(polytropic_efficiency):
+        if not (0 < polytropic_efficiency <= 1):
+            raise ValueError(
+                f"polytropic_efficiency must be greater than 0 and less than or equal to 1. Invalid value: {polytropic_efficiency}"
+            )

--- a/src/libecalc/domain/process/core/compressor/train/types.py
+++ b/src/libecalc/domain/process/core/compressor/train/types.py
@@ -1,23 +1,27 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, model_validator
-
 from libecalc.common.logger import logger
 from libecalc.domain.process.core.compressor.train.fluid import FluidStream
 
 
-class FluidStreamObjectForMultipleStreams(BaseModel):
+class FluidStreamObjectForMultipleStreams:
     """Inlet streams needs a fluid with composition attached
     Outlet stream is what comes out of the compressor.
     """
 
-    name: str | None = None
-    fluid: FluidStream | None = None
-    is_inlet_stream: bool
-    connected_to_stage_no: int = 0
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    def __init__(
+        self,
+        is_inlet_stream: bool,
+        name: str | None = None,
+        fluid: FluidStream | None = None,
+        connected_to_stage_no: int = 0,
+    ):
+        self.name = name
+        self.fluid = fluid
+        self.is_inlet_stream = is_inlet_stream
+        self.connected_to_stage_no = connected_to_stage_no
+        self.check_valid_input()
 
-    @model_validator(mode="after")
     def check_valid_input(self):
         if not self.is_inlet_stream and self.fluid:
             msg = "Outgoing stream should not have a fluid model defined"
@@ -27,4 +31,3 @@ class FluidStreamObjectForMultipleStreams(BaseModel):
             msg = "Ingoing stream needs a fluid model to be define"
             logger.error(msg)
             raise ValueError(msg)
-        return self

--- a/src/libecalc/domain/process/core/compressor/train/types.py
+++ b/src/libecalc/domain/process/core/compressor/train/types.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from libecalc.common.logger import logger
+from libecalc.domain.component_validation_error import ModelValidationError, ProcessFluidModelValidationException
 from libecalc.domain.process.core.compressor.train.fluid import FluidStream
+from libecalc.presentation.yaml.validation_errors import Location
 
 
 class FluidStreamObjectForMultipleStreams:
@@ -26,8 +28,14 @@ class FluidStreamObjectForMultipleStreams:
         if not self.is_inlet_stream and self.fluid:
             msg = "Outgoing stream should not have a fluid model defined"
             logger.error(msg)
-            raise ValueError(msg)
+
+            raise ProcessFluidModelValidationException(
+                errors=[ModelValidationError(name=self.name, location=Location([self.name]), message=str(msg))],
+            )
+
         if self.is_inlet_stream and not self.fluid:
-            msg = "Ingoing stream needs a fluid model to be define"
+            msg = "Ingoing stream needs a fluid model to be defined"
             logger.error(msg)
-            raise ValueError(msg)
+            raise ProcessFluidModelValidationException(
+                errors=[ModelValidationError(name=self.name, location=Location([self.name]), message=str(msg))],
+            )

--- a/src/libecalc/domain/process/core/tabulated.py
+++ b/src/libecalc/domain/process/core/tabulated.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import BaseModel as PydanticBaseModel
-from pydantic import ConfigDict
 from scipy.interpolate import LinearNDInterpolator, interp1d
 
 from libecalc.common.energy_usage_type import EnergyUsageType
@@ -12,7 +10,6 @@ from libecalc.common.list.adjustment import transform_linear
 from libecalc.common.list.list_utils import array_to_list
 from libecalc.common.logger import logger
 from libecalc.common.units import Unit
-from libecalc.core.utils.array_type import PydanticNDArray
 from libecalc.domain.process.core.base import BaseModel
 from libecalc.domain.process.core.results.base import EnergyFunctionResult
 from libecalc.expression import Expression
@@ -90,12 +87,13 @@ def _check_variables_match_required(variables_to_evaluate: list[str], required_v
         raise IllegalStateException(msg)
 
 
-class VariableExpression(PydanticBaseModel):
-    name: str
-    expression: Expression
+class VariableExpression:
+    def __init__(self, name: str, expression: Expression):
+        self.name = name
+        self.expression = expression
 
 
-class Variable(PydanticBaseModel):
-    name: str
-    values: PydanticNDArray
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+class Variable:
+    def __init__(self, name: str, values: NDArray[np.float64]):
+        self.name = name
+        self.values = values


### PR DESCRIPTION
## Why is this pull request needed?

Part of libecalc refactoring and code improvements.

## What does this pull request change?

- Remove pydantic from: libecalc.domain.process.core (previously named models in main core folder)
- Remove mainly compressor related
- Update affected classes and methods


