### PR TITLE
chore: make sure enthalpy calculations for simplified train works wit…

### DIFF
--- a/src/libecalc/domain/process/compressor/core/train/chart/single_speed_compressor_chart.py
+++ b/src/libecalc/domain/process/compressor/core/train/chart/single_speed_compressor_chart.py
@@ -78,8 +78,8 @@ class SingleSpeedCompressorChart(SingleSpeedChart):
         polytropic_efficiency = self.efficiency_as_function_of_rate(rate_corrected_to_minimum_flow)
 
         return CompressorChartHeadEfficiencyResultSinglePoint(
-            polytropic_head=polytropic_head,
-            polytropic_efficiency=polytropic_efficiency,
+            polytropic_head=float(polytropic_head),
+            polytropic_efficiency=float(polytropic_efficiency),
             chart_area_flag=chart_area_flag,
             is_valid=point_is_valid,
         )

--- a/src/libecalc/domain/process/compressor/core/train/chart/variable_speed_compressor_chart.py
+++ b/src/libecalc/domain/process/compressor/core/train/chart/variable_speed_compressor_chart.py
@@ -220,8 +220,8 @@ class VariableSpeedCompressorChart(VariableSpeedChart):
         )
 
         return CompressorChartHeadEfficiencyResultSinglePoint(
-            polytropic_head=polytropic_head,
-            polytropic_efficiency=polytropic_efficiency,
+            polytropic_head=float(polytropic_head),
+            polytropic_efficiency=float(polytropic_efficiency),
             chart_area_flag=chart_area_flag,
             is_valid=point_is_valid,
         )

--- a/src/libecalc/domain/process/compressor/core/train/simplified_train.py
+++ b/src/libecalc/domain/process/compressor/core/train/simplified_train.py
@@ -95,10 +95,10 @@ class CompressorTrainSimplified(CompressorTrainModel):
         stage_inlet_pressure = suction_pressure
         mass_rate_kg_per_hour = self.fluid.standard_rate_to_mass_rate(standard_rates=rate)
         for stage_number, stage in enumerate(self.stages):
-            inlet_temperature_kelvin = stage.inlet_temperature_kelvin
+            inlet_temperature_kelvin = np.full_like(rate, fill_value=stage.inlet_temperature_kelvin, dtype=float)
             inlet_streams = self.fluid.get_fluid_streams(
                 pressure_bara=stage_inlet_pressure,
-                temperature_kelvin=np.full_like(rate, fill_value=inlet_temperature_kelvin, dtype=float),
+                temperature_kelvin=inlet_temperature_kelvin,
             )
             inlet_densities_kg_per_m3 = np.asarray([stream.density for stream in inlet_streams])
             inlet_actual_rate_m3_per_hour = mass_rate_kg_per_hour / inlet_densities_kg_per_m3

--- a/src/libecalc/domain/process/compressor/core/train/stage.py
+++ b/src/libecalc/domain/process/compressor/core/train/stage.py
@@ -105,7 +105,7 @@ class CompressorTrainStage:
         inlet_density_kg_per_m3 = inlet_stream_compressor.density
 
         actual_rate_m3_per_hour_to_use = actual_rate_m3_per_hour = mass_rate_kg_per_hour / inlet_density_kg_per_m3
