### PR TITLE
refactor: direct consumer function time series power loss factor

### DIFF
--- a/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/consumer_function/pump_consumer_function.py
+++ b/src/libecalc/domain/infrastructure/energy_components/legacy_consumer/consumer_function/pump_consumer_function.py
@@ -76,7 +76,7 @@ class PumpConsumerFunction(ConsumerFunction):
             power_loss_factor = self._power_loss_factor.get_values(length=len(energy_usage))
         else:
             energy_usage = energy_function_result.energy_usage
-            power_loss_factor = np.zeros_like(np.asarray(energy_usage, dtype=np.float64), dtype=np.float64)
+            power_loss_factor = None
 
         pump_consumer_function_result = ConsumerFunctionResult(
             periods=expression_evaluator.get_periods(),

--- a/src/libecalc/domain/time_series_flow_rate.py
+++ b/src/libecalc/domain/time_series_flow_rate.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from libecalc.common.time_utils import Periods
+
 
 class TimeSeriesFlowRate(ABC):
     """
@@ -14,5 +16,13 @@ class TimeSeriesFlowRate(ABC):
     def get_stream_day_values(self) -> list[float | None]:
         """
         Returns the evaluated flow rate values for each stream day.
+        """
+        pass
+
+    @abstractmethod
+    def get_periods(self) -> Periods:
+        """
+        Returns the periods associated with the flow rate time series.
+        This is used to align the flow rate values with the corresponding periods.
         """
         pass

--- a/src/libecalc/domain/time_series_power.py
+++ b/src/libecalc/domain/time_series_power.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from libecalc.common.time_utils import Periods
+
 
 class TimeSeriesPower(ABC):
     """
@@ -14,5 +16,13 @@ class TimeSeriesPower(ABC):
     def get_stream_day_values(self) -> list[float | None]:
         """
         Returns the evaluated power values for each stream day.
+        """
+        pass
+
+    @abstractmethod
+    def get_periods(self) -> Periods:
+        """
+        Returns the periods associated with the flow rate time series.
+        This is used to align the flow rate values with the corresponding periods.
         """
         pass

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_flow_rate.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_flow_rate.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from libecalc.common.time_utils import Period
+from libecalc.common.time_utils import Period, Periods
 from libecalc.common.utils.rates import Rates, RateType
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.utils import (
     apply_condition,
@@ -63,3 +63,11 @@ class ExpressionTimeSeriesFlowRate(TimeSeriesFlowRate):
         )
 
         return stream_day_rate.tolist()
+
+    def get_periods(self) -> Periods:
+        """
+        Returns the periods associated with the time series expression.
+
+        This is used to align the flow rate values with the corresponding periods.
+        """
+        return self._time_series_expression.expression_evaluator.get_periods()

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_power.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_power.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from libecalc.common.time_utils import Period
+from libecalc.common.time_utils import Period, Periods
 from libecalc.common.utils.rates import Rates, RateType
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.utils import (
     apply_condition,
@@ -63,3 +63,11 @@ class ExpressionTimeSeriesPower(TimeSeriesPower):
         )
 
         return stream_day_power.tolist()
+
+    def get_periods(self) -> Periods:
+        """
+        Returns the periods associated with the time series expression.
+
+        This is used to align the flow rate values with the corresponding periods.
+        """
+        return self._time_series_expression.expression_evaluator.get_periods()

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -211,9 +211,15 @@ class ConsumerFunctionMapper:
         period: Period,
     ) -> DirectConsumerFunction:
         period_regularity, period_evaluator = self._period_subsets[period]
+
+        power_loss_factor_expression = TimeSeriesExpression(
+            expressions=model.power_loss_factor, expression_evaluator=period_evaluator
+        )
+        power_loss_factor = ExpressionTimeSeriesPowerLossFactor(time_series_expression=power_loss_factor_expression)
+
         condition = convert_expression(_map_condition(model))
         consumption_rate_type = RateType((model.consumption_rate_type or ConsumptionRateType.STREAM_DAY).value)
-        power_loss_factor = convert_expression(model.power_loss_factor)
+
         if isinstance(model, YamlEnergyUsageModelDirectFuel):
             if consumes != ConsumptionType.FUEL:
                 raise InvalidConsumptionType(actual=ConsumptionType.FUEL, expected=consumes)
