### PR TITLE
Feat/add process units

### DIFF
--- a/src/libecalc/domain/common/__init__.py
+++ b/src/libecalc/domain/common/__init__.py
@@ -1,0 +1,3 @@
+from libecalc.domain.common.entity_id import ID, SimpleEntityID
+
+__all__ = ["ID", "SimpleEntityID"]

--- a/src/libecalc/domain/common/entity_id.py
+++ b/src/libecalc/domain/common/entity_id.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import uuid
+from typing import Protocol
+from uuid import UUID
+
+
+class ID(Protocol):
+    """Minimal interface for any entity identifier in the domain layer."""
+
+    def get_name(self) -> str:
+        """Get the human-readable name."""
+        ...
+
+    def get_uuid(self) -> UUID:
+        """Get the unique identifier."""
+        ...
+
+
+class SimpleEntityID:
+    """Simple entity ID implementation for standalone use cases and tests."""
+
+    def __init__(self, name: str):
+        self._name = name
+        self._uuid = uuid.uuid4()
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_uuid(self) -> UUID:
+        return self._uuid
+
+    def __str__(self) -> str:
+        return self._name
+
+    def __repr__(self) -> str:
+        return f"SimpleEntityID(name='{self._name}', uuid='{self._uuid}')"

--- a/src/libecalc/domain/infrastructure/path_id.py
+++ b/src/libecalc/domain/infrastructure/path_id.py
@@ -39,7 +39,7 @@ class PathID:
     def get_parent(self) -> PathID | None:
         return self._parent
 
-    def get_model_unique_id(self) -> uuid.UUID:
+    def get_uuid(self) -> uuid.UUID:
         return _generate_uuid(*self.get_unique_tuple_str())
 
     def has_unique_name(self) -> bool:

--- a/src/libecalc/domain/process/entities/base.py
+++ b/src/libecalc/domain/process/entities/base.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+from libecalc.domain.common.entity_id import ID
+
+ID_T = TypeVar("ID_T", bound=ID)
+
+
+class Entity(Generic[ID_T]):
+    """DDD entity base identity only, no behaviour assumptions."""
+
+    def __init__(self, entity_id: ID_T) -> None:
+        self._id = entity_id
+
+    def get_id(self) -> ID_T:
+        return self._id
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Entity) and self.get_id().get_uuid() == other.get_id().get_uuid()
+
+    def __hash__(self) -> int:
+        return hash(self.get_id().get_uuid())

--- a/src/libecalc/domain/process/entities/process_units/__init__.py
+++ b/src/libecalc/domain/process/entities/process_units/__init__.py
@@ -1,0 +1,14 @@
+from libecalc.domain.process.entities.base import Entity
+from libecalc.domain.process.entities.process_units.choke_valve import ChokeValve
+from libecalc.domain.process.entities.process_units.port_names import MixerIO, SeparatorIO, SingleIO, SplitterIO
+from libecalc.domain.process.entities.process_units.protocols import ProcessUnit
+
+__all__ = [
+    "ChokeValve",
+    "SingleIO",
+    "MixerIO",
+    "SplitterIO",
+    "SeparatorIO",
+    "ProcessUnit",
+    "Entity",
+]

--- a/src/libecalc/domain/process/entities/process_units/choke_valve/__init__.py
+++ b/src/libecalc/domain/process/entities/process_units/choke_valve/__init__.py
@@ -1,0 +1,5 @@
+from libecalc.domain.process.entities.process_units.choke_valve.choke_valve import ChokeValve
+
+__all__ = [
+    "ChokeValve",
+]

--- a/src/libecalc/domain/process/entities/process_units/choke_valve/choke_valve.py
+++ b/src/libecalc/domain/process/entities/process_units/choke_valve/choke_valve.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from types import MappingProxyType
+
+from libecalc.domain.common import ID
+from libecalc.domain.process.entities.base import Entity
+from libecalc.domain.process.entities.process_units.choke_valve.exceptions import (
+    ChokeValveNotCalculatedException,
+    InvalidPressureDropException,
+    NegativePressureDropException,
+)
+from libecalc.domain.process.entities.process_units.exceptions import NoInletStreamException
+from libecalc.domain.process.entities.process_units.port_names import PortName, SingleIO
+from libecalc.domain.process.entities.process_units.protocols import ProcessUnit
+from libecalc.domain.process.value_objects.fluid_stream.fluid_stream import FluidStream
+
+logger = logging.getLogger(__name__)
+
+
+class ChokeValve(Entity[ID], ProcessUnit):
+    """
+    Choke valve process unit that creates pressure drop.
+
+    Simulates isenthalpic throttling process where:
+    - Outlet pressure = inlet pressure - delta_P_bar
+    - Enthalpy remains constant (isenthalpic process Δh = 0)
+    - Temperature may change due to:
+      - Joule-Thomson effect (real-gas non-ideality)
+      - Phase transitions triggered by the lower pressure
+    Choked flow is handled by ensuring that the outlet pressure does not drop below pressure corresponding to critical pressure ratio.
+    Note: this is a simplified choke flow handling that assumes pure phase ideal gas.
+
+    Attributes:
+        entity_id: Unique identifier for this choke valve
+        delta_p_bar: Pressure drop across valve [bar]
+    """
+
+    def __init__(self, entity_id: ID, delta_p_bar: float = 0.0) -> None:
+        """Initialize choke valve with pressure drop.
+
+        Args:
+            entity_id: Unique identifier for this choke valve
+            delta_p_bar: Pressure drop across valve [bar], defaults to 0.0
+
+        Raises:
+            NegativePressureDropException: If delta_p_bar is negative
+        """
+        super().__init__(entity_id)
+        # Initialize ports and calculation state
+        self._inlet_ports: dict[PortName, FluidStream | None] = {SingleIO.INLET: None}
+        self._outlet_ports: dict[PortName, FluidStream | None] = {SingleIO.OUTLET: None}
+        self._calculated = False
+        self._delta_p_bar = 0.0  # Default value
+        self.delta_p_bar = delta_p_bar
+
+    @property
+    def delta_p_bar(self) -> float:
+        """Get the pressure drop across the valve [bar]."""
+        return self._delta_p_bar
+
+    @delta_p_bar.setter
+    def delta_p_bar(self, value: float) -> None:
+        """Set the pressure drop across the valve [bar].
+
+        Args:
+            value: The new pressure drop value in bar.
+
+        Raises:
+            NegativePressureDropException: If value is negative.
+        """
+        if value < 0:
+            raise NegativePressureDropException(value)
+
+        self._delta_p_bar = value
+        logger.warning(f"Outlet stream is set to None due to new delta_p_bar: {value:.2f} bar. ")
+        self._outlet_ports[SingleIO.OUTLET] = None
+        self._calculated = False
+
+    @property
+    def is_calculated(self) -> bool:
+        """Check if the choke valve calculation has been performed."""
+        return self._calculated
+
+    def get_inlet_ports(self) -> Mapping[PortName, FluidStream | None]:
+        """Get all inlet ports and their connected streams."""
+        return MappingProxyType(self._inlet_ports)
+
+    def get_outlet_ports(self) -> Mapping[PortName, FluidStream | None]:
+        """Get all outlet ports and their connected streams."""
+        return MappingProxyType(self._outlet_ports)
+
+    def connect_inlet_port(self, port_name: PortName, stream: FluidStream) -> None:
+        """Connect a fluid stream to the specified inlet port."""
+        if port_name not in self._inlet_ports:
+            raise ValueError(f"Unknown inlet port: {port_name}")
+
+        # Validate pressure drop won't cause negative outlet pressure
+        outlet_pressure = stream.pressure_bara - self._delta_p_bar
+        if outlet_pressure <= 0:
+            raise InvalidPressureDropException(stream.pressure_bara, self._delta_p_bar)
+
+        self._inlet_ports[port_name] = stream
+        self._outlet_ports[SingleIO.OUTLET] = None
+        self._calculated = False
+
+    def get_stream_from_port(self, port: PortName) -> FluidStream:
+        """
+        Get the stream for the given port.
+
+        Args:
+            port: The port name to get the stream from
+
+        Returns:
+            The fluid stream connected to the port
+
+        Raises:
+            ValueError: If the port name is unknown
+            NoInletStreamException: If no stream is connected to an inlet port
+            ChokeValveNotCalculatedException: If the outlet port is accessed but the valve has not been calculated
+        """
+        if port in self._inlet_ports:
+            stream = self._inlet_ports[port]
+            if stream is None:
+                raise NoInletStreamException()
+            return stream
+        elif port in self._outlet_ports:
+            stream = self._outlet_ports[port]
+            if stream is None:
+                raise ChokeValveNotCalculatedException()
+            return stream
+        else:
+            raise ValueError(f"Unknown port: {port}")
+
+    def calculate(self) -> None:
+        """
+        Calculate the outlet stream conditions after throttling/choking.
+
+        Raises:
+            NoInletStreamForCalculationException: If no inlet stream is available
+        """
+        inlet_stream = self._inlet_ports[SingleIO.INLET]
+        if inlet_stream is None:
+            raise NoInletStreamException()
+
+        kappa = inlet_stream.kappa
+        pressure_ratio_crit = (2 / (kappa + 1)) ** (kappa / (kappa - 1))  # Critical pressure ratio for choked flow
+        p_min = inlet_stream.pressure_bara * pressure_ratio_crit  # Minimum outlet pressure for choked flow
+        if inlet_stream.pressure_bara - self.delta_p_bar < p_min:
+            logger.warning(
+                f"Choked flow condition met: Inlet pressure {inlet_stream.pressure_bara:.2f} bara, "
+                f"delta P {self.delta_p_bar:.2f} bar, "
+                f"critical pressure ratio {pressure_ratio_crit:.2f}, "
+                f"minimum outlet pressure {p_min:.2f} bara."
+                f" Outlet pressure will be set to minimum achievable value for choked gas flow {p_min:.2f} bara."
+            )
+        # If choked flow, set outlet pressure to critical value (max of p_min and the calculated pressure)
+        outlet_pressure = max(p_min, inlet_stream.pressure_bara - self.delta_p_bar)
+
+        outlet_stream = inlet_stream.create_stream_with_new_pressure_and_enthalpy_change(
+            pressure_bara=outlet_pressure,
+            enthalpy_change=0.0,  # Isenthalpic process
+            remove_liquid=False,
+        )
+        self._outlet_ports[SingleIO.OUTLET] = outlet_stream
+        self._calculated = True
+
+    # Convenience methods specific to this unit ->
+    def connect_inlet_stream(self, stream: FluidStream) -> None:
+        """Connect a fluid stream to the inlet port."""
+        self.connect_inlet_port(SingleIO.INLET, stream)
+
+    def get_inlet_stream(self) -> FluidStream:
+        """Get the inlet stream connected to the inlet port."""
+        stream = self._inlet_ports[SingleIO.INLET]
+        if stream is None:
+            raise NoInletStreamException()
+        return stream
+
+    def get_outlet_stream(self) -> FluidStream:
+        """Get the outlet stream after calculation."""
+        stream = self._outlet_ports[SingleIO.OUTLET]
+        if stream is None:
+            raise ChokeValveNotCalculatedException()
+        return stream

