### PR TITLE
refactor: unify tabular consumer time series interfaces

### DIFF
--- a/src/libecalc/domain/time_series_variable.py
+++ b/src/libecalc/domain/time_series_variable.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+
+class TimeSeriesVariable(ABC):
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @abstractmethod
+    def get_values(self) -> list[float]: ...

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_variable.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_variable.py
@@ -25,8 +25,6 @@ class ExpressionTimeSeriesVariable(TimeSeriesVariable):
         self._regularity = regularity
         self._is_rate = is_rate
 
-        self._condition = self._time_series_expression.get_condition_mask()
-
     @property
     def name(self) -> str:
         return self._name
@@ -36,7 +34,7 @@ class ExpressionTimeSeriesVariable(TimeSeriesVariable):
         return self._is_rate
 
     def get_values(self) -> list[float]:
-        values: np.ndarray = np.asarray(self._time_series_expression.get_evaluated_expressions(), dtype=np.float64)
+        values: np.ndarray = np.asarray(self._time_series_expression.get_masked_values(), dtype=np.float64)
         # If some of these are rates, we need to calculate stream day rate for use
         # Also take a copy of the calendar day rate and stream day rate for input to result object
 
@@ -46,7 +44,6 @@ class ExpressionTimeSeriesVariable(TimeSeriesVariable):
                 regularity=self._regularity.values,
             )
 
-        values = self._condition.apply(values)
         return values.tolist()
 
     def get_periods(self) -> Periods:

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_variable.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_variable.py
@@ -2,9 +2,6 @@ import numpy as np
 
 from libecalc.common.time_utils import Periods
 from libecalc.common.utils.rates import Rates
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.utils import (
-    apply_condition,
-)
 from libecalc.domain.regularity import Regularity
 from libecalc.domain.time_series_variable import TimeSeriesVariable
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
@@ -49,10 +46,7 @@ class ExpressionTimeSeriesVariable(TimeSeriesVariable):
                 regularity=self._regularity.values,
             )
 
