### PR TITLE
fix: provide FileContext in validation errors

### DIFF
--- a/src/libecalc/common/temporal_model.py
+++ b/src/libecalc/common/temporal_model.py
@@ -8,6 +8,36 @@ from libecalc.common.time_utils import Period
 ModelType = TypeVar("ModelType")
 
 
+class InvalidTemporalModel(Exception): ...
+
+
+def _get_key_string(key: datetime | Period):
+    if isinstance(key, datetime):
+        return str(datetime)
+    else:
+        return str(key.start)
+
+
+def _get_keys_message(keys: list[datetime | Period]) -> str:
+    return ",".join(f"'{_get_key_string(key)}'" for key in keys)
+
+
+class InvalidKeys(InvalidTemporalModel):
+    def __init__(self, keys: list[datetime | Period]):
+        # Message to user, only mention dates since we don't take Periods as input
+        super().__init__(
+            f"All keys must be dates on the format 'YYYY-MM-DD', e.g. '1969-12-23'. Got {_get_keys_message(keys)}."
+        )
+
+
+class UnsortedKeys(InvalidTemporalModel):
+    def __init__(self, keys: list[datetime | Period]):
+        # Message to user, only mention dates since we don't take Periods as input
+        super().__init__(
+            f"Dates in a temporal model should be sorted with the earliest date first. Got {_get_keys_message(keys)}"
+        )
+
+
 @dataclass
 class Model(Generic[ModelType]):
     period: Period
@@ -18,29 +48,41 @@ class TemporalModel(Generic[ModelType]):
     """If data has datetime keys, convert to Period keys"""
 
     def __init__(self, data: dict[datetime, ModelType] | dict[Period, ModelType]):
+        periods = []
+        models = []
         if all(isinstance(key, datetime) for key in data.keys()):
             # convert date keys to Period keys
             model_dates: list[datetime] = list(data.keys()) + [datetime.max.replace(microsecond=0)]
-            for start_time, end_time in zip(model_dates[:-1], model_dates[1:]):
-                if not (isinstance(start_time, datetime) and isinstance(end_time, datetime)):
-                    raise TypeError("All keys must be datetime when converting to Period.")
-            data = {
-                Period(start=start_time, end=end_time): model
-                for start_time, end_time, model in zip(model_dates[:-1], model_dates[1:], data.values())
-            }
-        elif not all(isinstance(key, Period) for key in data.keys()):
-            raise TypeError("All keys must be either datetime or Period.")
+            for start_time, end_time, model in zip(model_dates[:-1], model_dates[1:], data.values()):
+                period = Period(
+                    start=start_time,
+                    end=end_time,
+                )
+                periods.append(period)
+                models.append(
+                    Model(
+                        period=period,
+                        model=model,
+                    )
+                )
+        elif all(isinstance(key, Period) for key in data.keys()):
+            for period, model in data.items():
+                assert isinstance(period, Period)
+                periods.append(period)
+                models.append(
+                    Model(
+                        period=period,
+                        model=model,
+                    )
+                )
+        else:
+            raise InvalidKeys(keys=list(data.keys()))
 
-        self._data = data
-        self._models = []
-        for period, model in data.items():
-            if not isinstance(period, Period):
-                raise TypeError(f"Expected Period, got {type(period)}")
-            self._models.append(Model(period=period, model=model))
+        self._periods: list[Period] = periods
+        self._models: list[Model[ModelType]] = models
 
-        self._periods = [model.period for model in self._models]
         if not (list(self._periods) == sorted(self._periods)):
-            raise ValueError("Dates in a temporal model should be sorted with the earliest date first")
+            raise UnsortedKeys(keys=list(data.keys()))
 
     def get_models(self) -> Iterable[ModelType]:
         for model in self._models:

--- a/src/libecalc/domain/component_validation_error.py
+++ b/src/libecalc/domain/component_validation_error.py
@@ -64,11 +64,6 @@ class ComponentValidationException(DomainValidationException):
     pass
 
 
-class InvalidRegularityException(DomainValidationException):
-    def __init__(self, message: str):
-        super().__init__(message=message)
-
-
 class ProcessEqualLengthValidationException(DomainValidationException):
     pass
 

