### PR TITLE
cicd: change pypi publishing to trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,25 +2,23 @@ name: Publish libeCalc package to PyPI
 
 on:
   workflow_call:
-    secrets:
-      PYPI_TOKEN:
-        required: true
-
-  workflow_dispatch: # Trigger manually, if needed
-
-permissions:
-  packages: write
-  contents: read
-  id-token: write
+  workflow_dispatch:
 
 jobs:
   publish:
+    environment:
+      name: pypi
+      url: https://pypi.org/project/libecalc/
+      #name: testpypi
+      #url: https://test.pypi.org/p/libecalc  # NOTE: If/when we need to test publishing etc to PyPI, we can use Test PyPI
+    permissions:
+      id-token: write  # Required for Trusted Publishing to PyPI, the pypa action uses this
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # Make sure we publish from main branch, not the triggering ref
+          # NOTE: Make sure we publish from main branch, not the triggering ref
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Python 3.11
@@ -33,26 +31,12 @@ jobs:
           version: 1.8.4
           virtualenvs-create: true
 
-      - name: Check pyproject.toml validity
-        run: poetry check --no-interaction
-
-      - name: Cache dependencies
-        id: cache-deps
-        uses: actions/cache@v4
-        with:
-          path: ${{github.workspace}}/.venv
-          key: poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: poetry-
-
-      - name: Install dependencies  # if cache has changed
-        if: steps.cache-deps.cache-hit != 'true'
+      - name: Build the libecalc package (wheel and sdist by default)
         run: |
-          poetry config virtualenvs.in-project true
-          poetry install --no-interaction
+          poetry build
 
       - name: Publish to PyPI
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          poetry config pypi-token.pypi $PYPI_TOKEN
-          poetry publish --build
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # repository-url: https://test.pypi.org/legacy/ # NOTE: Only needed to specify for Test PyPI
+          packages-dir: dist/

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,4 @@ jobs:
       id-token: write
     needs: release-please
     uses: equinor/ecalc/.github/workflows/publish.yml@main
-    secrets:
-      pypi_token: ${{ secrets.PYPI_TOKEN }}
     if: ${{ needs.release-please.outputs.release_created }}


### PR DESCRIPTION
Adding an Equinor user to avoid relying on single indivisuals, and avoid pwd/token with trusted publishing.

Refs: equinor/ecalc-internal#433

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