@@ -229,7 +235,7 @@ class ConsumerFunctionMapper:
             return DirectConsumerFunction(
                 energy_usage_type=EnergyUsageType.FUEL,
                 fuel_rate=fuel_rate,
-                power_loss_factor=power_loss_factor,  # type: ignore[arg-type]
+                power_loss_factor=power_loss_factor,
             )
         else:
             assert isinstance(model, YamlEnergyUsageModelDirectElectricity)
@@ -247,7 +253,7 @@ class ConsumerFunctionMapper:
             return DirectConsumerFunction(
                 energy_usage_type=EnergyUsageType.POWER,
                 load=load,
-                power_loss_factor=power_loss_factor,  # type: ignore[arg-type]
+                power_loss_factor=power_loss_factor,
             )
 
     def _map_tabular(self, model: YamlEnergyUsageModelTabulated, consumes: ConsumptionType) -> TabularConsumerFunction:

--- a/tests/libecalc/core/consumers/consumer_function/test_direct_expression_consumer_function.py
+++ b/tests/libecalc/core/consumers/consumer_function/test_direct_expression_consumer_function.py
@@ -17,6 +17,10 @@ from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_f
 from libecalc.domain.regularity import Regularity
 from libecalc.expression import Expression
 from libecalc.presentation.yaml.domain.expression_time_series_flow_rate import ExpressionTimeSeriesFlowRate
+from libecalc.presentation.yaml.domain.expression_time_series_power import ExpressionTimeSeriesPower
+from libecalc.presentation.yaml.domain.expression_time_series_power_loss_factor import (
+    ExpressionTimeSeriesPowerLossFactor,
+)
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 
 
@@ -213,10 +217,13 @@ def test_direct_expression_consumer_function(expression_evaluator_factory):
     fuel_rate_expression = TimeSeriesExpression(expressions="2", expression_evaluator=variables_map)
     fuel_rate = ExpressionTimeSeriesFlowRate(time_series_expression=fuel_rate_expression, regularity=regularity)
 
+    power_loss_factor_expression = TimeSeriesExpression(expressions=0.2, expression_evaluator=variables_map)
+    power_loss_factor = ExpressionTimeSeriesPowerLossFactor(time_series_expression=power_loss_factor_expression)
+
     np.testing.assert_allclose(
         actual=DirectConsumerFunction(
             fuel_rate=fuel_rate,
-            power_loss_factor=Expression.setup_from_expression(value=0.2),
+            power_loss_factor=power_loss_factor,
             energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.FUEL,
         )
         .evaluate(
@@ -243,7 +250,7 @@ def test_direct_expression_consumer_function_consumption_rate_type(direct_variab
     load_expression = TimeSeriesExpression(
         expressions=stream_day_consumption, expression_evaluator=direct_variables_map
     )
-    load_stream_day = ExpressionTimeSeriesFlowRate(
+    load_stream_day = ExpressionTimeSeriesPower(
         time_series_expression=load_expression,
         regularity=regularity,
         consumption_rate_type=libecalc.common.utils.rates.RateType.STREAM_DAY,
@@ -258,7 +265,7 @@ def test_direct_expression_consumer_function_consumption_rate_type(direct_variab
     load_expression = TimeSeriesExpression(
         expressions=calendar_day_consumption, expression_evaluator=direct_variables_map
     )
-    load_calendar_day = ExpressionTimeSeriesFlowRate(
+    load_calendar_day = ExpressionTimeSeriesPower(
         time_series_expression=load_expression,
         regularity=regularity,
         consumption_rate_type=libecalc.common.utils.rates.RateType.CALENDAR_DAY,


### PR DESCRIPTION
## Why is this pull request needed?

The current implementation of consumer functions uses generic expressions for power loss factors and period alignment, which limits flexibility and consistency when handling time series data.


## What does this pull request change?

This PR refactors the consumer function logic to use dedicated time series classes for power loss factors (`TimeSeriesPowerLossFactor`), flow rate, and power, including explicit period alignment via new get_periods() methods. It updates the mapping logic and tests to support these changes, ensuring clearer, more robust handling of time series data throughout the codebase.

Refs equinor/ecalc-internal#1001