--- a/src/libecalc/domain/hydrocarbon_export.py
+++ b/src/libecalc/domain/hydrocarbon_export.py
@@ -9,6 +9,12 @@ from libecalc.expression.expression import ExpressionType
 from libecalc.expression.temporal_expression import TemporalExpression
 
 
+class InvalidHydrocarbonExport(Exception):
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
 class HydrocarbonExport:
     """
     Represents the hydrocarbon export functionality for an installation.
@@ -26,11 +32,14 @@ class HydrocarbonExport:
     ):
         self.expression_evaluator = expression_evaluator
         self.target_period = target_period
-        self.temporal_expression = TemporalExpression(
-            expression=expression_input or self.default_expression_value(),
-            target_period=target_period,
-            expression_evaluator=expression_evaluator,
-        )
+        try:
+            self.temporal_expression = TemporalExpression(
+                expression=expression_input or self.default_expression_value(),
+                target_period=target_period,
+                expression_evaluator=expression_evaluator,
+            )
+        except ValueError as e:
+            raise InvalidHydrocarbonExport(str(e)) from e
         self.regularity = regularity
 
     @staticmethod

--- a/src/libecalc/domain/infrastructure/energy_components/fuel_consumer/fuel_consumer.py
+++ b/src/libecalc/domain/infrastructure/energy_components/fuel_consumer/fuel_consumer.py
@@ -40,7 +40,7 @@ class FuelConsumer(Emitter, TemporalProcessSystem, EnergyComponent):
         regularity: Regularity,
         user_defined_category: dict[Period, ConsumerUserDefinedCategoryType],
         component_type: ComponentType,
-        fuel: dict[Period, FuelType],
+        fuel: TemporalModel[FuelType],
         energy_usage_model: TemporalModel[ConsumerFunction],
         expression_evaluator: ExpressionEvaluator,
     ):
@@ -50,7 +50,7 @@ class FuelConsumer(Emitter, TemporalProcessSystem, EnergyComponent):
         self.user_defined_category = user_defined_category
         self.energy_usage_model: TemporalModel[ConsumerFunction] = energy_usage_model
         self.expression_evaluator = expression_evaluator
-        self.fuel = fuel
+        self.fuel: TemporalModel[FuelType] = fuel
         self.component_type = component_type
         self.consumer_results: dict[str, EcalcModelResult] = {}
         self.emission_results: dict[str, EmissionResult] | None = None

--- a/src/libecalc/domain/infrastructure/energy_components/fuel_model/fuel_model.py
+++ b/src/libecalc/domain/infrastructure/energy_components/fuel_model/fuel_model.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from libecalc.common.logger import logger
+from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.time_utils import Period, Periods
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import TimeSeriesStreamDayRate
@@ -15,7 +16,7 @@ class FuelModel:
     attributes which may be evaluated for some variables and a fuel_rate.
     """
 
-    def __init__(self, fuel_time_function_dict: dict[Period, FuelType]):
+    def __init__(self, fuel_time_function_dict: TemporalModel[FuelType]):
         logger.debug("Creating fuel model")
         self.temporal_fuel_model = fuel_time_function_dict
 

--- a/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
+++ b/src/libecalc/domain/infrastructure/energy_components/installation/installation.py
@@ -11,9 +11,6 @@ from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.regularity import Regularity
 from libecalc.dto.component_graph import ComponentGraph
 from libecalc.dto.types import InstallationUserDefinedCategoryType
-from libecalc.dto.utils.validators import (
-    convert_expression,
-)
 
 
 class Installation(EnergyComponent):
@@ -75,10 +72,6 @@ class Installation(EnergyComponent):
     @property
     def id(self) -> str:
         return self._path_id.get_name()  # id here is energy component name which is a str and expects a unique name
-
-    def convert_expression_installation(self, data):
-        # Implement the conversion logic here
-        return convert_expression(data)
 
     def get_graph(self) -> ComponentGraph:
         graph = ComponentGraph()

--- a/src/libecalc/domain/regularity.py
+++ b/src/libecalc/domain/regularity.py
@@ -4,9 +4,14 @@ from libecalc.common.time_utils import Period
 from libecalc.common.units import Unit
 from libecalc.common.utils.rates import TimeSeriesFloat
 from libecalc.common.variables import ExpressionEvaluator