--- a/src/libecalc/domain/process/entities/process_units/choke_valve/exceptions.py
+++ b/src/libecalc/domain/process/entities/process_units/choke_valve/exceptions.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from libecalc.domain.process.entities.process_units.exceptions import ProcessUnitException
+
+
+class ChokeValveException(ProcessUnitException):
+    """Base exception for choke valve operations."""
+
+    pass
+
+
+class NegativePressureDropException(ChokeValveException):
+    """Exception raised when pressure drop is negative."""
+
+    def __init__(self, delta_p_bar: float):
+        self.delta_p_bar = delta_p_bar
+        super().__init__(
+            f"Pressure drop cannot be negative: {delta_p_bar:.2f} bar. "
+            "Use a positive value to reduce outlet pressure."
+        )
+
+
+class InvalidPressureDropException(ChokeValveException):
+    """Exception raised when pressure drop would result in negative outlet pressure."""
+
+    def __init__(self, inlet_pressure: float, delta_p_bar: float):
+        self.inlet_pressure = inlet_pressure
+        self.delta_p_bar = delta_p_bar
+        outlet_pressure = inlet_pressure - delta_p_bar
+        super().__init__(
+            f"Invalid pressure drop: inlet pressure {inlet_pressure:.2f} bara - "
+            f"pressure drop {delta_p_bar:.2f} bar = {outlet_pressure:.2f} bara (negative pressure not allowed)"
+        )
+
+
+class ChokeValveNotCalculatedException(ChokeValveException):
+    """Exception raised when trying to access calculation results before calculation."""
+
+    def __init__(self):
+        super().__init__("ChokeValve has not been calculated yet. Call calculate() first.")

--- a/src/libecalc/domain/process/entities/process_units/exceptions.py
+++ b/src/libecalc/domain/process/entities/process_units/exceptions.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+
+class ProcessUnitException(Exception):
+    """Base exception for all process unit operations."""
+
+    pass
+
+
+class NoInletStreamException(ProcessUnitException):
+    """Exception raised when trying to access inlet stream that hasn't been set."""
+
+    def __init__(self):
+        super().__init__("No inlet stream has been set for this process unit")

