### PR TITLE
refactor: introduce PathID

### DIFF
--- a/src/libecalc/domain/infrastructure/emitters/venting_emitter.py
+++ b/src/libecalc/domain/infrastructure/emitters/venting_emitter.py
@@ -3,7 +3,6 @@ import abc
 import numpy as np
 
 from libecalc.common.component_type import ComponentType
-from libecalc.common.string.string_utils import generate_id
 from libecalc.common.time_utils import Period
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import Rates, RateType, TimeSeriesFloat, TimeSeriesStreamDayRate
@@ -14,6 +13,7 @@ from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_f
     apply_condition,
     get_condition_from_expression,
 )
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.regularity import Regularity
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.dto.utils.validators import convert_expression
@@ -71,14 +71,14 @@ class VentingVolume:
 class VentingEmitter(Emitter, EnergyComponent, abc.ABC):
     def __init__(
         self,
-        name: str,
+        path_id: PathID,
         expression_evaluator: ExpressionEvaluator,
         component_type: ComponentType,
         user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
         emitter_type: VentingType,
         regularity: Regularity,
     ):
-        self.name = name
+        self._path_id = path_id
         self.expression_evaluator = expression_evaluator
         self.component_type = component_type
         self.user_defined_category = user_defined_category
@@ -87,8 +87,12 @@ class VentingEmitter(Emitter, EnergyComponent, abc.ABC):
         self.emission_results: dict[str, EmissionResult] | None = None
 
     @property
+    def name(self) -> str:
+        return self._path_id.get_name()
+
+    @property
     def id(self) -> str:
-        return generate_id(self.name)
+        return self._path_id.get_name()
 
     def evaluate_emissions(
         self,

--- a/src/libecalc/domain/infrastructure/energy_components/asset/asset.py
+++ b/src/libecalc/domain/infrastructure/energy_components/asset/asset.py
@@ -1,23 +1,27 @@
 from libecalc.common.component_type import ComponentType
-from libecalc.common.string.string_utils import generate_id
 from libecalc.domain.energy import EnergyComponent
 from libecalc.domain.infrastructure.energy_components.installation.installation import Installation
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.dto.component_graph import ComponentGraph
 
 
 class Asset(EnergyComponent):
     def __init__(
         self,
-        name: str,
+        path_id: PathID,
         installations: list[Installation],
     ):
-        self.name = name
+        self._path_id = path_id
         self.installations = installations
         self.component_type = ComponentType.ASSET
 
     @property
     def id(self):
-        return generate_id(self.name)
+        return self._path_id.get_name()
+
+    @property
+    def name(self):
+        return self._path_id.get_name()
 
     def is_fuel_consumer(self) -> bool:
         return True

--- a/src/libecalc/domain/infrastructure/energy_components/electricity_consumer/electricity_consumer.py
+++ b/src/libecalc/domain/infrastructure/energy_components/electricity_consumer/electricity_consumer.py
@@ -3,7 +3,6 @@ from typing import Literal
 from libecalc.common.component_type import ComponentType
 from libecalc.common.consumption_type import ConsumptionType
 from libecalc.common.energy_usage_type import EnergyUsageType
-from libecalc.common.string.string_utils import generate_id
 from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.time_utils import Period
 from libecalc.common.variables import ExpressionEvaluator
@@ -19,6 +18,7 @@ from libecalc.domain.infrastructure.energy_components.utils import (
     _convert_keys_in_dictionary_from_str_to_periods,
     check_model_energy_usage_type,
 )
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.process.dto.energy_usage_model_types import ElectricEnergyUsageModel
 from libecalc.domain.process.process_system import ProcessSystem
 from libecalc.domain.regularity import Regularity
@@ -42,7 +42,7 @@ class ElectricityConsumer(EnergyComponent, TemporalProcessSystem):
 
     def __init__(
         self,
-        name: str,
+        path_id: PathID,
         regularity: Regularity,
         user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
         component_type: Literal[
@@ -56,7 +56,7 @@ class ElectricityConsumer(EnergyComponent, TemporalProcessSystem):
         expression_evaluator: ExpressionEvaluator,
         consumes: Literal[ConsumptionType.ELECTRICITY] = ConsumptionType.ELECTRICITY,
     ):
-        self.name = name
+        self._path_id = path_id
         self.regularity = regularity
         self.user_defined_category = user_defined_category
         self.energy_usage_model = self.check_energy_usage_model(energy_usage_model)
@@ -69,7 +69,11 @@ class ElectricityConsumer(EnergyComponent, TemporalProcessSystem):
 
     @property
     def id(self) -> str:
-        return generate_id(self.name)
+        return self._path_id.get_name()
+
+    @property
+    def name(self):
+        return self._path_id.get_name()
 
     def is_fuel_consumer(self) -> bool:
         return False
@@ -84,7 +88,7 @@ class ElectricityConsumer(EnergyComponent, TemporalProcessSystem):
         return self.component_type
 
     def get_name(self) -> str:
-        return self.name
+        return self._path_id.get_name()
 
     def evaluate_energy_usage(self, context: ComponentEnergyContext) -> dict[str, EcalcModelResult]:
         consumer = ConsumerEnergyComponent(

--- a/src/libecalc/domain/infrastructure/energy_components/fuel_consumer/fuel_consumer.py
+++ b/src/libecalc/domain/infrastructure/energy_components/fuel_consumer/fuel_consumer.py
@@ -3,7 +3,6 @@ from typing import Literal
 from libecalc.common.component_type import ComponentType
 from libecalc.common.consumption_type import ConsumptionType
 from libecalc.common.energy_usage_type import EnergyUsageType
-from libecalc.common.string.string_utils import generate_id
 from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.time_utils import Period
 from libecalc.common.variables import ExpressionEvaluator
@@ -25,6 +24,7 @@ from libecalc.domain.infrastructure.energy_components.utils import (
     _convert_keys_in_dictionary_from_str_to_periods,
     check_model_energy_usage_type,
 )
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.process.dto.energy_usage_model_types import FuelEnergyUsageModel
 from libecalc.domain.process.process_system import ProcessSystem
 from libecalc.domain.regularity import Regularity
@@ -50,7 +50,7 @@ class FuelConsumer(Emitter, TemporalProcessSystem, EnergyComponent):
 
     def __init__(
         self,
-        name: str,
+        path_id: PathID,
         regularity: Regularity,
         user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
         component_type: Literal[
@@ -63,7 +63,7 @@ class FuelConsumer(Emitter, TemporalProcessSystem, EnergyComponent):
         expression_evaluator: ExpressionEvaluator,
         consumes: Literal[ConsumptionType.FUEL] = ConsumptionType.FUEL,
     ):
-        self.name = name
+        self._path_id = path_id
         self.regularity = regularity
         self.user_defined_category = user_defined_category
         self.energy_usage_model = self.check_energy_usage_model(energy_usage_model)
@@ -77,8 +77,12 @@ class FuelConsumer(Emitter, TemporalProcessSystem, EnergyComponent):
         self.emission_results: dict[str, EmissionResult] | None = None
 
     @property
+    def name(self):
+        return self._path_id.get_name()
+
+    @property
     def id(self) -> str:
-        return generate_id(self.name)
+        return self._path_id.get_name()
 
     def is_fuel_consumer(self) -> bool:
         return True
@@ -93,7 +97,7 @@ class FuelConsumer(Emitter, TemporalProcessSystem, EnergyComponent):
         return self.component_type
 
     def get_name(self) -> str:
-        return self.name
+        return self._path_id.get_name()
 
     def evaluate_energy_usage(self, context: ComponentEnergyContext) -> dict[str, EcalcModelResult]:
         consumer = ConsumerEnergyComponent(

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_component.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_component.py
@@ -7,7 +7,6 @@ from libecalc.common.component_type import ComponentType
 from libecalc.common.errors.exceptions import EcalcError, ProgrammingError
 from libecalc.common.list.list_utils import array_to_list
 from libecalc.common.logger import logger
-from libecalc.common.string.string_utils import generate_id
 from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.time_utils import Period, Periods
 from libecalc.common.units import Unit
@@ -27,6 +26,7 @@ from libecalc.domain.infrastructure.energy_components.electricity_consumer.elect
 from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consumer import FuelConsumer
 from libecalc.domain.infrastructure.energy_components.fuel_model.fuel_model import FuelModel
 from libecalc.domain.infrastructure.energy_components.utils import _convert_keys_in_dictionary_from_str_to_periods
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
 from libecalc.domain.regularity import Regularity
 from libecalc.dto.component_graph import ComponentGraph
@@ -42,7 +42,7 @@ from libecalc.presentation.yaml.validation_errors import Location
 class GeneratorSetEnergyComponent(Emitter, EnergyComponent):
     def __init__(
         self,
-        name: str,
+        path_id: PathID,
         user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
         generator_set_model: dict[Period, GeneratorSetProcessUnit],
         regularity: Regularity,
@@ -53,7 +53,7 @@ class GeneratorSetEnergyComponent(Emitter, EnergyComponent):
         max_usage_from_shore: ExpressionType | None = None,
         component_type: Literal[ComponentType.GENERATOR_SET] = ComponentType.GENERATOR_SET,
     ):
-        self.name = name
+        self._path_id = path_id
         self.user_defined_category = user_defined_category
         self.regularity = regularity
         self.expression_evaluator = expression_evaluator
@@ -71,7 +71,11 @@ class GeneratorSetEnergyComponent(Emitter, EnergyComponent):
 
     @property
     def id(self) -> str:
-        return generate_id(self.name)
+        return self._path_id.get_name()
+
+    @property
+    def name(self) -> str:
+        return self._path_id.get_name()
 
     def is_fuel_consumer(self) -> bool:
         return True
@@ -86,7 +90,7 @@ class GeneratorSetEnergyComponent(Emitter, EnergyComponent):
         return self.component_type
 
     def get_name(self) -> str:
-        return self.name
+        return self._path_id.get_name()
 
     def evaluate_process_model(
         self,

--- a/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
+++ b/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
@@ -1,15 +1,13 @@
 from libecalc.common.component_type import ComponentType
-from libecalc.common.string.string_utils import generate_id
 from libecalc.common.variables import ExpressionEvaluator
 from libecalc.domain.energy import EnergyComponent
-from libecalc.domain.energy.process_change_event import ProcessChangedEvent
 from libecalc.domain.hydrocarbon_export import HydrocarbonExport
 from libecalc.domain.infrastructure.emitters.venting_emitter import VentingEmitter
 from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consumer import FuelConsumer
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_component import (
     GeneratorSetEnergyComponent,
 )
-from libecalc.domain.process.process_system import ProcessSystem
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.regularity import Regularity
 from libecalc.dto.component_graph import ComponentGraph
 from libecalc.dto.types import InstallationUserDefinedCategoryType
@@ -30,16 +28,9 @@ class Installation(EnergyComponent):
     across multiple components.
     """
 
-    def get_process_changed_events(self) -> list[ProcessChangedEvent]:
-        # No process directly on installation currently
-        return []
-
-    def get_process_system(self, event: ProcessChangedEvent) -> ProcessSystem | None:
-        return None
-
     def __init__(
         self,
-        name: str,
+        path_id: PathID,
         regularity: Regularity,
         hydrocarbon_export: HydrocarbonExport,
         fuel_consumers: list[GeneratorSetEnergyComponent | FuelConsumer],
@@ -47,7 +38,7 @@ class Installation(EnergyComponent):
         venting_emitters: list[VentingEmitter] | None = None,
         user_defined_category: InstallationUserDefinedCategoryType | None = None,
     ):
-        self.name = name
+        self._path_id = path_id
         self.hydrocarbon_export = hydrocarbon_export
         self.regularity = regularity
         self.fuel_consumers = fuel_consumers
@@ -60,6 +51,10 @@ class Installation(EnergyComponent):
         if venting_emitters is None:
             venting_emitters = []
         self.venting_emitters = venting_emitters
+
+    @property
+    def name(self) -> str:
+        return self._path_id.get_name()
 
     def is_fuel_consumer(self) -> bool:
         return True
@@ -75,11 +70,11 @@ class Installation(EnergyComponent):
         return self.component_type
 
     def get_name(self) -> str:
-        return self.name
+        return self._path_id.get_name()
 
     @property
     def id(self) -> str:
-        return generate_id(self.name)
+        return self._path_id.get_name()  # id here is energy component name which is a str and expects a unique name
 
     def convert_expression_installation(self, data):
         # Implement the conversion logic here

--- a/src/libecalc/domain/infrastructure/path_id.py
+++ b/src/libecalc/domain/infrastructure/path_id.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import uuid
+
+
+def _generate_id(*args: str) -> str:
+    """
+    Generate an id from one or more strings. The string is encoded to avoid it being used to get other info than
+    the id, i.e. it should not be used to get the name of a consumer, even if the name might be used to create the id.
+
+    If there are many strings they are joined together.
+    """
+    return "-".join(args)
+
+
+def _generate_uuid_from_string(value: str) -> uuid.UUID:
+    """Generate a UUID from a string"""
+    return uuid.uuid5(uuid.NAMESPACE_DNS, value)
+
+
+def _generate_uuid(*args: str) -> uuid.UUID:
+    return _generate_uuid_from_string(_generate_id(*args))
+
+
+class PathID:
+    """
+    An ID used by entities.
+    Some entities have unique names, others need a path to be unique.
+    This class keeps track of that and can provide model unique ids, model unique tuple and the name of the entity with the id.
+    """
+
+    def __init__(self, name: str, parent: PathID | None = None):
+        self._name = name
+        self._parent = parent
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_parent(self) -> PathID | None:
+        return self._parent
+
+    def get_model_unique_id(self) -> uuid.UUID:
+        return _generate_uuid(*self.get_unique_tuple_str())
+
+    def has_unique_name(self) -> bool:
+        return self._parent is None
+
+    def get_unique_tuple_str(self) -> tuple[str, ...]:
+        if self.has_unique_name():
+            return (self._name,)
+
+        return (self._name, *self._parent.get_unique_tuple_str())

--- a/src/libecalc/fixtures/cases/consumer_with_time_slots_models.py
+++ b/src/libecalc/fixtures/cases/consumer_with_time_slots_models.py
@@ -19,6 +19,7 @@ from libecalc.domain.infrastructure.energy_components.generator_set.generator_se
     GeneratorSetEnergyComponent,
 )
 from libecalc.domain.infrastructure.energy_components.installation.installation import Installation
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.process.compressor.dto import (
     CompressorConsumerFunction,
     CompressorStage,
@@ -80,7 +81,7 @@ def tabulated_fuel_consumer_with_time_slots(fuel_gas, time_vector=None, variable
 
     expression_evaluator = VariablesMap(time_vector=time_vector, variables=variables)
     return FuelConsumer(
-        name="fuel_consumer_with_time_slots",
+        path_id=PathID("fuel_consumer_with_time_slots"),
         component_type=ComponentType.GENERIC,
         fuel=fuel_gas,
         regularity=Regularity.create(expression_evaluator=expression_evaluator, expression_input=1),
@@ -150,7 +151,7 @@ def time_slot_electricity_consumer_with_changing_model_type(simple_compressor_mo
             variables = {}
         expression_evaluator = VariablesMap(time_vector=time_vector, variables=variables)
         return ElectricityConsumer(
-            name="el-consumer1",
+            path_id=PathID("el-consumer1"),
             component_type=ComponentType.GENERIC,
             user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.GAS_DRIVEN_COMPRESSOR},
             regularity=Regularity.create(expression_evaluator=expression_evaluator, expression_input=1),
@@ -178,7 +179,7 @@ def time_slot_electricity_consumer_with_same_model_type():
 
         expression_evaluator = VariablesMap(time_vector=time_vector, variables=variables)
         return ElectricityConsumer(
-            name="el-consumer2",
+            path_id=PathID("el-consumer2"),
             component_type=ComponentType.GENERIC,
             user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.GAS_DRIVEN_COMPRESSOR},
             regularity=Regularity.create(expression_evaluator=expression_evaluator, expression_input=1),
@@ -205,7 +206,7 @@ def time_slot_electricity_consumer_with_same_model_type2():
             variables = {}
         expression_evaluator = VariablesMap(time_vector=time_vector, variables=variables)
         return ElectricityConsumer(
-            name="el-consumer4",
+            path_id=PathID("el-consumer4"),
             component_type=ComponentType.GENERIC,
             user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.GAS_DRIVEN_COMPRESSOR},
             regularity=Regularity.create(expression_evaluator=expression_evaluator, expression_input=1),
@@ -229,7 +230,7 @@ def time_slot_electricity_consumer_with_same_model_type3(simple_compressor_model
             variables = {}
         expression_evaluator = VariablesMap(time_vector=time_vector, variables=variables)
         return ElectricityConsumer(
-            name="el-consumer-simple-compressor-model-with-timeslots",
+            path_id=PathID("el-consumer-simple-compressor-model-with-timeslots"),
             component_type=ComponentType.COMPRESSOR,
             user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.GAS_DRIVEN_COMPRESSOR},
             regularity=Regularity.create(expression_evaluator=expression_evaluator, expression_input=1),
@@ -252,7 +253,7 @@ def time_slot_electricity_consumer_too_late_startup():
         if variables is None:
             variables = {}
         return ElectricityConsumer(
-            name="el-consumer3",
+            path_id=PathID("el-consumer3"),
             component_type=ComponentType.GENERIC,
             user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.GAS_DRIVEN_COMPRESSOR},
             energy_usage_model={Period(datetime(2050, 1, 1)): direct_consumer(power=5)},
@@ -312,7 +313,7 @@ def time_slots_simplified_compressor_system(
         energy_usage_model_upgrade.compressors[1].name = "train2_upgrade"
         expression_evaluator = VariablesMap(time_vector=time_vector, variables=variables)
         return ElectricityConsumer(
-            name="simplified_compressor_system",
+            path_id=PathID("simplified_compressor_system"),
             component_type=ComponentType.COMPRESSOR_SYSTEM,
             user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.COMPRESSOR},
             regularity=Regularity.create(expression_evaluator=expression_evaluator, expression_input=1),
@@ -348,16 +349,16 @@ def consumer_with_time_slots_models_dto(
 
     return DTOCase(
         ecalc_model=Asset(
-            name="time_slots_model",
+            path_id=PathID("time_slots_model"),
             installations=[
                 Installation(
                     user_defined_category=InstallationUserDefinedCategoryType.FIXED,
-                    name="some_installation",
+                    path_id=PathID("some_installation"),
                     regularity=regularity,
                     hydrocarbon_export=hydrocarbon_export,
                     fuel_consumers=[
                         GeneratorSetEnergyComponent(
-                            name="some_genset",
+                            path_id=PathID("some_genset"),
                             user_defined_category={
                                 Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR
                             },
@@ -375,7 +376,7 @@ def consumer_with_time_slots_models_dto(
                             expression_evaluator=variables_map,
                         ),
                         GeneratorSetEnergyComponent(
-                            name="some_genset_startup_after_consumer",
+                            path_id=PathID("some_genset_startup_after_consumer"),
                             user_defined_category={
                                 Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR
                             },

--- a/src/libecalc/presentation/yaml/mappers/component_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/component_mapper.py
@@ -32,6 +32,7 @@ from libecalc.domain.infrastructure.energy_components.generator_set.generator_se
     GeneratorSetEnergyComponent,
 )
 from libecalc.domain.infrastructure.energy_components.installation.installation import Installation
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.process.dto import ConsumerFunction
 from libecalc.domain.regularity import Regularity
 from libecalc.dto import FuelType
@@ -149,7 +150,7 @@ class ConsumerMapper:
             try:
                 fuel_consumer_name = data.name
                 return FuelConsumer(
-                    name=fuel_consumer_name,
+                    path_id=PathID(fuel_consumer_name),
                     user_defined_category=define_time_model_for_period(
                         data.category, target_period=self._target_period
                     ),
@@ -166,7 +167,7 @@ class ConsumerMapper:
             try:
                 electricity_consumer_name = data.name
                 return ElectricityConsumer(
-                    name=electricity_consumer_name,
+                    path_id=PathID(electricity_consumer_name),
                     regularity=regularity,
                     user_defined_category=define_time_model_for_period(
                         data.category, target_period=self._target_period
@@ -229,7 +230,7 @@ class GeneratorSetMapper:
         try:
             generator_set_name = data.name
             return GeneratorSetEnergyComponent(
-                name=generator_set_name,
+                path_id=PathID(generator_set_name),
                 fuel=fuel,
                 regularity=regularity,
                 generator_set_model=generator_set_model,
@@ -271,7 +272,7 @@ class InstallationMapper:
             ]
 
             return DirectVentingEmitter(
-                name=data.name,
+                path_id=PathID(data.name),
                 expression_evaluator=expression_evaluator,
                 component_type=data.component_type,
                 user_defined_category=data.category,
@@ -281,7 +282,7 @@ class InstallationMapper:
             )
         elif isinstance(data, YamlOilTypeEmitter):
             return OilVentingEmitter(
-                name=data.name,
+                path_id=PathID(data.name),
                 expression_evaluator=expression_evaluator,
                 component_type=data.component_type,
                 user_defined_category=data.category,
@@ -321,8 +322,6 @@ class InstallationMapper:
                 ]
             ) from e
 
-        installation_name = data.name
-
         hydrocarbon_export = HydrocarbonExport(
             expression_input=data.hydrocarbon_export,
             expression_evaluator=expression_evaluator,
@@ -361,7 +360,7 @@ class InstallationMapper:
 
         try:
             return Installation(
-                name=installation_name,
+                path_id=PathID(data.name),
                 regularity=regularity,
                 hydrocarbon_export=hydrocarbon_export,
                 fuel_consumers=[*generator_sets, *fuel_consumers],
@@ -387,7 +386,7 @@ class EcalcModelMapper:
     def from_yaml_to_domain(self, configuration: YamlValidator) -> Asset:
         try:
             ecalc_model = Asset(
-                name=configuration.name,
+                path_id=PathID(configuration.name),
                 installations=[
                     self.__installation_mapper.from_yaml_to_domain(
                         installation, expression_evaluator=self.__expression_evaluator

--- a/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
@@ -31,7 +31,7 @@ class YamlValidator(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def name(self): ...
+    def name(self) -> str: ...
 
     @property
     @abc.abstractmethod

--- a/tests/libecalc/core/consumers/conftest.py
+++ b/tests/libecalc/core/consumers/conftest.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 import libecalc.common.energy_usage_type
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.process import dto
 from libecalc.domain.infrastructure.energy_components.electricity_consumer.electricity_consumer import (
     ElectricityConsumer,
@@ -59,7 +60,7 @@ def tabulated_fuel_consumer(fuel_gas) -> FuelConsumer:
         expression_evaluator=variables,
     )
     return FuelConsumer(
-        name="fuel_consumer",
+        path_id=PathID("fuel_consumer"),
         component_type=ComponentType.GENERIC,
         fuel=fuel_gas,
         energy_usage_model={Period(datetime(1900, 1, 1)): tabulated},
@@ -74,7 +75,7 @@ def direct_el_consumer():
     def _direct_el_consumer(variables: VariablesMap) -> ElectricityConsumer:
         regularity = Regularity.create(expression_evaluator=variables, expression_input=1)
         return ElectricityConsumer(
-            name="direct_consumer",
+            path_id=PathID("direct_consumer"),
             component_type=ComponentType.GENERIC,
             user_defined_category={Period(datetime(1900, 1, 1)): "FIXED-PRODUCTION-LOAD"},
             energy_usage_model={
@@ -133,7 +134,7 @@ def genset_2mw_dto(fuel_dto, direct_el_consumer, generator_set_sampled_model_2mw
     def _genset_2mw_dto(variables: VariablesMap) -> GeneratorSetEnergyComponent:
         regularity = Regularity.create(expression_evaluator=variables, expression_input=1)
         return GeneratorSetEnergyComponent(
-            name="genset",
+            path_id=PathID("genset"),
             user_defined_category={Period(datetime(1900, 1, 1)): "TURBINE-GENERATOR"},
             fuel={Period(datetime(1900, 1, 1)): fuel_dto},
             generator_set_model={
@@ -153,7 +154,7 @@ def genset_1000mw_late_startup_dto(fuel_dto, direct_el_consumer, generator_set_s
     def _genset_1000mw_late_startup_dto(variables: VariablesMap) -> GeneratorSetEnergyComponent:
         regularity = Regularity.create(expression_evaluator=variables, expression_input=1)
         return GeneratorSetEnergyComponent(
-            name="genset_late_startup",
+            path_id=PathID("genset_late_startup"),
             user_defined_category={Period(datetime(1900, 1, 1)): "TURBINE-GENERATOR"},
             fuel={Period(datetime(1900, 1, 1)): fuel_dto},
             generator_set_model={

--- a/tests/libecalc/core/consumers/test_genset.py
+++ b/tests/libecalc/core/consumers/test_genset.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 
 from libecalc.application.energy_calculator import EnergyCalculator
-from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.time_utils import Period
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import (
@@ -14,7 +13,7 @@ from libecalc.common.utils.rates import (
 )
 from libecalc.common.variables import VariablesMap
 from libecalc.core.result.results import GenericComponentResult
-from libecalc.domain.energy import ComponentEnergyContext
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_component import (
     GeneratorSetEnergyComponent,
 )
@@ -67,7 +66,7 @@ def test_genset_with_elconsumer_nan_results(genset_2mw_dto, fuel_dto):
     fuel_dict = {Period(datetime(2020, 1, 1), datetime(2026, 1, 1)): fuel_dto}
 
     genset = GeneratorSetEnergyComponent(
-        name=genset_2mw_dto.name,
+        path_id=PathID(genset_2mw_dto.name),
         user_defined_category=genset_2mw_dto.user_defined_category,
         generator_set_model=genset_2mw_dto.generator_set_model,
         regularity=genset_2mw_dto.regularity,
@@ -109,7 +108,7 @@ def test_genset_outside_capacity(genset_2mw_dto, fuel_dto):
     fuel_dict = {Period(datetime(2020, 1, 1), datetime(2026, 1, 1)): fuel_dto}
 
     genset = GeneratorSetEnergyComponent(
-        name=genset_2mw_dto.name,
+        path_id=PathID(genset_2mw_dto.name),
         user_defined_category=genset_2mw_dto.user_defined_category,
         expression_evaluator=variables,
         generator_set_model=genset_2mw_dto.generator_set_model,

--- a/tests/libecalc/domain/infrastructure/emitters/test_venting_emitter.py
+++ b/tests/libecalc/domain/infrastructure/emitters/test_venting_emitter.py
@@ -5,6 +5,7 @@ from libecalc.common.component_type import ComponentType
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import RateType
 from libecalc.common.variables import VariablesMap
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.infrastructure.emitters.venting_emitter import (
     VentingEmission,
     EmissionRate,
@@ -52,7 +53,7 @@ def test_direct_venting_emitter_with_condition():
         ),
     ]
     emitter = DirectVentingEmitter(
-        name="TestEmitter",
+        path_id=PathID("TestEmitter"),
         emitter_type=VentingType.DIRECT_EMISSION,
         expression_evaluator=expression_evaluator,
         component_type=ComponentType.VENTING_EMITTER,
@@ -94,7 +95,7 @@ def test_direct_venting_emitter_with_conditions():
         ),
     ]
     emitter = DirectVentingEmitter(
-        name="TestEmitter",
+        path_id=PathID("TestEmitter"),
         emitter_type=VentingType.DIRECT_EMISSION,
         expression_evaluator=expression_evaluator,
         component_type=ComponentType.VENTING_EMITTER,
@@ -132,7 +133,7 @@ def test_oil_venting_emitter_with_condition():
     regularity = Regularity.create(expression_evaluator=expression_evaluator)
 
     emitter = OilVentingEmitter(
-        name="TestOilEmitter",
+        path_id=PathID("TestOilEmitter"),
         emitter_type=VentingType.OIL_VOLUME,
         expression_evaluator=expression_evaluator,
         component_type=ComponentType.VENTING_EMITTER,
@@ -178,7 +179,7 @@ def test_oil_venting_emitter_with_conditions():
     regularity = Regularity.create(expression_evaluator=expression_evaluator)
 
     emitter = OilVentingEmitter(
-        name="TestOilEmitter",
+        path_id=PathID("TestOilEmitter"),
         emitter_type=VentingType.OIL_VOLUME,
         expression_evaluator=expression_evaluator,
         component_type=ComponentType.VENTING_EMITTER,

--- a/tests/libecalc/domain/infrastructure/test_path_id.py
+++ b/tests/libecalc/domain/infrastructure/test_path_id.py
@@ -1,0 +1,23 @@
+import uuid
+
+from libecalc.domain.infrastructure.path_id import PathID
+
+
+def test_unique_name_path_id():
+    path_id = PathID("some_name")
+    assert path_id.get_name() == "some_name"
+    assert isinstance(path_id.get_model_unique_id(), uuid.UUID)
+    assert path_id.get_parent() is None
+    assert path_id.get_unique_tuple_str() == ("some_name",)
+
+
+def test_path_id_is_reproducible():
+    parent_id = PathID("parent")
+
+    child_id = PathID("child", parent=parent_id)
+
+    assert child_id.get_parent() == parent_id
+
+    second_instance_child_id = PathID("child", parent_id)
+
+    assert second_instance_child_id.get_model_unique_id() == child_id.get_model_unique_id()

--- a/tests/libecalc/dto/test_electricity_consumer.py
+++ b/tests/libecalc/dto/test_electricity_consumer.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.process import dto
 from libecalc.common.variables import VariablesMap
 from libecalc.domain.infrastructure.energy_components.electricity_consumer.electricity_consumer import (
@@ -18,7 +19,7 @@ class TestElectricityConsumer:
     def test_invalid_energy_usage(self):
         with pytest.raises(ComponentValidationException) as e:
             ElectricityConsumer(
-                name="Test",
+                path_id=PathID("Test"),
                 component_type=ComponentType.GENERIC,
                 user_defined_category={Period(datetime(1900, 1, 1)): "MISCELLANEOUS"},
                 energy_usage_model={
@@ -34,7 +35,7 @@ class TestElectricityConsumer:
     def test_valid_electricity_consumer(self):
         # Should not raise ValidationError
         ElectricityConsumer(
-            name="Test",
+            path_id=PathID("Test"),
             component_type=ComponentType.GENERIC,
             user_defined_category={Period(datetime(1900, 1, 1)): "MISCELLANEOUS"},
             energy_usage_model={

--- a/tests/libecalc/dto/test_fuel_consumer.py
+++ b/tests/libecalc/dto/test_fuel_consumer.py
@@ -4,6 +4,7 @@ from io import StringIO
 import pytest
 
 import libecalc
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.regularity import Regularity
 from libecalc.dto.types import FuelTypeUserDefinedCategoryType
 from libecalc.domain.process import dto
@@ -103,7 +104,7 @@ class TestFuelConsumer:
             yaml_model_factory(resource_stream=asset_stream, resources={}, frequency=Frequency.YEAR).validate_for_run()
 
         assert (
-            "Validation error\n\n\tLocation: flare\n\tName: flare\n\t" "Message: Missing fuel for fuel consumer\n"
+            "Validation error\n\n\tLocation: flare\n\tName: flare\n\tMessage: Missing fuel for fuel consumer\n"
         ) in str(exc_info.value)
 
     def test_negative_fuel_rate_direct_fuel_consumer(self, test_fuel_consumer_helper):
@@ -117,7 +118,7 @@ class TestFuelConsumer:
         positive_fuel = Expression.setup_from_expression(value=1)
 
         consumer_results = FuelConsumer(
-            name="Test",
+            path_id=PathID("Test"),
             component_type=ComponentType.GENERIC,
             user_defined_category={periods.period: "MISCELLANEOUS"},
             energy_usage_model={

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -4,6 +4,7 @@ from typing import Union
 
 import pytest
 
+from libecalc.domain.infrastructure.path_id import PathID
 import libecalc.dto.fuel_type
 from libecalc.domain.process import dto
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_component import (
@@ -191,7 +192,7 @@ class TestGeneratorSet:
     def test_valid(self):
         expression_evaluator = VariablesMap(time_vector=[datetime(1900, 1, 1)])
         generator_set_dto = GeneratorSetEnergyComponent(
-            name="Test",
+            path_id=PathID("Test"),
             user_defined_category={Period(datetime(1900, 1, 1)): "MISCELLANEOUS"},
             generator_set_model={
                 Period(datetime(1900, 1, 1)): GeneratorSetProcessUnit(
@@ -237,7 +238,7 @@ class TestGeneratorSet:
         )
         expression_evaluator = VariablesMap(time_vector=[datetime(2000, 1, 1)])
         fuel_consumer = FuelConsumer(
-            name="test",
+            path_id=PathID("test"),
             fuel={Period(datetime(2000, 1, 1)): fuel},
             consumes=ConsumptionType.FUEL,
             component_type=ComponentType.GENERIC,
@@ -253,7 +254,7 @@ class TestGeneratorSet:
         )
         with pytest.raises(ComponentValidationException):
             GeneratorSetEnergyComponent(
-                name="Test",
+                path_id=PathID("Test"),
                 user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.MISCELLANEOUS},
                 generator_set_model={},
                 regularity={},

--- a/tests/libecalc/output/flow_diagram/conftest.py
+++ b/tests/libecalc/output/flow_diagram/conftest.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 import libecalc.common.energy_usage_type
+from libecalc.domain.infrastructure.path_id import PathID
 import libecalc.dto.fuel_type
 from libecalc.domain.hydrocarbon_export import HydrocarbonExport
 from libecalc.domain.regularity import Regularity
@@ -74,7 +75,7 @@ def fuel_type_fd() -> libecalc.dto.fuel_type.FuelType:
 @pytest.fixture
 def compressor_system_consumer_dto_fd(fuel_type_fd) -> FuelConsumer:
     return FuelConsumer(
-        name="Compressor system 1",
+        path_id=PathID("Compressor system 1"),
         component_type=ComponentType.COMPRESSOR_SYSTEM,
         user_defined_category={Period(datetime.datetime(1900, 1, 1), datetime.datetime(2021, 1, 1)): "COMPRESSOR"},
         fuel={Period(datetime.datetime(1900, 1, 1), datetime.datetime(2021, 1, 1)): fuel_type_fd},
@@ -160,7 +161,7 @@ def compressor_system_consumer_dto_fd(fuel_type_fd) -> FuelConsumer:
 @pytest.fixture
 def compressor_consumer_dto_fd(fuel_type_fd) -> FuelConsumer:
     return FuelConsumer(
-        name="Compressor 1",
+        path_id=PathID("Compressor 1"),
         component_type=ComponentType.GENERIC,
         user_defined_category={Period(datetime.datetime(1900, 1, 1), datetime.datetime(2021, 1, 1)): "COMPRESSOR"},
         fuel={Period(datetime.datetime(1900, 1, 1), datetime.datetime(2021, 1, 1)): fuel_type_fd},
@@ -184,10 +185,10 @@ def installation_with_dates_dto_fd(
     compressor_consumer_dto_fd: FuelConsumer,
 ) -> Asset:
     return Asset(
-        name="installation_with_dates",
+        path_id=PathID("installation_with_dates"),
         installations=[
             Installation(
-                name="Installation1",
+                path_id=PathID("Installation1"),
                 fuel_consumers=[compressor_system_consumer_dto_fd, compressor_consumer_dto_fd],
                 regularity=Regularity.create(
                     period=Period(datetime.datetime(1900, 1, 1), datetime.datetime(2021, 1, 1)),

--- a/tests/libecalc/presentation/json_result/test_aggregators.py
+++ b/tests/libecalc/presentation/json_result/test_aggregators.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pandas as pd
 
 import libecalc.common.energy_usage_type
+from libecalc.domain.infrastructure.path_id import PathID
 import libecalc.dto.fuel_type
 import libecalc.dto.types
 from libecalc.domain.hydrocarbon_export import HydrocarbonExport
@@ -44,7 +45,7 @@ def get_installation(
         components.Installation
     """
     inst = Installation(
-        name=name_inst,
+        path_id=PathID(name_inst),
         regularity=Regularity.create(expression_evaluator=variables),
         hydrocarbon_export=HydrocarbonExport.create(expression_evaluator=variables),
         fuel_consumers=[
@@ -94,7 +95,7 @@ def direct_fuel_consumer(
     """
 
     return FuelConsumer(
-        name=name,
+        path_id=PathID(name),
         component_type=ComponentType.GENERIC,
         fuel={Period(datetime(2024, 1, 1)): fuel(name=name_fuel, co2_factor=co2_factor)},
         regularity=Regularity.create(expression_input=1),
@@ -197,7 +198,7 @@ class TestAggregateEmissions:
         )
 
         asset = Asset(
-            name="Main asset",
+            path_id=PathID("Main asset"),
             installations=[inst_a, inst_b],
         )
 

--- a/tests/libecalc/presentation/yaml/test_venting_emitter.py
+++ b/tests/libecalc/presentation/yaml/test_venting_emitter.py
@@ -8,13 +8,14 @@ from libecalc.common.variables import VariablesMap
 from libecalc.core.result.emission import EmissionResult
 from libecalc.domain.infrastructure.emitters.venting_emitter import (
     DirectVentingEmitter,
-    OilVentingEmitter,
-    VentingVolume,
-    OilVolumeRate,
-    VentingVolumeEmission,
-    VentingEmission,
     EmissionRate,
+    OilVentingEmitter,
+    OilVolumeRate,
+    VentingEmission,
+    VentingVolume,
+    VentingVolumeEmission,
 )
+from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.regularity import Regularity
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.expression import Expression
@@ -33,13 +34,13 @@ from libecalc.presentation.yaml.yaml_types.yaml_stream_conditions import (
     YamlOilVolumeRate,
 )
 from libecalc.testing.yaml_builder import (
-    YamlVentingEmitterDirectTypeBuilder,
+    YamlEmissionRateBuilder,
     YamlInstallationBuilder,
+    YamlOilVolumeRateBuilder,
+    YamlVentingEmissionBuilder,
+    YamlVentingEmitterDirectTypeBuilder,
     YamlVentingEmitterOilTypeBuilder,
     YamlVentingVolumeBuilder,
-    YamlOilVolumeRateBuilder,
-    YamlEmissionRateBuilder,
-    YamlVentingEmissionBuilder,
 )
 
 
@@ -94,7 +95,7 @@ class TestVentingEmitter:
         )
 
         venting_emitter_dto = DirectVentingEmitter(
-            name=venting_emitter.name,
+            path_id=PathID(venting_emitter.name),
             expression_evaluator=variables,
             component_type=venting_emitter.component_type,
             user_defined_category=venting_emitter.user_defined_category,
@@ -158,7 +159,7 @@ class TestVentingEmitter:
         )
 
         venting_emitter_dto = OilVentingEmitter(
-            name=venting_emitter.name,
+            path_id=PathID(venting_emitter.name),
             expression_evaluator=variables,
             component_type=venting_emitter.component_type,
             user_defined_category=venting_emitter.user_defined_category,


### PR DESCRIPTION
Since we are going to separate energy from process into two separate
representations, we need to be able to connect components based on a
common id. PathID should be able to handle both components with unique
name and components that require a path to be unique.