-        compressor_maximum_actual_rate_m3_per_hour = (
+        compressor_maximum_actual_rate_m3_per_hour = float(
             self.compressor_chart.maximum_rate_as_function_of_speed(speed)
             if isinstance(self.compressor_chart, VariableSpeedCompressorChart)
             else self.compressor_chart.maximum_rate

--- a/src/libecalc/domain/process/compressor/core/train/utils/enthalpy_calculations.py
+++ b/src/libecalc/domain/process/compressor/core/train/utils/enthalpy_calculations.py
@@ -19,42 +19,48 @@ from libecalc.domain.process.compressor.core.train.fluid import FluidStream
 
 
 def calculate_enthalpy_change_head_iteration(
-    inlet_pressure: NDArray[np.float64],
-    outlet_pressure: NDArray[np.float64],
-    inlet_temperature_kelvin: NDArray[np.float64],
+    inlet_pressure: NDArray[np.float64] | float,
+    outlet_pressure: NDArray[np.float64] | float,
+    inlet_temperature_kelvin: NDArray[np.float64] | float,
     polytropic_efficiency_vs_rate_and_head_function: Callable,
     molar_mass: float,
-    inlet_streams: list[FluidStream],
-    inlet_actual_rate_m3_per_hour: NDArray[np.float64],
-) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Simplified method of finding enthalpy change in compressors
+    inlet_streams: list[FluidStream] | FluidStream,
+    inlet_actual_rate_m3_per_hour: NDArray[np.float64] | float,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]] | tuple[float, float]:
+    """
+    Simplified method of finding enthalpy change in compressors.
 
     Only used in Simplified Compressor train
 
     Args:
-        inlet_pressure: Inlet pressure array [bara]
-        outlet_pressure: Outlet pressure array [bara]
-        inlet_temperature_kelvin: Inlet temperature array [K]
-        polytropic_efficiency_vs_rate_and_head_function:
-        molar_mass: Molar mass [kg/mol]
-        inlet_streams:list of FluidStream-objects
-        inlet_actual_rate_m3_per_hour: Mass rate through compressor [m3/h]
+        inlet_pressure: Inlet pressure array [bara] or scalar.
+        outlet_pressure: Outlet pressure array [bara] or scalar.
+        inlet_temperature_kelvin: Inlet temperature array [K] or scalar.
+        polytropic_efficiency_vs_rate_and_head_function: Callable for efficiency calculation.
+        molar_mass: Molar mass [kg/mol].
+        inlet_streams: List of FluidStream objects or a single FluidStream.
+        inlet_actual_rate_m3_per_hour: Mass rate through compressor [m3/h] or scalar.
 
     Returns:
-       list of enthalphy changes [J/kg]
-       list of polytropic efficiencies [-]
-
+        Tuple of enthalpy changes [J/kg] and polytropic efficiencies [-].
     """
+    # Ensure inputs are numpy arrays for consistent operations
+    inlet_pressure = np.atleast_1d(inlet_pressure)
+    outlet_pressure = np.atleast_1d(outlet_pressure)
+    inlet_temperature_kelvin = np.atleast_1d(inlet_temperature_kelvin)
+    inlet_actual_rate_m3_per_hour = np.atleast_1d(inlet_actual_rate_m3_per_hour)
 
-    pressure_ratios = np.divide(outlet_pressure, inlet_pressure)  # Using divide seems to keep the float64 type
+    if isinstance(inlet_streams, FluidStream):
+        inlet_streams = [inlet_streams]
+
+    pressure_ratios = np.divide(outlet_pressure, inlet_pressure)
     inlet_kappa = np.asarray([stream.kappa for stream in inlet_streams])
     inlet_z = np.asarray([stream.z for stream in inlet_streams])
 
-    # Set start values for iteration
     polytropic_heads = np.full_like(inlet_actual_rate_m3_per_hour, 0.0)
     z = deepcopy(inlet_z)
     kappa = deepcopy(inlet_kappa)
