### PR TITLE
fix/refactor time series cable loss category

### DIFF
--- a/src/libecalc/domain/time_series_cable_loss.py
+++ b/src/libecalc/domain/time_series_cable_loss.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+
+
+class TimeSeriesCableLoss(ABC):
+    """
+    Interface for evaluating cable loss time series.
+
+    """
+
+    @abstractmethod
+    def get_values(self) -> list[float]:
+        """
+        Returns the evaluated cable loss values.
+        """
+        pass

--- a/src/libecalc/domain/time_series_max_usage_from_shore.py
+++ b/src/libecalc/domain/time_series_max_usage_from_shore.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+
+
+class TimeSeriesMaxUsageFromShore(ABC):
+    """
+    Interface for evaluating max usage from shore time series.
+
+    """
+
+    @abstractmethod
+    def get_values(self) -> list[float]:
+        """
+        Returns the evaluated max usage from shore values.
+        """
+        pass

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
@@ -1,0 +1,55 @@
+from libecalc.common.time_utils import Periods
+from libecalc.domain.time_series_cable_loss import TimeSeriesCableLoss
+from libecalc.dto.types import ConsumerUserDefinedCategoryType
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
+from libecalc.presentation.yaml.model import DEFAULT_START_TIME
+from libecalc.presentation.yaml.yaml_types.yaml_temporal_model import YamlTemporalModel
+
+
+class ExpressionTimeSeriesCableLoss(TimeSeriesCableLoss):
+    """
+    Provides cable loss values by evaluating a time series expression.
+    Only applies cable loss when the category is POWER_FROM_SHORE; otherwise, returns 0.
+    """
+
+    def __init__(
+        self, time_series_expression: TimeSeriesExpression, category: YamlTemporalModel[ConsumerUserDefinedCategoryType]
+    ):
+        self._time_series_expression = time_series_expression
+        self._category = category
+
+    def get_values(self) -> list[float]:
+        # Evaluate the cable loss expression for all periods (returns a list of values)
+        cable_loss_values = self._time_series_expression.get_evaluated_expressions()
+        periods = self.get_periods()
+        category_model = self._category
+
+        # Handle both single value and dict (temporal) cases
+        if isinstance(category_model, dict):
+            # Sort change points by datetime
+            change_points = sorted(category_model.items())
+        else:
+            # Single value for all periods
+            change_points = [(DEFAULT_START_TIME, category_model)]
+
+        result = []
+        change_idx = 0
+
+        for idx, period in enumerate(periods):
+            # Advance to the correct category for this period
+            while change_idx + 1 < len(change_points) and period.start >= change_points[change_idx + 1][0]:
+                change_idx += 1
+            current_category = change_points[change_idx][1]
+
+            if current_category == ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
+                result.append(cable_loss_values[idx])
+            else:
+                result.append(0.0)
+        return result
+
+    def get_periods(self) -> Periods:
+        """
+        Returns the periods associated with the time series expression.
+        Used to align cable loss values with the correct periods.
+        """
+        return self._time_series_expression.expression_evaluator.get_periods()

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
@@ -1,10 +1,8 @@
-from datetime import datetime
-
+from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.time_utils import Periods
 from libecalc.domain.time_series_cable_loss import TimeSeriesCableLoss
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
-from libecalc.presentation.yaml.yaml_types.yaml_temporal_model import YamlTemporalModel
 
 
 class ExpressionTimeSeriesCableLoss(TimeSeriesCableLoss):
@@ -14,7 +12,7 @@ class ExpressionTimeSeriesCableLoss(TimeSeriesCableLoss):
     """
 
     def __init__(
-        self, time_series_expression: TimeSeriesExpression, category: YamlTemporalModel[ConsumerUserDefinedCategoryType]
+        self, time_series_expression: TimeSeriesExpression, category: TemporalModel[ConsumerUserDefinedCategoryType]
     ):
         self._time_series_expression = time_series_expression
         self._category = category
@@ -23,27 +21,12 @@ class ExpressionTimeSeriesCableLoss(TimeSeriesCableLoss):
         # Evaluate the cable loss expression for all periods (returns a list of values)
         cable_loss_values = self._time_series_expression.get_evaluated_expressions()
         periods = self.get_periods()
-        category_model = self._category
-
-        # Handle both single value and dict (temporal) cases
-        if isinstance(category_model, dict):
-            # Sort change points by datetime
-            change_points = sorted(category_model.items())
-        else:
-            # Single value for all periods
-            change_points = [(datetime(1900, 1, 1), category_model)]
 
         result = []
-        change_idx = 0
 
-        for idx, period in enumerate(periods):
-            # Advance to the correct category for this period
-            while change_idx + 1 < len(change_points) and period.start >= change_points[change_idx + 1][0]:
-                change_idx += 1
-            current_category = change_points[change_idx][1]
-
-            if current_category == ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
-                result.append(cable_loss_values[idx])
+        for period, cable_loss in zip(periods, cable_loss_values):
+            if self._category.get_model(period) == ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
+                result.append(cable_loss)
             else:
                 result.append(0.0)
         return result

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
@@ -1,3 +1,4 @@
+from libecalc.common.logger import logger
 from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.time_utils import Periods
 from libecalc.domain.time_series_cable_loss import TimeSeriesCableLoss
@@ -31,6 +32,9 @@ class ExpressionTimeSeriesCableLoss(TimeSeriesCableLoss):
                 else:
                     result.append(0.0)
             except ValueError:
+                logger.warning(
+                    f"Temporal model for generator set category is not defined for period {period}. Assuming 0.0 cable loss."
+                )
                 result.append(0.0)
         return result
 

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
@@ -25,9 +25,12 @@ class ExpressionTimeSeriesCableLoss(TimeSeriesCableLoss):
         result = []
 
         for period, cable_loss in zip(periods, cable_loss_values):
-            if self._category.get_model(period) == ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
-                result.append(cable_loss)
-            else:
+            try:
+                if self._category.get_model(period) == ConsumerUserDefinedCategoryType.POWER_FROM_SHORE:
+                    result.append(cable_loss)
+                else:
+                    result.append(0.0)
+            except ValueError:
                 result.append(0.0)
         return result
 

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_cable_loss.py
@@ -1,8 +1,9 @@
+from datetime import datetime
+
 from libecalc.common.time_utils import Periods
 from libecalc.domain.time_series_cable_loss import TimeSeriesCableLoss
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
-from libecalc.presentation.yaml.model import DEFAULT_START_TIME
 from libecalc.presentation.yaml.yaml_types.yaml_temporal_model import YamlTemporalModel
 
 
@@ -30,7 +31,7 @@ class ExpressionTimeSeriesCableLoss(TimeSeriesCableLoss):
             change_points = sorted(category_model.items())
         else:
             # Single value for all periods
-            change_points = [(DEFAULT_START_TIME, category_model)]
+            change_points = [(datetime(1900, 1, 1), category_model)]
 
         result = []
         change_idx = 0

--- a/src/libecalc/presentation/yaml/domain/expression_time_series_max_usage_from_shore.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_max_usage_from_shore.py
@@ -1,0 +1,20 @@
+from libecalc.domain.time_series_max_usage_from_shore import TimeSeriesMaxUsageFromShore
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
+
+
+class ExpressionTimeSeriesMaxUsageFromShore(TimeSeriesMaxUsageFromShore):
+    """
+    Provides max usage from shore values by evaluating a time series expression.
+    """
+
+    def __init__(self, time_series_expression: TimeSeriesExpression):
+        self._time_series_expression = time_series_expression
+
+    def get_values(self) -> list[float]:
+        """
+        Returns the max usage from shore values.
+        """
+
+        max_usage_from_shore_values = self._time_series_expression.get_evaluated_expressions()
+
+        return max_usage_from_shore_values

--- a/src/libecalc/presentation/yaml/mappers/component_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/component_mapper.py
@@ -394,16 +394,17 @@ class GeneratorSetMapper:
             consumers.append(parsed_consumer)
 
         try:
-            cable_loss = (
-                ExpressionTimeSeriesCableLoss(
+            category_model = TemporalModel.create(data.category, target_period=self._target_period)
+            if data.cable_loss and category_model is not None:
+                cable_loss = ExpressionTimeSeriesCableLoss(
                     time_series_expression=TimeSeriesExpression(
                         expressions=data.cable_loss, expression_evaluator=expression_evaluator
                     ),
-                    category=data.category,
+                    category=category_model,
                 )
-                if data.cable_loss
-                else None
-            )
+            else:
+                cable_loss = None
+
         except InvalidExpressionError as e:
             raise ComponentValidationException(errors=[create_error(str(e), key="CABLE_LOSS")]) from e
 

--- a/tests/ecalc_cli/snapshots/test_app/test_new_ltp_export_properly/test.POWER_FROM_SHORE_EVENT.ltp.tsv
+++ b/tests/ecalc_cli/snapshots/test_app/test_new_ltp_export_properly/test.POWER_FROM_SHORE_EVENT.ltp.tsv
@@ -1,7 +1,7 @@
 forecastYear	forecastMonth	turbineFuelGasConsumption	turbineFuelGasCo2Mass	turbineFuelGasNoxMass	turbineFuelGasNmvocMass	turbineFuelGasCh4Mass	gasTurbineGeneratorConsumption	fromShoreConsumption	powerSupplyOnshore
 #Years	Months	Fuel Consumption[Sm3]	CO2 From Fuel Gas[t]	NOX From Fuel Gas[t]	NMVOC From Fuel Gas[t]	CH4 From Fuel Gas[t]	Total Electricity Generated[GWh]	Total Electricity Consumed From Power-From-Shore[GWh]	Power Supply Onshore[GWh]
 2021	01	0	0	0	0	0	0	0	0
-2022	01	50156012	105829.2	459.4291	12.03744	45.64197	175.3752	0	0
+2022	01	50156012	105829.2	459.4291	12.03744	45.64197	159.432	0	0
 2023	01	0	0	0	0	0	0	159.432	175.3752
 2024	01	0	0	0	0	0	0	149.328	164.2608
 2025	01	0	0	0	0	0	0	168.192	185.0112

--- a/tests/ecalc_cli/snapshots/test_app/test_new_ltp_export_properly/test.POWER_FROM_SHORE_EVENT.ltp.tsv.json
+++ b/tests/ecalc_cli/snapshots/test_app/test_new_ltp_export_properly/test.POWER_FROM_SHORE_EVENT.ltp.tsv.json
@@ -114,7 +114,7 @@
   "gasTurbineGeneratorConsumption":{
     "0":"Total Electricity Generated[GWh]",
     "1":"0",
-    "2":"175.3752",
+    "2":"159.432",
     "3":"0",
     "4":"0",
     "5":"0",

--- a/tests/libecalc/presentation/yaml/domain/test_time_series_cable_loss.py
+++ b/tests/libecalc/presentation/yaml/domain/test_time_series_cable_loss.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from libecalc.common.temporal_model import TemporalModel
 from libecalc.common.time_utils import Period
 from libecalc.dto.types import ConsumerUserDefinedCategoryType
 from libecalc.presentation.yaml.domain.expression_time_series_cable_loss import ExpressionTimeSeriesCableLoss
@@ -19,7 +20,10 @@ def test_single_category_power_from_shore(expression_evaluator_factory):
     )
     cable_loss_expr = TimeSeriesExpression(expressions="SIM1;CABLE_LOSS", expression_evaluator=evaluator)
     cable_loss = ExpressionTimeSeriesCableLoss(
-        time_series_expression=cable_loss_expr, category=ConsumerUserDefinedCategoryType.POWER_FROM_SHORE
+        time_series_expression=cable_loss_expr,
+        category=TemporalModel.create(
+            ConsumerUserDefinedCategoryType.POWER_FROM_SHORE, target_period=evaluator.get_period()
+        ),
     )
     assert cable_loss.get_values() == [0.1, 0.2, 0.3]
 
@@ -31,7 +35,10 @@ def test_single_category_other(expression_evaluator_factory):
     )
     cable_loss_expr = TimeSeriesExpression(expressions="SIM1;CABLE_LOSS", expression_evaluator=evaluator)
     cable_loss = ExpressionTimeSeriesCableLoss(
-        time_series_expression=cable_loss_expr, category=ConsumerUserDefinedCategoryType.TURBINE_GENERATOR
+        time_series_expression=cable_loss_expr,
+        category=TemporalModel.create(
+            ConsumerUserDefinedCategoryType.TURBINE_GENERATOR, target_period=evaluator.get_period()
+        ),
     )
     assert cable_loss.get_values() == [0.0, 0.0, 0.0]
 
@@ -50,7 +57,10 @@ def test_temporal_category_switch(expression_evaluator_factory):
         periods=periods, variables={"SIM1;CABLE_LOSS": [0.1, 0.2, 0.3]}
     )
     cable_loss_expr = TimeSeriesExpression(expressions="SIM1;CABLE_LOSS", expression_evaluator=evaluator)
-    cable_loss = ExpressionTimeSeriesCableLoss(time_series_expression=cable_loss_expr, category=category_model)
+    cable_loss = ExpressionTimeSeriesCableLoss(
+        time_series_expression=cable_loss_expr,
+        category=TemporalModel.create(category_model, target_period=evaluator.get_period()),
+    )
     assert cable_loss.get_values() == [0.0, 0.2, 0.3]
 
 
@@ -68,5 +78,8 @@ def test_temporal_category_switch_back(expression_evaluator_factory):
         periods=periods, variables={"SIM1;CABLE_LOSS": [0.1, 0.2, 0.3]}
     )
     cable_loss_expr = TimeSeriesExpression(expressions="SIM1;CABLE_LOSS", expression_evaluator=evaluator)
-    cable_loss = ExpressionTimeSeriesCableLoss(time_series_expression=cable_loss_expr, category=category_model)
+    cable_loss = ExpressionTimeSeriesCableLoss(
+        time_series_expression=cable_loss_expr,
+        category=TemporalModel.create(category_model, target_period=evaluator.get_period()),
+    )
     assert cable_loss.get_values() == [0.1, 0.0, 0.0]

--- a/tests/libecalc/presentation/yaml/domain/test_time_series_cable_loss.py
+++ b/tests/libecalc/presentation/yaml/domain/test_time_series_cable_loss.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+
+from libecalc.common.time_utils import Period
+from libecalc.dto.types import ConsumerUserDefinedCategoryType
+from libecalc.presentation.yaml.domain.expression_time_series_cable_loss import ExpressionTimeSeriesCableLoss
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
+
+periods = [
+    Period(start=datetime(2020, 1, 1), end=datetime(2021, 1, 1)),
+    Period(start=datetime(2021, 1, 1), end=datetime(2022, 1, 1)),
+    Period(start=datetime(2022, 1, 1), end=datetime(2023, 1, 1)),
+]
+
+
+def test_single_category_power_from_shore(expression_evaluator_factory):
+    """Cable loss is used for all periods when category is POWER_FROM_SHORE."""
+    evaluator = expression_evaluator_factory.from_periods(
+        periods=periods, variables={"SIM1;CABLE_LOSS": [0.1, 0.2, 0.3]}
+    )
+    cable_loss_expr = TimeSeriesExpression(expressions="SIM1;CABLE_LOSS", expression_evaluator=evaluator)
+    cable_loss = ExpressionTimeSeriesCableLoss(
+        time_series_expression=cable_loss_expr, category=ConsumerUserDefinedCategoryType.POWER_FROM_SHORE
+    )
+    assert cable_loss.get_values() == [0.1, 0.2, 0.3]
+
+
+def test_single_category_other(expression_evaluator_factory):
+    """Cable loss is zero for all periods when category is not POWER_FROM_SHORE."""
+    evaluator = expression_evaluator_factory.from_periods(
+        periods=periods, variables={"SIM1;CABLE_LOSS": [0.1, 0.2, 0.3]}
+    )
+    cable_loss_expr = TimeSeriesExpression(expressions="SIM1;CABLE_LOSS", expression_evaluator=evaluator)
+    cable_loss = ExpressionTimeSeriesCableLoss(
+        time_series_expression=cable_loss_expr, category=ConsumerUserDefinedCategoryType.TURBINE_GENERATOR
+    )
+    assert cable_loss.get_values() == [0.0, 0.0, 0.0]
+
+
+def test_temporal_category_switch(expression_evaluator_factory):
+    """
+    Cable loss is set to zero for periods before switching to POWER_FROM_SHORE,
+    and applied for periods after the switch.
+    """
+
+    category_model = {
+        periods[0].start: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
+        periods[1].start: ConsumerUserDefinedCategoryType.POWER_FROM_SHORE,
+    }
+    evaluator = expression_evaluator_factory.from_periods(
+        periods=periods, variables={"SIM1;CABLE_LOSS": [0.1, 0.2, 0.3]}
+    )
+    cable_loss_expr = TimeSeriesExpression(expressions="SIM1;CABLE_LOSS", expression_evaluator=evaluator)
+    cable_loss = ExpressionTimeSeriesCableLoss(time_series_expression=cable_loss_expr, category=category_model)
+    assert cable_loss.get_values() == [0.0, 0.2, 0.3]
+
+
+def test_temporal_category_switch_back(expression_evaluator_factory):
+    """
+    Cable loss is applied for periods before switching away from POWER_FROM_SHORE,
+    and set to zero for periods after the switch.
+    """
+
+    category_model = {
+        periods[0].start: ConsumerUserDefinedCategoryType.POWER_FROM_SHORE,
+        periods[1].start: ConsumerUserDefinedCategoryType.TURBINE_GENERATOR,
+    }
+    evaluator = expression_evaluator_factory.from_periods(
+        periods=periods, variables={"SIM1;CABLE_LOSS": [0.1, 0.2, 0.3]}
+    )
+    cable_loss_expr = TimeSeriesExpression(expressions="SIM1;CABLE_LOSS", expression_evaluator=evaluator)
+    cable_loss = ExpressionTimeSeriesCableLoss(time_series_expression=cable_loss_expr, category=category_model)
+    assert cable_loss.get_values() == [0.1, 0.0, 0.0]


### PR DESCRIPTION
Refs equinor/ecalc-internal#1038

## Why is this pull request needed?

Previously, the cable loss was applied regardless of the electricity category, which led to incorrect results when the generator set was not categorized as "POWER_FROM_SHORE". The cable loss should only be considered for periods where the category is "POWER_FROM_SHORE". This fix is needed to ensure the domain logic matches the intended behavior and to prevent misleading power calculations.

## What does this pull request change?

- Refactors how cable loss and maximum usage from shore are handled in the generator set component.
- Introduces abstract interfaces (`TimeSeriesCableLoss`, `TimeSeriesMaxUsageFromShore`) for time series logic.
- Implements logic so that cable loss is only applied when the category is POWER_FROM_SHORE; otherwise, zero cable loss is used.
- Updates mapping and construction of generator set components to use the new time series abstractions.
- Adds tests to verify correct handling of cable loss depending on electricity category, including support for temporal switching between categories.
