### PR TITLE
Refactor/introduce time series fluid density

### DIFF
--- a/src/libecalc/domain/time_series_fluid_density.py
+++ b/src/libecalc/domain/time_series_fluid_density.py
@@ -1,7 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Sequence
-
-import numpy as np
+from collections.abc import Sequence
 
 
 class TimeSeriesFluidDensity(ABC):

--- a/src/libecalc/domain/time_series_fluid_density.py
+++ b/src/libecalc/domain/time_series_fluid_density.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+import numpy as np
+
+
+class TimeSeriesFluidDensity(ABC):
+    """
+    Interface for evaluating fluid density time series.
+
+    """
+
+    @abstractmethod
+    def get_values(self) -> Sequence[float]:
+        """
+        Returns the evaluated fluid density values as a NumPy array.
+        """
+        pass

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_fluid_density.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_fluid_density.py
@@ -1,0 +1,22 @@
+from typing import Sequence
+
+from libecalc.domain.time_series_fluid_density import TimeSeriesFluidDensity
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
+
+
+class ExpressionTimeSeriesFluidDensity(TimeSeriesFluidDensity):
+    """
+    Provides fluid density values by evaluating a time series expression.
+    """
+
+    def __init__(self, time_series_expression: TimeSeriesExpression):
+        self._time_series_expression = time_series_expression
+
+    def get_values(self) -> Sequence[float]:
+        """
+        Returns the fluid density values as a NumPy array.
+        """
+
+        fluid_density_values = self._time_series_expression.get_evaluated_expressions()
+
+        return fluid_density_values

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_fluid_density.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_fluid_density.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from libecalc.domain.time_series_fluid_density import TimeSeriesFluidDensity
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -46,6 +46,7 @@ from libecalc.domain.regularity import Regularity
 from libecalc.dto.utils.validators import convert_expression, convert_expressions
 from libecalc.expression import Expression
 from libecalc.presentation.yaml.domain.expression_time_series_flow_rate import ExpressionTimeSeriesFlowRate
+from libecalc.presentation.yaml.domain.expression_time_series_fluid_density import ExpressionTimeSeriesFluidDensity
 from libecalc.presentation.yaml.domain.expression_time_series_pressure import ExpressionTimeSeriesPressure
 from libecalc.presentation.yaml.domain.reference_service import ReferenceService
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
@@ -275,6 +276,12 @@ class ConsumerFunctionMapper:
             condition_expression=condition,
         )
 
+        fluid_density_expression = TimeSeriesExpression(
+            expressions=model.fluid_density, expression_evaluator=period_evaluator
+        )
+        fluid_density = ExpressionTimeSeriesFluidDensity(time_series_expression=fluid_density_expression)
+
+
         suction_pressure_expression = TimeSeriesExpression(
             expressions=model.suction_pressure, expression_evaluator=period_evaluator
         )
@@ -285,7 +292,6 @@ class ConsumerFunctionMapper:
         )
         discharge_pressure = ExpressionTimeSeriesPressure(time_series_expression=discharge_pressure_expression)
 
-        fluid_density = convert_expression(model.fluid_density)
         pump_model = create_pump_model(pump_model_dto=energy_model)
         return PumpConsumerFunction(
             power_loss_factor_expression=power_loss_factor,  # type: ignore[arg-type]
@@ -293,7 +299,7 @@ class ConsumerFunctionMapper:
             rate=rate_standard_m3_day,
             suction_pressure=suction_pressure,
             discharge_pressure=discharge_pressure,
-            fluid_density_expression=fluid_density,  # type: ignore[arg-type]
+            fluid_density=fluid_density,
         )
 
     def _map_multiple_streams_compressor(

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -281,7 +281,6 @@ class ConsumerFunctionMapper:
         )
         fluid_density = ExpressionTimeSeriesFluidDensity(time_series_expression=fluid_density_expression)
 
-
         suction_pressure_expression = TimeSeriesExpression(
             expressions=model.suction_pressure, expression_evaluator=period_evaluator
         )

--- a/tests/libecalc/core/consumers/system/test_consumer_system.py
+++ b/tests/libecalc/core/consumers/system/test_consumer_system.py
@@ -377,7 +377,6 @@ class TestPumpSystemConsumerFunction:
         fluid_density_expression = TimeSeriesExpression(expressions=1021.0, expression_evaluator=variables_map)
         fluid_density = ExpressionTimeSeriesFluidDensity(time_series_expression=fluid_density_expression)
 
-
         suction_pressure_expression = TimeSeriesExpression(expressions=1.0, expression_evaluator=variables_map)
         suction_pressure = ExpressionTimeSeriesPressure(time_series_expression=suction_pressure_expression)
 

--- a/tests/libecalc/core/consumers/system/test_consumer_system.py
+++ b/tests/libecalc/core/consumers/system/test_consumer_system.py
@@ -28,6 +28,7 @@ from libecalc.domain.process.value_objects.chart import SingleSpeedChart
 from libecalc.domain.regularity import Regularity
 from libecalc.expression import Expression
 from libecalc.presentation.yaml.domain.expression_time_series_pressure import ExpressionTimeSeriesPressure
+from libecalc.presentation.yaml.domain.expression_time_series_fluid_density import ExpressionTimeSeriesFluidDensity
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 from libecalc.presentation.yaml.domain.expression_time_series_flow_rate import ExpressionTimeSeriesFlowRate
 
@@ -373,6 +374,10 @@ class TestPumpSystemConsumerFunction:
         rate_expression = TimeSeriesExpression(expressions=6648.0, expression_evaluator=variables_map)
         rate = ExpressionTimeSeriesFlowRate(time_series_expression=rate_expression, regularity=regularity)
 
+        fluid_density_expression = TimeSeriesExpression(expressions=1021.0, expression_evaluator=variables_map)
+        fluid_density = ExpressionTimeSeriesFluidDensity(time_series_expression=fluid_density_expression)
+
+
         suction_pressure_expression = TimeSeriesExpression(expressions=1.0, expression_evaluator=variables_map)
         suction_pressure = ExpressionTimeSeriesPressure(time_series_expression=suction_pressure_expression)
 
@@ -382,17 +387,17 @@ class TestPumpSystemConsumerFunction:
         pump_consumer_function = PumpConsumerFunction(
             pump_function=pump,
             rate=rate,
+            fluid_density=fluid_density,
             suction_pressure=suction_pressure,
             discharge_pressure=discharge_pressure,
-            fluid_density_expression=Expression.setup_from_expression(1021),
         )
         power_loss_factor = 0.03
         pump_consumer_function_with_power_loss_factor = PumpConsumerFunction(
             pump_function=pump,
             rate=rate,
+            fluid_density=fluid_density,
             suction_pressure=suction_pressure,
             discharge_pressure=discharge_pressure,
-            fluid_density_expression=Expression.setup_from_expression(1021),
             power_loss_factor_expression=Expression.setup_from_expression(str(power_loss_factor)),
         )
 


### PR DESCRIPTION
## Why is this pull request needed?

This pull request is needed to improve the handling of fluid density in pump consumer functions by supporting time series evaluation instead of only static expressions.

## What does this pull request change?

It introduces a `TimeSeriesFluidDensity` interface and implements `ExpressionTimeSeriesFluidDensity` to evaluate fluid density as a time series. The `PumpConsumerFunction` and its mappers are updated to use this new interface. Relevant tests are also updated to reflect these changes.
