### PR TITLE
ci: set up default dependabot alerts for all package systems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,37 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  # We do not want to automatically create PRs for other deps, as we update them ourselves with our tooling.
+
+  # Monitor Python dependencies (pip ecosystem = poetry; poetry.lock) for security vulnerabilities only
+  # TODO: Rename pre-commit-requirements.txt to requirements.txt or similar to detect it.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  # UV when added
+  #- package-ecosystem: "uv"
+  #  directory: "/"
+  #  schedule:
+  #    interval: "daily"
+  #  open-pull-requests-limit: 0
+
+  # Monitor npm/node dependencies for security vulnerabilities only
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  # Monitor docker dependencies for security vulnerabilities only
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/.devcontainer/node"
+      - "/.devcontainer/python"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Refs: equinor/ecalc-internal#979

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
