### PR TITLE
refactor: tabular consumer function part 3

### DIFF
--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/tabulated/tabular_consumer_function.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/tabulated/tabular_consumer_function.py
@@ -1,6 +1,10 @@
 import numpy as np
 
+from libecalc.common.energy_usage_type import EnergyUsageType
+from libecalc.common.errors.exceptions import IllegalStateException
 from libecalc.common.list.list_utils import array_to_list
+from libecalc.common.logger import logger
+from libecalc.common.units import Unit
 from libecalc.common.utils.rates import Rates
 from libecalc.common.variables import ExpressionEvaluator
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function import (
@@ -20,13 +24,17 @@ from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.tabular_energy_function import (
     TabularEnergyFunction,
 )
+from libecalc.domain.process.core.results import EnergyFunctionResult
 from libecalc.expression import Expression
 
 
 class TabularConsumerFunction(ConsumerFunction):
     def __init__(
         self,
-        tabulated_energy_function: TabularEnergyFunction,
+        headers: list[str],
+        data: list[list[float]],
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
         variables_expressions: list[VariableExpression],
         condition_expression: Expression | None = None,
         power_loss_factor_expression: Expression | None = None,
@@ -34,7 +42,12 @@ class TabularConsumerFunction(ConsumerFunction):
         """Tabulated consumer function [MW] (energy) or [Sm3/day] (fuel)."""
         # Consistency of variables between tabulated_energy_function and variables_expressions must be validated up
         # front
-        self._tabulated_energy_function = tabulated_energy_function
+        self._tabular_energy_function = TabularEnergyFunction(
+            headers=headers,
+            data=data,
+            energy_usage_adjustment_constant=energy_usage_adjustment_constant,
+            energy_usage_adjustment_factor=energy_usage_adjustment_factor,
+        )
         self._variables_expressions = variables_expressions
 
         self._condition_expression = condition_expression
@@ -60,7 +73,7 @@ class TabularConsumerFunction(ConsumerFunction):
                 )
             variables_for_calculation.append(Variable(name=variable.name, values=variable_values.tolist()))
 
-        energy_function_result = self._tabulated_energy_function.evaluate_variables(
+        energy_function_result = self.evaluate_variables(
             variables=variables_for_calculation,
         )
 
@@ -104,3 +117,46 @@ class TabularConsumerFunction(ConsumerFunction):
                 power_loss_factor=power_loss_factor,
             ),
         )
