### PR TITLE
fix: add check for maximum power in multiple streams compressor train

### DIFF
--- a/docs/drafts/next.draft.md
+++ b/docs/drafts/next.draft.md
@@ -12,4 +12,6 @@ sidebar_position: -44
 
 ## Bug Fixes
 
+* The MAXIMUM_POWER keyword has not had any effect on the results for VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES. This has been fixed.
+
 ## Breaking changes

--- a/src/libecalc/domain/process/core/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/domain/process/core/compressor/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -652,6 +652,10 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
             outlet_stream=FluidStreamDTO.from_fluid_domain_object(fluid_stream=previous_outlet_stream),
             stage_results=stage_results,
             speed=speed,
+            above_maximum_power=sum([stage_result.power_megawatt for stage_result in stage_results])
+            > self.maximum_power
+            if self.maximum_power
+            else False,
             target_pressure_status=target_pressure_status,
         )
 
@@ -1095,6 +1099,12 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
             outlet_stream=compressor_train_results_to_return_last_part.outlet_stream,
             speed=speed,
             stage_results=compressor_train_results_to_return_stage_results,
+            above_maximum_power=sum(
+                [stage_result.power_megawatt for stage_result in compressor_train_results_to_return_stage_results]
+            )
+            > self.maximum_power
+            if self.maximum_power
+            else False,
             target_pressure_status=target_pressure_status,
         )
 

--- a/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
@@ -118,6 +118,7 @@ def variable_speed_compressor_train_one_compressor_one_stream(
     """
     dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
     dto_copy.stages = cast(list[dto.MultipleStreamsCompressorStage], [variable_speed_compressor_train_stage_dto])
+    dto_copy.maximum_power = 7
     return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=[
             FluidStreamObjectForMultipleStreams(
@@ -465,6 +466,23 @@ def test_get_maximum_standard_rate_at_stone_wall(
     np.testing.assert_allclose(below_stone_wall, below_stone_wall_multiple_streams[0], rtol=0.01)
     np.testing.assert_allclose(maximum_rate_stone_wall_100, maximum_rate_stone_wall_100_multiple_streams[0], rtol=0.01)
     np.testing.assert_allclose(maximum_rate_stone_wall_200, maximum_rate_stone_wall_200_multiple_streams[0], rtol=0.01)
+
+
+def test_variable_speed_multiple_streams_and_pressures_maximum_power(
+    variable_speed_compressor_train_one_compressor_one_stream,
+):
+    result_variable_speed_compressor_train_one_compressor_one_stream_maximum_power = (
+        variable_speed_compressor_train_one_compressor_one_stream.evaluate_rate_ps_pd(
+            rate=np.asarray([[3000000, 3500000]]),
+            suction_pressure=np.asarray([30, 30]),
+            discharge_pressure=np.asarray([100, 100]),
+        )
+    )
+    assert result_variable_speed_compressor_train_one_compressor_one_stream_maximum_power.is_valid == [True, False]
+    assert result_variable_speed_compressor_train_one_compressor_one_stream_maximum_power.failure_status == [
+        CompressorTrainCommonShaftFailureStatus.NO_FAILURE,
+        CompressorTrainCommonShaftFailureStatus.ABOVE_MAXIMUM_POWER,
+    ]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
The check for power being above/below maximum power has for some reason not been implemented for multiple streams compressor trains. This PR adds this fix (in addition to a test to check that it works).
