### PR TITLE
fix: add stream definition

### DIFF
--- a/src/libecalc/domain/energy/energy_component.py
+++ b/src/libecalc/domain/energy/energy_component.py
@@ -4,7 +4,7 @@ from libecalc.common.component_type import ComponentType
 from libecalc.core.result import EcalcModelResult
 from libecalc.domain.energy.component_energy_context import ComponentEnergyContext
 from libecalc.domain.energy.process_change_event import ProcessChangedEvent
-from libecalc.domain.process.process_system import ProcessSystem
+from libecalc.domain.process.process_system import ProcessSystem, ProcessUnit
 
 
 class EnergyComponent(abc.ABC):
@@ -50,7 +50,7 @@ class EnergyComponent(abc.ABC):
     def get_process_changed_events(self) -> list[ProcessChangedEvent]: ...
 
     @abc.abstractmethod
-    def get_process_system(self, event: ProcessChangedEvent) -> ProcessSystem | None:
+    def get_process_system(self, event: ProcessChangedEvent) -> ProcessSystem | ProcessUnit | None:
         """
         Get the process system that is active from the given event.
         Args:

--- a/src/libecalc/domain/process/process_system.py
+++ b/src/libecalc/domain/process/process_system.py
@@ -1,12 +1,43 @@
 import abc
+from typing import Generic, TypeVar
 from uuid import UUID
 
-from libecalc.domain.process.core.stream.stream import Stream
+ProcessUnitID = UUID
 
 
-class ProcessUnit(abc.ABC):
+class Stream(abc.ABC):
+    @property
     @abc.abstractmethod
-    def get_id(self) -> UUID: ...
+    def from_process_unit_id(self) -> ProcessUnitID | None: ...
+
+    @property
+    @abc.abstractmethod
+    def to_process_unit_id(self) -> ProcessUnitID | None: ...
+
+
+class MultiPhaseStream(Stream, abc.ABC):
+    """
+    Represents a fluid stream with multiple phases, liquid and gas.
+
+    """
+
+    ...
+
+
+class LiquidStream(Stream, abc.ABC):
+    """
+    Represents a fluid stream with only a liquid phase.
+    """
+
+    ...
+
+
+TStream = TypeVar("TStream", bound=LiquidStream | MultiPhaseStream)
+
+
+class ProcessUnit(abc.ABC, Generic[TStream]):
+    @abc.abstractmethod
+    def get_id(self) -> ProcessUnitID: ...
 
     @abc.abstractmethod
     def get_type(self) -> str: ...
@@ -14,10 +45,10 @@ class ProcessUnit(abc.ABC):
     @abc.abstractmethod
     def get_name(self) -> str: ...
 
-
-class ProcessSystem(abc.ABC):
     @abc.abstractmethod
-    def get_process_units(self) -> list[ProcessUnit]: ...
+    def get_streams(self) -> list[TStream]: ...
 
+
+class ProcessSystem(ProcessUnit, abc.ABC, Generic[TStream]):
     @abc.abstractmethod
-    def get_streams(self) -> list[Stream]: ...
+    def get_process_units(self) -> list["ProcessSystem[TStream]" | ProcessUnit[TStream]]: ...


### PR DESCRIPTION
Also allow for ProcessUnit directly instead of always requiring a
ProcessSystem. This is relevant for a pump electricity consumer for
example.
