### PR TITLE
chore: allow pressure input values to be zero

### DIFF
--- a/src/libecalc/presentation/yaml/domain/expression_time_series_pressure.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_pressure.py
@@ -9,9 +9,9 @@ class InvalidPressureException(DomainValidationException):
 
     def __init__(self, pressure: float, pressure_expression: str):
         if str(pressure) == pressure_expression:
-            msg = f"All pressure values must be positive, got {pressure}."
+            msg = f"All pressure values must be non-negative, got {pressure}."
         else:
-            msg = f"All pressure values must be positive, got {pressure} in {pressure_expression}."
+            msg = f"All pressure values must be non-negative, got {pressure} in {pressure_expression}."
         super().__init__(message=msg)
 
 
@@ -30,9 +30,13 @@ class ExpressionTimeSeriesPressure(TimeSeriesPressure):
         self._validate()
 
     def _validate(self):
-        """Validate that all pressure values are positive."""
+        """Validate that all pressure values are non-negative."""
+        # TODO: Currently all pressures must be non-negative, but in the future we want to only allow positive pressures
+        #       There are many situations where input values of zero means that equipment should be turned off
+        #       When the rest of the codebase is more mature with this respect (specific start/end dates for equipment,
+        #       instead of using rates/pressures of zero), we can tighten this validation
         for pressure in self._pressure_values:
-            if pressure <= 0:
+            if pressure < 0:
                 raise InvalidPressureException(pressure, str(self._time_series_expression.get_expression()))
 
     def get_periods(self) -> Periods:

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -129,17 +129,21 @@ def validate_increasing_pressure(
     discharge_pressure: list[float],
     intermediate_pressure: list[float] | None = None,
 ):
+    # TODO: Currently all pressures must be non-negative, meaning that we allow zero pressures. This also means that we
+    #       allow zero discharge pressure, which is not physically meaningful in most cases. The compressor does no work.
+    #       In the future we want to only allow positive pressures, and then we can tighten this validation to require
+    #       strictly increasing pressures (i.e. suction < discharge, and suction < intermediate < discharge).
     for i in range(len(suction_pressure)):
         sp = suction_pressure[i]
         dp = discharge_pressure[i]
         if intermediate_pressure:
             ip = intermediate_pressure[i]
-            if not (sp < ip < dp):
+            if not (sp <= ip <= dp):
                 raise ProcessPressureRatioValidationException(
                     message=f"Invalid pressures at index {i+1}: suction pressure ({sp}) must be less than intermediate pressure ({ip}), which must be less than discharge pressure ({dp})."
                 )
         else:
-            if not (sp < dp):
+            if not (sp <= dp):
                 raise ProcessPressureRatioValidationException(
                     message=f"Invalid pressures at index {i+1}: suction pressure ({sp}) must be less than discharge pressure ({dp})."
                 )

--- a/tests/libecalc/presentation/yaml/domain/test_time_series_pressure.py
+++ b/tests/libecalc/presentation/yaml/domain/test_time_series_pressure.py
@@ -19,7 +19,7 @@ periods = [
 
 
 def test_expression_with_negative_pressure(expression_evaluator_factory):
-    evaluator = expression_evaluator_factory.from_periods(periods=periods, variables={"SIM1;PS": [10, 0, 20]})
+    evaluator = expression_evaluator_factory.from_periods(periods=periods, variables={"SIM1;PS": [10, -1, 20]})
     with pytest.raises(InvalidPressureException):
         ExpressionTimeSeriesPressure(
             time_series_expression=TimeSeriesExpression(expression="SIM1;PS", expression_evaluator=evaluator)
@@ -40,7 +40,7 @@ def test_expression_where_sum_of_variables_give_negative_pressure(expression_eva
 
 def test_expressions_with_pressure_ratio_less_than_one(expression_evaluator_factory):
     evaluator = expression_evaluator_factory.from_periods(
-        periods=periods, variables={"SIM1;PS": [10, 15, 20], "SIM1;PMID": [10, 15, 20], "SIM1;PD": [15, 15, 20]}
+        periods=periods, variables={"SIM1;PS": [10, 15, 20], "SIM1;PMID": [10, 14, 20], "SIM1;PD": [15, 13, 20]}
     )
 
     with pytest.raises(ProcessPressureRatioValidationException):


### PR DESCRIPTION
## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