-from libecalc.domain.component_validation_error import InvalidRegularityException
 from libecalc.expression.expression import ExpressionType
 from libecalc.expression.temporal_expression import TemporalExpression
+
+
+class InvalidRegularity(Exception):
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
 
 
 class Regularity:
@@ -65,4 +70,4 @@ class Regularity:
         invalid_values = [value for value in values if not (0 <= value <= 1)]
         if invalid_values:
             msg = f"REGULARITY must evaluate to fractions between 0 and 1. " f"Invalid values: {invalid_values}"
-            raise InvalidRegularityException(message=msg)
+            raise InvalidRegularity(message=msg)

--- a/src/libecalc/expression/temporal_expression.py
+++ b/src/libecalc/expression/temporal_expression.py
@@ -42,7 +42,7 @@ class TemporalExpression:
                 Expression.setup_from_expression(self.expression), target_period=self.target_period
             )
         else:
-            raise ValueError("Expression must be provided for TemporalExpression.")
+            raise ValueError("Expression must be provided")
 
         return TemporalModel(data)
 

--- a/src/libecalc/presentation/yaml/file_context.py
+++ b/src/libecalc/presentation/yaml/file_context.py
@@ -1,7 +1,4 @@
 from dataclasses import dataclass
-from typing import Self
-
-from libecalc.presentation.yaml.yaml_node import YamlDict
 
 
 @dataclass
@@ -27,24 +24,3 @@ class FileContext:
         file_context_string += str(self.start)
 
         return file_context_string
-
-    @classmethod
-    def from_yaml_dict(cls, data: YamlDict) -> Self:
-        if not hasattr(data, "end_mark") or not hasattr(data, "start_mark"):
-            return None
-
-        # This only works with our implementation of pyyaml read
-        # In the future, we can move this logic into PyYamlYamlModel with a better interface in YamlValidator.
-        # Specifically with our own definition of the returned data in each property in YamlValidator.
-        start_mark = data.start_mark
-        end_mark = data.end_mark
-        return FileContext(
-            start=FileMark(
-                line_number=start_mark.line + 1,
-                column_number=start_mark.column,
-            ),
-            end=FileMark(
-                line_number=end_mark.line + 1,
-                column_number=end_mark.column,
-            ),
-        )

--- a/src/libecalc/presentation/yaml/mappers/yaml_mapping_context.py
+++ b/src/libecalc/presentation/yaml/mappers/yaml_mapping_context.py
@@ -1,0 +1,29 @@
+from libecalc.presentation.yaml.mappers.yaml_path import YamlPath
+from libecalc.presentation.yaml.validation_errors import Location
+
+
+class MappingContext:
+    def __init__(self):
+        self._name_map = {}
+
+    def register_component_name(self, yaml_path: YamlPath, name: str):
+        self._name_map[yaml_path.keys] = name
+
+    def get_component_name(self, yaml_path: YamlPath) -> str | None:
+        return self._name_map.get(yaml_path.keys)
+
+    def get_location_from_yaml_path(self, yaml_path: YamlPath) -> Location:
+        """
+        Replace indices with names of the objects to create a Location, which is displayed to user
+        """
+        location_keys = []
+
+        current_path = YamlPath()
+        for key in yaml_path.keys:
+            current_path = current_path.append(key)
+            if isinstance(key, int):
+                location_keys.append(self.get_component_name(current_path) or key)
+            else:
+                location_keys.append(key)
+
+        return Location(keys=location_keys)

--- a/src/libecalc/presentation/yaml/mappers/yaml_path.py
+++ b/src/libecalc/presentation/yaml/mappers/yaml_path.py
@@ -1,0 +1,13 @@
+Key = str | int
+
+
+class YamlPath:
+    def __init__(self, keys: tuple[Key, ...] = None):
+        self._keys = keys or ()
+
+    @property
+    def keys(self) -> tuple[Key, ...]:
+        return self._keys
+
+    def append(self, key: Key):
+        return YamlPath((*self._keys, key))

--- a/src/libecalc/presentation/yaml/validation_errors.py
+++ b/src/libecalc/presentation/yaml/validation_errors.py
@@ -1,6 +1,7 @@
 # mypy: disable-error-code=import-untyped
 import enum
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
 from textwrap import indent