+
+    def evaluate_variables(self, variables: list[Variable]) -> EnergyFunctionResult:
+        variables_map_by_name = {variable.name: variable.values for variable in variables}
+        _check_variables_match_required(
+            variables_to_evaluate=list(variables_map_by_name.keys()),
+            required_variables=self._tabular_energy_function.required_variables,
+        )
+        variables_array_for_evaluation = np.asarray(
+            [
+                variables_map_by_name.get(variable_name)
+                for variable_name in self._tabular_energy_function.required_variables
+            ]
+        )
+        variables_array_for_evaluation = np.squeeze(variables_array_for_evaluation)  # Remove empty dimensions
+        variables_array_for_evaluation = np.transpose(variables_array_for_evaluation)
+        energy_usage = self._tabular_energy_function.interpolate(variables_array_for_evaluation)
+
+        energy_usage_list = array_to_list(energy_usage)
+        if energy_usage_list is None:
+            energy_usage_list = []  # Provide empty list as fallback
+
+        return EnergyFunctionResult(
+            energy_usage=energy_usage_list,
+            energy_usage_unit=Unit.MEGA_WATT
+            if self._tabular_energy_function.energy_usage_type == EnergyUsageType.POWER
+            else Unit.STANDARD_CUBIC_METER_PER_DAY,
+            power=energy_usage_list
+            if self._tabular_energy_function.energy_usage_type == EnergyUsageType.POWER
+            else None,
+            power_unit=Unit.MEGA_WATT
+            if self._tabular_energy_function.energy_usage_type == EnergyUsageType.POWER
+            else None,
+        )
+
+
+def _check_variables_match_required(variables_to_evaluate: list[str], required_variables: list[str]):
+    if set(variables_to_evaluate) != set(required_variables):
+        msg = (
+            "Variables to evaluate must correspond to required variables. You should not end up"
+            " here, please contact support."
+        )
+        logger.exception(msg)
+        raise IllegalStateException(msg)

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -32,9 +32,6 @@ from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated 
     TabularConsumerFunction,
 )
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.common import VariableExpression
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.tabular_energy_function import (
-    TabularEnergyFunction,
-)
 from libecalc.domain.process.compressor.core import create_compressor_model
 from libecalc.domain.process.compressor.dto import (
     CompressorTrainSimplifiedWithKnownStages,
@@ -226,15 +223,11 @@ class ConsumerFunctionMapper:
         condition = convert_expression(_map_condition(model))
         power_loss_factor = convert_expression(model.power_loss_factor)
 
-        tabulated_energy_function = TabularEnergyFunction(
+        return TabularConsumerFunction(
             headers=energy_model.headers,
             data=energy_model.data,
             energy_usage_adjustment_constant=energy_model.energy_usage_adjustment_constant,
             energy_usage_adjustment_factor=energy_model.energy_usage_adjustment_factor,
-        )
-
-        return TabularConsumerFunction(
-            tabulated_energy_function=tabulated_energy_function,
             variables_expressions=[
                 VariableExpression(
                     name=variable.name,

--- a/tests/libecalc/core/conftest.py
+++ b/tests/libecalc/core/conftest.py
@@ -8,10 +8,14 @@ import libecalc.common.fluid
 import libecalc.common.serializable_chart
 import libecalc.dto.fuel_type
 from libecalc.common.fluid import FluidModel
+from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.common import VariableExpression
 from libecalc.domain.infrastructure.energy_components.turbine import Turbine
 from libecalc.domain.process.compressor import dto
 from libecalc.domain.process.compressor.core.sampled import CompressorModelSampled
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularEnergyFunction
+from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import (
+    TabularEnergyFunction,
+    TabularConsumerFunction,
+)
 from libecalc.domain.process.pump.pump import PumpSingleSpeed, PumpVariableSpeed
 from libecalc.domain.process.value_objects.chart import SingleSpeedChart, VariableSpeedChart
 from libecalc.domain.process.value_objects.fluid_stream.fluid_composition import FluidComposition
@@ -331,18 +335,23 @@ def turbine_factory(yaml_turbine):
 
 
 @pytest.fixture
-def tabulated_energy_function_factory():
-    def create_tabulated_energy_function(
+def tabular_consumer_function_factory():
+    def create_tabular_consumer_function(
         function_values: list[float],
         variables: dict[str, list[float]],
         energy_usage_adjustment_constant: float = 0,
         energy_usage_adjustment_factor: float = 1,
-    ) -> TabularEnergyFunction:
-        return TabularEnergyFunction(
+    ) -> TabularConsumerFunction:
+        variables_expressions = [
+            VariableExpression(name=name, expression=Expression.setup_from_expression(name))
+            for name in variables.keys()
+        ]
+        return TabularConsumerFunction(
             headers=[*variables.keys(), "FUEL"],
             data=[*variables.values(), function_values],
             energy_usage_adjustment_factor=energy_usage_adjustment_factor,
             energy_usage_adjustment_constant=energy_usage_adjustment_constant,
+            variables_expressions=variables_expressions,
         )
 
-    return create_tabulated_energy_function
+    return create_tabular_consumer_function

--- a/tests/libecalc/core/consumers/conftest.py
+++ b/tests/libecalc/core/consumers/conftest.py
@@ -182,16 +182,18 @@ def genset_1000mw_late_startup_dto(fuel_dto, electricity_consumer_factory, gener
 
 
 @pytest.fixture
-def tabulated_energy_usage_model_factory(tabulated_energy_function_factory):
+def tabulated_energy_usage_model_factory(tabular_consumer_function_factory):
     def create_tabulated_energy_usage_model(
         function_values: list[float],
         variables: dict[str, list[float]],
+        energy_usage_adjustment_constant: float = 0.0,
+        energy_usage_adjustment_factor: float = 1.0,
     ) -> TabularConsumerFunction:
         return TabularConsumerFunction(
-            tabulated_energy_function=tabulated_energy_function_factory(
-                function_values=function_values,
-                variables=variables,
-            ),
+            headers=[*variables.keys(), "FUEL"],
+            data=[*variables.values(), function_values],
+            energy_usage_adjustment_factor=energy_usage_adjustment_factor,
+            energy_usage_adjustment_constant=energy_usage_adjustment_constant,
             variables_expressions=[
                 VariableExpression(name=name, expression=Expression.setup_from_expression(name))
                 for name in variables.keys()

--- a/tests/libecalc/core/models/test_consumer_tabular_energy_function.py
+++ b/tests/libecalc/core/models/test_consumer_tabular_energy_function.py
@@ -4,7 +4,7 @@ import pytest
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.common import Variable
 
 
-def test_ConsumerTabularEnergyFunction(tabulated_energy_function_factory):
+def test_ConsumerTabularEnergyFunction(tabular_consumer_function_factory):
     variable_name = "Qg"
     variables = {
         variable_name: [
@@ -29,7 +29,7 @@ def test_ConsumerTabularEnergyFunction(tabulated_energy_function_factory):
     }
     function_values = [0.0, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.9, 2.5, 3.1, 3.7, 4.3, 4.9, 5.4, 5.8, 5.8]
 
-    tab_1d = tabulated_energy_function_factory(
+    tab_1d = tabular_consumer_function_factory(
         function_values=function_values,
         variables=variables,
     )
@@ -39,7 +39,7 @@ def test_ConsumerTabularEnergyFunction(tabulated_energy_function_factory):
 
     constant = -200
     factor = 1.3
-    tab_1d_adjusted = tabulated_energy_function_factory(
+    tab_1d_adjusted = tabular_consumer_function_factory(
         function_values=function_values,
         variables=variables,
         energy_usage_adjustment_constant=constant,
@@ -116,7 +116,7 @@ def test_ConsumerTabularEnergyFunction(tabulated_energy_function_factory):
             190.12,
         ],
     }
-    tab_3d = tabulated_energy_function_factory(
+    tab_3d = tabular_consumer_function_factory(
         function_values=function_values_3d,
         variables=variables_3d,
     )
@@ -130,7 +130,7 @@ def test_ConsumerTabularEnergyFunction(tabulated_energy_function_factory):
     expected = np.asarray([np.nan, 101007.4, 102669.8, 104969.8])
     assert list(tab_3d.evaluate_variables(x_input).energy_usage) == pytest.approx(expected, nan_ok=True)
 
-    tab_3d_adjusted = tabulated_energy_function_factory(
+    tab_3d_adjusted = tabular_consumer_function_factory(
         function_values=function_values_3d,
         variables=variables_3d,
         energy_usage_adjustment_constant=constant,


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is part 3 of a multi-step refactoring to improve the structure, maintainability, and clarity of the codebase for tabular energy functions related to legacy consumers. While the previous parts focused on reorganizing, renaming, and consolidating logic, this part is necessary to further decouple responsibilities and clarify the flow of tabular energy calculations. Specifically, this PR moves the responsibility for evaluating tabular energy variables out of `TabularEnergyFunction` and into `TabularConsumerFunction`, making the separation between core interpolation logic and consumer-specific evaluation more explicit. Splitting the work into several PRs ensures that each step remains manageable and reviewable.

## What does this pull request change?

- Refactors `TabularConsumerFunction` to directly construct and own its `TabularEnergyFunction`, rather than receiving an instance as a dependency.
- Moves the `evaluate_variables` logic out of `TabularEnergyFunction` and into `TabularConsumerFunction`, clarifying the distinction between generic tabular interpolation and consumer-specific evaluation.
- Removes now-obsolete evaluation and variable-checking logic from `TabularEnergyFunction`.
- Updates YAML mappers, factory functions, and tests to reflect the new initialization and evaluation flow.
- Consolidates and simplifies test fixtures to match the new ownership and construction pattern.
- No user-facing behavior or core calculation logic is changed; this is a structural refactor aimed at clearer separation of concerns and easier future maintenance.