### PR TITLE
refactor: remove dto from compressor train multiple streams and pressures

### DIFF
--- a/src/libecalc/domain/process/compressor/core/train/base.py
+++ b/src/libecalc/domain/process/compressor/core/train/base.py
@@ -80,6 +80,10 @@ class CompressorTrainModel(CompressorModel, ABC, Generic[TModel]):
     def pressure_control(self) -> FixedSpeedPressureControl | None:
         return self._pressure_control
 
+    @pressure_control.setter
+    def pressure_control(self, value: FixedSpeedPressureControl | None):
+        self._pressure_control = value
+
     @property
     def maximum_discharge_pressure(self) -> float | None:
         return self._maximum_discharge_pressure

--- a/src/libecalc/domain/process/compressor/core/train/stage.py
+++ b/src/libecalc/domain/process/compressor/core/train/stage.py
@@ -12,6 +12,7 @@ from libecalc.domain.process.compressor.core.train.utils.common import (
     calculate_power_in_megawatt,
 )
 from libecalc.domain.process.compressor.core.train.utils.numeric_methods import find_root
+from libecalc.domain.process.compressor.dto import InterstagePressureControl
 from libecalc.domain.process.value_objects.chart.compressor import (
     SingleSpeedCompressorChart,
     VariableSpeedCompressorChart,
@@ -31,11 +32,17 @@ class CompressorTrainStage:
         inlet_temperature_kelvin: float,
         remove_liquid_after_cooling: bool,
         pressure_drop_ahead_of_stage: float | None = None,
+        interstage_pressure_control: InterstagePressureControl | None = None,
     ):
         self.compressor_chart = compressor_chart
         self.inlet_temperature_kelvin = inlet_temperature_kelvin
         self.remove_liquid_after_cooling = remove_liquid_after_cooling
         self.pressure_drop_ahead_of_stage = pressure_drop_ahead_of_stage
+        self.interstage_pressure_control = interstage_pressure_control
+
+    @property
+    def has_control_pressure(self):
+        return self.interstage_pressure_control is not None
 
     def evaluate(
         self,

--- a/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -833,12 +833,6 @@ def split_train_on_stage_number(
             - The first sub-train (stages before the split).
             - The second sub-train (stages from the split onward).
     """
-    first_part_data_transfer_object = deepcopy(compressor_train)
-    last_part_data_transfer_object = deepcopy(compressor_train)
-    first_part_data_transfer_object.stages = first_part_data_transfer_object.stages[:stage_number]
-    last_part_data_transfer_object.stages = last_part_data_transfer_object.stages[stage_number:]
-    first_part_data_transfer_object.pressure_control = pressure_control_first_part
-    last_part_data_transfer_object.pressure_control = pressure_control_last_part
 
     # Create streams for first part
     streams_first_part = [stream for stream in compressor_train.streams if stream.connected_to_stage_no < stage_number]
@@ -849,15 +843,15 @@ def split_train_on_stage_number(
     compressor_train_first_part = VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=streams_first_part,
         fluid_factory=fluid_factory_first_part,
-        energy_usage_adjustment_constant=first_part_data_transfer_object.energy_usage_adjustment_constant,
-        energy_usage_adjustment_factor=first_part_data_transfer_object.energy_usage_adjustment_factor,
-        stages=first_part_data_transfer_object.stages,
-        calculate_max_rate=first_part_data_transfer_object.calculate_max_rate
-        if first_part_data_transfer_object.calculate_max_rate is not None
+        energy_usage_adjustment_constant=compressor_train.energy_usage_adjustment_constant,
+        energy_usage_adjustment_factor=compressor_train.energy_usage_adjustment_factor,
+        stages=compressor_train.stages[:stage_number],
+        calculate_max_rate=compressor_train.calculate_max_rate
+        if compressor_train.calculate_max_rate is not None
         else False,
-        maximum_power=first_part_data_transfer_object.maximum_power,
-        pressure_control=first_part_data_transfer_object.pressure_control,
-        stage_number_interstage_pressure=first_part_data_transfer_object.stage_number_interstage_pressure,
+        maximum_power=compressor_train.maximum_power,
+        pressure_control=pressure_control_first_part,
+        stage_number_interstage_pressure=compressor_train.stage_number_interstage_pressure,
     )
 
     # Create streams for last part
@@ -883,15 +877,15 @@ def split_train_on_stage_number(
     compressor_train_last_part = VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=streams_last_part,
         fluid_factory=fluid_factory_last_part,
-        energy_usage_adjustment_constant=last_part_data_transfer_object.energy_usage_adjustment_constant,
-        energy_usage_adjustment_factor=last_part_data_transfer_object.energy_usage_adjustment_factor,
-        stages=last_part_data_transfer_object.stages,
-        calculate_max_rate=last_part_data_transfer_object.calculate_max_rate
-        if last_part_data_transfer_object.calculate_max_rate is not None
+        energy_usage_adjustment_constant=compressor_train.energy_usage_adjustment_constant,
+        energy_usage_adjustment_factor=compressor_train.energy_usage_adjustment_factor,
+        stages=compressor_train.stages[stage_number:],
+        calculate_max_rate=compressor_train.calculate_max_rate
+        if compressor_train.calculate_max_rate is not None
         else False,
-        maximum_power=last_part_data_transfer_object.maximum_power,
-        pressure_control=last_part_data_transfer_object.pressure_control,
-        stage_number_interstage_pressure=last_part_data_transfer_object.stage_number_interstage_pressure,
+        maximum_power=compressor_train.maximum_power,
+        pressure_control=pressure_control_last_part,
+        stage_number_interstage_pressure=compressor_train.stage_number_interstage_pressure,
     )
 
     return compressor_train_first_part, compressor_train_last_part

--- a/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/domain/process/compressor/core/train/variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -4,20 +4,24 @@ from copy import deepcopy
 import numpy as np
 from numpy._typing import NDArray
 
+from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.common.errors.exceptions import IllegalStateException
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
 from libecalc.common.logger import logger
+from libecalc.common.serializable_chart import VariableSpeedChartDTO
+from libecalc.domain.component_validation_error import ProcessChartTypeValidationException
 from libecalc.domain.process.compressor.core.results import CompressorTrainResultSingleTimeStep
 from libecalc.domain.process.compressor.core.train.base import CompressorTrainModel
+from libecalc.domain.process.compressor.core.train.stage import CompressorTrainStage
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
 from libecalc.domain.process.compressor.core.train.types import FluidStreamObjectForMultipleStreams
 from libecalc.domain.process.compressor.core.train.utils.common import EPSILON
 from libecalc.domain.process.compressor.core.train.utils.numeric_methods import (
     maximize_x_given_boolean_condition_function,
 )
-from libecalc.domain.process.compressor.core.utils import map_compressor_train_stage_to_domain
 from libecalc.domain.process.compressor.dto import VariableSpeedCompressorTrainMultipleStreamsAndPressures
 from libecalc.domain.process.core.results.compressor import TargetPressureStatus
+from libecalc.domain.process.value_objects.chart.compressor import VariableSpeedCompressorChart
 from libecalc.domain.process.value_objects.fluid_stream import ProcessConditions, SimplifiedStreamMixing
 from libecalc.domain.process.value_objects.fluid_stream.fluid_factory import FluidFactoryInterface
 from libecalc.domain.process.value_objects.fluid_stream.fluid_model import FluidModel
@@ -58,27 +62,31 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
 
     def __init__(
         self,
-        data_transfer_object: VariableSpeedCompressorTrainMultipleStreamsAndPressures,
         streams: list[FluidStreamObjectForMultipleStreams],
         fluid_factory: FluidFactoryInterface,
+        energy_usage_adjustment_constant: float,
+        energy_usage_adjustment_factor: float,
+        stages: list[CompressorTrainStage],
+        calculate_max_rate: bool = False,
+        maximum_power: float | None = None,
+        pressure_control: FixedSpeedPressureControl | None = None,
+        stage_number_interstage_pressure: int | None = None,
     ):
-        logger.debug(
-            f"Creating {type(self).__name__} with\n"
-            f"n_stages: {len(data_transfer_object.stages)} and n_streams: {len(streams)}"
-        )
-        stages = [map_compressor_train_stage_to_domain(stage_dto) for stage_dto in data_transfer_object.stages]
+        logger.debug(f"Creating {type(self).__name__} with\n" f"n_stages: {len(stages)} and n_streams: {len(streams)}")
         super().__init__(
             fluid_factory=fluid_factory,
-            energy_usage_adjustment_constant=data_transfer_object.energy_usage_adjustment_constant,
-            energy_usage_adjustment_factor=data_transfer_object.energy_usage_adjustment_factor,
+            energy_usage_adjustment_constant=energy_usage_adjustment_constant,
+            energy_usage_adjustment_factor=energy_usage_adjustment_factor,
             stages=stages,
-            typ=data_transfer_object.typ,
-            maximum_power=data_transfer_object.maximum_power,
-            pressure_control=data_transfer_object.pressure_control,
-            calculate_max_rate=data_transfer_object.calculate_max_rate,
-            stage_number_interstage_pressure=data_transfer_object.stage_number_interstage_pressure,
+            typ=EnergyModelType.VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES,
+            maximum_power=maximum_power,
+            pressure_control=pressure_control,
+            calculate_max_rate=calculate_max_rate,
+            stage_number_interstage_pressure=stage_number_interstage_pressure,
         )
-        self.data_transfer_object = data_transfer_object
+        if pressure_control and not isinstance(pressure_control, FixedSpeedPressureControl):
+            raise TypeError(f"pressure_control must be of type FixedSpeedPressureControl, got {type(pressure_control)}")
+        self._validate_stages(stages)
         self.streams = streams
         self.number_of_compressor_streams = len(self.streams)
 
@@ -100,6 +108,22 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
             else:
                 self.outlet_stream_connected_to_stage[stream.connected_to_stage_no].append(i)
 
+    @property
+    def pressure_control_first_part(self) -> FixedSpeedPressureControl:
+        return (
+            self.stages[self.stage_number_interstage_pressure].interstage_pressure_control.upstream_pressure_control
+            if self.stage_number_interstage_pressure
+            else None
+        )
+
+    @property
+    def pressure_control_last_part(self) -> FixedSpeedPressureControl:
+        return (
+            self.stages[self.stage_number_interstage_pressure].interstage_pressure_control.downstream_pressure_control
+            if self.stage_number_interstage_pressure
+            else None
+        )
+
     def set_evaluation_input(
         self,
         rate: NDArray[np.float64],
@@ -107,7 +131,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         discharge_pressure: NDArray[np.float64] | None,
         intermediate_pressure: NDArray[np.float64] | None = None,
     ):
-        has_interstage_pressure = any(stage.has_control_pressure for stage in self.data_transfer_object.stages)
+        has_interstage_pressure = any(stage.interstage_pressure_control is not None for stage in self.stages)
         if has_interstage_pressure and intermediate_pressure is None:
             raise ValueError("Energy model requires interstage control pressure to be defined")
         if not has_interstage_pressure and intermediate_pressure is not None:
@@ -121,7 +145,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
 
     @staticmethod
     def _check_intermediate_pressure_stage_number_is_valid(
-        _stage_number_intermediate_pressure: int,
+        _stage_number_intermediate_pressure: int | None,
         number_of_stages: int,
     ):
         """Fixme: Move to dto validation.
@@ -149,6 +173,28 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
             )
             logger.exception(msg)
             raise IllegalStateException(msg)
+
+    def _validate_stages(self, stages):
+        min_speed_per_stage = []
+        max_speed_per_stage = []
+        for stage in stages:
+            if not isinstance(stage.compressor_chart, VariableSpeedCompressorChart | VariableSpeedChartDTO):
+                msg = "Variable Speed Compressor train only accepts Variable Speed Compressor Charts."
+                f" Given type was {type(stage.compressor_chart)}"
+
+                raise ProcessChartTypeValidationException(message=str(msg))
+            if isinstance(stage.compressor_chart, VariableSpeedCompressorChart):
+                max_speed_per_stage.append(stage.compressor_chart.maximum_speed)
+                min_speed_per_stage.append(stage.compressor_chart.minimum_speed)
+            else:
+                max_speed_per_stage.append(stage.compressor_chart.max_speed)
+                min_speed_per_stage.append(stage.compressor_chart.min_speed)
+        if max(min_speed_per_stage) > min(max_speed_per_stage):
+            msg = "Variable speed compressors in compressor train have incompatible compressor charts."
+            f" Stage {min_speed_per_stage.index(max(min_speed_per_stage)) + 1}'s minimum speed is higher"
+            f" than max speed of stage {max_speed_per_stage.index(min(max_speed_per_stage)) + 1}"
+
+            raise ProcessChartTypeValidationException(message=str(msg))
 
     def evaluate_given_constraints(
         self,
@@ -189,14 +235,14 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         else:
             if constraints.interstage_pressure is not None:
                 self._check_intermediate_pressure_stage_number_is_valid(
-                    _stage_number_intermediate_pressure=self.data_transfer_object.stage_number_interstage_pressure,
+                    _stage_number_intermediate_pressure=self.stage_number_interstage_pressure,
                     number_of_stages=len(self.stages),
                 )
                 return self.find_and_calculate_for_compressor_train_with_two_pressure_requirements(
-                    stage_number_for_intermediate_pressure_target=self.data_transfer_object.stage_number_interstage_pressure,
+                    stage_number_for_intermediate_pressure_target=self.stage_number_interstage_pressure,
                     constraints=constraints,
-                    pressure_control_first_part=self.data_transfer_object.pressure_control_first_part,
-                    pressure_control_last_part=self.data_transfer_object.pressure_control_last_part,
+                    pressure_control_first_part=self.pressure_control_first_part,
+                    pressure_control_last_part=self.pressure_control_last_part,
                 )
             else:
                 if constraints.speed is None:
@@ -509,7 +555,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
 
     def find_and_calculate_for_compressor_train_with_two_pressure_requirements(
         self,
-        stage_number_for_intermediate_pressure_target: int,
+        stage_number_for_intermediate_pressure_target: int | None,
         constraints: CompressorTrainEvaluationInput,
         pressure_control_first_part: FixedSpeedPressureControl,
         pressure_control_last_part: FixedSpeedPressureControl,
@@ -537,6 +583,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         """
         # This method requires stream_rates to be set for splitting operations
         assert constraints.stream_rates is not None
+        assert stage_number_for_intermediate_pressure_target is not None
 
         # Split train into two and calculate minimum speed to reach required pressures
         compressor_train_first_part, compressor_train_last_part = split_train_on_stage_number(
@@ -586,7 +633,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
                 )
             )
 
-        if self.data_transfer_object.calculate_max_rate:
+        if self.calculate_max_rate:
             max_standard_rate_per_stream = [
                 compressor_train_first_part.get_max_standard_rate(  # type: ignore[call-arg]
                     constraints=CompressorTrainEvaluationInput(
@@ -645,7 +692,7 @@ class VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
                 )
             )
 
-        if self.data_transfer_object.calculate_max_rate:
+        if self.calculate_max_rate:
             for stream_index, _ in enumerate(compressor_train_last_part.streams):
                 if stream_index > 0:
                     max_standard_rate_per_stream.append(
@@ -786,8 +833,8 @@ def split_train_on_stage_number(
             - The first sub-train (stages before the split).
             - The second sub-train (stages from the split onward).
     """
-    first_part_data_transfer_object = deepcopy(compressor_train.data_transfer_object)
-    last_part_data_transfer_object = deepcopy(compressor_train.data_transfer_object)
+    first_part_data_transfer_object = deepcopy(compressor_train)
+    last_part_data_transfer_object = deepcopy(compressor_train)
     first_part_data_transfer_object.stages = first_part_data_transfer_object.stages[:stage_number]
     last_part_data_transfer_object.stages = last_part_data_transfer_object.stages[stage_number:]
     first_part_data_transfer_object.pressure_control = pressure_control_first_part
@@ -801,8 +848,16 @@ def split_train_on_stage_number(
 
     compressor_train_first_part = VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=streams_first_part,
-        data_transfer_object=first_part_data_transfer_object,
         fluid_factory=fluid_factory_first_part,
+        energy_usage_adjustment_constant=first_part_data_transfer_object.energy_usage_adjustment_constant,
+        energy_usage_adjustment_factor=first_part_data_transfer_object.energy_usage_adjustment_factor,
+        stages=first_part_data_transfer_object.stages,
+        calculate_max_rate=first_part_data_transfer_object.calculate_max_rate
+        if first_part_data_transfer_object.calculate_max_rate is not None
+        else False,
+        maximum_power=first_part_data_transfer_object.maximum_power,
+        pressure_control=first_part_data_transfer_object.pressure_control,
+        stage_number_interstage_pressure=first_part_data_transfer_object.stage_number_interstage_pressure,
     )
 
     # Create streams for last part
@@ -827,8 +882,16 @@ def split_train_on_stage_number(
 
     compressor_train_last_part = VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
         streams=streams_last_part,
-        data_transfer_object=last_part_data_transfer_object,
         fluid_factory=fluid_factory_last_part,
+        energy_usage_adjustment_constant=last_part_data_transfer_object.energy_usage_adjustment_constant,
+        energy_usage_adjustment_factor=last_part_data_transfer_object.energy_usage_adjustment_factor,
+        stages=last_part_data_transfer_object.stages,
+        calculate_max_rate=last_part_data_transfer_object.calculate_max_rate
+        if last_part_data_transfer_object.calculate_max_rate is not None
+        else False,
+        maximum_power=last_part_data_transfer_object.maximum_power,
+        pressure_control=last_part_data_transfer_object.pressure_control,
+        stage_number_interstage_pressure=last_part_data_transfer_object.stage_number_interstage_pressure,
     )
 
     return compressor_train_first_part, compressor_train_last_part

--- a/src/libecalc/domain/process/compressor/core/utils.py
+++ b/src/libecalc/domain/process/compressor/core/utils.py
@@ -63,6 +63,7 @@ def _create_compressor_train_stage(
         compressor_chart=compressor_chart,  # type: ignore[arg-type]
         pressure_drop_ahead_of_stage=stage_data.pressure_drop_before_stage,
         remove_liquid_after_cooling=stage_data.remove_liquid_after_cooling,
+        interstage_pressure_control=stage_data.interstage_pressure_control,
     )
 
 

--- a/src/libecalc/domain/process/compressor/dto/stage.py
+++ b/src/libecalc/domain/process/compressor/dto/stage.py
@@ -39,7 +39,3 @@ class CompressorStage:
         self.control_margin = control_margin
         self.stream_reference = stream_reference
         self.interstage_pressure_control = interstage_pressure_control
-
-    @property
-    def has_control_pressure(self):
-        return self.interstage_pressure_control is not None

--- a/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
+++ b/src/libecalc/presentation/yaml/yaml_types/models/yaml_compressor_trains.py
@@ -220,6 +220,19 @@ class YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures(YamlCompressor
     def to_dto(self):
         raise NotImplementedError
 
+    @model_validator(mode="after")
+    def check_interstage_control_pressure(self):
+        count = len(
+            [
+                stage.interstage_control_pressure
+                for stage in self.stages
+                if stage.interstage_control_pressure is not None
+            ]
+        )
+        if count > 1:
+            raise ValueError("Only one stage can have interstage control pressure defined.")
+        return self
+
 
 YamlCompressorTrain = Union[
     YamlVariableSpeedCompressorTrain,

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_with_turbine.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_with_turbine.py
@@ -1,34 +1,19 @@
 import numpy as np
 import pytest
 
-from libecalc.domain.process.compressor import dto
 from libecalc.domain.process.compressor.core.base import CompressorWithTurbineModel
-
-
-@pytest.fixture()
-def compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine_dto(
-    variable_speed_compressor_train_two_compressors_one_stream_dto,
-    turbine_dto,
-) -> dto.CompressorWithTurbine:
-    return dto.CompressorWithTurbine(
-        compressor_train=variable_speed_compressor_train_two_compressors_one_stream_dto,
-        turbine=turbine_dto,
-        energy_usage_adjustment_constant=1.0,
-        energy_usage_adjustment_factor=1.0,
-    )
 
 
 @pytest.fixture()
 def compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine(
     turbine_factory,
     variable_speed_compressor_train_two_compressors_one_stream,
-    compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine_dto,
 ) -> CompressorWithTurbineModel:
     return CompressorWithTurbineModel(
         turbine_model=turbine_factory(),
         compressor_energy_function=variable_speed_compressor_train_two_compressors_one_stream,
-        energy_usage_adjustment_constant=compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine_dto.energy_usage_adjustment_constant,
-        energy_usage_adjustment_factor=compressor_train_variable_speed_multiple_streams_and_pressures_with_turbine_dto.energy_usage_adjustment_factor,
+        energy_usage_adjustment_constant=variable_speed_compressor_train_two_compressors_one_stream.energy_usage_adjustment_constant,
+        energy_usage_adjustment_factor=variable_speed_compressor_train_two_compressors_one_stream.energy_usage_adjustment_factor,
     )
 
 

--- a/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_variable_speed_compressor_train_multiple_streams.py
@@ -1,22 +1,17 @@
-from copy import deepcopy
-from typing import cast
-
 import numpy as np
 import pytest
 
-import libecalc.common.fixed_speed_pressure_control
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
+from libecalc.common.serializable_chart import VariableSpeedChartDTO
 from libecalc.domain.process.compressor import dto
 from libecalc.domain.process.compressor.core.train.types import FluidStreamObjectForMultipleStreams
 from libecalc.domain.process.compressor.core.train.variable_speed_compressor_train_common_shaft_multiple_streams_and_pressures import (
     VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures,
 )
+from libecalc.domain.process.compressor.core.utils import map_compressor_train_stage_to_domain
 from libecalc.domain.process.core.results.compressor import CompressorTrainCommonShaftFailureStatus
 from libecalc.domain.process.value_objects.chart.chart_area_flag import ChartAreaFlag
-from libecalc.domain.process.value_objects.fluid_stream.multiple_streams_stream import (
-    FluidStreamType,
-    MultipleStreamsAndPressureStream,
-)
+from libecalc.domain.process.value_objects.fluid_stream.fluid_model import FluidModel
 from libecalc.infrastructure.neqsim_fluid_provider.neqsim_fluid_factory import NeqSimFluidFactory
 
 
@@ -25,247 +20,80 @@ def calculate_relative_difference(value1, value2):
 
 
 @pytest.fixture
-def mock_variable_speed_compressor_train_multiple_streams_and_pressures(
-    variable_speed_compressor_chart_dto,
-    fluid_model_medium,
-) -> dto.VariableSpeedCompressorTrainMultipleStreamsAndPressures:
-    stream = MultipleStreamsAndPressureStream(
-        name="inlet",
-        typ=FluidStreamType.INGOING,
-        fluid_model=fluid_model_medium,
-    )
-    stage2 = dto.CompressorStage(
-        compressor_chart=variable_speed_compressor_chart_dto,
-        inlet_temperature_kelvin=303.15,
-        remove_liquid_after_cooling=True,
-        pressure_drop_before_stage=0,
-        control_margin=0,
-    )
-    stage1 = deepcopy(stage2)
-    stage1.stream_reference = "inlet"
-    return dto.VariableSpeedCompressorTrainMultipleStreamsAndPressures(
-        streams=[stream],
-        stages=[stage1, stage2],
-        calculate_max_rate=False,
-        energy_usage_adjustment_constant=0.0,
-        energy_usage_adjustment_factor=1.0,
-        pressure_control=libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.INDIVIDUAL_ASV_PRESSURE,
-    )
+def variable_speed_compressor_train_multiple_streams_and_pressures(fluid_model_medium, create_stages):
+    def create_compressor_train(
+        fluid_model: FluidModel = None,
+        fluid_streams: list[FluidStreamObjectForMultipleStreams] = None,
+        energy_adjustment_constant: float = 0.0,
+        energy_adjustment_factor: float = 1.0,
+        stages: list[dto.CompressorStage] = None,
+        pressure_control: FixedSpeedPressureControl = FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
+        maximum_power: float = None,
+    ) -> VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures:
+        if fluid_model is None:
+            fluid_model = fluid_model_medium
+        if stages is None:
+            stages = create_stages()
+        if fluid_streams is None:
+            fluid_streams = [
+                FluidStreamObjectForMultipleStreams(
+                    fluid_model=fluid_model, is_inlet_stream=True, connected_to_stage_no=0
+                )
+            ]
+        fluid_factory = NeqSimFluidFactory(fluid_model)
+        mapped_stages = [map_compressor_train_stage_to_domain(stage) for stage in stages]
+        has_interstage_pressure = any(stage.interstage_pressure_control is not None for stage in mapped_stages)
+        stage_number_interstage_pressure = (
+            [i for i, stage in enumerate(mapped_stages) if stage.interstage_pressure_control is not None][0]
+            if has_interstage_pressure
+            else None
+        )
+        return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
+            streams=fluid_streams,
+            fluid_factory=fluid_factory,
+            energy_usage_adjustment_constant=energy_adjustment_constant,
+            energy_usage_adjustment_factor=energy_adjustment_factor,
+            stages=mapped_stages,
+            pressure_control=pressure_control,
+            maximum_power=maximum_power,
+            stage_number_interstage_pressure=stage_number_interstage_pressure,
+        )
+
+    return create_compressor_train
 
 
 @pytest.fixture
-def variable_speed_compressor_train_one_compressor_one_stream(
-    variable_speed_compressor_train_stage_dto,
-    fluid_model_medium,
-    mock_variable_speed_compressor_train_multiple_streams_and_pressures,
-) -> VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures:
-    """Train with only one compressor, and standard medium fluid, no liquid off take,
-    using multiple streams and pressures class.
-    """
-    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
-    dto_copy.stages = cast(list[dto.CompressorStage], [variable_speed_compressor_train_stage_dto])
-    dto_copy.stages[0].interstage_pressure_control = None
-    dto_copy.maximum_power = 7
-    fluid_factory = NeqSimFluidFactory(fluid_model_medium)
-    return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
-        streams=[
-            FluidStreamObjectForMultipleStreams(
-                fluid_model=fluid_model_medium, is_inlet_stream=True, connected_to_stage_no=0
+def create_stages(variable_speed_compressor_chart_dto, process_simulator_variable_compressor_data):
+    def _create_stages(
+        n_stages=1,
+        chart: VariableSpeedChartDTO = None,
+        interstage_pressure_control=None,
+        inlet_temperature: float = 303.15,
+        pressure_drop_before_stage: float = 0,
+        control_margin: float = 0,
+        remove_liquid_after_cooling: bool = False,
+    ) -> list[dto.CompressorStage]:
+        # Return a list of CompressorTrainStage objects
+        if chart is None:
+            chart = process_simulator_variable_compressor_data.compressor_chart
+        return [
+            dto.CompressorStage(
+                compressor_chart=chart,
+                inlet_temperature_kelvin=inlet_temperature,
+                interstage_pressure_control=interstage_pressure_control,
+                pressure_drop_before_stage=pressure_drop_before_stage,
+                control_margin=control_margin,
+                remove_liquid_after_cooling=remove_liquid_after_cooling,
             )
-        ],
-        data_transfer_object=dto_copy,
-        fluid_factory=fluid_factory,
-    )
+            for _ in range(n_stages)
+        ]
+
+    return _create_stages
 
 
 @pytest.fixture
-def variable_speed_compressor_train_one_compressor_one_stream_downstream_choke(
-    variable_speed_compressor_train_stage_dto,
-    fluid_model_medium,
-    mock_variable_speed_compressor_train_multiple_streams_and_pressures,
-) -> VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures:
-    """Train with only one compressor, and standard medium fluid, no liquid off take,
-    using multiple streams and pressures class.
-    """
-    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
-    dto_copy.stages = cast(list[dto.CompressorStage], [variable_speed_compressor_train_stage_dto])
-    dto_copy.stages[0].interstage_pressure_control = None
-    dto_copy.pressure_control = libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE
-
-    fluid_factory = NeqSimFluidFactory(fluid_model_medium)
-    return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
-        streams=[
-            FluidStreamObjectForMultipleStreams(
-                fluid_model=fluid_model_medium, is_inlet_stream=True, connected_to_stage_no=0
-            )
-        ],
-        data_transfer_object=dto_copy,
-        fluid_factory=fluid_factory,
-    )
-
-
-@pytest.fixture
-def variable_speed_compressor_train_two_compressors_one_stream_downstream_choke(
-    variable_speed_compressor_train_stage_dto,
-    fluid_model_medium,
-    mock_variable_speed_compressor_train_multiple_streams_and_pressures,
-) -> VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures:
-    """Train with only two compressors, and standard medium fluid, one stream in per stage, no liquid off take."""
-    fluid_streams = [
-        FluidStreamObjectForMultipleStreams(
-            fluid_model=fluid_model_medium,
-            is_inlet_stream=True,
-            connected_to_stage_no=0,
-        ),
-    ]
-    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
-    dto_copy.stages = cast(list[dto.CompressorStage], [variable_speed_compressor_train_stage_dto] * 2)
-    dto_copy.stages[0].interstage_pressure_control = None
-    dto_copy.stages[1].interstage_pressure_control = None
-    dto_copy.pressure_control = libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE
-
-    fluid_factory = NeqSimFluidFactory(fluid_model_medium)
-    return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
-        streams=fluid_streams,
-        data_transfer_object=dto_copy,
-        fluid_factory=fluid_factory,
-    )
-
-
-@pytest.fixture
-def variable_speed_compressor_train_two_compressors_one_stream_individual_asv_pressure(
-    variable_speed_compressor_train_stage_dto,
-    fluid_model_medium,
-    mock_variable_speed_compressor_train_multiple_streams_and_pressures,
-) -> VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures:
-    """Train with only two compressors, and standard medium fluid, one stream in per stage, no liquid off take."""
-    fluid_streams = [
-        FluidStreamObjectForMultipleStreams(
-            fluid_model=fluid_model_medium,
-            is_inlet_stream=True,
-            connected_to_stage_no=0,
-        ),
-    ]
-    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
-    dto_copy.stages = cast(list[dto.CompressorStage], [variable_speed_compressor_train_stage_dto] * 2)
-    dto_copy.pressure_control = (
-        libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.INDIVIDUAL_ASV_PRESSURE
-    )
-
-    fluid_factory = NeqSimFluidFactory(fluid_model_medium)
-    return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
-        streams=fluid_streams,
-        data_transfer_object=dto_copy,
-        fluid_factory=fluid_factory,
-    )
-
-
-@pytest.fixture
-def variable_speed_compressor_train_two_compressors_two_streams(
-    variable_speed_compressor_train_stage_dto,
-    fluid_model_medium,
-    mock_variable_speed_compressor_train_multiple_streams_and_pressures,
-) -> VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures:
-    """Train with only two compressors, and standard medium fluid, on stream in per stage, no liquid off take."""
-    fluid_streams = [
-        FluidStreamObjectForMultipleStreams(
-            fluid_model=fluid_model_medium,
-            is_inlet_stream=True,
-            connected_to_stage_no=0,
-        ),
-        FluidStreamObjectForMultipleStreams(
-            fluid_model=fluid_model_medium,
-            is_inlet_stream=True,
-            connected_to_stage_no=1,
-        ),
-    ]
-    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
-    dto_copy.stages = cast(list[dto.CompressorStage], [variable_speed_compressor_train_stage_dto] * 2)
-
-    fluid_factory = NeqSimFluidFactory(fluid_model_medium)
-    return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
-        streams=fluid_streams,
-        data_transfer_object=dto_copy,
-        fluid_factory=fluid_factory,
-    )
-
-
-@pytest.fixture
-def variable_speed_compressor_train_two_compressors_ingoning_and_outgoing_streams_between_compressors(
-    variable_speed_compressor_train_stage_dto,
-    fluid_model_dry,
-    fluid_model_rich,
-    mock_variable_speed_compressor_train_multiple_streams_and_pressures,
-) -> VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures:
-    """Train with only two compressors, and standard medium fluid, on stream in per stage, no liquid off take."""
-    fluid_streams = [
-        FluidStreamObjectForMultipleStreams(
-            fluid_model=fluid_model_rich,
-            is_inlet_stream=True,
-            connected_to_stage_no=0,
-        ),
-        FluidStreamObjectForMultipleStreams(
-            is_inlet_stream=False,
-            connected_to_stage_no=1,
-        ),
-        FluidStreamObjectForMultipleStreams(
-            fluid_model=fluid_model_dry,
-            is_inlet_stream=True,
-            connected_to_stage_no=1,
-        ),
-    ]
-    dto_copy = deepcopy(mock_variable_speed_compressor_train_multiple_streams_and_pressures)
-    dto_copy.stages = cast(list[dto.CompressorStage], [variable_speed_compressor_train_stage_dto] * 2)
-    dto_copy.pressure_control = libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.DOWNSTREAM_CHOKE
-
-    # Use the first inlet stream's fluid model for the factory
-    fluid_factory = NeqSimFluidFactory(fluid_model_rich)
-    return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
-        streams=fluid_streams,
-        data_transfer_object=dto_copy,
-        fluid_factory=fluid_factory,
-    )
-
-
-@pytest.fixture
-def variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream(
-    variable_speed_compressor_train_stage_dto,
-    fluid_model_medium,
-    variable_speed_compressor_chart_dto,
-) -> VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures:
-    """Train with only two compressors, and standard medium fluid, on stream in per stage, no liquid off take."""
-    stage = dto.CompressorStage(
-        compressor_chart=variable_speed_compressor_chart_dto,
-        inlet_temperature_kelvin=303.15,
-        remove_liquid_after_cooling=True,
-        pressure_drop_before_stage=0,
-        control_margin=0,
-        stream_reference="inlet",
-    )
-    stage2 = dto.CompressorStage(
-        compressor_chart=variable_speed_compressor_chart_dto,
-        inlet_temperature_kelvin=303.15,
-        remove_liquid_after_cooling=True,
-        pressure_drop_before_stage=0,
-        control_margin=0,
-        interstage_pressure_control=dto.InterstagePressureControl(
-            downstream_pressure_control=FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
-            upstream_pressure_control=FixedSpeedPressureControl.UPSTREAM_CHOKE,
-        ),
-        stream_reference="outlet",
-    )
-    fluid_streams_dto = [
-        MultipleStreamsAndPressureStream(
-            fluid_model=fluid_model_medium,
-            name="inlet",
-            typ=FluidStreamType.INGOING,
-        ),
-        MultipleStreamsAndPressureStream(
-            name="outlet",
-            typ=FluidStreamType.OUTGOING,
-        ),
-    ]
-    fluid_streams = [
+def two_streams(fluid_model_medium) -> list[FluidStreamObjectForMultipleStreams]:
+    return [
         FluidStreamObjectForMultipleStreams(
             fluid_model=fluid_model_medium,
             is_inlet_stream=True,
@@ -277,30 +105,16 @@ def variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing
             connected_to_stage_no=1,
         ),
     ]
-    mock_variable_speed_compressor_train_multiple_streams_and_pressures_with_pressure_control = dto.VariableSpeedCompressorTrainMultipleStreamsAndPressures(
-        streams=fluid_streams_dto,
-        stages=[stage, stage2],
-        calculate_max_rate=False,
-        energy_usage_adjustment_constant=0.0,
-        energy_usage_adjustment_factor=1.0,
-        pressure_control=libecalc.common.fixed_speed_pressure_control.FixedSpeedPressureControl.INDIVIDUAL_ASV_PRESSURE,
-    )
-
-    fluid_factory = NeqSimFluidFactory(fluid_model_medium)
-    return VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures(
-        streams=fluid_streams,
-        data_transfer_object=mock_variable_speed_compressor_train_multiple_streams_and_pressures_with_pressure_control,
-        fluid_factory=fluid_factory,
-    )
 
 
 @pytest.mark.slow
 def test_get_maximum_standard_rate_max_speed_curve(
-    variable_speed_compressor_train,
-    variable_speed_compressor_train_two_compressors_one_stream_downstream_choke,
+    variable_speed_compressor_train, variable_speed_compressor_train_multiple_streams_and_pressures, create_stages
 ):
     compressor_train = variable_speed_compressor_train(nr_stages=2)
-    compressor_train_multiple_streams = variable_speed_compressor_train_two_compressors_one_stream_downstream_choke
+    compressor_train_multiple_streams = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=create_stages(n_stages=2)
+    )
     """Values are pinned against self. Need QA."""
     outside_right_end_of_max_speed_curve_1 = compressor_train.get_max_standard_rate(
         suction_pressures=np.asarray([30]),
@@ -380,14 +194,13 @@ def test_get_maximum_standard_rate_max_speed_curve(
 
 @pytest.mark.slow
 def test_get_maximum_standard_rate_at_stone_wall(
-    variable_speed_compressor_train,
-    variable_speed_compressor_train_two_compressors_one_stream_individual_asv_pressure,
+    variable_speed_compressor_train, variable_speed_compressor_train_multiple_streams_and_pressures, create_stages
 ):
     compressor_train = variable_speed_compressor_train(
         pressure_control=FixedSpeedPressureControl.INDIVIDUAL_ASV_PRESSURE, nr_stages=2
     )
-    compressor_train_multiple_streams = (
-        variable_speed_compressor_train_two_compressors_one_stream_individual_asv_pressure
+    compressor_train_multiple_streams = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=create_stages(n_stages=2), pressure_control=FixedSpeedPressureControl.INDIVIDUAL_ASV_PRESSURE
     )
     """Values are pinned against self. Need QA."""
     below_stone_wall = compressor_train.get_max_standard_rate(
@@ -431,16 +244,16 @@ def test_get_maximum_standard_rate_at_stone_wall(
 
 
 def test_variable_speed_multiple_streams_and_pressures_maximum_power(
-    variable_speed_compressor_train_one_compressor_one_stream,
+    variable_speed_compressor_train_multiple_streams_and_pressures,
 ):
-    variable_speed_compressor_train_one_compressor_one_stream.set_evaluation_input(
+    compressor_train = variable_speed_compressor_train_multiple_streams_and_pressures(maximum_power=7)
+    compressor_train.set_evaluation_input(
         rate=np.asarray([[3000000, 3500000]]),
         suction_pressure=np.asarray([30, 30]),
         discharge_pressure=np.asarray([100, 100]),
     )
-    result_variable_speed_compressor_train_one_compressor_one_stream_maximum_power = (
-        variable_speed_compressor_train_one_compressor_one_stream.evaluate()
-    )
+    result_variable_speed_compressor_train_one_compressor_one_stream_maximum_power = compressor_train.evaluate()
+
     assert result_variable_speed_compressor_train_one_compressor_one_stream_maximum_power.is_valid == [True, False]
     assert result_variable_speed_compressor_train_one_compressor_one_stream_maximum_power.failure_status == [
         CompressorTrainCommonShaftFailureStatus.NO_FAILURE,
@@ -450,17 +263,13 @@ def test_variable_speed_multiple_streams_and_pressures_maximum_power(
 
 @pytest.mark.slow
 def test_variable_speed_vs_variable_speed_multiple_streams_and_pressures(
-    variable_speed_compressor_train,
-    variable_speed_compressor_train_one_compressor_one_stream_downstream_choke,
-    variable_speed_compressor_train_two_compressors_one_stream_downstream_choke,
+    variable_speed_compressor_train, variable_speed_compressor_train_multiple_streams_and_pressures, create_stages
 ):
     compressor_train_one_compressor = variable_speed_compressor_train(nr_stages=1)
     compressor_train_two_compressors = variable_speed_compressor_train(nr_stages=2)
-    compressor_train_multiple_streams_one_compressor = (
-        variable_speed_compressor_train_one_compressor_one_stream_downstream_choke
-    )
-    compressor_train_multiple_streams_two_compressors = (
-        variable_speed_compressor_train_two_compressors_one_stream_downstream_choke
+    compressor_train_multiple_streams_one_compressor = variable_speed_compressor_train_multiple_streams_and_pressures()
+    compressor_train_multiple_streams_two_compressors = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=create_stages(n_stages=2)
     )
 
     compressor_train_one_compressor.set_evaluation_input(
@@ -512,26 +321,41 @@ def test_variable_speed_vs_variable_speed_multiple_streams_and_pressures(
 
 
 def test_points_within_capacity_two_compressors_two_streams(
-    variable_speed_compressor_train_two_compressors_two_streams,
+    variable_speed_compressor_train_multiple_streams_and_pressures, create_stages, two_streams
 ):
-    variable_speed_compressor_train_two_compressors_two_streams.set_evaluation_input(
+    compressor_train = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=create_stages(n_stages=2),
+        fluid_streams=two_streams,
+    )
+    compressor_train.set_evaluation_input(
         rate=np.asarray([[6000], [2000]]),
         suction_pressure=np.asarray([30]),
         discharge_pressure=np.asarray([110.0]),
     )
-    result = variable_speed_compressor_train_two_compressors_two_streams.evaluate()
+    result = compressor_train.evaluate()
     assert result.energy_usage
 
 
 @pytest.mark.slow
 def test_get_maximum_standard_rate_too_high_pressure_ratio(
     variable_speed_compressor_train,
-    variable_speed_compressor_train_two_compressors_one_stream,
-    variable_speed_compressor_train_two_compressors_two_streams,
+    variable_speed_compressor_train_multiple_streams_and_pressures,
+    create_stages,
+    two_streams,
+    fluid_model_medium,
 ):
+    fluid_streams = two_streams
+    fluid_streams[1].fluid_model = fluid_model_medium
+    fluid_streams[1].is_inlet_stream = True
+
     compressor_train = variable_speed_compressor_train(nr_stages=2)
-    compressor_train_multiple_streams_one_stream = variable_speed_compressor_train_two_compressors_one_stream
-    compressor_train_multiple_streams_two_streams = variable_speed_compressor_train_two_compressors_two_streams
+    compressor_train_multiple_streams_one_stream = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=create_stages(n_stages=2),
+    )
+    compressor_train_multiple_streams_two_streams = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=create_stages(n_stages=2),
+        fluid_streams=fluid_streams,
+    )
 
     """Values are pinned against self. Need QA."""
     # Check point where head requirement is too high. ASV should make no difference here.
@@ -557,17 +381,27 @@ def test_get_maximum_standard_rate_too_high_pressure_ratio(
     np.testing.assert_allclose(maximum_rate_max_not_existing, 0)
 
 
-def test_zero_rate_zero_pressure_multiple_streams(variable_speed_compressor_train_two_compressors_two_streams):
+def test_zero_rate_zero_pressure_multiple_streams(
+    variable_speed_compressor_train_multiple_streams_and_pressures, create_stages, fluid_model_medium, two_streams
+):
     """We want to get a result object when rate is zero regardless of invalid/zero pressures. To ensure
     this we set pressure -> 1 when both rate and pressure is zero. This may happen when pressure is a function
     of rate.
     """
-    variable_speed_compressor_train_two_compressors_two_streams.set_evaluation_input(
+    fluid_streams = two_streams
+    fluid_streams[1].fluid_model = fluid_model_medium
+    fluid_streams[1].is_inlet_stream = True
+
+    compressor_train = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=create_stages(n_stages=2),
+        fluid_streams=fluid_streams,
+    )
+    compressor_train.set_evaluation_input(
         rate=np.array([[0, 1, 0, 1], [0, 1, 1, 0]]),
         suction_pressure=np.array([0, 1, 1, 1]),
         discharge_pressure=np.array([0, 5, 5, 5]),
     )
-    result = variable_speed_compressor_train_two_compressors_two_streams.evaluate()
+    result = compressor_train.evaluate()
 
     # Ensuring that first stage returns zero energy usage and no failure (zero rate should always be valid).
     assert result.is_valid == [True, True, True, True]
@@ -584,30 +418,41 @@ def test_zero_rate_zero_pressure_multiple_streams(variable_speed_compressor_trai
 
 
 def test_different_volumes_of_ingoing_and_outgoing_streams(
-    variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream,
+    variable_speed_compressor_train_multiple_streams_and_pressures,
+    create_stages,
+    two_streams,
 ):
     """Make sure that we get NOT_CALCULATED if the requested volume leaving the compressor train exceeds the
     volume entering the compressor train.
     """
-    variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.set_evaluation_input(
+    compressor_train = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=create_stages(n_stages=2),
+        fluid_streams=two_streams,
+    )
+    compressor_train.stages[1].interstage_pressure_control = dto.InterstagePressureControl(
+        downstream_pressure_control=FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
+        upstream_pressure_control=FixedSpeedPressureControl.UPSTREAM_CHOKE,
+    )
+
+    compressor_train.set_evaluation_input(
         rate=np.array([[0, 0, 100000], [0, 107000, 107000]]),
         suction_pressure=np.array([1, 1, 1]),
         intermediate_pressure=np.array([2, 2, 2]),
         discharge_pressure=np.array([3, 3, 3]),
     )
-    result = variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.evaluate()
+    result = compressor_train.evaluate()
 
     assert result.stage_results[0].chart_area_flags[0] == ChartAreaFlag.NOT_CALCULATED
     assert result.stage_results[0].chart_area_flags[1] == ChartAreaFlag.NOT_CALCULATED
     assert result.stage_results[0].chart_area_flags[2] == ChartAreaFlag.NOT_CALCULATED
 
-    variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.set_evaluation_input(
+    compressor_train.set_evaluation_input(
         rate=np.array([[0, 0, 100000], [0, 107000, 107000]]),
         suction_pressure=np.array([1, 1, 1]),
         intermediate_pressure=np.array([2, 2, 2]),
         discharge_pressure=np.array([3, 3, 3]),
     )
-    result = variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.evaluate()
+    result = compressor_train.evaluate()
 
     assert result.stage_results[0].chart_area_flags[0] == ChartAreaFlag.NOT_CALCULATED
     assert result.stage_results[0].chart_area_flags[1] == ChartAreaFlag.NOT_CALCULATED
@@ -615,15 +460,30 @@ def test_different_volumes_of_ingoing_and_outgoing_streams(
 
 
 def test_evaluate_variable_speed_compressor_train_multiple_streams_and_pressures_with_interstage_pressure(
-    variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream,
+    variable_speed_compressor_train_multiple_streams_and_pressures,
+    create_stages,
+    two_streams,
 ):
-    variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.set_evaluation_input(
+    stage1 = create_stages(n_stages=1)[0]
+    stage2 = create_stages(
+        n_stages=1,
+        interstage_pressure_control=dto.InterstagePressureControl(
+            downstream_pressure_control=FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
+            upstream_pressure_control=FixedSpeedPressureControl.UPSTREAM_CHOKE,
+        ),
+    )[0]
+    compressor_train = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=[stage1, stage2],
+        fluid_streams=two_streams,
+    )
+
+    compressor_train.set_evaluation_input(
         rate=np.array([[1000000, 1200000, 1300000], [0, 107000, 107000]]),
         suction_pressure=np.array([10, 10, 10]),
         intermediate_pressure=np.array([30, 30, 30]),
         discharge_pressure=np.array([90, 90, 90]),
     )
-    result = variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.evaluate()
+    result = compressor_train.evaluate()
 
     np.testing.assert_allclose(result.stage_results[0].speed, [10850.87, 11118.95, 11321.47], rtol=0.1)
     np.testing.assert_allclose(
@@ -636,38 +496,59 @@ def test_evaluate_variable_speed_compressor_train_multiple_streams_and_pressures
 
 @pytest.mark.parametrize("energy_usage_adjustment_constant", [1, 2, 3, 5, 10])
 def test_adjust_energy_usage(
-    variable_speed_compressor_train_one_compressor_one_stream_downstream_choke,
-    variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream,
     energy_usage_adjustment_constant,
+    variable_speed_compressor_train_multiple_streams_and_pressures,
+    create_stages,
+    fluid_model_medium,
+    two_streams,
 ):
-    variable_speed_compressor_train_one_compressor_one_stream_downstream_choke.set_evaluation_input(
+    compressor_train_one_compressor_one_stream_downstream_choke = (
+        variable_speed_compressor_train_multiple_streams_and_pressures()
+    )
+    compressor_train_one_compressor_one_stream_downstream_choke.set_evaluation_input(
         rate=np.asarray([[3000000]]),
         suction_pressure=np.asarray([30]),
         discharge_pressure=np.asarray([100]),
     )
-    result_comparison = variable_speed_compressor_train_one_compressor_one_stream_downstream_choke.evaluate()
-    variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.set_evaluation_input(
+    result_comparison = compressor_train_one_compressor_one_stream_downstream_choke.evaluate()
+
+    stage1 = create_stages(n_stages=1)[0]
+    stage2 = create_stages(
+        n_stages=1,
+        interstage_pressure_control=dto.InterstagePressureControl(
+            downstream_pressure_control=FixedSpeedPressureControl.DOWNSTREAM_CHOKE,
+            upstream_pressure_control=FixedSpeedPressureControl.UPSTREAM_CHOKE,
+        ),
+    )[0]
+    compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream = (
+        variable_speed_compressor_train_multiple_streams_and_pressures(
+            stages=[stage1, stage2],
+            fluid_streams=two_streams,
+        )
+    )
+    compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.set_evaluation_input(
         rate=np.array([[1000000], [0]]),
         suction_pressure=np.array([10]),
         intermediate_pressure=np.array([30]),
         discharge_pressure=np.array([90]),
     )
-    result_comparison_intermediate = (
-        variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.evaluate()
-    )
 
-    variable_speed_compressor_train_one_compressor_one_stream_downstream_choke.energy_usage_adjustment_constant = (
+    result_comparison_intermediate = compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.evaluate()
+
+    compressor_train_one_compressor_one_stream_downstream_choke.energy_usage_adjustment_constant = (
         energy_usage_adjustment_constant  # MW
     )
-    variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.energy_usage_adjustment_constant = energy_usage_adjustment_constant
+    compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.energy_usage_adjustment_constant = (
+        energy_usage_adjustment_constant
+    )
 
-    variable_speed_compressor_train_one_compressor_one_stream_downstream_choke.set_evaluation_input(
+    compressor_train_one_compressor_one_stream_downstream_choke.set_evaluation_input(
         rate=np.asarray([[3000000]]),
         suction_pressure=np.asarray([30]),
         discharge_pressure=np.asarray([100]),
     )
-    result = variable_speed_compressor_train_one_compressor_one_stream_downstream_choke.evaluate()
-    result_intermediate = variable_speed_compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.evaluate()
+    result = compressor_train_one_compressor_one_stream_downstream_choke.evaluate()
+    result_intermediate = compressor_train_two_compressors_one_ingoing_and_one_outgoing_stream.evaluate()
 
     np.testing.assert_allclose(
         np.asarray(result_comparison.energy_usage) + energy_usage_adjustment_constant, result.energy_usage
@@ -679,9 +560,30 @@ def test_adjust_energy_usage(
 
 
 def test_recirculate_mixing_streams_with_zero_mass_rate(
-    variable_speed_compressor_train_two_compressors_ingoning_and_outgoing_streams_between_compressors,
+    fluid_model_rich, fluid_model_dry, variable_speed_compressor_train_multiple_streams_and_pressures, create_stages
 ):
-    variable_speed_compressor_train_two_compressors_ingoning_and_outgoing_streams_between_compressors.set_evaluation_input(
+    fluid_streams = [
+        FluidStreamObjectForMultipleStreams(
+            fluid_model=fluid_model_rich,
+            is_inlet_stream=True,
+            connected_to_stage_no=0,
+        ),
+        FluidStreamObjectForMultipleStreams(
+            is_inlet_stream=False,
+            connected_to_stage_no=1,
+        ),
+        FluidStreamObjectForMultipleStreams(
+            fluid_model=fluid_model_dry,
+            is_inlet_stream=True,
+            connected_to_stage_no=1,
+        ),
+    ]
+    compressor_train = variable_speed_compressor_train_multiple_streams_and_pressures(
+        stages=create_stages(n_stages=2),
+        fluid_model=fluid_model_rich,
+        fluid_streams=fluid_streams,
+    )
+    compressor_train.set_evaluation_input(
         rate=np.asarray(
             [
                 [3000000, 3000000, 3000000, 3000000, 3000000, 3000000],
@@ -692,9 +594,7 @@ def test_recirculate_mixing_streams_with_zero_mass_rate(
         suction_pressure=np.asarray([30, 30, 30, 30, 30, 30]),
         discharge_pressure=np.asarray([150, 150, 150, 150, 150, 150]),
     )
-    result = (
-        variable_speed_compressor_train_two_compressors_ingoning_and_outgoing_streams_between_compressors.evaluate()
-    )
+    result = compressor_train.evaluate()
     np.testing.assert_almost_equal(result.power[0], result.power[1], decimal=4)
     np.testing.assert_almost_equal(
         result.power[0], result.power[3], decimal=4

--- a/tests/libecalc/presentation/yaml/yaml_types/models/test_yaml_variable_speed_compressor_train_multiple_streams_and_pressures.py
+++ b/tests/libecalc/presentation/yaml/yaml_types/models/test_yaml_variable_speed_compressor_train_multiple_streams_and_pressures.py
@@ -58,6 +58,7 @@ def test_check_interstage_control_pressure_invalid():
     with pytest.raises(ValueError) as e:
         compressor_train(
             stages=[
+                make_stage(),
                 make_stage(interstage_control_pressure=make_pressure()),
                 make_stage(interstage_control_pressure=make_pressure()),
             ]

--- a/tests/libecalc/presentation/yaml/yaml_types/models/test_yaml_variable_speed_compressor_train_multiple_streams_and_pressures.py
+++ b/tests/libecalc/presentation/yaml/yaml_types/models/test_yaml_variable_speed_compressor_train_multiple_streams_and_pressures.py
@@ -1,0 +1,65 @@
+import pytest
+from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_trains import (
+    YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures,
+    YamlMultipleStreamsStream,
+)
+from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import (
+    YamlCompressorStageMultipleStreams,
+    YamlInterstageControlPressure,
+    YamlControlMarginUnits,
+    YamlCompressorStageWithMarginAndPressureDrop,
+)
+from libecalc.presentation.yaml.yaml_types.models.yaml_enums import YamlPressureControl, YamlModelType
+
+
+def make_stage(interstage_control_pressure: YamlInterstageControlPressure = None):
+    return YamlCompressorStageMultipleStreams(
+        compressor_chart="chart1",
+        stream="stream1",
+        inlet_temperature=300,
+        interstage_control_pressure=interstage_control_pressure,
+        control_margin=0.0,
+        control_margin_unit=YamlControlMarginUnits.FRACTION,
+        pressure_drop_ahead_of_stage=0.0,
+    )
+
+
+def make_pressure():
+    return YamlInterstageControlPressure(
+        upstream_pressure_control=YamlPressureControl.UPSTREAM_CHOKE,
+        downstream_pressure_control=YamlPressureControl.DOWNSTREAM_CHOKE,
+    )
+
+
+def compressor_train(stages: list[YamlCompressorStageMultipleStreams]):
+    return YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures(
+        name="train1",
+        type=YamlModelType.VARIABLE_SPEED_COMPRESSOR_TRAIN_MULTIPLE_STREAMS_AND_PRESSURES,
+        streams=[YamlMultipleStreamsStream(type="INGOING", name="stream1", fluid_model=None)],
+        stages=stages,
+        pressure_control=YamlPressureControl.DOWNSTREAM_CHOKE,
+        power_adjustment_constant=0.0,
+        power_adjustment_factor=1.0,
+        maximum_power=10.0,
+    )
+
+
+def test_check_interstage_control_pressure_valid():
+    """
+    Test that a compressor train with a valid interstage control pressure configuration does not raise an error.
+    """
+    compressor_train(stages=[make_stage(), make_stage(interstage_control_pressure=make_pressure())])
+
+
+def test_check_interstage_control_pressure_invalid():
+    """
+    Test that a compressor train with more than one stage having interstage control pressure raises a ValueError.
+    """
+    with pytest.raises(ValueError) as e:
+        compressor_train(
+            stages=[
+                make_stage(interstage_control_pressure=make_pressure()),
+                make_stage(interstage_control_pressure=make_pressure()),
+            ]
+        )
+    assert "Only one stage can have interstage control pressure defined." in str(e.value)


### PR DESCRIPTION
## Why is this pull request needed?

Remove the use of DTOs in the compressor train code.

## What does this pull request change?
- Refactors the handling of compressor train stages and interstage pressure control by moving logic from DTO classes into the domain model.
- Updates the construction and validation of `VariableSpeedCompressorTrainCommonShaftMultipleStreamsAndPressures` to work directly with domain model stages, rather than DTOs.
- Moves validation of stage compatibility and interstage pressure control from DTOs to the domain model and YAML layer.
- Updates related tests and fixtures to use the new approach.


