### PR TITLE
refactor: add evaluate method for stage given speed and target discha…

### DIFF
--- a/src/libecalc/domain/process/compressor/core/train/utils/common.py
+++ b/src/libecalc/domain/process/compressor/core/train/utils/common.py
@@ -4,6 +4,7 @@ from libecalc.domain.process.compressor.core.train.fluid import FluidStream
 from libecalc.domain.process.compressor.core.train.utils.enthalpy_calculations import calculate_outlet_pressure_campbell
 from libecalc.domain.process.compressor.core.train.utils.numeric_methods import DampState, adaptive_pressure_update
 
+EPSILON = 1e-5
 PRESSURE_CALCULATION_TOLERANCE = 1e-3
 POWER_CALCULATION_TOLERANCE = 1e-3
 RATE_CALCULATION_TOLERANCE = 1e-3

--- a/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft.py
+++ b/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft.py
@@ -17,6 +17,7 @@ from libecalc.domain.process.compressor.core.train.single_speed_compressor_train
 )
 from libecalc.domain.process.compressor.core.train.stage import CompressorTrainStage
 from libecalc.domain.process.compressor.core.train.utils.common import (
+    EPSILON,
     POWER_CALCULATION_TOLERANCE,
     PRESSURE_CALCULATION_TOLERANCE,
     RATE_CALCULATION_TOLERANCE,
@@ -34,8 +35,6 @@ from libecalc.domain.process.compressor.dto import (
     VariableSpeedCompressorTrain,
 )
 from libecalc.domain.process.core.results.compressor import TargetPressureStatus
-
-EPSILON = 1e-5
 
 
 class VariableSpeedCompressorTrainCommonShaft(CompressorTrainModel):

--- a/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -18,6 +18,7 @@ from libecalc.domain.process.compressor.core.train.stage import CompressorTrainS
 from libecalc.domain.process.compressor.core.train.types import (
     FluidStreamObjectForMultipleStreams,
 )
+from libecalc.domain.process.compressor.core.train.utils.common import EPSILON
 from libecalc.domain.process.compressor.core.train.utils.numeric_methods import (
     find_root,
     maximize_x_given_boolean_condition_function,
@@ -33,8 +34,6 @@ from libecalc.domain.process.compressor.dto import (
 from libecalc.domain.process.core.results.compressor import (
     TargetPressureStatus,
 )
-
-EPSILON = 1e-5
 
 
 class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(

--- a/tests/libecalc/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
@@ -6,7 +6,6 @@ from libecalc.domain.process.chart.chart_area_flag import ChartAreaFlag
 from libecalc.domain.process.compressor.core.train.fluid import FluidStream
 from libecalc.domain.process.compressor.core.train.single_speed_compressor_train_common_shaft import (
     SingleSpeedCompressorTrainCommonShaft,
-    calculate_single_speed_compressor_stage_given_target_discharge_pressure,
 )
 from libecalc.domain.process.compressor.core.train.stage import CompressorTrainStage
 from libecalc.domain.process.core.results.compressor import (
@@ -437,17 +436,16 @@ def test_calculate_single_speed_compressor_stage_given_target_discharge_pressure
     inlet_pressure_train_bara = 80.0
     mass_rate_kg_per_hour = 200000.0
     stage: CompressorTrainStage = single_speed_compressor_train_common_shaft_downstream_choking.stages[0]
-    inlet_stream_stage = single_speed_compressor_train_common_shaft_downstream_choking.fluid.get_fluid_streams(
-        pressure_bara=np.asarray([inlet_pressure_train_bara]),
-        temperature_kelvin=np.asarray([stage.inlet_temperature_kelvin]),
-    )[0]
+    inlet_stream_stage = single_speed_compressor_train_common_shaft_downstream_choking.fluid.get_fluid_stream(
+        pressure_bara=inlet_pressure_train_bara,
+        temperature_kelvin=stage.inlet_temperature_kelvin,
+    )
     target_outlet_pressure = 130
 
-    result = calculate_single_speed_compressor_stage_given_target_discharge_pressure(
+    result = stage.evaluate_given_speed_and_target_discharge_pressure(
         inlet_stream_stage=inlet_stream_stage,
-        outlet_pressure_stage_bara=target_outlet_pressure,
+        target_discharge_pressure=target_outlet_pressure,
         mass_rate_kg_per_hour=mass_rate_kg_per_hour,
-        stage=stage,
     )
     np.testing.assert_allclose(result.outlet_stream.pressure_bara, target_outlet_pressure, rtol=0.01)
 


### PR DESCRIPTION
…rge pressure

Today variable speed compressor trains use single speed compressor train at minimum speed for INDIVIDUAL_ASV_PRESSURE. This should allow for making a better method for variable speed compressor trains

## Why is this pull request needed?

Make a method on the CompressorStage class that can evaluate both single and variable speed compressor charts given a speed (for variable speed) and target discharge pressure. This method was "hidden" inside the single speed compressor train. It should now be possible to make a method of INDIVIDUAL_ASV_PRESSURE for variable speed compressor trains without going via a single speed compressor train.
