### PR TITLE
ci: make release please correctly update uv.lock on new version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,13 @@
   "include-component-in-tag": false,
   "packages": {
     ".": {
+      "extra-files": [
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='libecalc')].version"
+        }
+      ],
       "package-name": "libecalc",
       "changelog-path": "docs/docs/changelog/changelog.md",
       "changelog-sections": [


### PR DESCRIPTION
since uv.lock files includes the current package as well, with the current version, we will also have to update uv.lock.

there is currently not support for this in release-please, and we will therefore have to add a "hack" to make sure the uv.lock file is updated on release

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
