### PR TITLE
refactor: simplify condition handling in time series expressions

### DIFF
--- a/src/libecalc/presentation/yaml/domain/expression_time_series_flow_rate.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_flow_rate.py
@@ -1,14 +1,9 @@
 import numpy as np
 
-from libecalc.common.time_utils import Period, Periods
+from libecalc.common.time_utils import Periods
 from libecalc.common.utils.rates import Rates, RateType
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.utils import (
-    apply_condition,
-    get_condition_from_expression,
-)
 from libecalc.domain.regularity import Regularity
 from libecalc.domain.time_series_flow_rate import TimeSeriesFlowRate
-from libecalc.expression import Expression
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 
 
@@ -26,17 +21,12 @@ class ExpressionTimeSeriesFlowRate(TimeSeriesFlowRate):
         self,
         time_series_expression: TimeSeriesExpression,
         regularity: Regularity,
-        condition_expression: Expression | dict[Period, Expression] | None = None,
         consumption_rate_type: RateType | None = RateType.CALENDAR_DAY,
     ):
         self._time_series_expression = time_series_expression
         self._regularity = regularity
         assert isinstance(consumption_rate_type, RateType)
         self._consumption_rate_type = consumption_rate_type
-        self.condition = get_condition_from_expression(
-            expression_evaluator=self._time_series_expression.expression_evaluator,
-            condition_expression=condition_expression,
-        )
 
     def get_stream_day_values(self) -> list[float | None]:
         """
@@ -47,7 +37,7 @@ class ExpressionTimeSeriesFlowRate(TimeSeriesFlowRate):
         """
 
         # if regularity is 0 for a calendar day rate, set stream day rate to 0 for that step
-        rate = self._time_series_expression.get_evaluated_expressions()
+        rate = self._time_series_expression.get_masked_values()
         rate_array = np.asarray(rate, dtype=np.float64)
 
         if self._consumption_rate_type == RateType.CALENDAR_DAY:
@@ -56,13 +46,7 @@ class ExpressionTimeSeriesFlowRate(TimeSeriesFlowRate):
                 regularity=self._regularity.values,
             )
 
-        # If already stream_day, no conversion needed
-        stream_day_rate = apply_condition(
-            input_array=rate_array,
-            condition=self.condition,
-        )
-
-        return stream_day_rate.tolist()
+        return rate_array.tolist()
 
     def get_periods(self) -> Periods:
         """

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_power.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_power.py
@@ -2,10 +2,6 @@ import numpy as np
 
 from libecalc.common.time_utils import Period, Periods
 from libecalc.common.utils.rates import Rates, RateType
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.utils import (
-    apply_condition,
-    get_condition_from_expression,
-)
 from libecalc.domain.regularity import Regularity
 from libecalc.domain.time_series_power import TimeSeriesPower
 from libecalc.expression import Expression
@@ -33,10 +29,6 @@ class ExpressionTimeSeriesPower(TimeSeriesPower):
         self._regularity = regularity
         assert isinstance(consumption_rate_type, RateType)
         self._consumption_rate_type = consumption_rate_type
-        self.condition = get_condition_from_expression(
-            expression_evaluator=self._time_series_expression.expression_evaluator,
-            condition_expression=condition_expression,
-        )
 
     def get_stream_day_values(self) -> list[float | None]:
         """
@@ -47,7 +39,7 @@ class ExpressionTimeSeriesPower(TimeSeriesPower):
         """
 
         # if regularity is 0 for a calendar day value, set stream day value to 0 for that step
-        power = self._time_series_expression.get_evaluated_expressions()
+        power = self._time_series_expression.get_masked_values()
         power_array = np.asarray(power, dtype=np.float64)
 
         if self._consumption_rate_type == RateType.CALENDAR_DAY:
@@ -56,13 +48,7 @@ class ExpressionTimeSeriesPower(TimeSeriesPower):
                 regularity=self._regularity.values,
             )
 
-        # If already stream_day, no conversion needed
-        stream_day_power = apply_condition(
-            input_array=power_array,
-            condition=self.condition,
-        )
-
-        return stream_day_power.tolist()
+        return power_array.tolist()
 
     def get_periods(self) -> Periods:
         """

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -219,19 +219,17 @@ class ConsumerFunctionMapper:
         )
         power_loss_factor = ExpressionTimeSeriesPowerLossFactor(time_series_expression=power_loss_factor_expression)
 
-        condition = convert_expression(_map_condition(model))
         consumption_rate_type = RateType((model.consumption_rate_type or ConsumptionRateType.STREAM_DAY).value)
 
         if isinstance(model, YamlEnergyUsageModelDirectFuel):
             if consumes != ConsumptionType.FUEL:
                 raise InvalidConsumptionType(actual=ConsumptionType.FUEL, expected=consumes)
             fuel_rate_expression = TimeSeriesExpression(
-                expressions=model.fuel_rate, expression_evaluator=period_evaluator
+                expressions=model.fuel_rate, expression_evaluator=period_evaluator, condition=_map_condition(model)
             )
             fuel_rate = ExpressionTimeSeriesFlowRate(
                 time_series_expression=fuel_rate_expression,
                 regularity=period_regularity,
-                condition_expression=condition,
                 consumption_rate_type=consumption_rate_type,
             )
             return DirectConsumerFunction(
@@ -245,11 +243,12 @@ class ConsumerFunctionMapper:
             if consumes != ConsumptionType.ELECTRICITY:
                 raise InvalidConsumptionType(actual=ConsumptionType.ELECTRICITY, expected=consumes)
 
-            load_expression = TimeSeriesExpression(expressions=model.load, expression_evaluator=period_evaluator)
+            load_expression = TimeSeriesExpression(
+                expressions=model.load, expression_evaluator=period_evaluator, condition=_map_condition(model)
+            )
             load = ExpressionTimeSeriesPower(
                 time_series_expression=load_expression,
                 regularity=period_regularity,
-                condition_expression=condition,
                 consumption_rate_type=consumption_rate_type,
             )
             return DirectConsumerFunction(
@@ -312,13 +311,12 @@ class ConsumerFunctionMapper:
         )
         power_loss_factor = ExpressionTimeSeriesPowerLossFactor(time_series_expression=power_loss_factor_expression)
 
-        condition = convert_expression(_map_condition(model))
-
-        rate_expression = TimeSeriesExpression(expressions=model.rate, expression_evaluator=period_evaluator)
+        rate_expression = TimeSeriesExpression(
+            expressions=model.rate, expression_evaluator=period_evaluator, condition=_map_condition(model)
+        )
         rate_standard_m3_day = ExpressionTimeSeriesFlowRate(
             time_series_expression=rate_expression,
             regularity=period_regularity,
-            condition_expression=condition,
         )
 
         fluid_density_expression = TimeSeriesExpression(
@@ -394,7 +392,6 @@ class ConsumerFunctionMapper:
             if model.power_loss_factor is not None
             else None
         )
-        condition = convert_expression(_map_condition(model))
         suction_pressure = ExpressionTimeSeriesPressure(
             time_series_expression=TimeSeriesExpression(
                 model.suction_pressure, expression_evaluator=expression_evaluator
@@ -417,8 +414,9 @@ class ConsumerFunctionMapper:
         compressor_model = create_compressor_model(compressor_model_dto=compressor_train_model)
         rates_per_stream: list[TimeSeriesFlowRate] = [
             ExpressionTimeSeriesFlowRate(
-                time_series_expression=TimeSeriesExpression(rate_expression, expression_evaluator=expression_evaluator),
-                condition_expression=condition,
+                time_series_expression=TimeSeriesExpression(
+                    rate_expression, expression_evaluator=expression_evaluator, condition=_map_condition(model)
+                ),
                 regularity=regularity,
                 consumption_rate_type=RateType.CALENDAR_DAY,
             )
@@ -462,15 +460,15 @@ class ConsumerFunctionMapper:
             if model.power_loss_factor is not None
             else None
         )
-        condition = convert_expression(_map_condition(model))
         compressor_model = create_compressor_model(compressor_model_dto=energy_model)
 
         return CompressorConsumerFunction(
             power_loss_factor_expression=power_loss_factor,
             compressor_function=compressor_model,
             rate_expression=ExpressionTimeSeriesFlowRate(
-                time_series_expression=TimeSeriesExpression(model.rate, expression_evaluator=expression_evaluator),
-                condition_expression=condition,
+                time_series_expression=TimeSeriesExpression(
+                    model.rate, expression_evaluator=expression_evaluator, condition=_map_condition(model)
+                ),
                 consumption_rate_type=RateType.CALENDAR_DAY,
                 regularity=regularity,
             ),

--- a/tests/libecalc/core/consumers/consumer_function/test_direct_expression_consumer_function.py
+++ b/tests/libecalc/core/consumers/consumer_function/test_direct_expression_consumer_function.py
@@ -172,11 +172,12 @@ def test_direct_expression_consumer_function(expression_evaluator_factory):
         desired=[0, 0],
     )
     # With condition
-    fuel_rate_expression = TimeSeriesExpression(expressions="2 {+} 3.1", expression_evaluator=variables_map)
+    fuel_rate_expression = TimeSeriesExpression(
+        expressions="2 {+} 3.1", expression_evaluator=variables_map, condition="2 < 1"
+    )
     fuel_rate = ExpressionTimeSeriesFlowRate(
         time_series_expression=fuel_rate_expression,
         regularity=regularity,
-        condition_expression=Expression.setup_from_expression(value="2 < 1"),
     )
 
     np.testing.assert_allclose(
@@ -191,14 +192,14 @@ def test_direct_expression_consumer_function(expression_evaluator_factory):
         .energy_usage,
         desired=[0, 0],
     )
-    fuel_rate_expression = TimeSeriesExpression(expressions="3.1", expression_evaluator=variables_map)
+    fuel_rate_expression = TimeSeriesExpression(
+        expressions="3.1",
+        expression_evaluator=variables_map,
+        condition="(2 > 1) {*} (" + time_series_name + ";Flare > 4" + ")",
+    )
     fuel_rate = ExpressionTimeSeriesFlowRate(
         time_series_expression=fuel_rate_expression,
         regularity=regularity,
-        condition_expression=Expression.multiply(
-            Expression.setup_from_expression(value="2 > 1"),
-            Expression.setup_from_expression(value=time_series_name + ";Flare > 4"),
-        ),
     )
 
     np.testing.assert_allclose(


### PR DESCRIPTION
## Why is this pull request needed?

This PR is needed to simplify and improve the handling of conditional logic for time series expressions in the codebase. Previously, condition expressions were managed separately and added unnecessary complexity when mapping and evaluating time series data for flow rates and power. By refactoring how conditions are passed and evaluated, the code becomes easier to maintain, less error-prone, and more consistent.

## What does this pull request change?

- Removes the separate handling of condition_expression in several classes and mapping functions.
- Integrates the condition directly into the TimeSeriesExpression object via a new condition argument.
- Updates usage throughout the codebase, including constructors and mapper functions, to reflect this new structure.
- Refactors the implementation to use get_masked_values() instead of applying condition logic manually.
- Simplifies corresponding tests, passing conditions as part of the TimeSeriesExpression instead of separately.

This improves code clarity, reduces duplication, and ensures consistent evaluation of conditions in time series calculations.

