### PR TITLE
fix: array to list return list if 0D arrays

### DIFF
--- a/src/libecalc/common/list/list_utils.py
+++ b/src/libecalc/common/list/list_utils.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy import float64
 from numpy.typing import NDArray
 
+from libecalc.common.logger import logger
 from libecalc.common.time_utils import Periods
 
 T = TypeVar("T")
@@ -127,4 +128,10 @@ def array_to_list(
         # Filter out None values and flatten the list
         return [x for sublist in result if sublist is not None for x in sublist]
     elif isinstance(result_array, np.ndarray):
+        if result_array.shape == ():  # Handle 0D array (scalar)
+            return [result_array.item()]
         return cast(list[float | None], result_array.tolist())
+    else:
+        # Unexpected type, log a warning and return an empty list)
+        logger.warning(f"array_to_list received unexpected type: {type(result_array)}. Returning empty list.")
+        return []

--- a/tests/libecalc/common/test_list_utils.py
+++ b/tests/libecalc/common/test_list_utils.py
@@ -1,9 +1,11 @@
+import numpy as np
 import pytest
 
 from libecalc.common.list.list_utils import (
     elementwise_multiplication,
     elementwise_sum,
     group_data_by_value_at_index,
+    array_to_list,
 )
 
 
@@ -40,3 +42,26 @@ def test_elementwise_multiplication():
     result = list(elementwise_multiplication(list1, list2))
 
     assert result == expected_result
+
+
+def test_array_to_list_always_returns_list():
+    # 0D array
+    arr_0d = np.array(42.0)
+    assert array_to_list(arr_0d) == [42.0]
+
+    # 1D array
+    arr_1d = np.array([1.0, 2.0])
+    assert array_to_list(arr_1d) == [1.0, 2.0]
+
+    # List of arrays
+    arr_list = [np.array([1.0]), np.array([2.0])]
+    assert array_to_list(arr_list) == [1.0, 2.0]
+
+    # Scalar float
+    assert array_to_list(3.14) == [3.14]
+
+    # Scalar int
+    assert array_to_list(7) == [7]
+
+    # None
+    assert array_to_list(None) is None

--- a/tests/libecalc/domain/infrastructure/energy_components/legacy_consumer/test_tabular_consumer_function.py
+++ b/tests/libecalc/domain/infrastructure/energy_components/legacy_consumer/test_tabular_consumer_function.py
@@ -1,0 +1,31 @@
+from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularConsumerFunction
+from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.common import (
+    Variable,
+    VariableExpression,
+)
+from libecalc.expression import Expression
+
+
+def test_tabular_consumer_single_period_returns_list():
+    # Minimal setup: one variable, one function value
+    headers = ["RATE", "FUEL"]
+    data = [[1.0], [10.0]]  # Variable value and function value
+    variables_expressions = [VariableExpression(name="RATE", expression=Expression.setup_from_expression("RATE"))]
+    consumer_function = TabularConsumerFunction(
+        headers=headers,
+        data=data,
+        energy_usage_adjustment_constant=0.0,
+        energy_usage_adjustment_factor=1.0,
+        variables_expressions=variables_expressions,
+        condition_expression=None,
+        power_loss_factor_expression=None,
+    )
+
+    # Test with a single variable and a single value (e.g. only one period).
+    # Ensures that the function returns a flat list (not a scalar)
+    # even when only one period and one value are present.
+    rate_input = [Variable(name="RATE", values=[1.0])]
+
+    result = consumer_function.evaluate_variables(rate_input)
+    assert isinstance(result.energy_usage, list)
+    assert result.energy_usage == [10.0]


### PR DESCRIPTION
Refs equinor/ecalc-internal#941

## Why is this pull request needed?

This pull request addresses an edge case where the function handling tabular consumer data receives only a single period (one variable, one value). Previously, this could result in inconsistent return types or unhandled input types, making downstream processing error-prone and harder to debug.

## What does this pull request change?

- Ensures that the function always returns a list, even for single-period input, improving consistency.
- Adds a warning log if the function receives an unexpected input type, making debugging easier.
- Updates tests to explicitly check for correct handling of single-period cases.

