### PR TITLE
ci: use latest v4 cache action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         with:
           path: ${{github.workspace}}/.venv
           key: poetry-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
v4.0.2 is deprecated, v4.2.0 contains important changes. https://github.com/actions/cache/releases/tag/v4.2.0