### PR TITLE
refactor: validate input before evaluating compressor model

### DIFF
--- a/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -1,5 +1,8 @@
 from copy import deepcopy
 
+import numpy as np
+from numpy._typing import NDArray
+
 from libecalc.common.errors.exceptions import IllegalStateException
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
 from libecalc.common.logger import logger
@@ -82,6 +85,25 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
                 self.inlet_stream_connected_to_stage[stream.connected_to_stage_no].append(i)
             else:
                 self.outlet_stream_connected_to_stage[stream.connected_to_stage_no].append(i)
+
+    def set_evaluation_input(
+        self,
+        rate: NDArray[np.float64],
+        suction_pressure: NDArray[np.float64] | None,
+        discharge_pressure: NDArray[np.float64] | None,
+        intermediate_pressure: NDArray[np.float64] | None = None,
+    ):
+        has_interstage_pressure = any(stage.has_control_pressure for stage in self.data_transfer_object.stages)
+        if has_interstage_pressure and intermediate_pressure is None:
+            raise ValueError("Energy model requires interstage control pressure to be defined")
+        if not has_interstage_pressure and intermediate_pressure is not None:
+            raise ValueError("Energy model does not accept interstage control pressure to be defined")
+        super().set_evaluation_input(
+            rate=rate,
+            suction_pressure=suction_pressure,
+            discharge_pressure=discharge_pressure,
+            intermediate_pressure=intermediate_pressure,
+        )
 
     @staticmethod
     def _check_intermediate_pressure_stage_number_is_valid(

--- a/src/libecalc/presentation/yaml/domain/reference_service.py
+++ b/src/libecalc/presentation/yaml/domain/reference_service.py
@@ -3,7 +3,7 @@ from typing import Protocol
 
 from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularEnergyFunction
-from libecalc.domain.process.compressor.dto.model_types import CompressorModelTypes
+from libecalc.domain.process.compressor.core import CompressorModel
 from libecalc.domain.process.pump.pump import PumpModel
 from libecalc.dto import FuelType
 
@@ -22,7 +22,7 @@ class ReferenceService(Protocol):
 
     def get_generator_set_model(self, reference: str) -> GeneratorSetModel: ...
 
-    def get_compressor_model(self, reference: str) -> CompressorModelTypes: ...
+    def get_compressor_model(self, reference: str) -> CompressorModel: ...
 
     def get_pump_model(self, reference: str) -> PumpModel: ...
 

--- a/src/libecalc/presentation/yaml/mappers/facility_input.py
+++ b/src/libecalc/presentation/yaml/mappers/facility_input.py
@@ -80,8 +80,6 @@ def _create_compressor_train_sampled_dto_model_data(
     resource: Resource,
     facility_data: YamlCompressorTabularModel,
 ) -> CompressorTrainSampledDTO:
-    # kwargs just to allow this to be used with _default_facility_to_dto_model_data which needs type until we have
-    # replaced _default_facility_to_dto_model_data and have separate functions for all types
     rate_header = EcalcYamlKeywords.consumer_function_rate
     suction_pressure_header = EcalcYamlKeywords.consumer_function_suction_pressure
     discharge_pressure_header = EcalcYamlKeywords.consumer_function_discharge_pressure

--- a/src/libecalc/presentation/yaml/yaml_entities.py
+++ b/src/libecalc/presentation/yaml/yaml_entities.py
@@ -17,6 +17,7 @@ from libecalc.common.errors.exceptions import (
 )
 from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularEnergyFunction
+from libecalc.domain.process.compressor.core import CompressorModel, create_compressor_model
 from libecalc.domain.process.compressor.dto.model_types import CompressorModelTypes
 from libecalc.domain.process.dto.base import EnergyModel
 from libecalc.domain.process.pump.pump import PumpModel
@@ -182,7 +183,7 @@ class References(ReferenceService):
             return self.models[reference]
         except (KeyError, TypeError) as e:
             # KeyError: key does not exist
-            # TypeError: fuel_types is None
+            # TypeError: models is None
             raise InvalidReferenceException(reference_type_name, reference, self.models.keys()) from e
 
     def get_generator_set_model(self, reference: str) -> GeneratorSetModel:
@@ -191,11 +192,11 @@ class References(ReferenceService):
             raise InvalidReferenceException("generator set model", reference)
         return model
 
-    def get_compressor_model(self, reference: str) -> CompressorModelTypes:
+    def get_compressor_model(self, reference: str) -> CompressorModel:
         model = self._get_model_reference(reference, "compressor model")
         if not isinstance(model, get_args(CompressorModelTypes)):
             raise InvalidReferenceException("compressor model", reference)
-        return model  # noqa
+        return create_compressor_model(model)
 
     def get_pump_model(self, reference: str) -> PumpModel:
         model = self._get_model_reference(reference, "compressor model")

--- a/tests/libecalc/core/models/compressor_modelling/sampled/test_compressor_sampled.py
+++ b/tests/libecalc/core/models/compressor_modelling/sampled/test_compressor_sampled.py
@@ -2,8 +2,8 @@ import numpy as np
 import pandas as pd
 
 import libecalc.common.energy_usage_type
-from libecalc.domain.process.compressor import dto
 from libecalc.common.units import Unit
+from libecalc.domain.process.compressor import dto
 from libecalc.domain.process.compressor.core.sampled import CompressorModelSampled
 from libecalc.domain.process.compressor.core.sampled.compressor_model_sampled_1d import (
     CompressorModelSampled1D,
@@ -80,11 +80,12 @@ def test_full_3d_compressor():
         144574,
     ]
 
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=rate,
         suction_pressure=suction_pressure,
         discharge_pressure=discharge_pressure,
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 
@@ -116,11 +117,12 @@ def test_full_3d_compressor_degenerated_ps():
     assert isinstance(energy_func._qhull_sampled, CompressorModelSampled2DRatePd)
     expected = [0, 0, 52765, 52765, np.nan]
 
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=np.asarray([-1, 0, 1e6, 1e6, 1e6]),
         suction_pressure=np.asarray([50, 50, 50, 52, 49]),
         discharge_pressure=np.asarray([162, 162, 162, 162, 162]),
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 
@@ -156,11 +158,12 @@ def test_full_3d_compressor_degenerated_rate():
 
     expected = [0, 0, 52765, 54441, 54441, 131998.5, 52882.5, 52882.5, np.nan]
 
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=np.asarray([-1, 0, 1e6, 1e6, 1e6, 1e6, 1e6, 1e6 + 1e-15, 2e6]),
         suction_pressure=np.asarray([50, 50, 50, 52, 53, 50, 50.5, 50.5, 50]),
         discharge_pressure=np.asarray([162, 162, 162, 150, 150, 432.5, 162, 162, 162]),
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 
@@ -192,11 +195,12 @@ def test_full_3d_compressor_degenerated_pd():
     assert isinstance(energy_func._qhull_sampled, CompressorModelSampled2DRatePs)
     expected = [0, 0, 6, 12, 5.95, np.nan]
 
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=np.asarray([-1, 0, 1e6, 2e6, 1e6, 1e6]),
         suction_pressure=np.asarray([50, 50, 50, 50, 50.5, 50]),
         discharge_pressure=np.asarray([162, 162, 300, 162, 300, 301]),
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 
@@ -219,11 +223,12 @@ def test_full_3d_compressor_degenerated_rate_ps():
     )
     assert isinstance(energy_func._qhull_sampled, CompressorModelSampled1D)
     expected = [0, 0, 52765, 52765, np.nan]
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=np.asarray([-1, 0, 1e6, 1, 1e6]),
         suction_pressure=np.asarray([50, 50, 50, 50, 50]),
         discharge_pressure=np.asarray([162, 162, 162, 162, 472]),
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 
@@ -257,11 +262,12 @@ def test_2d_compressor_degenerated_ps():
 
     expected = [0, 0, 52765, 52765, 52765]
 
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=np.asarray([-1, 0, 1e6, 1e6, 1e6]),
         suction_pressure=np.asarray([50, 50, 50, 52, 49]),
         discharge_pressure=np.asarray([162, 162, 162, 162, 162]),
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 
@@ -296,11 +302,12 @@ def test_2d_compressor_degenerated_rate():
     assert isinstance(energy_func._qhull_sampled, CompressorModelSampled2DPsPd)
     expected = [0, 0, 52765, 54441, 54441, 131998.5, 52882.5, 52882.5, 52765]
 
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=np.asarray([-1, 0, 1e6, 1e6, 1e6, 1e6, 1e6, 1e6 + 1e-15, 2e6]),
         suction_pressure=np.asarray([50, 50, 50, 52, 53, 50, 50.5, 50.5, 50]),
         discharge_pressure=np.asarray([162, 162, 162, 150, 150, 432.5, 162, 162, 162]),
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 
@@ -319,11 +326,12 @@ def test_2d_compressor_degenerated_pd():
     assert isinstance(energy_func._qhull_sampled, CompressorModelSampled2DRatePs)
     expected = [0, 0, 6, 12, 5.95, 6]
 
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=np.asarray([-1, 0, 1e6, 2e6, 1e6, 1e6]),
         suction_pressure=np.asarray([50, 50, 50, 50, 50.5, 50]),
         discharge_pressure=np.asarray([162, 162, 300, 162, 300, 301]),
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 
@@ -345,14 +353,16 @@ def test_1d_compressor_rate():
     rate = np.asarray([-1, 0, 1e6, 7.2e6, 8e6])
     expected = [0, 0, 52765, 144574, np.nan]
 
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=np.asarray([-1, 0, 1e6, 7.2e6, 8e6]),
         suction_pressure=np.asarray([50, 50, 50, 53, 50]),
         discharge_pressure=np.asarray([162, 162, 150, 150, 432.5]),
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
+    energy_func.set_evaluation_input(rate=rate, suction_pressure=None, discharge_pressure=None)
 
-    res = energy_func.evaluate(rate=rate, suction_pressure=None, discharge_pressure=None).energy_usage
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 
@@ -374,16 +384,18 @@ def test_1d_compressor_pd():
     pr_d = np.asarray([-1, 0, 1e6, 7.2e6, 8e6])
     expected = [52765, 52765, 52765, 144574, np.nan]
 
-    res = energy_func.evaluate(
+    energy_func.set_evaluation_input(
         rate=None,
         suction_pressure=None,
         discharge_pressure=pr_d,
-    ).energy_usage
+    )
+    res = energy_func.evaluate().energy_usage
+    energy_func.set_evaluation_input(rate=None, suction_pressure=None, discharge_pressure=pr_d)
     np.testing.assert_allclose(res, expected)
-    res = energy_func.evaluate(rate=None, suction_pressure=None, discharge_pressure=pr_d).energy_usage
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
-
-    res = energy_func.evaluate(rate=None, suction_pressure=pr_d, discharge_pressure=pr_d).energy_usage
+    energy_func.set_evaluation_input(rate=None, suction_pressure=pr_d, discharge_pressure=pr_d)
+    res = energy_func.evaluate().energy_usage
     np.testing.assert_allclose(res, expected)
 
 

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_with_turbine.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_with_turbine.py
@@ -35,11 +35,13 @@ def compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine(
 def test_variable_speed_multiple_streams_and_pressures_with_turbine(
     compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine,
 ):
-    result_with_turbine = compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine.evaluate(
+    compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine.set_evaluation_input(
         rate=np.asarray([[3000000]]),
         suction_pressure=np.asarray([30]),
+        intermediate_pressure=np.array([65]),
         discharge_pressure=np.asarray([100]),
     )
+    result_with_turbine = compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine.evaluate()
 
     expected_load = (
         compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine._energy_usage_adjustment_factor

--- a/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
@@ -142,11 +142,12 @@ def test_simplified_compressor_train_known_stages(
         data_transfer_object=simplified_compressor_train_with_known_stages_dto,
         fluid_factory=fluid_factory,
     )
-    compressor_train.evaluate(
+    compressor_train.set_evaluation_input(
         rate=rates,
         suction_pressure=suction_pressures,
         discharge_pressure=discharge_pressures,
     )
+    compressor_train.evaluate()
 
 
 def test_simplified_compressor_train_unknown_stages(simplified_compressor_train_unknown_stages_dto):
@@ -155,16 +156,13 @@ def test_simplified_compressor_train_unknown_stages(simplified_compressor_train_
         data_transfer_object=simplified_compressor_train_unknown_stages_dto,
         fluid_factory=fluid_factory,
     )
-    compressor_train.check_for_undefined_stages(
+    compressor_train.set_evaluation_input(
         rate=np.linspace(start=1000, stop=10000, num=10),
         suction_pressure=np.linspace(start=10, stop=20, num=10),
         discharge_pressure=np.linspace(start=200, stop=400, num=10),
     )
-    compressor_train.evaluate(
-        rate=np.linspace(start=1000, stop=10000, num=10),
-        suction_pressure=np.linspace(start=10, stop=20, num=10),
-        discharge_pressure=np.linspace(start=200, stop=400, num=10),
-    )
+    compressor_train.check_for_undefined_stages()
+    compressor_train.evaluate()
 
 
 def test_simplified_compressor_train_unknown_stages_with_constant_power_adjustment(
@@ -175,26 +173,19 @@ def test_simplified_compressor_train_unknown_stages_with_constant_power_adjustme
         data_transfer_object=simplified_compressor_train_unknown_stages_dto,
         fluid_factory=fluid_factory,
     )
-    compressor_train_energy_function.check_for_undefined_stages(
+    compressor_train_energy_function.set_evaluation_input(
         rate=np.linspace(start=1000, stop=10000, num=10),
         suction_pressure=np.linspace(start=10, stop=20, num=10),
         discharge_pressure=np.linspace(start=200, stop=400, num=10),
     )
-    result_comparison = compressor_train_energy_function.evaluate(
-        rate=np.linspace(start=1000, stop=10000, num=10),
-        suction_pressure=np.linspace(start=10, stop=20, num=10),
-        discharge_pressure=np.linspace(start=200, stop=400, num=10),
-    )
+    compressor_train_energy_function.check_for_undefined_stages()
+    result_comparison = compressor_train_energy_function.evaluate()
 
     energy_usage_adjustment_constant = 10
     compressor_train_energy_function.data_transfer_object.energy_usage_adjustment_constant = (
         energy_usage_adjustment_constant
     )
-    result = compressor_train_energy_function.evaluate(
-        rate=np.linspace(start=1000, stop=10000, num=10),
-        suction_pressure=np.linspace(start=10, stop=20, num=10),
-        discharge_pressure=np.linspace(start=200, stop=400, num=10),
-    )
+    result = compressor_train_energy_function.evaluate()
 
     np.testing.assert_allclose(
         np.asarray(result_comparison.energy_usage) + energy_usage_adjustment_constant, result.energy_usage
@@ -286,12 +277,12 @@ def test_compressor_train_simplified_known_stages_predefined_chart(
         data_transfer_object=simplified_compressor_train_known_stages_dto,
         fluid_factory=fluid_factory,
     )
-
-    results = compressor_train.evaluate(
+    compressor_train.set_evaluation_input(
         rate=rates / 5,
         suction_pressure=suction_pressures,
         discharge_pressure=discharge_pressures,
     )
+    results = compressor_train.evaluate()
     # Testing that the polytropic efficiency for the compressor in this compressor train model (with one compressor with
     # a predefined variable speed compressor chart) uses polytropic efficiency calculated from the chart input (and not
     # some hardcoded/fixed value)
@@ -315,11 +306,12 @@ def test_compressor_train_simplified_known_stages_generic_chart(
         data_transfer_object=simplified_compressor_train_with_known_stages_dto,
         fluid_factory=fluid_factory,
     )
-    results = simple_compressor_train_model.evaluate(
+    simple_compressor_train_model.set_evaluation_input(
         rate=rates,
         suction_pressure=suction_pressures,
         discharge_pressure=discharge_pressures,
     )
+    results = simple_compressor_train_model.evaluate()
 
     assert len(results.stage_results) == 2
     np.testing.assert_allclose(
@@ -374,11 +366,12 @@ def test_compressor_train_simplified_known_stages_generic_chart(
         fluid_factory=fluid_factory,
     )
     # Make the undefined compressor chart, using rate and pressure input
-    simple_compressor_train_model_extra_generic_stage_from_data.check_for_undefined_stages(
+    simple_compressor_train_model_extra_generic_stage_from_data.set_evaluation_input(
         rate=rates,
         suction_pressure=suction_pressures,
         discharge_pressure=discharge_pressures,
     )
+    simple_compressor_train_model_extra_generic_stage_from_data.check_for_undefined_stages()
 
     pressure_ratios_per_stage = simple_compressor_train_model.calculate_pressure_ratios_per_stage(
         suction_pressure=suction_pressures,
@@ -450,16 +443,13 @@ def test_compressor_train_simplified_unknown_stages(
         data_transfer_object=simplified_compressor_train_unknown_stages_generic_compressor_from_input_dto,
         fluid_factory=fluid_factory,
     )
-    simple_compressor_train_model.check_for_undefined_stages(
+    simple_compressor_train_model.set_evaluation_input(
         rate=rates,
         suction_pressure=suction_pressures,
         discharge_pressure=discharge_pressures,
     )
-    results = simple_compressor_train_model.evaluate(
-        rate=rates,
-        suction_pressure=suction_pressures,
-        discharge_pressure=discharge_pressures,
-    )
+    simple_compressor_train_model.check_for_undefined_stages()
+    results = simple_compressor_train_model.evaluate()
 
     max_standard_rates = []
     for suction_pressure, discharge_pressure in zip(suction_pressures, discharge_pressures):
@@ -498,11 +488,12 @@ def test_compressor_train_simplified_known_stages_no_indices_to_calulate(
         data_transfer_object=simplified_compressor_train_with_known_stages_dto,
         fluid_factory=fluid_factory,
     )
-    results = simple_compressor_train_model.evaluate(
+    simple_compressor_train_model.set_evaluation_input(
         rate=np.array([0.0, 0.0, 0.0, 0.0]),
         suction_pressure=np.array([1.0, 1.0, 1.0, 0.0]),
         discharge_pressure=np.array([2.0, 4.0, 8.0, 3.0]),
     )
+    results = simple_compressor_train_model.evaluate()
     assert np.all(np.asarray(results.energy_usage) == 0)
 
 
@@ -851,11 +842,12 @@ def test_calculate_compressor_work(fluid_factory_medium):
         data_transfer_object=compressor_train_dto,
         fluid_factory=fluid_factory2,
     )
-    compressor_train.check_for_undefined_stages(
+    compressor_train.set_evaluation_input(
         rate=fluid_factory2.mass_rate_to_standard_rate(mass_rates),
         suction_pressure=inlet_pressures,
         discharge_pressure=np.multiply(inlet_pressures, pressure_ratios_per_stage),
     )
+    compressor_train.check_for_undefined_stages()
     compressor_result_chart_from_input_data = []
     for mass_rate, inlet_pressure, pressure_ratio in zip(mass_rates, inlet_pressures, pressure_ratios_per_stage):
         inlet_stream = fluid_factory2.create_stream_from_mass_rate(

--- a/tests/libecalc/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
@@ -104,11 +104,12 @@ class TestSingleSpeedCompressorTrainCommonShaft:
     ):
         target_discharge_pressures = np.asarray([300.0, 310.0, 300.0, 300.0])
         suction_pressures = 4 * [80.0]
-        result = single_speed_compressor_train_common_shaft_downstream_choking.evaluate(
+        single_speed_compressor_train_common_shaft_downstream_choking.set_evaluation_input(
             rate=np.asarray([5800000.0, 5800000.0, 1000.0, 8189000.0]),
             suction_pressure=np.asarray(suction_pressures),
             discharge_pressure=target_discharge_pressures,
         )
+        result = single_speed_compressor_train_common_shaft_downstream_choking.evaluate()
         np.testing.assert_almost_equal(
             result.outlet_stream_condition.pressure,
             [300.0, 305.0, 300.0, 216.9],
@@ -136,18 +137,20 @@ class TestSingleSpeedCompressorTrainCommonShaft:
         suction_pressures = 4 * [80.0]
         energy_usage_adjustment_constant = 10  # MW
 
-        result_comparison = single_speed_compressor_train_common_shaft_downstream_choking.evaluate(
+        single_speed_compressor_train_common_shaft_downstream_choking.set_evaluation_input(
             rate=np.asarray([5800000.0, 5800000.0, 1000.0, 8189000.0]),
             suction_pressure=np.asarray(suction_pressures),
             discharge_pressure=target_discharge_pressures,
         )
+        result_comparison = single_speed_compressor_train_common_shaft_downstream_choking.evaluate()
 
         single_speed_compressor_train_common_shaft_downstream_choking.data_transfer_object.energy_usage_adjustment_constant = energy_usage_adjustment_constant
-        result = single_speed_compressor_train_common_shaft_downstream_choking.evaluate(
+        single_speed_compressor_train_common_shaft_downstream_choking.set_evaluation_input(
             rate=np.asarray([5800000.0, 5800000.0, 1000.0, 8189000.0]),
             suction_pressure=np.asarray(suction_pressures),
             discharge_pressure=target_discharge_pressures,
         )
+        result = single_speed_compressor_train_common_shaft_downstream_choking.evaluate()
 
         np.testing.assert_allclose(
             np.asarray(result_comparison.energy_usage) + energy_usage_adjustment_constant, result.energy_usage
@@ -161,10 +164,13 @@ class TestSingleSpeedCompressorTrainCommonShaft:
         # And the suction pressure and other relevant attributes in the result should have been changed accordingly
         target_discharge_pressures = np.asarray([300.0, 310.0, 300.0, 300.0])
         suction_pressures = 4 * [80.0]
-        result = single_speed_compressor_train_common_shaft_downstream_choking_with_maximum_discharge_pressure.evaluate(
+        single_speed_compressor_train_common_shaft_downstream_choking_with_maximum_discharge_pressure.set_evaluation_input(
             rate=np.asarray([5800000.0, 5800000.0, 1000.0, 8189000.0]),
             suction_pressure=np.asarray(suction_pressures),
             discharge_pressure=target_discharge_pressures,
+        )
+        result = (
+            single_speed_compressor_train_common_shaft_downstream_choking_with_maximum_discharge_pressure.evaluate()
         )
         np.testing.assert_almost_equal(
             result.outlet_stream_condition.pressure,
@@ -201,11 +207,12 @@ class TestSingleSpeedCompressorTrainCommonShaft:
     ):
         target_suction_pressures = np.asarray(5 * [80.0])
         suction_pressures_after_upstream_choking = np.asarray([79.34775, 80.67131, 64.52168, 85.95488, 49.11668])
-        result = single_speed_compressor_train_common_shaft_upstream_choking.evaluate(
+        single_speed_compressor_train_common_shaft_upstream_choking.set_evaluation_input(
             rate=np.asarray([5800000.0, 5800000.0, 1000.0, 8000000.0, 5800000.0]),
             suction_pressure=target_suction_pressures,
             discharge_pressure=np.asarray([300.0, 310.0, 300.0, 250.0, 100.0]),
         )
+        result = single_speed_compressor_train_common_shaft_upstream_choking.evaluate()
         np.testing.assert_almost_equal(
             suction_pressures_after_upstream_choking, result.stage_results[0].inlet_stream_condition.pressure, decimal=1
         )
@@ -226,11 +233,12 @@ class TestSingleSpeedCompressorTrainCommonShaft:
 
     def test_evaluate_rate_ps_pd_asv_rate_control(self, single_speed_compressor_train_common_shaft_asv_rate_control):
         target_discharge_pressures = np.asarray([100, 300.0, 310.0, 300.0, 250.0])
-        result = single_speed_compressor_train_common_shaft_asv_rate_control.evaluate(
+        single_speed_compressor_train_common_shaft_asv_rate_control.set_evaluation_input(
             rate=np.asarray([5800000.0, 5800000.0, 5800000.0, 1000.0, 8000000.0]),
             suction_pressure=np.asarray(5 * [80.0]),
             discharge_pressure=target_discharge_pressures,
         )
+        result = single_speed_compressor_train_common_shaft_asv_rate_control.evaluate()
         np.testing.assert_almost_equal(
             result.outlet_stream_condition.pressure,
             [167.0, 300.00, 305.0, 300.00, 220.4],
@@ -255,11 +263,12 @@ class TestSingleSpeedCompressorTrainCommonShaft:
         self, single_speed_compressor_train_common_shaft_asv_pressure_control
     ):
         target_discharge_pressures = np.asarray([300.0, 310.0, 300.0, 250.0, 200.0])
-        result = single_speed_compressor_train_common_shaft_asv_pressure_control.evaluate(
+        single_speed_compressor_train_common_shaft_asv_pressure_control.set_evaluation_input(
             rate=np.asarray([6800000.0, 6200000.0, 7000000.0, 8000000.0, 7000000.0]),
             suction_pressure=np.asarray([100, 100, 100, 110, 110], dtype=float),
             discharge_pressure=target_discharge_pressures,
         )
+        result = single_speed_compressor_train_common_shaft_asv_pressure_control.evaluate()
 
         np.testing.assert_almost_equal(
             result.outlet_stream.pressure,
@@ -277,11 +286,12 @@ class TestSingleSpeedCompressorTrainCommonShaft:
 
     def test_evaluate_rate_ps_pd_common_asv(self, single_speed_compressor_train_common_shaft_common_asv):
         target_discharge_pressures = np.asarray([200.0, 270.0, 350.0, 250.0])
-        result = single_speed_compressor_train_common_shaft_common_asv.evaluate(
+        single_speed_compressor_train_common_shaft_common_asv.set_evaluation_input(
             rate=np.asarray([5800000.0, 5800000.0, 1000.0, 8000000.0]),
             suction_pressure=np.asarray(4 * [80.0]),
             discharge_pressure=target_discharge_pressures,
         )
+        result = single_speed_compressor_train_common_shaft_common_asv.evaluate()
 
         np.testing.assert_almost_equal(
             result.outlet_stream.pressure,
@@ -382,11 +392,12 @@ def test_calculate_evaluate_rate_ps_pd_single_speed_train_with_max_rate(single_s
         data_transfer_object=single_speed_compressor_train,
         fluid_factory=fluid_factory,
     )
-    result = compressor_train.evaluate(
+    compressor_train.set_evaluation_input(
         rate=np.asarray(rate),
         suction_pressure=np.asarray(suction_pressure),
         discharge_pressure=np.asarray(discharge_pressure),
     )
+    result = compressor_train.evaluate()
 
     assert np.isnan(result.max_standard_rate[1])
     assert result.max_standard_rate[0] == pytest.approx(407354, rel=0.001)
@@ -402,9 +413,10 @@ def test_calculate_single_speed_train_zero_mass_rate(fluid_model_medium, single_
         data_transfer_object=single_speed_compressor_train,
         fluid_factory=fluid_factory,
     )
-    result = compressor_train.evaluate(
+    compressor_train.set_evaluation_input(
         rate=np.array([0, 1, 1]), suction_pressure=np.array([0, 1, 1]), discharge_pressure=np.array([0, 2, 2])
     )
+    result = compressor_train.evaluate()
 
     # Ensuring that first stage returns zero energy usage and no failure.
     assert result.is_valid == [True, True, True]
@@ -428,9 +440,10 @@ def test_calculate_single_speed_train_zero_pressure_non_zero_rate(fluid_model_me
 
     # These inputs should all result in compressor not running. Zero pressure should return failure_status about invalid
     # pressure input. Zero rate and valid pressure input should just result in compressor not running.
-    result = compressor_train.evaluate(
+    compressor_train.set_evaluation_input(
         rate=np.array([0, 0, 1, 1]), suction_pressure=np.array([0, 1, 1, 0]), discharge_pressure=np.array([0, 1, 0, 1])
     )
+    result = compressor_train.evaluate()
 
     # Results with zero rate should be valid
     assert result.is_valid == [True, True, False, False]
@@ -473,11 +486,12 @@ def test_calculate_single_speed_compressor_stage_given_target_discharge_pressure
 def test_single_speed_compressor_train_vs_unisim_methane(single_speed_compressor_train_unisim_methane):
     compressor_train = single_speed_compressor_train_unisim_methane
 
-    result = compressor_train.evaluate(
+    compressor_train.set_evaluation_input(
         rate=np.asarray([5305771.971, 3890899.445, 6013208.233, 5305771.971, 5305771.971]),
         suction_pressure=np.asarray([40, 40, 40, 35, 60]),
         discharge_pressure=np.asarray([200, 200, 200, 200, 200]),  # Dummy values.
     )
+    result = compressor_train.evaluate()
 
     expected_power = np.array([7.577819961, 6.440134787, 7.728668854, 6.687897402, 9.620088576])
 
@@ -514,11 +528,12 @@ def test_single_speed_compressor_train_vs_unisim_methane(single_speed_compressor
 
 
 def test_points_above_and_below_maximum_power(single_speed_compressor_train_common_shaft_maximum_power):
-    result = single_speed_compressor_train_common_shaft_maximum_power.evaluate(
+    single_speed_compressor_train_common_shaft_maximum_power.set_evaluation_input(
         rate=np.asarray([1800000, 2200000]),
         suction_pressure=np.asarray([30, 30]),
         discharge_pressure=np.asarray([80.0, 80.0]),
     )
+    result = single_speed_compressor_train_common_shaft_maximum_power.evaluate()
     assert result.is_valid[1]
     assert not result.is_valid[0]
     assert result.failure_status[1] == CompressorTrainCommonShaftFailureStatus.NO_FAILURE

--- a/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_common_shaft.py
@@ -79,22 +79,24 @@ def variable_speed_compressor_train_two_compressors(
 
 class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:
     def test_single_point_within_capacity_one_compressor(self, variable_speed_compressor_train_one_compressor):
-        result = variable_speed_compressor_train_one_compressor.evaluate(
+        variable_speed_compressor_train_one_compressor.set_evaluation_input(
             rate=np.asarray([7000]),
             suction_pressure=np.asarray([30]),
             discharge_pressure=np.asarray([100.0]),
         )
+        result = variable_speed_compressor_train_one_compressor.evaluate()
         assert result.mass_rate_kg_per_hr[0] == pytest.approx(240.61266437085808)
         assert result.power[0] == pytest.approx(6.889951698413056)
         assert result.outlet_stream.pressure[0] == pytest.approx(100.00000000000007)
         assert result.inlet_stream.density_kg_per_m3[0] == pytest.approx(24.888039288426715)
 
     def test_points_above_and_below_maximum_power(self, variable_speed_compressor_train_one_compressor_maximum_power):
-        result = variable_speed_compressor_train_one_compressor_maximum_power.evaluate(
+        variable_speed_compressor_train_one_compressor_maximum_power.set_evaluation_input(
             rate=np.asarray([3000000, 3500000]),
             suction_pressure=np.asarray([30, 30]),
             discharge_pressure=np.asarray([100.0, 100.0]),
         )
+        result = variable_speed_compressor_train_one_compressor_maximum_power.evaluate()
         assert result.is_valid[0]
         assert not result.is_valid[1]
         assert result.failure_status[0] == CompressorTrainCommonShaftFailureStatus.NO_FAILURE
@@ -109,11 +111,12 @@ class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:
         In some cases we don't have this mechanism, and we want the train to fail instead.
         """
         target_pressure = 35.0  # Low target discharge pressure normally forces downstream choke.
-        result = variable_speed_compressor_train_one_compressor_no_pressure_control.evaluate(
+        variable_speed_compressor_train_one_compressor_no_pressure_control.set_evaluation_input(
             rate=np.asarray([7000]),
             suction_pressure=np.asarray([30]),
             discharge_pressure=np.asarray([target_pressure]),
         )
+        result = variable_speed_compressor_train_one_compressor_no_pressure_control.evaluate()
         assert not np.any(result.is_valid)
         assert not np.any(result.pressure_is_choked)
         assert result.failure_status[0] == CompressorTrainCommonShaftFailureStatus.TARGET_DISCHARGE_PRESSURE_TOO_LOW
@@ -121,11 +124,12 @@ class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:
     def test_single_point_recirculate_on_minimum_speed_curve_one_compressor(
         self, variable_speed_compressor_train_one_compressor_asv_rate
     ):
-        result = variable_speed_compressor_train_one_compressor_asv_rate.evaluate(
+        variable_speed_compressor_train_one_compressor_asv_rate.set_evaluation_input(
             rate=np.asarray([1500000]),
             suction_pressure=np.asarray([30]),
             discharge_pressure=np.asarray([55.0]),
         )
+        result = variable_speed_compressor_train_one_compressor_asv_rate.evaluate()
 
         np.testing.assert_allclose(result.mass_rate_kg_per_hr[0], 51559.9, rtol=0.001)
         np.testing.assert_allclose(result.power[0], 2.5070, rtol=0.001)
@@ -137,11 +141,12 @@ class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:
         this we set pressure -> 1 when both rate and pressure is zero. This may happen when pressure is a function
         of rate.
         """
-        result = variable_speed_compressor_train_one_compressor.evaluate(
+        variable_speed_compressor_train_one_compressor.set_evaluation_input(
             rate=np.array([0, 1, 1]),
             suction_pressure=np.array([0, 1, 1]),
             discharge_pressure=np.array([0, 2, 2]),
         )
+        result = variable_speed_compressor_train_one_compressor.evaluate()
 
         # Ensuring that first stage returns zero energy usage and no failure (zero rate should always be valid).
         assert result.is_valid == [True, True, True]
@@ -162,9 +167,10 @@ class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:
         this we set pressure -> 1 when both rate and pressure is zero. This may happen when pressure is a function
         of rate.
         """
-        result = variable_speed_compressor_train_one_compressor.evaluate(
+        variable_speed_compressor_train_one_compressor.set_evaluation_input(
             rate=np.array([0, 1, 1]), suction_pressure=np.array([0, 1, 0]), discharge_pressure=np.array([0, 0, 1])
         )
+        result = variable_speed_compressor_train_one_compressor.evaluate()
 
         # Result object generated but result marked as invalid when rates or pressures are altered by validation
         assert not all(result.is_valid)
@@ -181,20 +187,22 @@ class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:
     ):
         energy_usage_adjustment_constant = 10
 
-        result_comparison = variable_speed_compressor_train_one_compressor.evaluate(
+        variable_speed_compressor_train_one_compressor.set_evaluation_input(
             rate=np.asarray([3000000]),
             suction_pressure=np.asarray([30]),
             discharge_pressure=np.asarray([100.0]),
         )
+        result_comparison = variable_speed_compressor_train_one_compressor.evaluate()
 
         variable_speed_compressor_train_one_compressor.data_transfer_object.energy_usage_adjustment_constant = (
             energy_usage_adjustment_constant
         )
-        result = variable_speed_compressor_train_one_compressor.evaluate(
+        variable_speed_compressor_train_one_compressor.set_evaluation_input(
             rate=np.asarray([3000000]),
             suction_pressure=np.asarray([30]),
             discharge_pressure=np.asarray([100.0]),
         )
+        result = variable_speed_compressor_train_one_compressor.evaluate()
 
         np.testing.assert_allclose(
             np.asarray(result_comparison.energy_usage) + energy_usage_adjustment_constant,
@@ -207,11 +215,12 @@ class TestVariableSpeedCompressorTrainCommonShaftOneRateTwoPressures:
         variable_speed_compressor_train_one_compressor,
     ):
         # Testing internal point and ensure that choking is working correctly using DOWNSTREAM CHOKE (default)
-        result = variable_speed_compressor_train_one_compressor.evaluate(
+        variable_speed_compressor_train_one_compressor.set_evaluation_input(
             rate=np.asarray([3000000]),
             suction_pressure=np.asarray([30]),
             discharge_pressure=np.asarray([40.0]),
         )
+        result = variable_speed_compressor_train_one_compressor.evaluate()
 
         assert result.outlet_stream.pressure[0] == 40
         np.testing.assert_allclose(result.stage_results[-1].outlet_stream_condition.pressure, 51, atol=1)
@@ -332,11 +341,12 @@ def test_find_and_calculate_for_compressor_shaft_speed_given_rate_ps_pd_invalid_
 def test_variable_speed_compressor_train_vs_unisim_methane(variable_speed_compressor_train_unisim_methane):
     compressor_train = variable_speed_compressor_train_unisim_methane
 
-    result = compressor_train.evaluate(
+    compressor_train.set_evaluation_input(
         rate=np.asarray([3537181, 5305772, 6720644, 5305772, 5305772]),
         suction_pressure=np.asarray([40, 40, 40, 40, 40]),
         discharge_pressure=np.asarray([100, 100, 100, 110, 70]),
     )
+    result = compressor_train.evaluate()
 
     expected_power = np.array(
         [6.64205229725697, 8.49608791013644, 11.1289812020102, 9.57095479322606, 5.15465592172343]
@@ -386,20 +396,22 @@ def test_adjustment_constant_and_factor_one_compressor(variable_speed_compressor
     compressor_train = variable_speed_compressor_train_one_compressor
     adjustment_constant = 10
     adjustment_factor = 1.5
-    result = compressor_train.evaluate(
+    compressor_train.set_evaluation_input(
         rate=np.asarray([7000]),
         suction_pressure=np.asarray([30]),
         discharge_pressure=np.asarray([100.0]),
     )
+    result = compressor_train.evaluate()
 
     compressor_train.data_transfer_object.energy_usage_adjustment_factor = adjustment_factor
     compressor_train.data_transfer_object.energy_usage_adjustment_constant = adjustment_constant
 
-    result_adjusted = compressor_train.evaluate(
+    compressor_train.set_evaluation_input(
         rate=np.asarray([7000]),
         suction_pressure=np.asarray([30]),
         discharge_pressure=np.asarray([100.0]),
     )
+    result_adjusted = compressor_train.evaluate()
     assert result_adjusted.power[0] == result.power[0] * 1.5 + adjustment_constant
 
 
@@ -417,17 +429,19 @@ def test_get_max_standard_rate_with_and_without_maximum_power(
             discharge_pressures=np.asarray([100]),
         )
     )
-    power_at_max_standard_rate_without_maximum_power = variable_speed_compressor_train_one_compressor.evaluate(
+    variable_speed_compressor_train_one_compressor.set_evaluation_input(
         rate=np.asarray([max_standard_rate_without_maximum_power], dtype=float),
         suction_pressure=np.asarray([30], dtype=float),
         discharge_pressure=np.asarray([100], dtype=float),
-    ).power
+    )
+    power_at_max_standard_rate_without_maximum_power = variable_speed_compressor_train_one_compressor.evaluate().power
+    variable_speed_compressor_train_one_compressor_maximum_power.set_evaluation_input(
+        rate=np.asarray([max_standard_rate_with_maximum_power], dtype=float),
+        suction_pressure=np.asarray([30], dtype=float),
+        discharge_pressure=np.asarray([100], dtype=float),
+    )
     power_at_max_standard_rate_with_maximum_power = (
-        variable_speed_compressor_train_one_compressor_maximum_power.evaluate(
-            rate=np.asarray([max_standard_rate_with_maximum_power], dtype=float),
-            suction_pressure=np.asarray([30], dtype=float),
-            discharge_pressure=np.asarray([100], dtype=float),
-        ).power
+        variable_speed_compressor_train_one_compressor_maximum_power.evaluate().power
     )
 
     assert max_standard_rate_without_maximum_power > max_standard_rate_with_maximum_power


### PR DESCRIPTION
Cleans up mapping by removing some implementation specific checks. It
also makes the validation better for rate and pressure inputs as we can
check that they are provided when required.
