### PR TITLE
refactor generator set classes: move, rename and update inheritance

### DIFF
--- a/src/libecalc/domain/component_validation_error.py
+++ b/src/libecalc/domain/component_validation_error.py
@@ -116,6 +116,14 @@ class ProcessFluidModelValidationException(DomainValidationException):
     pass
 
 
+class GeneratorSetHeaderValidationException(DomainValidationException):
+    pass
+
+
+class GeneratorSetEqualLengthValidationException(DomainValidationException):
+    pass
+
+
 class ComponentDtoValidationError(Exception):
     def __init__(self, errors: list[ModelValidationError]):
         self.errors = errors

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/__init__.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/__init__.py
@@ -1,0 +1,1 @@
+from .generator_set_model import GeneratorSetModel

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_component.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_component.py
@@ -25,9 +25,9 @@ from libecalc.domain.infrastructure.energy_components.electricity_consumer.elect
 )
 from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consumer import FuelConsumer
 from libecalc.domain.infrastructure.energy_components.fuel_model.fuel_model import FuelModel
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.infrastructure.energy_components.utils import _convert_keys_in_dictionary_from_str_to_periods
 from libecalc.domain.infrastructure.path_id import PathID
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
 from libecalc.domain.regularity import Regularity
 from libecalc.dto.component_graph import ComponentGraph
 from libecalc.dto.fuel_type import FuelType
@@ -40,11 +40,18 @@ from libecalc.presentation.yaml.validation_errors import Location
 
 
 class GeneratorSetEnergyComponent(Emitter, EnergyComponent):
+    """
+    Represents a generator set as an energy component in the energy model.
+
+    Handles the evaluation of energy usage, emission calculations, and integration with the energy modeling framework.
+    Typically, uses a GeneratorSetModel to perform calculations for each timestep, and a FuelModel to evaluate emissions based on fuel usage.
+    """
+
     def __init__(
         self,
         path_id: PathID,
         user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
-        generator_set_model: dict[Period, GeneratorSetProcessUnit],
+        generator_set_model: dict[Period, GeneratorSetModel],
         regularity: Regularity,
         expression_evaluator: ExpressionEvaluator,
         consumers: list[ElectricityConsumer] = None,
@@ -230,13 +237,13 @@ class GeneratorSetEnergyComponent(Emitter, EnergyComponent):
 
     @staticmethod
     def _validate_genset_temporal_models(
-        generator_set_model: dict[Period, GeneratorSetProcessUnit], fuel: dict[Period, FuelType]
+        generator_set_model: dict[Period, GeneratorSetModel], fuel: dict[Period, FuelType]
     ):
         validate_temporal_model(generator_set_model)
         validate_temporal_model(fuel)
 
     @staticmethod
-    def check_generator_set_model(generator_set_model: dict[Period, GeneratorSetProcessUnit]):
+    def check_generator_set_model(generator_set_model: dict[Period, GeneratorSetModel]):
         if isinstance(generator_set_model, dict) and len(generator_set_model.values()) > 0:
             generator_set_model = _convert_keys_in_dictionary_from_str_to_periods(generator_set_model)
         return generator_set_model

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_model.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_model.py
@@ -6,11 +6,19 @@ from scipy.interpolate import interp1d
 from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.common.list.adjustment import transform_linear
 from libecalc.common.string.string_utils import generate_id
-from libecalc.domain.process.generator_set.generator_set_validator import GeneratorSetValidator
-from libecalc.domain.process.process_system import LiquidStream, ProcessUnit
+from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_validator import GeneratorSetValidator
 
 
-class GeneratorSetProcessUnit(ProcessUnit):
+class GeneratorSetModel:
+    """
+    Provides an interpolation-based mapping from electrical power output to fuel consumption for a generator set,
+    based on sampled data.
+
+    This class validates and stores sampled generator set data (power vs. fuel usage), applies optional linear
+    adjustments, and exposes methods to evaluate fuel usage and available capacity margin for a given power demand.
+    It does not model process streams, but focuses solely on the energy domain.
+    """
+
     typ: Literal[EnergyModelType.GENERATOR_SET_SAMPLED] = EnergyModelType.GENERATOR_SET_SAMPLED
 
     def __init__(
@@ -72,9 +80,6 @@ class GeneratorSetProcessUnit(ProcessUnit):
     def get_name(self) -> str:
         return self._name
 
-    def get_streams(self) -> list[LiquidStream]:
-        return []
-
     def evaluate_fuel_usage(self, power: float) -> float:
         """Return the fuel usage for a given power input."""
         return float(self._func(power)) if power > 0 else 0.0
@@ -84,7 +89,7 @@ class GeneratorSetProcessUnit(ProcessUnit):
         return float(self.max_capacity - power)
 
     def __eq__(self, other):
-        if not isinstance(other, GeneratorSetProcessUnit):
+        if not isinstance(other, GeneratorSetModel):
             return False
         return (
             self.typ == other.typ

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_model.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_model.py
@@ -86,13 +86,24 @@ class GeneratorSetModel:
         return float(self.max_capacity - power)
 
     def __eq__(self, other):
+        """
+        Compare two GeneratorSetModel instances for equality based on their unique identity (_id).
+
+        Args:
+            other: The object to compare with.
+
+        Returns:
+            True if both are GeneratorSetModel instances with the same _id, False otherwise.
+        """
         if not isinstance(other, GeneratorSetModel):
             return False
-        return (
-            self.typ == other.typ
-            and self.resource == other.resource
-            and self.get_name() == other.get_name()
-            and self.get_id() == other.get_id()
-            and self.energy_usage_adjustment_constant == other.energy_usage_adjustment_constant
-            and self.energy_usage_adjustment_factor == other.energy_usage_adjustment_factor
-        )
+        return self.get_id() == other.get_id()
+
+    def __hash__(self):
+        """
+        Return the hash based on the unique identity (_id) of the GeneratorSetModel.
+
+        Returns:
+            An integer hash value.
+        """
+        return hash(self.get_id())

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_model.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_model.py
@@ -7,6 +7,7 @@ from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.common.list.adjustment import transform_linear
 from libecalc.common.string.string_utils import generate_id
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_validator import GeneratorSetValidator
+from libecalc.domain.resource import Resource
 
 
 class GeneratorSetModel:
@@ -24,18 +25,16 @@ class GeneratorSetModel:
     def __init__(
         self,
         name: str,
-        headers: list[str],
-        data: list[list[float]],
+        resource: Resource,
         energy_usage_adjustment_constant: float,
         energy_usage_adjustment_factor: float,
     ):
         self._name = name
         self._id = generate_id(self._name)
-        self.headers = headers
-        self.data = data
+        self.resource = resource
         self.energy_usage_adjustment_constant = energy_usage_adjustment_constant
         self.energy_usage_adjustment_factor = energy_usage_adjustment_factor
-        self.validator = GeneratorSetValidator(headers, data, self.typ.value)
+        self.validator = GeneratorSetValidator(resource=self.resource, typ=self.typ.value)
         self.validator.validate()
 
         # Initialize the generator model
@@ -55,13 +54,11 @@ class GeneratorSetModel:
 
     @property
     def electricity2fuel_fuel_axis(self) -> list[float]:
-        fuel_index = self.headers.index("FUEL")
-        return [row[fuel_index] for row in zip(*self.data)]
+        return [float(x) for x in self.resource.get_column("FUEL")]
 
     @property
     def electricity2fuel_power_axis(self) -> list[float]:
-        power_index = self.headers.index("POWER")
-        return [row[power_index] for row in zip(*self.data)]
+        return [float(x) for x in self.resource.get_column("POWER")]
 
     @property
     def max_capacity(self) -> float:
@@ -93,8 +90,7 @@ class GeneratorSetModel:
             return False
         return (
             self.typ == other.typ
-            and self.headers == other.headers
-            and self.data == other.data
+            and self.resource == other.resource
             and self.get_name() == other.get_name()
             and self.get_id() == other.get_id()
             and self.energy_usage_adjustment_constant == other.energy_usage_adjustment_constant

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_validator.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_validator.py
@@ -1,9 +1,10 @@
 from libecalc.common.errors.exceptions import InvalidColumnException
 from libecalc.domain.component_validation_error import (
+    GeneratorSetEqualLengthValidationException,
+    GeneratorSetHeaderValidationException,
     ModelValidationError,
-    ProcessEqualLengthValidationException,
-    ProcessHeaderValidationException,
 )
+from libecalc.domain.resource import Resource
 from libecalc.presentation.yaml.validation_errors import Location
 
 
@@ -14,9 +15,9 @@ class GeneratorSetValidator:
     Raises detailed exceptions for invalid input to support robust data ingestion.
     """
 
-    def __init__(self, headers: list[str], data: list[list[float]], typ: str):
-        self.headers = headers
-        self.data = data
+    def __init__(self, resource: Resource, typ: str):
+        self.headers = resource.get_headers()
+        self.data = [resource.get_column(header) for header in self.headers]
         self.typ = typ
 
     def validate(self):
@@ -28,7 +29,7 @@ class GeneratorSetValidator:
         if not is_valid_headers:
             msg = "Sampled generator set data should have a 'FUEL' and 'POWER' header"
 
-            raise ProcessHeaderValidationException(
+            raise GeneratorSetHeaderValidationException(
                 errors=[ModelValidationError(name=self.typ, location=Location([self.typ]), message=str(msg))],
             )
 
@@ -36,7 +37,7 @@ class GeneratorSetValidator:
         # Ensure data is column-wise.
         # Check if the number of data columns matches the number of headers.
         if len(self.data) != len(self.headers):
-            raise ProcessEqualLengthValidationException(
+            raise GeneratorSetEqualLengthValidationException(
                 errors=[
                     ModelValidationError(
                         name=self.typ,
@@ -52,7 +53,7 @@ class GeneratorSetValidator:
             problematic_vectors = [(i, len(lst)) for i, lst in enumerate(self.data)]
             msg = f"Sampled generator set data should have equal number of datapoints for FUEL and POWER. Found lengths: {problematic_vectors}"
 
-            raise ProcessEqualLengthValidationException(
+            raise GeneratorSetEqualLengthValidationException(
                 errors=[ModelValidationError(name=self.typ, location=Location([self.typ]), message=str(msg))],
             )
 

--- a/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_validator.py
+++ b/src/libecalc/domain/infrastructure/energy_components/generator_set/generator_set_validator.py
@@ -8,6 +8,12 @@ from libecalc.presentation.yaml.validation_errors import Location
 
 
 class GeneratorSetValidator:
+    """
+    Validates the structure and content of sampled generator set data.
+    Ensures that headers and data columns are correct, numeric, and consistent.
+    Raises detailed exceptions for invalid input to support robust data ingestion.
+    """
+
     def __init__(self, headers: list[str], data: list[list[float]], typ: str):
         self.headers = headers
         self.data = data

--- a/src/libecalc/domain/process/generator_set/__init__.py
+++ b/src/libecalc/domain/process/generator_set/__init__.py
@@ -1,1 +1,0 @@
-from .generator_set_process_unit import GeneratorSetProcessUnit

--- a/src/libecalc/fixtures/cases/consumer_with_time_slots_models.py
+++ b/src/libecalc/fixtures/cases/consumer_with_time_slots_models.py
@@ -15,6 +15,7 @@ from libecalc.domain.infrastructure.energy_components.electricity_consumer.elect
     ElectricityConsumer,
 )
 from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consumer import FuelConsumer
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_component import (
     GeneratorSetEnergyComponent,
 )
@@ -36,7 +37,6 @@ from libecalc.domain.process.dto.consumer_system import (
     CompressorSystemConsumerFunction,
     CompressorSystemOperationalSetting,
 )
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
 from libecalc.domain.regularity import Regularity
 from libecalc.dto.types import ConsumerUserDefinedCategoryType, InstallationUserDefinedCategoryType
 from libecalc.expression import Expression
@@ -50,8 +50,8 @@ def direct_consumer(power: float) -> DirectConsumerFunction:
     )
 
 
-def generator_set_sampled_300mw() -> GeneratorSetProcessUnit:
-    return GeneratorSetProcessUnit(
+def generator_set_sampled_300mw() -> GeneratorSetModel:
+    return GeneratorSetModel(
         name="generator_set_sampled_300mw",
         headers=["POWER", "FUEL"],
         data=[[0, 1, 300], [0, 1, 300]],

--- a/src/libecalc/fixtures/cases/consumer_with_time_slots_models.py
+++ b/src/libecalc/fixtures/cases/consumer_with_time_slots_models.py
@@ -41,6 +41,7 @@ from libecalc.domain.regularity import Regularity
 from libecalc.dto.types import ConsumerUserDefinedCategoryType, InstallationUserDefinedCategoryType
 from libecalc.expression import Expression
 from libecalc.fixtures.case_types import DTOCase
+from libecalc.presentation.yaml.yaml_entities import MemoryResource
 
 
 def direct_consumer(power: float) -> DirectConsumerFunction:
@@ -51,10 +52,13 @@ def direct_consumer(power: float) -> DirectConsumerFunction:
 
 
 def generator_set_sampled_300mw() -> GeneratorSetModel:
-    return GeneratorSetModel(
-        name="generator_set_sampled_300mw",
+    resource = MemoryResource(
         headers=["POWER", "FUEL"],
         data=[[0, 1, 300], [0, 1, 300]],
+    )
+    return GeneratorSetModel(
+        name="generator_set_sampled_300mw",
+        resource=resource,
         energy_usage_adjustment_constant=0.0,
         energy_usage_adjustment_factor=1.0,
     )

--- a/src/libecalc/presentation/yaml/domain/reference_service.py
+++ b/src/libecalc/presentation/yaml/domain/reference_service.py
@@ -1,9 +1,9 @@
 from collections.abc import Iterable
 from typing import Protocol
 
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.process.compressor.dto.model_types import CompressorModelTypes
 from libecalc.domain.process.dto import TabulatedData
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
 from libecalc.domain.process.pump.pump import PumpModelDTO
 from libecalc.dto import FuelType
 
@@ -20,7 +20,7 @@ class InvalidReferenceException(Exception):
 class ReferenceService(Protocol):
     def get_fuel_reference(self, reference: str) -> FuelType: ...
 
-    def get_generator_set_model(self, reference: str) -> GeneratorSetProcessUnit: ...
+    def get_generator_set_model(self, reference: str) -> GeneratorSetModel: ...
 
     def get_compressor_model(self, reference: str) -> CompressorModelTypes: ...
 

--- a/src/libecalc/presentation/yaml/mappers/energy_model_factory.py
+++ b/src/libecalc/presentation/yaml/mappers/energy_model_factory.py
@@ -1,11 +1,11 @@
 from typing import Union
 
 from libecalc.common.energy_model_type import EnergyModelType
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.process.compressor.dto import CompressorSampled as CompressorTrainSampledDTO
 from libecalc.domain.process.dto import TabulatedData
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
 
-EnergyModelUnionType = Union[GeneratorSetProcessUnit, TabulatedData, CompressorTrainSampledDTO]
+EnergyModelUnionType = Union[GeneratorSetModel, TabulatedData, CompressorTrainSampledDTO]
 
 
 class EnergyModelFactory:
@@ -26,7 +26,7 @@ class EnergyModelFactory:
         if typ == EnergyModelType.GENERATOR_SET_SAMPLED:
             # Ensure 'name' is present in model_data, with a default value if missing
             model_data.setdefault("name", "generator_set_sampled_default_name")
-            return GeneratorSetProcessUnit(**model_data)
+            return GeneratorSetModel(**model_data)
         elif typ == EnergyModelType.TABULATED:
             return TabulatedData(**model_data)
         elif typ == EnergyModelType.COMPRESSOR_SAMPLED:

--- a/src/libecalc/presentation/yaml/mappers/facility_input.py
+++ b/src/libecalc/presentation/yaml/mappers/facility_input.py
@@ -7,9 +7,9 @@ from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.errors.exceptions import InvalidResourceException
 from libecalc.common.serializable_chart import ChartCurveDTO, SingleSpeedChartDTO, VariableSpeedChartDTO
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.process.compressor.dto import CompressorSampled as CompressorTrainSampledDTO
 from libecalc.domain.process.dto import EnergyModel, TabulatedData
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
 from libecalc.domain.process.pump.pump import PumpModelDTO
 from libecalc.domain.resource import Resource, Resources
 from libecalc.presentation.yaml.mappers.energy_model_factory import EnergyModelFactory
@@ -39,7 +39,7 @@ from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model im
 )
 
 # Used here to make pydantic understand which object to instantiate.
-EnergyModelUnionType = Union[GeneratorSetProcessUnit, TabulatedData, CompressorTrainSampledDTO]
+EnergyModelUnionType = Union[GeneratorSetModel, TabulatedData, CompressorTrainSampledDTO]
 
 energy_model_type_map = {
     EcalcYamlKeywords.facility_type_electricity2fuel: EnergyModelType.GENERATOR_SET_SAMPLED,
@@ -175,7 +175,7 @@ def _create_pump_chart_variable_speed_dto_model_data(
 
 def _create_generator_set_dto_model_data(
     resource: Resource, facility_data: YamlGeneratorSetModel, **kwargs
-) -> GeneratorSetProcessUnit:
+) -> GeneratorSetModel:
     # Extract headers and data from the resource
     headers = resource.get_headers()
     data = [resource.get_column(header) for header in headers]
@@ -188,7 +188,7 @@ def _create_generator_set_dto_model_data(
     name = getattr(facility_data, "name", "default_generator_set_name")
 
     # Create and return the GeneratorSetProcessUnit instance
-    return GeneratorSetProcessUnit(
+    return GeneratorSetModel(
         name=name,
         headers=headers,
         data=data,

--- a/src/libecalc/presentation/yaml/mappers/facility_input.py
+++ b/src/libecalc/presentation/yaml/mappers/facility_input.py
@@ -176,10 +176,6 @@ def _create_pump_chart_variable_speed_dto_model_data(
 def _create_generator_set_dto_model_data(
     resource: Resource, facility_data: YamlGeneratorSetModel, **kwargs
 ) -> GeneratorSetModel:
-    # Extract headers and data from the resource
-    headers = resource.get_headers()
-    data = [resource.get_column(header) for header in headers]
-
     # Extract adjustment constants from facility data
     adjustment_constant = _get_adjustment_constant(facility_data)
     adjustment_factor = _get_adjustment_factor(facility_data)
@@ -190,8 +186,7 @@ def _create_generator_set_dto_model_data(
     # Create and return the GeneratorSetProcessUnit instance
     return GeneratorSetModel(
         name=name,
-        headers=headers,
-        data=data,
+        resource=resource,
         energy_usage_adjustment_constant=adjustment_constant,
         energy_usage_adjustment_factor=adjustment_factor,
     )

--- a/src/libecalc/presentation/yaml/yaml_entities.py
+++ b/src/libecalc/presentation/yaml/yaml_entities.py
@@ -15,10 +15,10 @@ from libecalc.common.errors.exceptions import (
     InvalidHeaderException,
     InvalidResourceException,
 )
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.process.compressor.dto.model_types import CompressorModelTypes
 from libecalc.domain.process.dto.base import EnergyModel
 from libecalc.domain.process.dto.tabulated import TabulatedData
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
 from libecalc.domain.process.pump.pump import PumpModelDTO
 from libecalc.domain.resource import Resource
 from libecalc.dto import FuelType
@@ -185,9 +185,9 @@ class References(ReferenceService):
             # TypeError: fuel_types is None
             raise InvalidReferenceException(reference_type_name, reference, self.models.keys()) from e
 
-    def get_generator_set_model(self, reference: str) -> GeneratorSetProcessUnit:
+    def get_generator_set_model(self, reference: str) -> GeneratorSetModel:
         model = self._get_model_reference(reference, "generator set model")
-        if not isinstance(model, GeneratorSetProcessUnit):
+        if not isinstance(model, GeneratorSetModel):
             raise InvalidReferenceException("generator set model", reference)
         return model
 

--- a/tests/libecalc/core/consumers/conftest.py
+++ b/tests/libecalc/core/consumers/conftest.py
@@ -19,6 +19,7 @@ from libecalc.common.utils.rates import RateType
 from libecalc.common.variables import VariablesMap
 from libecalc.domain.regularity import Regularity
 from libecalc.expression import Expression
+from libecalc.presentation.yaml.yaml_entities import MemoryResource
 
 
 @pytest.fixture
@@ -109,10 +110,13 @@ def direct_el_consumer():
 
 @pytest.fixture
 def generator_set_sampled_model_2mw() -> GeneratorSetModel:
-    return GeneratorSetModel(
-        name="generator_set_sampled_model_2mw",
+    resource = MemoryResource(
         headers=["POWER", "FUEL"],
         data=[[0, 0.5, 1, 2], [0, 0.6, 1, 2]],
+    )
+    return GeneratorSetModel(
+        name="generator_set_sampled_model_2mw",
+        resource=resource,
         energy_usage_adjustment_constant=0.0,
         energy_usage_adjustment_factor=1.0,
     )
@@ -120,10 +124,13 @@ def generator_set_sampled_model_2mw() -> GeneratorSetModel:
 
 @pytest.fixture
 def generator_set_sampled_model_1000mw() -> GeneratorSetModel:
-    return GeneratorSetModel(
-        name="generator_set_sampled_model_1000mw",
+    resource = MemoryResource(
         headers=["POWER", "FUEL"],
         data=[[0, 0.1, 1, 1000], [0, 0.1, 1, 1000]],
+    )
+    return GeneratorSetModel(
+        name="generator_set_sampled_model_1000mw",
+        resource=resource,
         energy_usage_adjustment_constant=0.0,
         energy_usage_adjustment_factor=1.0,
     )

--- a/tests/libecalc/core/consumers/conftest.py
+++ b/tests/libecalc/core/consumers/conftest.py
@@ -8,7 +8,7 @@ from libecalc.domain.process import dto
 from libecalc.domain.infrastructure.energy_components.electricity_consumer.electricity_consumer import (
     ElectricityConsumer,
 )
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consumer import FuelConsumer
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_component import (
     GeneratorSetEnergyComponent,
@@ -108,8 +108,8 @@ def direct_el_consumer():
 
 
 @pytest.fixture
-def generator_set_sampled_model_2mw() -> GeneratorSetProcessUnit:
-    return GeneratorSetProcessUnit(
+def generator_set_sampled_model_2mw() -> GeneratorSetModel:
+    return GeneratorSetModel(
         name="generator_set_sampled_model_2mw",
         headers=["POWER", "FUEL"],
         data=[[0, 0.5, 1, 2], [0, 0.6, 1, 2]],
@@ -119,8 +119,8 @@ def generator_set_sampled_model_2mw() -> GeneratorSetProcessUnit:
 
 
 @pytest.fixture
-def generator_set_sampled_model_1000mw() -> GeneratorSetProcessUnit:
-    return GeneratorSetProcessUnit(
+def generator_set_sampled_model_1000mw() -> GeneratorSetModel:
+    return GeneratorSetModel(
         name="generator_set_sampled_model_1000mw",
         headers=["POWER", "FUEL"],
         data=[[0, 0.1, 1, 1000], [0, 0.1, 1, 1000]],

--- a/tests/libecalc/core/models/test_generator_model.py
+++ b/tests/libecalc/core/models/test_generator_model.py
@@ -2,33 +2,22 @@ import numpy as np
 import pandas as pd
 
 from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
+from libecalc.presentation.yaml.yaml_entities import MemoryResource
 
 
 class TestGeneratorModelSampled:
     def test_evaluate(self):
-        df = pd.DataFrame(
-            [
-                [0, 0],
-                [0.1, 50400],
-                [5, 50400],
-                [10, 76320],
-                [15, 99888],
-                [20, 123480],
-                [21, 129000],
-                [21.5, 160080],
-                [25, 176640],
-                [30, 199800],
+        resource = MemoryResource(
+            headers=["POWER", "FUEL"],
+            data=[
+                [0, 0.1, 5, 10, 15, 20, 21, 21.5, 25, 30],
+                [0, 50400, 50400, 76320, 99888, 123480, 129000, 160080, 176640, 199800],
             ],
-            columns=["POWER", "FUEL"],
         )
-
-        headers = df.columns.tolist()
-        data = [list(row) for row in zip(*df.values.tolist())]
 
         el2fuel = GeneratorSetModel(
             name="el2fuel",
-            headers=headers,
-            data=data,
+            resource=resource,
             energy_usage_adjustment_factor=1,
             energy_usage_adjustment_constant=0,
         )
@@ -41,19 +30,14 @@ class TestGeneratorModelSampled:
 
     def test_capacity_margin(self):
         # Testing the capacity factor when using sampled genset.
-        df = pd.DataFrame(
-            {
-                "POWER": [1, 2, 3],
-                "FUEL": [1, 2, 3],
-            }
+        resource = MemoryResource(
+            headers=["POWER", "FUEL"],
+            data=[[1, 2, 3], [1, 2, 3]],
         )
-        headers = df.columns.tolist()
-        data = [list(row) for row in zip(*df.values.tolist())]
 
         el2fuel_function = GeneratorSetModel(
             name="el2fuel",
-            headers=headers,
-            data=data,
+            resource=resource,
             energy_usage_adjustment_factor=1,
             energy_usage_adjustment_constant=0,
         )
@@ -64,28 +48,23 @@ class TestGeneratorModelSampled:
     def test_energy_adjustment(self):
         # Testing adjustment of energy usage according to factor and constant specified in facility input.
 
-        df = pd.DataFrame(
-            {
-                "POWER": [1, 2, 3],
-                "FUEL": [1, 2, 3],
-            }
+        resource = MemoryResource(
+            headers=["POWER", "FUEL"],
+            data=[[1, 2, 3], [1, 2, 3]],
         )
-        headers = df.columns.tolist()
-        data = [list(row) for row in zip(*df.values.tolist())]
 
         adjustment_factor = 1.5
         adjustment_constant = 0.5
 
         el2fuel = GeneratorSetModel(
             name="el2fuel",
-            headers=headers,
-            data=data,
+            resource=resource,
             energy_usage_adjustment_factor=adjustment_factor,
             energy_usage_adjustment_constant=adjustment_constant,
         )
 
-        fuel_values = df["FUEL"].tolist()
-        power_values = df["POWER"].tolist()
+        fuel_values = resource.get_column("FUEL")
+        power_values = resource.get_column("POWER")
 
         expected_adjusted_fuel = list(np.array(fuel_values) * adjustment_factor + adjustment_constant)
         result = np.array([el2fuel.evaluate_fuel_usage(value) for value in np.asarray(power_values)])

--- a/tests/libecalc/core/models/test_generator_model.py
+++ b/tests/libecalc/core/models/test_generator_model.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 
 
 class TestGeneratorModelSampled:
@@ -25,7 +25,7 @@ class TestGeneratorModelSampled:
         headers = df.columns.tolist()
         data = [list(row) for row in zip(*df.values.tolist())]
 
-        el2fuel = GeneratorSetProcessUnit(
+        el2fuel = GeneratorSetModel(
             name="el2fuel",
             headers=headers,
             data=data,
@@ -50,7 +50,7 @@ class TestGeneratorModelSampled:
         headers = df.columns.tolist()
         data = [list(row) for row in zip(*df.values.tolist())]
 
-        el2fuel_function = GeneratorSetProcessUnit(
+        el2fuel_function = GeneratorSetModel(
             name="el2fuel",
             headers=headers,
             data=data,
@@ -76,7 +76,7 @@ class TestGeneratorModelSampled:
         adjustment_factor = 1.5
         adjustment_constant = 0.5
 
-        el2fuel = GeneratorSetProcessUnit(
+        el2fuel = GeneratorSetModel(
             name="el2fuel",
             headers=headers,
             data=data,

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -12,7 +12,7 @@ from libecalc.domain.infrastructure.energy_components.generator_set.generator_se
 )
 from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consumer import FuelConsumer
 from libecalc.domain.component_validation_error import ComponentValidationException, ProcessHeaderValidationException
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.common.component_type import ComponentType
 from libecalc.common.consumption_type import ConsumptionType
 from libecalc.common.energy_model_type import EnergyModelType
@@ -35,7 +35,7 @@ from libecalc.testing.yaml_builder import (
 
 class TestGeneratorSetSampled:
     def test_valid(self):
-        generator_set_sampled = GeneratorSetProcessUnit(
+        generator_set_sampled = GeneratorSetModel(
             name="generator_set_sampled",
             headers=["FUEL", "POWER"],
             data=[
@@ -54,7 +54,7 @@ class TestGeneratorSetSampled:
 
     def test_invalid_headers(self):
         with pytest.raises(ProcessHeaderValidationException) as exc_info:
-            GeneratorSetProcessUnit(
+            GeneratorSetModel(
                 name="generator_set_sampled",
                 headers=["FUEL", "POWAH"],
                 data=[
@@ -195,7 +195,7 @@ class TestGeneratorSet:
             path_id=PathID("Test"),
             user_defined_category={Period(datetime(1900, 1, 1)): "MISCELLANEOUS"},
             generator_set_model={
-                Period(datetime(1900, 1, 1)): GeneratorSetProcessUnit(
+                Period(datetime(1900, 1, 1)): GeneratorSetModel(
                     name="generator_set_sampled",
                     headers=["FUEL", "POWER"],
                     data=[
@@ -218,7 +218,7 @@ class TestGeneratorSet:
             expression_evaluator=expression_evaluator,
         )
         assert generator_set_dto.generator_set_model == {
-            Period(datetime(1900, 1, 1)): GeneratorSetProcessUnit(
+            Period(datetime(1900, 1, 1)): GeneratorSetModel(
                 name="generator_set_sampled",
                 headers=["FUEL", "POWER"],
                 data=[

--- a/tests/libecalc/input/mappers/test_facility_input.py
+++ b/tests/libecalc/input/mappers/test_facility_input.py
@@ -19,5 +19,11 @@ class TestFacilityInputMapper:
 
         assert isinstance(generator_set_sampled, GeneratorSetModel)
         assert generator_set_sampled.typ == EnergyModelType.GENERATOR_SET_SAMPLED
-        assert generator_set_sampled.headers == ["POWER", "FUEL"]
-        assert generator_set_sampled.data == [[0, 0.4, 1], [0, 0.7, 1]]
+        assert generator_set_sampled.resource.get_headers() == ["POWER", "FUEL"]
+        assert [
+            generator_set_sampled.resource.get_column("POWER"),
+            generator_set_sampled.resource.get_column("FUEL"),
+        ] == [
+            [0, 0.4, 1],
+            [0, 0.7, 1],
+        ]

--- a/tests/libecalc/input/mappers/test_facility_input.py
+++ b/tests/libecalc/input/mappers/test_facility_input.py
@@ -2,7 +2,7 @@ from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.presentation.yaml.mappers.facility_input import FacilityInputMapper
 from libecalc.presentation.yaml.yaml_entities import MemoryResource
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import YamlGeneratorSetModel
-from libecalc.domain.process.generator_set import GeneratorSetProcessUnit
+from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 
 
 class TestFacilityInputMapper:
@@ -17,7 +17,7 @@ class TestFacilityInputMapper:
             )
         )
 
-        assert isinstance(generator_set_sampled, GeneratorSetProcessUnit)
+        assert isinstance(generator_set_sampled, GeneratorSetModel)
         assert generator_set_sampled.typ == EnergyModelType.GENERATOR_SET_SAMPLED
         assert generator_set_sampled.headers == ["POWER", "FUEL"]
         assert generator_set_sampled.data == [[0, 0.4, 1], [0, 0.7, 1]]


### PR DESCRIPTION
## Why is this pull request needed?

This PR refactors the generator set-related classes to improve code organization and clarity

## What does this pull request change?

- **Moved** `GeneratorSetProcessUnit` and `GeneratorSetValidator` from domain.process.generator_set to domain.infrastructure.energy_components.generator_set to better reflect their domain and usage.
- **Renamed** `GeneratorSetProcessUnit` to `GeneratorSetModel` for a more accurate and descriptive class name.
- **Removed inheritance** from `ProcessUnit` in the new `GeneratorSetModel`, as it doesn´t handle streams but is mainly relevant in the energy domain.
- Updated imports and references throughout the codebase to reflect these changes.

No functional changes to the generator set logic are introduced.