-        values = apply_condition(
-            input_array=values,
-            condition=self._condition,
-        )
+        values = self._condition.apply(values)
         return values.tolist()
 
     def get_periods(self) -> Periods:

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_variable.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_variable.py
@@ -1,0 +1,68 @@
+import numpy as np
+
+from libecalc.common.time_utils import Period, Periods
+from libecalc.common.utils.rates import Rates
+from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.utils import (
+    apply_condition,
+    get_condition_from_expression,
+)
+from libecalc.domain.regularity import Regularity
+from libecalc.domain.time_series_variable import TimeSeriesVariable
+from libecalc.expression import Expression
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
+
+
+class ExpressionTimeSeriesVariable(TimeSeriesVariable):
+    """
+    Wraps a time series expression for use as a variable in tabular consumer functions.
+    Handles rate conversion and conditional masking.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        time_series_expression: TimeSeriesExpression,
+        regularity: Regularity,
+        is_rate: bool = True,
+        condition_expression: Expression | dict[Period, Expression] | None = None,
+    ):
+        self._name = name
+        self._time_series_expression = time_series_expression
+        self._regularity = regularity
+        self._is_rate = is_rate
+        self.condition = get_condition_from_expression(
+            expression_evaluator=self._time_series_expression.expression_evaluator,
+            condition_expression=condition_expression,
+        )
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def is_rate(self) -> bool:
+        return self._is_rate
+
+    def get_values(self) -> list[float]:
+        values: np.ndarray = np.asarray(self._time_series_expression.get_evaluated_expressions(), dtype=np.float64)
+        # If some of these are rates, we need to calculate stream day rate for use
+        # Also take a copy of the calendar day rate and stream day rate for input to result object
+
+        if self.is_rate:
+            values = Rates.to_stream_day(
+                calendar_day_rates=values,
+                regularity=self._regularity.values,
+            )
+
+        values = apply_condition(
+            input_array=values,
+            condition=self.condition,
+        )
+        return values.tolist()
+
+    def get_periods(self) -> Periods:
+        """
+        Returns the periods associated with the time series expression.
+
+        """
+        return self._time_series_expression.expression_evaluator.get_periods()

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_variable.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_variable.py
@@ -1,14 +1,12 @@
 import numpy as np
 
-from libecalc.common.time_utils import Period, Periods
+from libecalc.common.time_utils import Periods
 from libecalc.common.utils.rates import Rates
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.utils import (
     apply_condition,
-    get_condition_from_expression,
 )
 from libecalc.domain.regularity import Regularity
 from libecalc.domain.time_series_variable import TimeSeriesVariable
-from libecalc.expression import Expression
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 
 
@@ -24,16 +22,13 @@ class ExpressionTimeSeriesVariable(TimeSeriesVariable):
         time_series_expression: TimeSeriesExpression,
         regularity: Regularity,
         is_rate: bool = True,
-        condition_expression: Expression | dict[Period, Expression] | None = None,
     ):
         self._name = name
         self._time_series_expression = time_series_expression
         self._regularity = regularity
         self._is_rate = is_rate
-        self.condition = get_condition_from_expression(
-            expression_evaluator=self._time_series_expression.expression_evaluator,
-            condition_expression=condition_expression,
-        )
+
+        self._condition = self._time_series_expression.get_condition_mask()
 
     @property
     def name(self) -> str:
@@ -56,7 +51,7 @@ class ExpressionTimeSeriesVariable(TimeSeriesVariable):
 
         values = apply_condition(
             input_array=values,
-            condition=self.condition,
+            condition=self._condition,
         )
         return values.tolist()
 

--- a/src/libecalc/presentation/yaml/domain/time_series_expression.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_expression.py
@@ -54,6 +54,15 @@ class TimeSeriesExpression:
             arr = np.atleast_1d(arr[0])  # Flattens (1, N) to (N,)
         return arr.tolist()
 
+    def get_masked_values(self) -> list[float]:
+        """
+        Returns the evaluated expressions with the condition mask applied.
+        """
+        values = np.asarray(self.get_evaluated_expressions(), dtype=np.float64)
+        mask = self.get_condition_mask()
+        masked = mask.apply(values)
+        return masked.tolist()
+
     def get_condition_mask(self) -> TimeSeriesMask:
         mask = self.expression_evaluator.evaluate(expression=self._condition) if self._condition is not None else None
         return TimeSeriesMask.from_evaluated_mask(mask)

--- a/src/libecalc/presentation/yaml/domain/time_series_expression.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_expression.py
@@ -10,7 +10,12 @@ class TimeSeriesExpression:
     Handles and evaluates one or more time series expressions.
     """
 
-    def __init__(self, expressions: ExpressionType | list[ExpressionType], expression_evaluator: ExpressionEvaluator):
+    def __init__(
+        self,
+        expressions: ExpressionType | list[ExpressionType],
+        expression_evaluator: ExpressionEvaluator,
+        condition: ExpressionType | None = None,
+    ):
         """
         Initializes the TimeSeriesExpression with one or more expressions and an evaluator.
 
@@ -23,6 +28,7 @@ class TimeSeriesExpression:
         else:
             self._expressions = [convert_expression(expressions)]
         self.expression_evaluator = expression_evaluator
+        self._condition = convert_expression(condition) if condition is not None else None
 
     def get_expressions(self) -> list[Expression]:
         """
@@ -46,3 +52,9 @@ class TimeSeriesExpression:
         if arr.shape[0] == 1:
             arr = np.atleast_1d(arr[0])  # Flattens (1, N) to (N,)
         return arr.tolist()
+
+    def get_condition_mask(self):
+        if self._condition is None:
+            return None
+        mask = self.expression_evaluator.evaluate(expression=self._condition)
+        return (np.asarray(mask) != 0).astype(int)

--- a/src/libecalc/presentation/yaml/domain/time_series_expression.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_expression.py
@@ -65,4 +65,4 @@ class TimeSeriesExpression:
 
     def get_condition_mask(self) -> TimeSeriesMask:
         mask = self.expression_evaluator.evaluate(expression=self._condition) if self._condition is not None else None
-        return TimeSeriesMask.from_evaluated_mask(mask)
+        return TimeSeriesMask.from_array(mask)

