### PR TITLE
fix: ensure location is non-None to resolve backend type mismatch

### DIFF
--- a/src/libecalc/domain/component_validation_error.py
+++ b/src/libecalc/domain/component_validation_error.py
@@ -9,8 +9,8 @@ from libecalc.presentation.yaml.validation_errors import Location
 @dataclass
 class ModelValidationError:
     message: str
+    location: Location
     name: str | None = None
-    location: Location | None = None
     data: dict | None = None
     file_context: FileContext | None = None
 

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_component.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_component.py
@@ -292,6 +292,7 @@ class GeneratorSetEnergyComponent(Emitter, EnergyComponent):
                         name=consumer.name,
                         message="The consumer is not an electricity consumer. "
                         "Generators can not have fuel consumers.",
+                        location=Location([consumer.name]),  # for now, we will use the name as the location
                     )
                 )
 

--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/consumer_function/results.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/consumer_function/results.py
@@ -18,6 +18,7 @@ from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_f
     ConsumerFunctionType,
 )
 from libecalc.domain.process.core.results.base import EnergyFunctionResult
+from libecalc.presentation.yaml.validation_errors import Location
 
 
 class ConsumerFunctionResultBase:
@@ -103,6 +104,7 @@ class ConsumerFunctionResult(ConsumerFunctionResultBase):
                     ModelValidationError(
                         name=self.__repr_name__(),
                         message=msg,
+                        location=Location([self.__repr_name__()]),  # for now, we will use the name as the location
                     )
                 ]
             )

--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/results.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/system/results.py
@@ -22,6 +22,7 @@ from libecalc.domain.infrastructure.energy_components.legacy_consumer.system.ope
     ConsumerSystemOperationalSetting,
 )
 from libecalc.domain.process.core.results import CompressorTrainResult, EnergyFunctionResult, PumpModelResult
+from libecalc.presentation.yaml.validation_errors import Location
 
 
 class ConsumerSystemComponentResult:
@@ -157,6 +158,7 @@ class ConsumerSystemConsumerFunctionResult(ConsumerFunctionResultBase):
                     ModelValidationError(
                         name=self.__repr_name__(),
                         message=msg,
+                        location=Location([self.__repr_name__()]),  # for now, we will use the name as the location
                     )
                 ]
             )

--- a/src/libecalc/domain/infrastructure/energy_components/utils.py
+++ b/src/libecalc/domain/infrastructure/energy_components/utils.py
@@ -8,6 +8,7 @@ from libecalc.domain.component_validation_error import (
     ModelValidationError,
 )
 from libecalc.domain.process.dto import ConsumerFunction
+from libecalc.presentation.yaml.validation_errors import Location
 
 
 def check_model_energy_usage_type(model_data: dict[Period, ConsumerFunction], energy_type: EnergyUsageType):
@@ -17,6 +18,7 @@ def check_model_energy_usage_type(model_data: dict[Period, ConsumerFunction], en
                 errors=[
                     ModelValidationError(
                         message=f"Model does not consume {energy_type.value}",
+                        location=Location(keys=[]),
                     )
                 ]
             )


### PR DESCRIPTION
Refs equinor/ecalc-internal#756

**Summary**
This pull request fixes a bug where `ModelValidationError.location` could be `None`, causing a type mismatch in the backend. The changes ensure that location is always non-None, improving validation consistency and preventing backend errors.

<hr></hr> 

**Changes**

- Updated `ModelValidationError` in libecalc/src/libecalc/domain/component_validation_error.py to ensure location cannot be None.
- Added location to errors that were previously missing it.

<hr></hr> 

**Type**
fix: Resolves a bug related to backend validation errors.