### PR TITLE
fix: stream using old method of getting fluid thermo engine

### DIFF
--- a/src/libecalc/domain/process/core/stream/stream.py
+++ b/src/libecalc/domain/process/core/stream/stream.py
@@ -45,36 +45,36 @@ class Stream:
     @cached_property
     def density(self) -> float:
         """Get density [kg/m³]."""
-        return self._get_thermodynamic_engine().get_density(
+        return self.fluid._thermodynamic_engine.get_density(
             self.fluid, pressure=self.pressure, temperature=self.temperature
         )
 
     @cached_property
     def molar_mass(self) -> float:
         """Get molar mass of the fluid [kg/kmol]."""
-        return self._get_thermodynamic_engine().get_molar_mass(self.fluid)
+        return self.fluid._thermodynamic_engine.get_molar_mass(self.fluid)
 
     @cached_property
     def standard_density_gas_phase_after_flash(self) -> float:
-        """Get gas phase density at standard conditions after TP flash and liquid removal [kg/m³]."""
-        return self._get_thermodynamic_engine().get_standard_density_gas_phase_after_flash(self.fluid)
+        """Get gas phase density at standard conditions after TP flash and liquid removal [kg/Sm³]."""
+        return self.fluid._thermodynamic_engine.get_standard_density_gas_phase_after_flash(self.fluid)
 
     @cached_property
     def enthalpy(self) -> float:
         """Get specific enthalpy [J/kg]."""
-        return self._get_thermodynamic_engine().get_enthalpy(
+        return self.fluid._thermodynamic_engine.get_enthalpy(
             self.fluid, pressure=self.pressure, temperature=self.temperature
         )
 
     @cached_property
     def z(self) -> float:
         """Get compressibility factor [-]."""
-        return self._get_thermodynamic_engine().get_z(self.fluid, pressure=self.pressure, temperature=self.temperature)
+        return self.fluid._thermodynamic_engine.get_z(self.fluid, pressure=self.pressure, temperature=self.temperature)
 
     @cached_property
     def kappa(self) -> float:
         """Get isentropic exponent [-]."""
-        return self._get_thermodynamic_engine().get_kappa(
+        return self.fluid._thermodynamic_engine.get_kappa(
             self.fluid, pressure=self.pressure, temperature=self.temperature
         )
 
@@ -153,10 +153,6 @@ class Stream:
             new_pressure=new_pressure, new_temperature=neqsim_fluid.temperature_kelvin
         )
 
-    def _get_thermodynamic_engine(self):
-        """Get the thermodynamic engine from the fluid."""
-        return self.fluid._get_thermodynamic_engine()
-
     @classmethod
     def from_standard_rate(
         cls,
@@ -175,7 +171,7 @@ class Stream:
             A new Stream instance with mass rate calculated from standard rate
         """
         # Create a temporary fluid to get standard density
-        standard_density = fluid._get_thermodynamic_engine().get_standard_density_gas_phase_after_flash(fluid)
+        standard_density = fluid._thermodynamic_engine.get_standard_density_gas_phase_after_flash(fluid)
 
         # Convert standard rate to mass rate
         mass_rate = standard_rate * standard_density / UnitConstants.HOURS_PER_DAY

--- a/tests/libecalc/domain/core/stream/test_stream.py
+++ b/tests/libecalc/domain/core/stream/test_stream.py
@@ -58,3 +58,91 @@ class TestStream:
         conditions = ProcessConditions(temperature_kelvin=310.0, pressure_bara=20.0)
         with pytest.raises(NegativeMassRateException):
             Stream(fluid=mock_fluid, conditions=conditions, mass_rate=-100.0)
+
+    def test_thermodynamic_properties(self, mock_fluid):
+        """Test that Stream properties correctly use the fluid's thermodynamic engine."""
+        # Setup test values
+        mock_density = 50.0
+        mock_molar_mass = 20.0
+        mock_std_density = 0.8
+        mock_enthalpy = 10000.0
+        mock_z = 0.8
+        mock_kappa = 1.3
+        test_temperature = 310.0
+        test_pressure = 20.0
+        mass_rate_test = 100.0
+
+        # Setup mock thermodynamic engine
+        mock_thermo_engine = Mock()
+        mock_fluid._thermodynamic_engine = mock_thermo_engine
+
+        # Configure return values for the mock engine
+        mock_thermo_engine.get_density.return_value = mock_density
+        mock_thermo_engine.get_molar_mass.return_value = mock_molar_mass
+        mock_thermo_engine.get_standard_density_gas_phase_after_flash.return_value = mock_std_density
+        mock_thermo_engine.get_enthalpy.return_value = mock_enthalpy
+        mock_thermo_engine.get_z.return_value = mock_z
+        mock_thermo_engine.get_kappa.return_value = mock_kappa
+
+        # Create stream with mocked fluid
+        conditions = ProcessConditions(temperature_kelvin=test_temperature, pressure_bara=test_pressure)
+        stream = Stream(fluid=mock_fluid, conditions=conditions, mass_rate=mass_rate_test)
+
+        # Test direct properties
+        assert stream.density == mock_density
+        mock_thermo_engine.get_density.assert_called_once_with(
+            mock_fluid, pressure=test_pressure, temperature=test_temperature
+        )
+
+        assert stream.molar_mass == mock_molar_mass
+        mock_thermo_engine.get_molar_mass.assert_called_once_with(mock_fluid)
+
+        assert stream.standard_density_gas_phase_after_flash == mock_std_density
+        mock_thermo_engine.get_standard_density_gas_phase_after_flash.assert_called_once_with(mock_fluid)
+
+        assert stream.enthalpy == mock_enthalpy
+        mock_thermo_engine.get_enthalpy.assert_called_once_with(
+            mock_fluid, pressure=test_pressure, temperature=test_temperature
+        )
+
+        assert stream.z == mock_z
+        mock_thermo_engine.get_z.assert_called_once_with(
+            mock_fluid, pressure=test_pressure, temperature=test_temperature
+        )
+
+        assert stream.kappa == mock_kappa
+        mock_thermo_engine.get_kappa.assert_called_once_with(
+            mock_fluid, pressure=test_pressure, temperature=test_temperature
+        )
+
+        # Test derived properties
+        assert stream.volumetric_rate == mass_rate_test / mock_density  # mass_rate / density
+        assert (
+            stream.standard_rate == (mass_rate_test / mock_std_density) * 24
+        )  # (mass_rate / std_density) * hours_per_day
+
+    def test_from_standard_rate(self, mock_fluid):
+        """Test creating a stream from standard rate."""
+        # Setup test values
+        mock_std_density = 0.8
+        test_temperature = 310.0
+        test_pressure = 20.0
+        standard_rate = 240.0  # Sm³/day
+        hours_per_day = 24  # UnitConstants.HOURS_PER_DAY
+
+        # Setup mock thermodynamic engine
+        mock_thermo_engine = Mock()
+        mock_fluid._thermodynamic_engine = mock_thermo_engine
+        mock_thermo_engine.get_standard_density_gas_phase_after_flash.return_value = mock_std_density
+
+        conditions = ProcessConditions(temperature_kelvin=test_temperature, pressure_bara=test_pressure)
+
+        # Create stream using from_standard_rate
+        stream = Stream.from_standard_rate(fluid=mock_fluid, conditions=conditions, standard_rate=standard_rate)
+
+        # Check that the correct methods were called
+        mock_thermo_engine.get_standard_density_gas_phase_after_flash.assert_called_once_with(mock_fluid)
+
+        # Check that mass_rate was calculated correctly (standard_rate * std_density / hours_per_day)
+        expected_mass_rate = standard_rate * mock_std_density / hours_per_day
+        assert stream.mass_rate == expected_mass_rate


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

Fix fluid thermo getter error in Stream object