@@ -37,7 +38,7 @@ def _get_position_in_file_message(mark: Mark) -> str:
 
 @dataclass
 class Location:
-    keys: list[str | int | date]
+    keys: Sequence[str | int | date]
 
     def is_empty(self) -> bool:
         return len(self.keys) == 0
@@ -270,7 +271,7 @@ class DtoValidationError(DataValidationError):
                 ModelValidationError(
                     location=Location.from_pydantic_loc(error["loc"]),
                     message=error["msg"],
-                    file_context=FileContext.from_yaml_dict(data),
+                    file_context=None,
                     data=data,
                 )
             )

--- a/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, TextIO
 
 from libecalc.common.logger import logger
+from libecalc.presentation.yaml.file_context import FileContext
 from libecalc.presentation.yaml.yaml_entities import (
     ResourceStream,
     YamlTimeseriesResource,
@@ -90,6 +91,9 @@ class YamlValidator(abc.ABC):
 
     @abc.abstractmethod
     def validate(self, context: YamlModelValidationContext) -> YamlAsset: ...
+
+    @abc.abstractmethod
+    def get_file_context(self, yaml_path: tuple[str | int | datetime.datetime, ...]) -> FileContext | None: ...
 
 
 class YamlReader(abc.ABC):

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_generator_set.py
@@ -41,6 +41,7 @@ class YamlGeneratorSet(YamlBase):
     )
     consumers: list[YamlElectricityConsumer] = Field(
         ...,
+        min_length=1,
         title="CONSUMERS",
         description="Consumers getting electrical power from the generator set.\n\n$ECALC_DOCS_KEYWORDS_URL/CONSUMERS",
     )

--- a/src/libecalc/presentation/yaml/yaml_types/yaml_variable.py
+++ b/src/libecalc/presentation/yaml/yaml_types/yaml_variable.py
@@ -16,9 +16,6 @@ class YamlSingleVariable(YamlBase):
 
     value: Expression
 
-    def to_dto(self):
-        raise NotImplementedError
-
 
 YamlTimeVariable = dict[YamlDefaultDatetime, YamlSingleVariable]
 

--- a/tests/libecalc/domain/test_regularity.py
+++ b/tests/libecalc/domain/test_regularity.py
@@ -3,8 +3,7 @@ from datetime import datetime
 import pytest
 
 from libecalc.common.time_utils import Period
-from libecalc.domain.component_validation_error import InvalidRegularityException
-from libecalc.domain.regularity import Regularity
+from libecalc.domain.regularity import InvalidRegularity, Regularity
 
 
 def test_valid_regularity(expression_evaluator_factory):
@@ -34,7 +33,7 @@ def test_invalid_regularity(expression_evaluator_factory):
     expression_evaluator = expression_evaluator_factory.from_periods(periods=[period1, period2])
 
     # Expect a ComponentValidationException for invalid regularity
-    with pytest.raises(InvalidRegularityException) as excinfo:
+    with pytest.raises(InvalidRegularity) as excinfo:
         Regularity(
             expression_evaluator=expression_evaluator,
             expression_input=expressions,

--- a/tests/libecalc/dto/test_fuel_consumer.py
+++ b/tests/libecalc/dto/test_fuel_consumer.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from io import StringIO
 
 import pytest
+from inline_snapshot import snapshot
 
 import libecalc
 from libecalc.common.component_type import ComponentType
@@ -89,6 +90,8 @@ def test_fuel_consumer_helper():
 
 
 class TestFuelConsumer:
+    @pytest.mark.snapshot
+    @pytest.mark.inlinesnapshot
     def test_no_fuel_installation_and_blank_reference_consumer(self, yaml_model_factory, test_fuel_consumer_helper):
         """
         Check scenario where FUEL is not entered as a keyword in installation.
@@ -102,9 +105,14 @@ class TestFuelConsumer:
         with pytest.raises(ModelValidationException) as exc_info:
             yaml_model_factory(configuration=asset_stream, resources={}, frequency=Frequency.YEAR).validate_for_run()
 
-        assert (
-            "Validation error\n" "\n" "\tLocation: \n" "\tMessage: Missing fuel for fuel consumer 'flare'\n"
-        ) in str(exc_info.value)
+        assert str(exc_info.value) == snapshot("""\
+Validation error
+
+	Object starting on line 13
+	Location: installations.Installation 1.FUELCONSUMERS.flare.fuel
+	Name: flare
+	Message: Missing fuel reference
+""")
 
     def test_negative_fuel_rate_direct_fuel_consumer(
         self, test_fuel_consumer_helper, expression_evaluator_factory, direct_expression_model_factory

--- a/tests/libecalc/dto/test_generator_set.py
+++ b/tests/libecalc/dto/test_generator_set.py
@@ -2,18 +2,16 @@ from datetime import datetime
 from io import StringIO
 
 import pytest
+from inline_snapshot import snapshot
 
 import libecalc.dto.fuel_type
 from libecalc.common.component_type import ComponentType
 from libecalc.common.energy_model_type import EnergyModelType
-from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.time_utils import Frequency, Period
 from libecalc.domain.component_validation_error import (
-    ComponentValidationException,
     GeneratorSetHeaderValidationException,
 )
-from libecalc.domain.infrastructure.energy_components.fuel_consumer.fuel_consumer import FuelConsumer
 from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.infrastructure.energy_components.generator_set.generator_set_component import (
     GeneratorSetEnergyComponent,
@@ -21,13 +19,13 @@ from libecalc.domain.infrastructure.energy_components.generator_set.generator_se
 from libecalc.domain.infrastructure.path_id import PathID
 from libecalc.domain.regularity import Regularity
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
-from libecalc.expression import Expression
 from libecalc.presentation.yaml.model_validation_exception import ModelValidationException
 from libecalc.presentation.yaml.yaml_entities import MemoryResource, ResourceStream
 from libecalc.presentation.yaml.yaml_models.pyyaml_yaml_model import PyYamlYamlModel
 from libecalc.testing.yaml_builder import (
     YamlAssetBuilder,
     YamlElectricity2fuelBuilder,
+    YamlFuelTypeBuilder,
     YamlGeneratorSetBuilder,
     YamlInstallationBuilder,
 )
@@ -162,14 +160,12 @@ class TestGeneratorSetHelper:
         asset = (
             YamlAssetBuilder()
             .with_test_data()
+            .with_fuel_types([YamlFuelTypeBuilder().with_test_data().with_name(self.defined_fuel).validate()])
             .with_installations([installation])
             .with_facility_inputs([el2fuel])
             .with_start(self.time_vector[0])
             .with_end(self.time_vector[-1])
         ).validate()
-
-        # Set the name of defined fuel type for the asset
-        asset.fuel_types[0].name = self.defined_fuel
 
         asset_dict = asset.model_dump(
             serialize_as_any=True,
@@ -195,27 +191,31 @@ class TestGeneratorSet:
         expression_evaluator = expression_evaluator_factory.from_periods(periods=[Period(datetime(1900, 1, 1))])
         generator_set_dto = GeneratorSetEnergyComponent(
             path_id=PathID("Test"),
-            user_defined_category={Period(datetime(1900, 1, 1)): "MISCELLANEOUS"},
-            generator_set_model={
-                Period(datetime(1900, 1, 1)): GeneratorSetModel(
-                    name="generator_set_sampled",
-                    resource=test_generator_set_helper.simple_el2fuel_resource(),
-                    energy_usage_adjustment_constant=0.0,
-                    energy_usage_adjustment_factor=1.0,
-                )
-            },
+            user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.MISCELLANEOUS},
+            generator_set_model=TemporalModel(
+                {
+                    Period(datetime(1900, 1, 1)): GeneratorSetModel(
+                        name="generator_set_sampled",
+                        resource=test_generator_set_helper.simple_el2fuel_resource(),
+                        energy_usage_adjustment_constant=0.0,
+                        energy_usage_adjustment_factor=1.0,
+                    )
+                }
+            ),
             regularity=Regularity(
                 expression_evaluator=expression_evaluator,
                 target_period=expression_evaluator.get_period(),
                 expression_input=1,
             ),
             consumers=[],
-            fuel={
-                Period(datetime(1900, 1, 1)): libecalc.dto.fuel_type.FuelType(
-                    name="fuel_gas",
-                    emissions=[],
-                )
-            },
+            fuel=TemporalModel(
+                {
+                    Period(datetime(1900, 1, 1)): libecalc.dto.fuel_type.FuelType(
+                        name="fuel_gas",
+                        emissions=[],
+                    )
+                }
+            ),
             component_type=ComponentType.GENERATOR_SET,
             expression_evaluator=expression_evaluator,
         )
@@ -229,49 +229,8 @@ class TestGeneratorSet:
             energy_usage_adjustment_factor=1.0,
         )
 
-    def test_genset_should_fail_with_fuel_consumer(self, expression_evaluator_factory, direct_expression_model_factory):
-        """This validation is done in the dto layer"""
-        fuel = libecalc.dto.fuel_type.FuelType(
-            name="fuel",
-            emissions=[],
-        )
-        expression_evaluator = expression_evaluator_factory.from_periods(periods=[Period(datetime(2000, 1, 1))])
-        fuel_consumer = FuelConsumer(
-            path_id=PathID("test"),
-            fuel={Period(datetime(2000, 1, 1)): fuel},
-            component_type=ComponentType.GENERIC,
-            energy_usage_model=TemporalModel(
-                {
-                    Period(datetime(2000, 1, 1)): direct_expression_model_factory(
-                        expression=Expression.setup_from_expression(1),
-                        energy_usage_type=EnergyUsageType.FUEL,
-                    )
-                }
-            ),
-            user_defined_category={Period(datetime(2000, 1, 1)): ConsumerUserDefinedCategoryType.MISCELLANEOUS},
-            expression_evaluator=expression_evaluator,
-            regularity=Regularity(
-                expression_evaluator=expression_evaluator,
-                target_period=expression_evaluator.get_period(),
-                expression_input=1,
-            ),
-        )
-        with pytest.raises(ComponentValidationException):
-            GeneratorSetEnergyComponent(
-                path_id=PathID("Test"),
-                user_defined_category={Period(datetime(1900, 1, 1)): ConsumerUserDefinedCategoryType.MISCELLANEOUS},
-                generator_set_model={},
-                regularity=Regularity(
-                    expression_evaluator=expression_evaluator,
-                    expression_input=1,
-                    target_period=expression_evaluator.get_period(),
-                ),
-                consumers=[fuel_consumer],
-                fuel={},
-                component_type=ComponentType.GENERATOR_SET,
-                expression_evaluator=expression_evaluator,
-            )
-
+    @pytest.mark.inlinesnapshot
+    @pytest.mark.snapshot
     def test_missing_installation_fuel(self, yaml_model_factory, test_generator_set_helper):
         """
         Check scenario where FUEL is not entered as a keyword in installation.
@@ -287,7 +246,11 @@ class TestGeneratorSet:
                 configuration=asset_data.resource_stream, resources=asset_data.resources, frequency=Frequency.YEAR
             ).validate_for_run()
 
