### PR TITLE
fix: some models crashes with monthly frequency

### DIFF
--- a/src/libecalc/common/time_utils.py
+++ b/src/libecalc/common/time_utils.py
@@ -296,6 +296,7 @@ def resample_periods(
         )
     else:
         periods = periods
+
     return periods
 
 

--- a/src/libecalc/common/utils/rates.py
+++ b/src/libecalc/common/utils/rates.py
@@ -192,7 +192,7 @@ class TimeSeries(BaseModel, Generic[TimeSeriesValue], ABC):
             TimeSeries resampled to the given frequency
         """
         if freq is Frequency.NONE:
-            return self.periods, self.values
+            return self.model_copy()
 
         ds = pd.Series(index=self.start_dates, data=self.values)
         new_periods = resample_periods(

--- a/src/libecalc/presentation/exporter/infrastructure.py
+++ b/src/libecalc/presentation/exporter/infrastructure.py
@@ -105,6 +105,7 @@ class InstallationExportable(Exportable):
                         ),
                     )
                 )
+
         return AttributeSet(attributes)
 
     def get_category(self) -> str | None:

--- a/src/libecalc/presentation/exporter/queries.py
+++ b/src/libecalc/presentation/exporter/queries.py
@@ -267,12 +267,15 @@ class MaxUsageFromShoreQuery(Query):
 
             # Max usage from shore is time series float (values)
             # The maximum value with in each period in sorted_results should be found for the new periods
+
             return {
                 period: TimeSeriesFloat(periods=Periods(period_keys), values=list(sorted_result.values()), unit=unit)
+                .resample(freq=frequency)
                 .for_period(period)
                 .max
                 for period in resample_periods(periods=installation_graph.get_periods(), frequency=frequency)
             }
+
         return None
 
 


### PR DESCRIPTION
turns out that max shore calculation for LTP had not been updated to use resampling for values, but only for periods. There was therefore a mismatch when running LTP when data-defined periods happened to not match monthly frequency resolution.

Refs: equinor/ecalc-internal#1028

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