--- a/src/libecalc/presentation/yaml/domain/time_series_expression.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_expression.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.typing import NDArray
 
 from libecalc.common.variables import ExpressionEvaluator
 from libecalc.dto.utils.validators import convert_expression
@@ -53,7 +54,7 @@ class TimeSeriesExpression:
             arr = np.atleast_1d(arr[0])  # Flattens (1, N) to (N,)
         return arr.tolist()
 
-    def get_condition_mask(self):
+    def get_condition_mask(self) -> NDArray[np.int_] | None:
         if self._condition is None:
             return None
         mask = self.expression_evaluator.evaluate(expression=self._condition)

--- a/src/libecalc/presentation/yaml/domain/time_series_expression.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_expression.py
@@ -1,9 +1,9 @@
 import numpy as np
-from numpy.typing import NDArray
 
 from libecalc.common.variables import ExpressionEvaluator
 from libecalc.dto.utils.validators import convert_expression
 from libecalc.expression.expression import Expression, ExpressionType
+from libecalc.presentation.yaml.domain.time_series_mask import TimeSeriesMask
 
 
 class TimeSeriesExpression:
@@ -54,8 +54,6 @@ class TimeSeriesExpression:
             arr = np.atleast_1d(arr[0])  # Flattens (1, N) to (N,)
         return arr.tolist()
 
-    def get_condition_mask(self) -> NDArray[np.int_] | None:
-        if self._condition is None:
-            return None
-        mask = self.expression_evaluator.evaluate(expression=self._condition)
-        return (np.asarray(mask) != 0).astype(int)
+    def get_condition_mask(self) -> TimeSeriesMask:
+        mask = self.expression_evaluator.evaluate(expression=self._condition) if self._condition is not None else None
+        return TimeSeriesMask.from_evaluated_mask(mask)

--- a/src/libecalc/presentation/yaml/domain/time_series_mask.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_mask.py
@@ -31,7 +31,7 @@ class TimeSeriesMask:
         return np.where(self._mask, array, 0)
 
     @staticmethod
-    def from_evaluated_mask(mask: np.ndarray | None) -> "TimeSeriesMask":
+    def from_array(mask: np.ndarray | None) -> "TimeSeriesMask":
         """
         Creates a TimeSeriesMask from an evaluated mask array.
 

--- a/src/libecalc/presentation/yaml/domain/time_series_mask.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_mask.py
@@ -1,0 +1,47 @@
+import numpy as np
+from numpy.typing import NDArray
+
+
+class TimeSeriesMask:
+    """
+    Encapsulates a mask for time series data, allowing conditional application to arrays.
+    """
+
+    def __init__(self, mask: NDArray[np.int_] | None):
+        """
+        Initializes the TimeSeriesMask.
+
+        Args:
+            mask: An integer NumPy array (1/0) or None. If None, no mask is applied.
+        """
+        self._mask = mask
+
+    def apply(self, array: np.ndarray) -> np.ndarray:
+        """
+        Applies the mask to the given array.
+
+        Args:
+            array: The input NumPy array to be masked.
+
+        Returns:
+            A new array where values are set to 0 where the mask is 0, or unchanged if mask is None.
+        """
+        if self._mask is None:
+            return np.asarray(array, copy=True)
+        return np.where(self._mask, array, 0)
+
+    @staticmethod
+    def from_evaluated_mask(mask: np.ndarray | None) -> "TimeSeriesMask":
+        """
+        Creates a TimeSeriesMask from an evaluated mask array.
+
+        Args:
+            mask: An integer NumPy array or None.
+
+        Returns:
+            A TimeSeriesMask instance with the processed mask.
+        """
+
+        if mask is None:
+            return TimeSeriesMask(None)
+        return TimeSeriesMask((np.asarray(mask) != 0).astype(int))

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -42,8 +42,8 @@ from libecalc.domain.process.compressor.dto import (
 from libecalc.domain.process.compressor.dto.model_types import CompressorModelTypes
 from libecalc.domain.process.pump.factory import create_pump_model
 from libecalc.domain.regularity import Regularity
-from libecalc.domain.time_series_variable import TimeSeriesVariable
 from libecalc.domain.time_series_flow_rate import TimeSeriesFlowRate
+from libecalc.domain.time_series_variable import TimeSeriesVariable
 from libecalc.dto.utils.validators import convert_expression, convert_expressions
 from libecalc.expression import Expression
 from libecalc.expression.expression import InvalidExpressionError

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Protocol, assert_never, cast
+from typing import Protocol, assert_never
 
 from libecalc.common.chart_type import ChartType
 from libecalc.common.consumption_type import ConsumptionType
@@ -271,22 +271,21 @@ class ConsumerFunctionMapper:
         if consumes != energy_usage_type_as_consumption_type:
             raise InvalidConsumptionType(actual=energy_usage_type_as_consumption_type, expected=consumes)
 
-        condition = convert_expression(_map_condition(model))
         power_loss_factor_expression = TimeSeriesExpression(
             expressions=model.power_loss_factor, expression_evaluator=period_evaluator
         )
         power_loss_factor = ExpressionTimeSeriesPowerLossFactor(time_series_expression=power_loss_factor_expression)
 
-        variables = [
+        variables: list[TimeSeriesVariable] = [
             ExpressionTimeSeriesVariable(
                 name=variable.name,
                 time_series_expression=TimeSeriesExpression(
                     expressions=variable.expression,
                     expression_evaluator=period_evaluator,
+                    condition=_map_condition(model),
                 ),
                 regularity=period_regularity,
                 is_rate=(variable.name.lower() == "rate"),
-                condition_expression=condition,
             )
             for variable in model.variables
         ]
@@ -296,7 +295,7 @@ class ConsumerFunctionMapper:
             data=energy_model.data,
             energy_usage_adjustment_constant=energy_model.energy_usage_adjustment_constant,
             energy_usage_adjustment_factor=energy_model.energy_usage_adjustment_factor,
-            variables=cast(list[TimeSeriesVariable], variables),
+            variables=variables,
             power_loss_factor=power_loss_factor,
         )
 

--- a/tests/libecalc/core/models/test_consumer_tabular_energy_function.py
+++ b/tests/libecalc/core/models/test_consumer_tabular_energy_function.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import pytest
 
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.common import Variable
 from libecalc.domain.regularity import Regularity
 from libecalc.presentation.yaml.domain.expression_time_series_variable import ExpressionTimeSeriesVariable
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression

--- a/tests/libecalc/core/models/test_consumer_tabular_energy_function.py
+++ b/tests/libecalc/core/models/test_consumer_tabular_energy_function.py
@@ -1,10 +1,15 @@
+from datetime import datetime, timedelta
+
 import numpy as np
 import pytest
 
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.common import Variable
+from libecalc.domain.regularity import Regularity
+from libecalc.presentation.yaml.domain.expression_time_series_variable import ExpressionTimeSeriesVariable
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 
 
-def test_ConsumerTabularEnergyFunction(tabular_consumer_function_factory):
+def test_ConsumerTabularEnergyFunction(tabular_consumer_function_factory, expression_evaluator_factory):
     variable_name = "Qg"
     variables = {
         variable_name: [
@@ -29,11 +34,39 @@ def test_ConsumerTabularEnergyFunction(tabular_consumer_function_factory):
     }
     function_values = [0.0, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.9, 2.5, 3.1, 3.7, 4.3, 4.9, 5.4, 5.8, 5.8]
 
+    # Create a time vector with the same length as the values
+    raw_values = [-1, 0, 3e6, 3.2e6, 3.5e6, 1e8]
+    n = len(raw_values)
+
+    time_vector = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n + 1)]
+    values_variables_map = {variable_name: raw_values}
+
+    # Create the expression_evaluator
+    expression_evaluator = expression_evaluator_factory.from_time_vector(
+        time_vector=time_vector, variables=values_variables_map
+    )
+    regularity = Regularity(
+        expression_evaluator=expression_evaluator,
+        target_period=expression_evaluator.get_period(),
+        expression_input=1,
+    )
+
     tab_1d = tabular_consumer_function_factory(
         function_values=function_values,
         variables=variables,
+        expression_evaluator=expression_evaluator,
+        regularity=regularity,
     )
-    x_input = [Variable(name=variable_name, values=[-1, 0, 3e6, 3.2e6, 3.5e6, 1e8])]
+    x_input = [
+        ExpressionTimeSeriesVariable(
+            name=variable_name,
+            time_series_expression=TimeSeriesExpression(
+                expressions=variable_name, expression_evaluator=expression_evaluator
+            ),
+            regularity=regularity,
+        )
+    ]
+
     expected = np.asarray([np.nan, 0, 1.3, 1.54, 1.9, np.nan])
     np.testing.assert_allclose(tab_1d.evaluate_variables(x_input).energy_usage, expected)
 
@@ -44,6 +77,8 @@ def test_ConsumerTabularEnergyFunction(tabular_consumer_function_factory):
         variables=variables,
         energy_usage_adjustment_constant=constant,
         energy_usage_adjustment_factor=factor,
+        expression_evaluator=expression_evaluator,
+        regularity=regularity,
     )
     np.testing.assert_allclose(
         tab_1d_adjusted.evaluate_variables(x_input).energy_usage,
@@ -116,15 +151,36 @@ def test_ConsumerTabularEnergyFunction(tabular_consumer_function_factory):
             190.12,
         ],
     }
+    variable_values = {
+        variable_headers[0]: [0, 2e6, 2e6, 2e6],
+        variable_headers[1]: [0, 40, 40, 40],
+        variable_headers[2]: [300, 220.69, 230.0, 242.88],
+    }
+    n = len(next(iter(variable_values.values())))
+    time_vector = [datetime(2020, 1, 1) + timedelta(days=i) for i in range(n + 1)]
+    values_variables_map = {header: values for header, values in variable_values.items()}
+
+    expression_evaluator = expression_evaluator_factory.from_time_vector(
+        time_vector=time_vector, variables=values_variables_map
+    )
+    regularity = Regularity(
+        expression_evaluator=expression_evaluator, target_period=expression_evaluator.get_period(), expression_input=1
+    )
+
     tab_3d = tabular_consumer_function_factory(
         function_values=function_values_3d,
         variables=variables_3d,
+        expression_evaluator=expression_evaluator,
+        regularity=regularity,
     )
 
     x_input = [
-        Variable(name=variable_headers[0], values=[0, 2e6, 2e6, 2e6]),
-        Variable(name=variable_headers[1], values=[0, 40, 40, 40]),
-        Variable(name=variable_headers[2], values=[300, 220.69, 230.0, 242.88]),
+        ExpressionTimeSeriesVariable(
+            name=header,
+            time_series_expression=TimeSeriesExpression(expressions=header, expression_evaluator=expression_evaluator),
+            regularity=regularity,
+        )
+        for header in variable_values
     ]
 
     expected = np.asarray([np.nan, 101007.4, 102669.8, 104969.8])
@@ -135,6 +191,8 @@ def test_ConsumerTabularEnergyFunction(tabular_consumer_function_factory):
         variables=variables_3d,
         energy_usage_adjustment_constant=constant,
         energy_usage_adjustment_factor=factor,
+        expression_evaluator=expression_evaluator,
+        regularity=regularity,
     )
     np.testing.assert_allclose(
         tab_3d_adjusted.evaluate_variables(x_input).energy_usage, expected * factor + constant, rtol=0.01

--- a/tests/libecalc/domain/infrastructure/energy_components/legacy_consumer/test_tabular_consumer_function.py
+++ b/tests/libecalc/domain/infrastructure/energy_components/legacy_consumer/test_tabular_consumer_function.py
@@ -1,31 +1,50 @@
+from datetime import datetime
+
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularConsumerFunction
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.common import (
     Variable,
     VariableExpression,
 )
+from libecalc.domain.regularity import Regularity
 from libecalc.expression import Expression
+from libecalc.presentation.yaml.domain.expression_time_series_variable import ExpressionTimeSeriesVariable
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
+from tests.conftest import expression_evaluator_factory
 
 
-def test_tabular_consumer_single_period_returns_list():
+def test_tabular_consumer_single_period_returns_list(expression_evaluator_factory):
+    test_time_vector = [datetime(2020, 1, 1), datetime(2030, 1, 1)]
     # Minimal setup: one variable, one function value
     headers = ["RATE", "FUEL"]
     data = [[1.0], [10.0]]  # Variable value and function value
-    variables_expressions = [VariableExpression(name="RATE", expression=Expression.setup_from_expression("RATE"))]
+
+    expression_evaluator = expression_evaluator_factory.from_time_vector(test_time_vector)
+    regularity = Regularity(
+        expression_evaluator=expression_evaluator, target_period=expression_evaluator.get_period(), expression_input=1
+    )
+
+    variables = ExpressionTimeSeriesVariable(
+        name="RATE",
+        time_series_expression=TimeSeriesExpression(expressions="RATE", expression_evaluator=expression_evaluator),
+        regularity=regularity,
+    )
     consumer_function = TabularConsumerFunction(
         headers=headers,
         data=data,
         energy_usage_adjustment_constant=0.0,
         energy_usage_adjustment_factor=1.0,
-        variables_expressions=variables_expressions,
-        condition_expression=None,
-        power_loss_factor_expression=None,
+        variables=[variables],
     )
 
     # Test with a single variable and a single value (e.g. only one period).
     # Ensures that the function returns a flat list (not a scalar)
     # even when only one period and one value are present.
-    rate_input = [Variable(name="RATE", values=[1.0])]
+    rate_input = ExpressionTimeSeriesVariable(
+        name="RATE",
+        time_series_expression=TimeSeriesExpression(expressions="1.0", expression_evaluator=expression_evaluator),
+        regularity=regularity,
+    )
 
-    result = consumer_function.evaluate_variables(rate_input)
+    result = consumer_function.evaluate_variables([rate_input])
     assert isinstance(result.energy_usage, list)
     assert result.energy_usage == [10.0]

--- a/tests/libecalc/domain/infrastructure/energy_components/legacy_consumer/test_tabular_consumer_function.py
+++ b/tests/libecalc/domain/infrastructure/energy_components/legacy_consumer/test_tabular_consumer_function.py
@@ -1,12 +1,7 @@
 from datetime import datetime
 
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularConsumerFunction
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated.common import (
-    Variable,
-    VariableExpression,
-)
 from libecalc.domain.regularity import Regularity
-from libecalc.expression import Expression
 from libecalc.presentation.yaml.domain.expression_time_series_variable import ExpressionTimeSeriesVariable
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 from tests.conftest import expression_evaluator_factory

--- a/tests/libecalc/presentation/yaml/domain/test_time_series_mask.py
+++ b/tests/libecalc/presentation/yaml/domain/test_time_series_mask.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+
+import numpy as np
+
+from libecalc.common.time_utils import Period
+from libecalc.domain.regularity import Regularity
+from libecalc.presentation.yaml.domain.time_series_mask import TimeSeriesMask
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
+from libecalc.presentation.yaml.domain.expression_time_series_variable import ExpressionTimeSeriesVariable
+
+
+periods = [
+    Period(start=datetime(2020, 1, 1), end=datetime(2021, 1, 1)),
+    Period(start=datetime(2021, 1, 1), end=datetime(2022, 1, 1)),
+    Period(start=datetime(2022, 1, 1), end=datetime(2023, 1, 1)),
+]
+
+
+def test_time_series_mask_none():
+    """Test that TimeSeriesMask with None mask returns the input array unchanged."""
+    mask = TimeSeriesMask.from_evaluated_mask(None)
+    arr = np.array([1, 2, 3])
+    np.testing.assert_array_equal(mask.apply(arr), arr)
+
+
+def test_time_series_mask_int_mask():
+    """Test that TimeSeriesMask with integer mask applies masking correctly."""
+    mask = TimeSeriesMask.from_evaluated_mask(np.array([1, 0, 1]))
+    arr = np.array([10, 20, 30])
+    np.testing.assert_array_equal(mask.apply(arr), [10, 0, 30])
+
+
+def test_time_series_mask_float_mask():
+    """Test that TimeSeriesMask with float mask applies masking (nonzero as 1, zero as 0)."""
+    mask = TimeSeriesMask.from_evaluated_mask(np.array([0.5, 0.0, -2.1]))
+    arr = np.array([7, 8, 9])
+    np.testing.assert_array_equal(mask.apply(arr), [7, 0, 9])
+
+
+def test_time_series_mask_condition_mask(expression_evaluator_factory):
+    """Test that TimeSeriesExpression uses condition mask correctly."""
+    evaluator = expression_evaluator_factory.from_periods(
+        periods, variables={"SIM1;GAS_PROD": [10.0, 5.0, 10.0], "TEST_VAR": [1.0, 2.0, 3.0]}
+    )
+
+    expr = TimeSeriesExpression(expressions="TEST_VAR", expression_evaluator=evaluator, condition="SIM1;GAS_PROD > 5")
+    # The condition "SIM1;GAS_PROD > 5" results in a mask [1, 0, 1], which is applied to the values of TEST_VAR
+    assert expr.get_masked_values() == [1, 0, 3]
+
+
+def test_expression_time_series_variable_get_values_with_mask(expression_evaluator_factory):
+    """Test that ExpressionTimeSeriesVariable applies mask to values as expected."""
+    evaluator = expression_evaluator_factory.from_periods(
+        periods, variables={"SIM1;GAS_PROD": [10.0, 5.0, 10.0], "TEST_VAR": [1.0, 2.0, 3.0]}
+    )
+    regularity = Regularity(expression_evaluator=evaluator, target_period=evaluator.get_period(), expression_input=1)
+    expr = TimeSeriesExpression(expressions="TEST_VAR", expression_evaluator=evaluator, condition="SIM1;GAS_PROD > 5")
+
+    var = ExpressionTimeSeriesVariable(name="test", time_series_expression=expr, regularity=regularity, is_rate=False)
+    # The mask [1, 0, 1], created from condition, is applied to [1.0, 2.0, 3.0], resulting in [1.0, 0.0, 3.0]
+    assert var.get_values() == [1, 0, 3]

--- a/tests/libecalc/presentation/yaml/domain/test_time_series_mask.py
+++ b/tests/libecalc/presentation/yaml/domain/test_time_series_mask.py
@@ -18,21 +18,21 @@ periods = [
 
 def test_time_series_mask_none():
     """Test that TimeSeriesMask with None mask returns the input array unchanged."""
-    mask = TimeSeriesMask.from_evaluated_mask(None)
+    mask = TimeSeriesMask.from_array(None)
     arr = np.array([1, 2, 3])
     np.testing.assert_array_equal(mask.apply(arr), arr)
 
 
 def test_time_series_mask_int_mask():
     """Test that TimeSeriesMask with integer mask applies masking correctly."""
-    mask = TimeSeriesMask.from_evaluated_mask(np.array([1, 0, 1]))
+    mask = TimeSeriesMask.from_array(np.array([1, 0, 1]))
     arr = np.array([10, 20, 30])
     np.testing.assert_array_equal(mask.apply(arr), [10, 0, 30])
 
 
 def test_time_series_mask_float_mask():
     """Test that TimeSeriesMask with float mask applies masking (nonzero as 1, zero as 0)."""
-    mask = TimeSeriesMask.from_evaluated_mask(np.array([0.5, 0.0, -2.1]))
+    mask = TimeSeriesMask.from_array(np.array([0.5, 0.0, -2.1]))
     arr = np.array([7, 8, 9])
     np.testing.assert_array_equal(mask.apply(arr), [7, 0, 9])
 


### PR DESCRIPTION
## Why is this pull request needed?

This PR is required to improve the handling and consistency of time series data in tabular consumer functions. 

## What does this pull request change?

- Refactors the tabular consumer function logic to use unified time series interfaces for variables and power loss factors.
- Introduces new abstractions (such as `TimeSeriesVariable` and `ExpressionTimeSeriesVariable`) to standardize how time series data is provided and evaluated.
- Updates the evaluation logic so that tabular consumer functions consistently handle rate conversion, conditional masking, and interpolation of tabular data.
- Cleans up legacy code, removing duplicated logic or interfaces.
- Updates related mappers, tests, and consumer factories to use the new interfaces.

Refs equinor/ecalc-internal#1001