### PR TITLE
ci: trigger publish based on another workflow completion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,14 @@
 name: Publish libeCalc package to PyPI
 
 on:
-  release: # Trigger automatically, when a new release is made (with release-please)
-    types: [published]
+  workflow_run:
+    workflows: [trigger-publish]
+    types:
+      - completed
+  # Note! We cannot trigger on published event, since that can only be triggered when done manually.
+  # Therefore we trigger this workflow independently, after the trigger-publish workflow has run, in
+  # order for this workflow to be the owner of the PyPI publishing job, and can be verified. This limits
+  # us to only allow this workflow to be allowed to publish to PyPI trustedly.
 
   workflow_dispatch: # Trigger manually, if needed
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,8 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+
+  deploy_prod:
+    needs: release-please
+    uses: equinor/ecalc/.github/workflows/trigger-publish.yml@main
+    if: ${{ needs.release-please.outputs.release_created }}

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -1,0 +1,15 @@
+name: trigger-publish
+
+# NOTE! This workflow is needed in order to trigger the publish workflow, which is not possible from within a reusable workflow.
+# If this is triggered, we will publish, as this should only trigger when a release is created by the release-please workflow.
+
+on:
+  workflow_dispatch: # Workflow dispatch is used for manual triggers.
+  workflow_call: # Workflow call is used for called from another workflow.
+
+jobs:
+  trigger-publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: trigger-publish
+        run: echo "Trigger publish workflow"


### PR DESCRIPTION
because github actions doesnt allow us to listen to published events for a release from an automatically triggered workflow, we instead need to check if another workflow has run to completion, and if so, we will run publish. We therefore trigger a trigger-publish workflow, if a release has been created, that we listen to in the publish workflow, and will then trigger

Refs: equinor/ecalc-internal#433

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