-        assert (
-            "Validation error\n\n\tLocation: DefaultGeneratorSet\n\tName: "
-            "DefaultGeneratorSet\n\tMessage: Missing fuel for generator set\n"
-        ) in str(exc_info.value)
+        assert str(exc_info.value) == snapshot("""\
+Validation error
+
+	Object starting on line 18
+	Location: installations.Installation 1.GENERATORSETS.DefaultGeneratorSet.fuel
+	Name: DefaultGeneratorSet
+	Message: Missing fuel reference
+""")

--- a/tests/libecalc/input/mappers/test_resolve_fuel.py
+++ b/tests/libecalc/input/mappers/test_resolve_fuel.py
@@ -6,7 +6,7 @@ from inline_snapshot import snapshot
 import libecalc.dto.fuel_type
 from libecalc.common.time_utils import Period
 from libecalc.presentation.yaml.domain.reference_service import InvalidReferenceException
-from libecalc.presentation.yaml.mappers.component_mapper import _resolve_fuel
+from libecalc.presentation.yaml.mappers.component_mapper import MissingFuelReference, _resolve_fuel
 from libecalc.presentation.yaml.yaml_entities import References
 
 
@@ -32,8 +32,13 @@ def all_the_time():
 
 
 class TestResolveFuel:
+    @pytest.mark.snapshot
+    @pytest.mark.inlinesnapshot
     def test_none(self, references, all_the_time):
