### PR TITLE
fix: validation/parsing of data with operational_settings_results

### DIFF
--- a/src/libecalc/presentation/json_result/result/results.py
+++ b/src/libecalc/presentation/json_result/result/results.py
@@ -115,6 +115,10 @@ class ConsumerSystemResult(EquipmentResultBase):
     )
     operational_settings_results: None = None
 
+    @field_validator("operational_settings_results", mode="before")
+    def set_none(cls, operational_settings_results):
+        return None
+
 
 class GenericConsumerResult(EquipmentResultBase):
     componentType: Literal[ComponentType.GENERIC]


### PR DESCRIPTION
Make sure an old json-result still is valid after removing
operational_settings_results
