### PR TITLE
Only validate pressure when rate and regularity are both positive

### DIFF
--- a/src/libecalc/presentation/yaml/domain/expression_time_series_flow_rate.py
+++ b/src/libecalc/presentation/yaml/domain/expression_time_series_flow_rate.py
@@ -40,12 +40,14 @@ class ExpressionTimeSeriesFlowRate(TimeSeriesFlowRate):
         assert isinstance(consumption_rate_type, RateType)
         self._consumption_rate_type = consumption_rate_type
         self._rate_values = self._get_stream_day_values()
-        self._validate()
+        if self._rate_values is not None:
+            self._validate()
 
     def _validate(self):
         """Validate that all flow rate values are positive."""
         for rate in self._rate_values:
-            if rate is not None and rate < 0:
+            assert rate is not None
+            if rate < 0:
                 raise InvalidFlowRateException(rate, str(self._time_series_expression.get_expression()))
 
     def _get_stream_day_values(self) -> list[float | None]:

--- a/tests/libecalc/presentation/yaml/domain/test_time_series_pressure.py
+++ b/tests/libecalc/presentation/yaml/domain/test_time_series_pressure.py
@@ -47,21 +47,21 @@ def test_expressions_with_pressure_ratio_less_than_one(expression_evaluator_fact
         validate_increasing_pressure(
             suction_pressure=ExpressionTimeSeriesPressure(
                 time_series_expression=TimeSeriesExpression(expression="SIM1;PS", expression_evaluator=evaluator)
-            ).get_values(),
+            ),
             discharge_pressure=ExpressionTimeSeriesPressure(
                 time_series_expression=TimeSeriesExpression(expression="SIM1;PD", expression_evaluator=evaluator)
-            ).get_values(),
+            ),
         )
 
     with pytest.raises(ProcessPressureRatioValidationException):
         validate_increasing_pressure(
             suction_pressure=ExpressionTimeSeriesPressure(
                 time_series_expression=TimeSeriesExpression(expression="SIM1;PS", expression_evaluator=evaluator)
-            ).get_values(),
+            ),
             discharge_pressure=ExpressionTimeSeriesPressure(
                 time_series_expression=TimeSeriesExpression(expression="SIM1;PD", expression_evaluator=evaluator)
-            ).get_values(),
+            ),
             intermediate_pressure=ExpressionTimeSeriesPressure(
                 time_series_expression=TimeSeriesExpression(expression="SIM1;PMID", expression_evaluator=evaluator)
-            ).get_values(),
+            ),
         )


### PR DESCRIPTION
Alternative to https://github.com/equinor/ecalc/pull/1111

Here, the validation of pressures is only performed for time steps where the rate and the regularity are both positive. Today RATE equal to zero or REGULARITY equal to zero is a means of turning off equipment.

## Have you remembered and considered?

- [ ] I have remembered to update documentation
- [ ] I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] I have committed with `BREAKING:` in footer or `!` in header, if breaking
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Jira issue ID somewhere in the commit body (`ECALC-XXXX`)

## Why is this pull request needed?

This pull request is needed because of....

## What does this pull request change?

Write summary of what this pull request changes if needed.

## Issues related to this change:
