### PR TITLE
ci: workflow for freezing reqs to seperate branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,14 @@ updates:
 
   # Monitor Python dependencies (pip ecosystem = poetry; poetry.lock) for security vulnerabilities only
   # TODO: Rename pre-commit-requirements.txt to requirements.txt or similar to detect it.
-  - package-ecosystem: "uv"
+  - package-ecosystem: "pip"
+    target-branch: "requirements-branch"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 0
 
-  # UV when added
+  # UV when properly supported
   #- package-ecosystem: "uv"
   #  directory: "/"
   #  schedule:

--- a/.github/workflows/on-push-main-branch.yml
+++ b/.github/workflows/on-push-main-branch.yml
@@ -26,6 +26,10 @@ jobs:
     uses: ./.github/workflows/docs-publish.yml
     secrets: inherit
 
+  check-dependencies:
+    uses: ./.github/workflows/update-requirements.yml
+    secrets: inherit
+
 # NOTE: We trigger release-please in the on_workflow_run instead, freeing it from this workflow,
 # and creating a separate workflow for it, that we again can listen to and trigger the publish workflow from.
 # Also, we want to build and test the library before we trigger the release-please workflow,

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -18,9 +18,6 @@ jobs:
           enable-cache: true
           python-version: 3.11
 
-      #      - name: Set up Python
-      #        run: uv python install
-
       - name: Install the project
         run: uv sync --locked --all-extras --dev
 

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -29,7 +29,7 @@ jobs:
           git config --local user.name "github-actions"
           git config --local user.email "github-actions@github.com"
           git add requirements.txt
-          git commit -m "Update requirements.txt" || echo "No changes to commit"
+          git commit -m "ci: update requirements.txt" || echo "No changes to commit"
           git push origin HEAD:requirements-branch  # Push to your requirements branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -1,0 +1,44 @@
+name: update-requirements.yml
+on:
+  workflow_call:
+permissions:
+  contents: write
+
+jobs:
+  update-requirements:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: 3.11
+
+      #      - name: Set up Python
+      #        run: uv python install
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
+      - name: Freeze dependencies
+        run: uv export --frozen --format=requirements.txt --all-extras --no-editable > requirements.txt
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.name "github-actions"
+          git config --local user.email "github-actions@github.com"
+          git add requirements.txt
+          git commit -m "Update requirements.txt" || echo "No changes to commit"
+          git push origin HEAD:requirements-branch  # Push to your requirements branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+
+
+
+


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?
Support for uv.lock is rather spotty.

## What does this pull request change?
Export uv requirements to requirements.txt format, push it to separate branch that can be scanned by dependabot.

## Issues related to this change:
