### PR TITLE
chore: allow versionstrings with v prefix to be treated as version

### DIFF
--- a/src/libecalc/common/version.py
+++ b/src/libecalc/common/version.py
@@ -29,6 +29,9 @@ class Version(EcalcBaseModel):
         if version_string is None:
             return cls()
 
+        if version_string.lower().startswith("v"):
+            version_string = version_string[1:]
+
         pattern = re.compile(VERSION_FORMAT)
         match = pattern.match(version_string)
 

--- a/tests/libecalc/common/test_version.py
+++ b/tests/libecalc/common/test_version.py
@@ -16,6 +16,11 @@ data = [
     ("100", Version(100, 0, 0)),
     ("0", Version(0, 0, 0)),
     ("0.1.2", Version(0, 1, 2)),
+    ("v1.1.1", Version(1, 1, 1)),
+    ("v2025.10.0", Version(2025, 10, 0)),
+    ("v2025.10.10", Version(2025, 10, 10)),
+    ("master", Version(0, 0, 0)),
+    ("master-latest", Version(0, 0, 0)),
 ]
 
 


### PR DESCRIPTION
Previously only versions on format X.Y.Z was allowed, all other version strings would be treated as version 0.0.0. Now vX.Y.Z is also allowed.

Refs: equinor/ecalc-internal#915

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