-    enthalpy_change_joule_per_kg = 0
+    enthalpy_change_joule_per_kg = np.zeros_like(inlet_actual_rate_m3_per_hour)
 
     polytropic_efficiency = polytropic_efficiency_vs_rate_and_head_function(
         inlet_actual_rate_m3_per_hour, polytropic_heads
@@ -66,12 +72,8 @@ def calculate_enthalpy_change_head_iteration(
     expected_diff = 1e-3
     while not converged and i < max_iterations:
         polytropic_heads_previous = polytropic_heads.copy()
-        """
-        Calculate polytropic head given current estimate for z (compressibility) and kappa
-        Calculate enthalpy change given polytropic head and efficiency
-        Calculate outlet enthalpy
-        Estimate outlet streams by updating inlet streams with new pressure and enthalpy
-        """
+
+        # Calculate polytropic head and enthalpy change
         polytropic_efficiency = polytropic_efficiency_vs_rate_and_head_function(
             inlet_actual_rate_m3_per_hour, polytropic_heads
         )
@@ -85,6 +87,7 @@ def calculate_enthalpy_change_head_iteration(
         )
         enthalpy_change_joule_per_kg = polytropic_heads / polytropic_efficiency
 
+        # Update outlet streams
         outlet_streams = [
             stream.set_new_pressure_and_enthalpy_change(
                 new_pressure=pressure, enthalpy_change_joule_per_kg=enthalpy_change
@@ -92,15 +95,13 @@ def calculate_enthalpy_change_head_iteration(
             for stream, pressure, enthalpy_change in zip(inlet_streams, outlet_pressure, enthalpy_change_joule_per_kg)
         ]
 
-        # Get z (compressibility) and kappa (heat capacity ratio) of the estimated outlet streams
+        # Update z and kappa estimates
         outlet_kappa = np.asarray([stream.kappa for stream in outlet_streams])
         outlet_z = np.asarray([stream.z for stream in outlet_streams])
-
-        # Update z and kappa estimates based on new outlet estimates
         z = (inlet_z + outlet_z) / 2
         kappa = (inlet_kappa + outlet_kappa) / 2
 
-        # Set convergence criterion on polytropic head
+        # Convergence check
         if np.linalg.norm(polytropic_heads_previous) != 0:
             rel_diff = float(
                 np.linalg.norm(polytropic_heads - polytropic_heads_previous) / np.linalg.norm(polytropic_heads_previous)
@@ -109,24 +110,21 @@ def calculate_enthalpy_change_head_iteration(
             rel_diff = 1
 
         converged = rel_diff < expected_diff
-
         i += 1
 
         if i == max_iterations:
             logger.error(
-                "calculate_enthalpy_change_head_iteration"
-                f" did not converge after {max_iterations} iterations."
-                f" inlet_z: {inlet_z}."
-                f" inlet_kappa: {inlet_kappa}."
-                f" polytropic_efficiency: {polytropic_efficiency}."
-                f" pressure_ratios: {pressure_ratios}."
-                f" polytropic_efficiency: {polytropic_efficiency}."
-                f" Final diff between target and result was {rel_diff}, while expected convergence diff criteria is set to diff lower than {expected_diff}"
-                f" NOTE! We will use as the closest result we got for target for further calculations."
-                " This should normally not happen. Please contact eCalc support."
+                "calculate_enthalpy_change_head_iteration did not converge after %d iterations. "
+                "Final relative difference: %f",
+                max_iterations,
+                rel_diff,
             )
 
-    return enthalpy_change_joule_per_kg, polytropic_efficiency
+    # If inputs were scalars, return scalars
+    if isinstance(inlet_streams, list):
+        return enthalpy_change_joule_per_kg, polytropic_efficiency
+
+    return float(enthalpy_change_joule_per_kg[0]), float(polytropic_efficiency[0])
 
 
 def calculate_polytropic_head_campbell(
@@ -138,54 +136,60 @@ def calculate_polytropic_head_campbell(
     temperatures_kelvin: float | NDArray[np.float64],
 ) -> NDArray[np.float64] | float:
     """
+    Calculate polytropic head for a compressor.
 
     Args:
-        polytropic_efficiency: Polytropic efficiency array (0, 1]
-        kappa: Heat capacity ratio/ratio of specific heats
-        z: Compressibility
-        molar_mass: Molar mass value or array [kg/mol]
-        pressure_ratios: Pressure ratios between stages
-        temperatures_kelvin: Temperature value or array [K]
+        polytropic_efficiency: Polytropic efficiency array (0, 1].
+        kappa: Heat capacity ratio/ratio of specific heats.
+        z: Compressibility.
+        molar_mass: Molar mass value or array [kg/mol].
+        pressure_ratios: Pressure ratios between stages.
+        temperatures_kelvin: Temperature value or array [K].
 
     Returns:
-        Polytropic head [J/kg]
-
+        Polytropic head [J/kg].
     """
+    input_is_numpy = isinstance(kappa, np.ndarray)
+    polytropic_efficiency = np.atleast_1d(polytropic_efficiency)
+    kappa = np.atleast_1d(kappa)
+    z = np.atleast_1d(z)
+    molar_mass = np.atleast_1d(molar_mass)
+    pressure_ratios = np.atleast_1d(pressure_ratios)
+    temperatures_kelvin = np.atleast_1d(temperatures_kelvin)
 
-    # http://www.jmcampbell.com/tip-of-the-month/2011/11/compressor-calculations-rigorous-using-equation-of-state-vs-shortcut-method/ Eqn 3B
-    n_minus_1_over_n = _calculate_polytropic_exponent_expression_n_minus_1_over_n(
-        kappa=kappa, polytropic_efficiency=polytropic_efficiency
-    )
-    return _calculate_head(
-        exponent_expression=n_minus_1_over_n,
+    result = _calculate_head(
+        exponent_expression=_calculate_polytropic_exponent_expression_n_minus_1_over_n(kappa, polytropic_efficiency),
         temperature_kelvin=temperatures_kelvin,
         pressure_ratio=pressure_ratios,
         z=z,
         molar_mass=molar_mass,
     )
 
+    # Return scalar if inputs were scalar
+    return result if input_is_numpy else result[0]
+
 
 def _calculate_head(
-    exponent_expression: float | NDArray[np.float64],
-    temperature_kelvin: float | NDArray[np.float64],
-    pressure_ratio: float | NDArray[np.float64],
-    z: float | NDArray[np.float64],
-    molar_mass: float | NDArray[np.float64],
+    exponent_expression: NDArray[np.float64],
+    temperature_kelvin: NDArray[np.float64],
+    pressure_ratio: NDArray[np.float64],
+    z: NDArray[np.float64],
+    molar_mass: NDArray[np.float64],
 ) -> NDArray[np.float64]:
-    """Calculate (polytropic?) head [J/kg].
+    """
+    Calculate polytropic head [J/kg].
 
     Args:
-        exponent_expression:
-        temperature_kelvin: Temperature array [K]
-        pressure_ratio: Pressure ratios between stages
-        z: Compressibility
-        molar_mass: Molar mass value or array [kg/mol]
+        exponent_expression: Exponent expression (n-1)/n as a numpy array.
+        temperature_kelvin: Temperature array [K].
+        pressure_ratio: Pressure ratios between stages as a numpy array.
+        z: Compressibility as a numpy array.
+        molar_mass: Molar mass array [kg/mol].
 
     Returns:
-        Polytropic head [J/kg]
-
+        Polytropic head [J/kg] as a numpy array.
     """
-    return np.array(
+    return (
         1
         / exponent_expression
         * (z * UnitConstants.GAS_CONSTANT * temperature_kelvin)
@@ -195,25 +199,22 @@ def _calculate_head(
 
 
 def _calculate_polytropic_exponent_expression_n_minus_1_over_n(
-    kappa: float | NDArray[np.float64],
-    polytropic_efficiency: float | NDArray[np.float64],
-) -> float | NDArray[np.float64]:
-    """Calculate (n-1)/n where n is the polytropic exponent.
+    kappa: NDArray[np.float64],
+    polytropic_efficiency: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """
+    Calculate (n-1)/n where n is the polytropic exponent.
 
     Based on https://www.jmcampbell.com/tip-of-the-month/2011/11/compressor-calculations-rigorous-using-equation-of-state-vs-shortcut-method/ Eqn 6  # noqa
 
-    Use float64 to avoid ZeroDivisionError and rather get Inf.
-
     Args:
-        kappa: Heat capacity ratio/ratio of specific heats
-        polytropic_efficiency: Polytropic efficiency array (0, 1]
+        kappa: Heat capacity ratio/ratio of specific heats as a numpy array.
+        polytropic_efficiency: Polytropic efficiency array (0, 1] as a numpy array.
 
     Returns:
-        (n-1)/n, where n is the polytropic exponent
-
+        (n-1)/n as a numpy array, where n is the polytropic exponent.
     """
-
-    return np.float64(kappa - 1.0) / np.float64(kappa * polytropic_efficiency)
+    return (kappa - 1.0) / (kappa * polytropic_efficiency)
 
 
 def calculate_outlet_pressure_campbell(
@@ -225,26 +226,34 @@ def calculate_outlet_pressure_campbell(
     inlet_temperature_K: float | NDArray[np.float64],
     inlet_pressure_bara: float | NDArray[np.float64],
 ) -> float | NDArray[np.float64]:
-    """Calculate outlet pressure of polytropic compressor.
+    """
+    Calculate outlet pressure of a polytropic compressor.
 
     Based on  https://www.jmcampbell.com/tip-of-the-month/2011/11/compressor-calculations-rigorous-using-equation-of-state-vs-shortcut-method/ Eqn 3B  # noqa.
 
-     If all inputs are given as floats, the output will be a float, if any of the inputs are given as a numpy array, the
+    If all inputs are given as floats, the output will be a float, if any of the inputs are given as a numpy array, the
     output will be an array
 
     Args:
-        kappa: heat capacity ratio/ratio of specific heats
-        polytropic_efficiency: Polytropic efficiency array or value (0, 1]
-        polytropic_head_fluid_Joule_per_kg: Polytropic head array or value [J/kg]
-        molar_mass: Molar mass [kg/mol]
-        z_inlet: Compressibility
-        inlet_temperature_K: Inlet temperature value or array [K]
-        inlet_pressure_bara: Inlet pressure value or array [bara]
+        kappa: Heat capacity ratio/ratio of specific heats.
+        polytropic_efficiency: Polytropic efficiency array or value (0, 1].
+        polytropic_head_fluid_Joule_per_kg: Polytropic head array or value [J/kg].
+        molar_mass: Molar mass [kg/mol].
+        z_inlet: Compressibility.
+        inlet_temperature_K: Inlet temperature value or array [K].
+        inlet_pressure_bara: Inlet pressure value or array [bara].
 
     Returns:
-        Outlet pressure [bara]
-
+        Outlet pressure [bara].
     """
+    input_is_numpy = isinstance(kappa, np.ndarray)
+    kappa = np.atleast_1d(kappa)
+    polytropic_efficiency = np.atleast_1d(polytropic_efficiency)
+    polytropic_head_fluid_Joule_per_kg = np.atleast_1d(polytropic_head_fluid_Joule_per_kg)
+    molar_mass = np.atleast_1d(molar_mass)
+    z_inlet = np.atleast_1d(z_inlet)
+    inlet_temperature_K = np.atleast_1d(inlet_temperature_K)
+    inlet_pressure_bara = np.atleast_1d(inlet_pressure_bara)
 
     n_over_n_minus_1 = 1.0 / _calculate_polytropic_exponent_expression_n_minus_1_over_n(
         kappa=kappa, polytropic_efficiency=polytropic_efficiency
@@ -259,7 +268,4 @@ def calculate_outlet_pressure_campbell(
     ) ** (n_over_n_minus_1)
     outlet_pressure_bara = inlet_pressure_bara * p2_p1_fraction
 
-    if isinstance(outlet_pressure_bara, np.ndarray):
-        return np.array(outlet_pressure_bara)
-    else:
-        return float(outlet_pressure_bara)
+    return outlet_pressure_bara if input_is_numpy else outlet_pressure_bara[0]


### PR DESCRIPTION
Preparation for making simplified compressor train calculations for single points in time, not arrays, by making sure that enthalpy calculations (also used when making a generic from input compressor chart) can be called (and return correct dimension) both with array and scalar input.