-        assert _resolve_fuel(None, None, references, target_period=all_the_time) is None
+        with pytest.raises(MissingFuelReference) as exc_info:
+            _resolve_fuel(None, None, references, target_period=all_the_time)
+
+        assert str(exc_info.value) == snapshot("Missing fuel reference")
 
     def test_parent_fuel(self, references, all_the_time):
         assert _resolve_fuel(None, "diesel", references, target_period=all_the_time).popitem()[1].name == "diesel"

--- a/tests/libecalc/presentation/yaml/yaml_types/test_categories.py
+++ b/tests/libecalc/presentation/yaml/yaml_types/test_categories.py
@@ -11,7 +11,6 @@ from libecalc.dto.types import (
     InstallationUserDefinedCategoryType,
 )
 from libecalc.presentation.yaml.yaml_types.components.legacy.yaml_fuel_consumer import YamlFuelConsumer
-from libecalc.presentation.yaml.yaml_types.components.yaml_generator_set import YamlGeneratorSet
 from libecalc.presentation.yaml.yaml_types.components.yaml_installation import YamlInstallation
 from libecalc.presentation.yaml.yaml_types.emitters.yaml_venting_emitter import (
     YamlDirectTypeEmitter,
@@ -250,15 +249,12 @@ class TestCategories:
 
     @pytest.mark.snapshot
     @pytest.mark.inlinesnapshot
-    def test_genset_categories(self):
+    def test_genset_categories(self, yaml_generator_set_builder_factory):
         # Check that illegal category raises error
         with pytest.raises(ValidationError) as exc_info:
-            YamlGeneratorSet(
-                name="Test",
+            yaml_generator_set_builder_factory().with_test_data().with_category(
                 category={datetime(1900, 1, 1): "GENERATOR-SET"},
-                electricity2fuel="dummy",
-                consumers=[],
-            )
+            ).validate()
 
         assert str(get_category_error(exc_info.value)) == snapshot(
             "Input should be 'BASE-LOAD', 'COLD-VENTING-FUGITIVE', 'COMPRESSOR', 'FIXED-PRODUCTION-LOAD', 'FLARE', 'MISCELLANEOUS', 'PUMP', 'GAS-DRIVEN-COMPRESSOR', 'TURBINE-GENERATOR', 'POWER-FROM-SHORE', 'OFFSHORE-WIND', 'LOADING', 'STORAGE', 'STEAM-TURBINE-GENERATOR', 'BOILER' or 'HEATER'"
@@ -266,23 +262,22 @@ class TestCategories:
 
         # Check that lower case raises error
         with pytest.raises(ValidationError) as exc_info:
-            YamlGeneratorSet(
-                name="Test",
+            yaml_generator_set_builder_factory().with_test_data().with_category(
                 category={datetime(1900, 1, 1): "turbine-generator"},
-                electricity2fuel="dummy",
-                consumers=[],
-            )
+            ).validate()
 
         assert str(get_category_error(exc_info.value)) == snapshot(
             "Input should be 'BASE-LOAD', 'COLD-VENTING-FUGITIVE', 'COMPRESSOR', 'FIXED-PRODUCTION-LOAD', 'FLARE', 'MISCELLANEOUS', 'PUMP', 'GAS-DRIVEN-COMPRESSOR', 'TURBINE-GENERATOR', 'POWER-FROM-SHORE', 'OFFSHORE-WIND', 'LOADING', 'STORAGE', 'STEAM-TURBINE-GENERATOR', 'BOILER' or 'HEATER'"
         )
 
         # Check correct category
-        generator_set_dto = YamlGeneratorSet(
-            name="Test",
-            category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR},
-            electricity2fuel="dummy",
-            consumers=[],
+        generator_set_dto = (
+            yaml_generator_set_builder_factory()
+            .with_test_data()
+            .with_category(
+                category={datetime(1900, 1, 1): ConsumerUserDefinedCategoryType.TURBINE_GENERATOR},
+            )
+            .validate()
         )
 
         assert generator_set_dto.category[datetime(1900, 1, 1)] == ConsumerUserDefinedCategoryType.TURBINE_GENERATOR


### PR DESCRIPTION
Expose FileContext from YamlValidator to be able to provide context to
yaml validation errors.
