### PR TITLE
refactor: remove dto from single speed compressor train

### DIFF
--- a/src/libecalc/domain/process/compressor/core/factory.py
+++ b/src/libecalc/domain/process/compressor/core/factory.py
@@ -105,8 +105,14 @@ def _create_single_speed_compressor_train(
     if fluid_factory is None:
         raise ValueError("Fluid model is required for compressor train")
     return SingleSpeedCompressorTrainCommonShaft(
-        data_transfer_object=compressor_model_dto,
         fluid_factory=fluid_factory,
+        energy_usage_adjustment_constant=compressor_model_dto.energy_usage_adjustment_constant,
+        energy_usage_adjustment_factor=compressor_model_dto.energy_usage_adjustment_factor,
+        stages=compressor_model_dto.stages,
+        pressure_control=compressor_model_dto.pressure_control,
+        calculate_max_rate=compressor_model_dto.calculate_max_rate,
+        maximum_power=compressor_model_dto.maximum_power,
+        maximum_discharge_pressure=compressor_model_dto.maximum_discharge_pressure,
     )
 
 

--- a/tests/libecalc/core/models/compressor_modelling/conftest.py
+++ b/tests/libecalc/core/models/compressor_modelling/conftest.py
@@ -222,8 +222,12 @@ def single_speed_compressor_train_unisim_methane(
         efficiency_fraction=curve.efficiency_fraction,
         speed_rpm=curve.speed_rpm,
     )
-    compressor_train_dto = dto.SingleSpeedCompressorTrain(
-        fluid_model=FluidModel(composition=FluidComposition(methane=1.0), eos_model=EoSModel.SRK),
+
+    fluid_factory = NeqSimFluidFactory(FluidModel(composition=FluidComposition(methane=1.0), eos_model=EoSModel.SRK))
+    return SingleSpeedCompressorTrainCommonShaft(
+        fluid_factory=fluid_factory,
+        energy_usage_adjustment_constant=0,
+        energy_usage_adjustment_factor=1,
         stages=[
             dto.CompressorStage(
                 compressor_chart=chart,
@@ -235,12 +239,7 @@ def single_speed_compressor_train_unisim_methane(
         ],
         pressure_control=libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
         calculate_max_rate=False,
-        energy_usage_adjustment_constant=0,
-        energy_usage_adjustment_factor=1,
     )
-
-    fluid_factory = NeqSimFluidFactory(compressor_train_dto.fluid_model)
-    return SingleSpeedCompressorTrainCommonShaft(data_transfer_object=compressor_train_dto, fluid_factory=fluid_factory)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why is this pull request needed?

The PR refactors how single speed compressor train models are constructed and tested. Previously, these models relied on a data transfer object (DTO) for initialization, which limited flexibility and clarity. This update aims to improve maintainability and make the codebase easier to test and extend, especially when adding new features or modifying model parameters.

## What does this pull request change?

- Refactors the `SingleSpeedCompressorTrainCommonShaft` class to accept explicit arguments instead of a DTO, enhancing clarity and flexibility.
- Updates the factory function and all relevant tests to use the new initialization pattern.
- Simplifies and unifies test fixtures, reducing duplication and making tests easier to configure with different parameters.
- Removes unused DTO properties and cleans up related code.