--- a/src/libecalc/domain/process/entities/process_units/port_names.py
+++ b/src/libecalc/domain/process/entities/process_units/port_names.py
@@ -1,0 +1,44 @@
+"""Canonical port-name constants for process units."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class PortName(str, Enum):
+    """Base class for all port name enums."""
+
+    pass
+
+
+class SingleIO(PortName):
+    """Default names for 1-in / 1-out units (valve, pump, compressor etc.)."""
+
+    INLET = "inlet"
+    OUTLET = "outlet"
+
+
+class MixerIO(PortName):
+    """Port names for multiple in, one out units."""
+
+    OUTLET = "outlet"
+    INLET_1 = "inlet_1"
+    INLET_2 = "inlet_2"
+    # Add more as needed
+
+
+class SplitterIO(PortName):
+    """Port names for one in, multiple out units."""
+
+    INLET = "inlet"
+    OUTLET_1 = "outlet_1"
+    OUTLET_2 = "outlet_2"
+    # Add more as needed
+
+
+class SeparatorIO(PortName):
+    """Port names for one in, multiple phase outlets."""
+
+    INLET = "inlet"
+    GAS_OUTLET = "gas_outlet"
+    LIQUID_OUTLET = "liquid_outlet"

--- a/src/libecalc/domain/process/entities/process_units/protocols.py
+++ b/src/libecalc/domain/process/entities/process_units/protocols.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+from libecalc.domain.process.entities.process_units.port_names import PortName
+from libecalc.domain.process.value_objects.fluid_stream.fluid_stream import FluidStream
+
+
+@runtime_checkable
+class ProcessUnit(Protocol):
+    """Base protocol for process units with port-based stream connections."""
+
+    def calculate(self) -> None:
+        """Calculate the process unit output conditions."""
+        ...
+
+    @property
+    def is_calculated(self) -> bool:
+        """Check if the process unit calculation has been performed."""
+        ...
+
+    def get_inlet_ports(self) -> Mapping[PortName, FluidStream | None]:
+        """Get all inlet ports and their connected streams."""
+        ...
+
+    def get_outlet_ports(self) -> Mapping[PortName, FluidStream | None]:
+        """Get all outlet ports and their connected streams."""
+        ...
+
+    def connect_inlet_port(self, port_name: PortName, stream: FluidStream) -> None:
+        """Connect a fluid stream to the specified inlet port."""
+        ...
+
+    def get_stream_from_port(self, port: PortName) -> FluidStream:
+        """
+        Get the stream for the given port.
+        For inlet ports, if no stream is connected, NoInletStreamException is raised.
+        For outlet ports, if the process has not been calculated, a "<UnitName>NotCalculatedException" is raised.
+        """
+        ...

--- a/tests/libecalc/core/conftest.py
+++ b/tests/libecalc/core/conftest.py
@@ -8,14 +8,11 @@ import libecalc.common.fluid
 import libecalc.common.serializable_chart
 import libecalc.dto.fuel_type
 from libecalc.common.fluid import FluidModel
+from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularConsumerFunction
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.common import VariableExpression
 from libecalc.domain.infrastructure.energy_components.turbine import Turbine
 from libecalc.domain.process.compressor import dto
 from libecalc.domain.process.compressor.core.sampled import CompressorModelSampled
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import (
-    TabularEnergyFunction,
-    TabularConsumerFunction,
-)
 from libecalc.domain.process.pump.pump import PumpSingleSpeed, PumpVariableSpeed
 from libecalc.domain.process.value_objects.chart import SingleSpeedChart, VariableSpeedChart
 from libecalc.domain.process.value_objects.fluid_stream.fluid_composition import FluidComposition

--- a/tests/libecalc/domain/infrastructure/test_path_id.py
+++ b/tests/libecalc/domain/infrastructure/test_path_id.py
@@ -6,7 +6,7 @@ from libecalc.domain.infrastructure.path_id import PathID
 def test_unique_name_path_id():
     path_id = PathID("some_name")
     assert path_id.get_name() == "some_name"
-    assert isinstance(path_id.get_model_unique_id(), uuid.UUID)
+    assert isinstance(path_id.get_uuid(), uuid.UUID)
     assert path_id.get_parent() is None
     assert path_id.get_unique_tuple_str() == ("some_name",)
 
@@ -20,4 +20,4 @@ def test_path_id_is_reproducible():
 
     second_instance_child_id = PathID("child", parent_id)
 
-    assert second_instance_child_id.get_model_unique_id() == child_id.get_model_unique_id()
+    assert second_instance_child_id.get_uuid() == child_id.get_uuid()

--- a/tests/libecalc/domain/process/process_units/choke_valve/test_choke_valve.py
+++ b/tests/libecalc/domain/process/process_units/choke_valve/test_choke_valve.py
@@ -1,0 +1,67 @@
+import pytest
+
+from libecalc.domain.common.entity_id import SimpleEntityID
+from libecalc.domain.process.entities.process_units.choke_valve import ChokeValve
+from libecalc.domain.process.entities.process_units.choke_valve.exceptions import InvalidPressureDropException
+from libecalc.domain.process.entities.process_units.port_names import SingleIO
+
+
+def test_single_choke_valve_pressure_drop(fluid_stream_mock):
+    """Test basic choke valve pressure drop calculation."""
+    valve = ChokeValve(SimpleEntityID("tv-1"), delta_p_bar=5.0)
+    # Use the constant for robustness
+    valve.connect_inlet_port(SingleIO.INLET, fluid_stream_mock)
+    valve.calculate()
+
+    outlet_stream = valve.get_outlet_stream()
+    assert outlet_stream.pressure_bara == pytest.approx(fluid_stream_mock.pressure_bara - 5.0)
+
+
+def test_choke_valve_invalid_pressure_drop(fluid_stream_mock):
+    """Test that InvalidPressureDropException is raised when inlet pressure is lower than delta_p."""
+    # fluid_stream_mock has 20.0 bara pressure, create valve with 100 bar pressure drop
+    valve = ChokeValve(SimpleEntityID("tv-1"), delta_p_bar=100.0)
+
+    # Should raise InvalidPressureDropException when trying to connect
+    with pytest.raises(InvalidPressureDropException) as exc_info:
+        valve.connect_inlet_port(SingleIO.INLET, fluid_stream_mock)
+
+    # Verify the exception contains relevant information
+    assert "20.00 bara" in str(exc_info.value)  # inlet pressure
+    assert "100.00 bar" in str(exc_info.value)  # pressure drop
+    assert "negative pressure not allowed" in str(exc_info.value)
+
+
+def test_choked_flow_handling(fluid_stream_mock, monkeypatch):
+    """Test that choke valve correctly handles choked flow by limiting outlet pressure."""
+    from unittest.mock import patch
+
+    # Based on the mock fluid_stream's kappa of 1.3
+    # Critical pressure ratio = (2/(1.3+1))^(1.3/(1.3-1)) ≈ 0.546
+    # For inlet pressure of 20 bara, critical pressure is about 10.92 bara
+    # Set a pressure drop that would cause outlet pressure to go below critical pressure
+    # if not limited (20 bara - 15 bara = 5 bara, which is below critical ~10.92 bara)
+    valve = ChokeValve(SimpleEntityID("choked-valve"), delta_p_bar=15.0)
+
+    # Calculate critical pressure ratio for verification
+    kappa = fluid_stream_mock.kappa
+    pressure_ratio_crit = (2 / (kappa + 1)) ** (kappa / (kappa - 1))
+    expected_critical_pressure = fluid_stream_mock.pressure_bara * pressure_ratio_crit
+
+    # Patch the logger to capture the warning
+    with patch("libecalc.domain.process.entities.process_units.choke_valve.choke_valve.logger") as mock_logger:
+        valve.connect_inlet_port(SingleIO.INLET, fluid_stream_mock)
+        valve.calculate()
+
+        # Verify warning was logged
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "Choked flow condition met" in warning_msg
+
+    # Get the outlet stream and verify pressure
+    outlet_stream = valve.get_outlet_stream()
+
+    # Outlet pressure should be limited to the critical pressure
+    assert outlet_stream.pressure_bara == pytest.approx(expected_critical_pressure, abs=0.01)
+    # This should be higher than the naively calculated outlet pressure (20 - 15 = 5 bara)
+    assert outlet_stream.pressure_bara > 5.0


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [x] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

Adding choke valve process unit and prepare for more modular process domain with possibility for graph based process system builder and solver.

## What does this pull request change?

- Add choke valve, entity base class and interfaces/protocols for different types of process units (equipment).
- Move fluid stream subdomain to value object dir since stream would possibly be better suited as VO and not entity.
- Add simple ID protocol (note: change name on one method in path_id) and SimpleEntityID for ID's when using units standalone.

Note: some renames (and test changes for fluid) causing the PR to look really big. But its not that extensive, its mostly in this dir:
src/libecalc/domain/process/entities/process_units
├── __init__.py
├── choke_valve
│   ├── __init__.py
│   ├── choke_valve.py
│   └── exceptions.py
├── exceptions.py
├── port_names.py
└── protocols.py

And also this file:
src/libecalc/domain/common/entity_id.py

## Issues related to this change:
