### PR TITLE
refactor: remove dto from compressor sampled

### DIFF
--- a/src/libecalc/domain/process/compressor/core/factory.py
+++ b/src/libecalc/domain/process/compressor/core/factory.py
@@ -195,7 +195,16 @@ def _create_compressor_train_simplified_with_unknown_stages(
 
 
 def _create_compressor_sampled(compressor_model_dto: CompressorSampled) -> CompressorModelSampled:
-    return CompressorModelSampled(data_transfer_object=compressor_model_dto)
+    return CompressorModelSampled(
+        energy_usage_adjustment_constant=compressor_model_dto.energy_usage_adjustment_constant,
+        energy_usage_adjustment_factor=compressor_model_dto.energy_usage_adjustment_factor,
+        energy_usage_type=compressor_model_dto.energy_usage_type,
+        energy_usage_values=compressor_model_dto.energy_usage_values,
+        rate_values=compressor_model_dto.rate_values,
+        suction_pressure_values=compressor_model_dto.suction_pressure_values,
+        discharge_pressure_values=compressor_model_dto.discharge_pressure_values,
+        power_interpolation_values=compressor_model_dto.power_interpolation_values,
+    )
 
 
 facility_model_map = {

--- a/src/libecalc/domain/process/compressor/dto/sampled.py
+++ b/src/libecalc/domain/process/compressor/dto/sampled.py
@@ -2,12 +2,6 @@ from typing import Literal
 
 from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.common.energy_usage_type import EnergyUsageType
-from libecalc.common.errors.exceptions import InvalidColumnException
-from libecalc.domain.component_validation_error import (
-    ProcessEqualLengthValidationException,
-    ProcessMissingVariableValidationException,
-    ProcessNegativeValuesValidationException,
-)
 from libecalc.domain.process.dto.base import EnergyModel
 
 
@@ -32,55 +26,3 @@ class CompressorSampled(EnergyModel):
         self.suction_pressure_values = suction_pressure_values
         self.discharge_pressure_values = discharge_pressure_values
         self.power_interpolation_values = power_interpolation_values
-
-        self.validate_minimum_one_variable()
-        self.validate_equal_list_lengths()
-        self.validate_non_negative_values()
-
-    # skip_on_failure required if not pre=True, we don't need validation of lengths if other validations fails
-    def validate_equal_list_lengths(self):
-        number_of_data_points = len(self.energy_usage_values)
-        for variable_name in (
-            "rate_values",
-            "suction_pressure_values",
-            "discharge_pressure_values",
-            "power_interpolation_values",
-        ):
-            variable = getattr(self, variable_name)
-            if variable is not None:
-                if len(variable) != number_of_data_points:
-                    msg = (
-                        f"{variable_name} has wrong number of points. "
-                        f"Should have {number_of_data_points} (equal to number of energy usage value points)"
-                    )
-
-                    raise ProcessEqualLengthValidationException(message=str(msg))
-
-    def validate_minimum_one_variable(self):
-        if not self.rate_values and not self.suction_pressure_values and not self.discharge_pressure_values:
-            msg = "Need at least one variable for CompressorTrainSampled (rate, suction_pressure or discharge_pressure)"
-
-            raise ProcessMissingVariableValidationException(message=str(msg))
-
-    def validate_non_negative_values(self):
-        for variable_name in (
-            "energy_usage_values",
-            "rate_values",
-            "suction_pressure_values",
-            "discharge_pressure_values",
-            "power_interpolation_values",
-        ):
-            variable = getattr(self, variable_name)
-            if variable is not None:
-                for i, value in enumerate(variable):
-                    try:
-                        float(value)
-                    except ValueError as e:
-                        raise InvalidColumnException(
-                            header=variable_name, message=f"Got non-numeric value '{value}'.", row_index=i
-                        ) from e
-
-                if any(value < 0 for value in variable):
-                    msg = f"All values in {variable_name} must be greater than or equal to 0"
-
-                    raise ProcessNegativeValuesValidationException(message=str(msg))

--- a/tests/libecalc/core/conftest.py
+++ b/tests/libecalc/core/conftest.py
@@ -145,26 +145,22 @@ def compressor_model_sampled():
     # Case with 1D function (rate vs fuel)
     # CompressorModelSampled with comp/pump extrapolations
     return CompressorModelSampled(
-        data_transfer_object=dto.CompressorSampled(
-            energy_usage_values=[146750.0, 148600.0, 150700.0, 153150.0, 156500.0, 166350.0, 169976.0],
-            energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.POWER,
-            rate_values=(1000000 * np.asarray([2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.26])).tolist(),
-            energy_usage_adjustment_constant=0,
-            energy_usage_adjustment_factor=1,
-        ),
+        energy_usage_values=[146750.0, 148600.0, 150700.0, 153150.0, 156500.0, 166350.0, 169976.0],
+        energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.POWER,
+        rate_values=(1000000 * np.asarray([2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 7.26])).tolist(),
+        energy_usage_adjustment_constant=0,
+        energy_usage_adjustment_factor=1,
     )
 
 
 @pytest.fixture
 def compressor_model_sampled_2():
     return CompressorModelSampled(
-        data_transfer_object=dto.CompressorSampled(
-            energy_usage_values=[0.0, 10.0, 11.0, 12.0],
-            energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.POWER,
-            rate_values=[0.0, 0.01, 1.0, 2.0],
-            energy_usage_adjustment_constant=0,
-            energy_usage_adjustment_factor=1,
-        ),
+        energy_usage_values=[0.0, 10.0, 11.0, 12.0],
+        energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.POWER,
+        rate_values=[0.0, 0.01, 1.0, 2.0],
+        energy_usage_adjustment_constant=0,
+        energy_usage_adjustment_factor=1,
     )
 
 
@@ -193,15 +189,13 @@ def compressor_model_sampled_3d():
     )
 
     return CompressorModelSampled(
-        data_transfer_object=dto.CompressorSampled(
-            energy_usage_values=df["FUEL"].tolist(),
-            energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.FUEL,
-            rate_values=df["RATE"].tolist(),
-            suction_pressure_values=df["SUCTION_PRESSURE"].tolist(),
-            discharge_pressure_values=df["DISCHARGE_PRESSURE"].tolist(),
-            energy_usage_adjustment_constant=0,
-            energy_usage_adjustment_factor=1,
-        ),
+        energy_usage_values=df["FUEL"].tolist(),
+        energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.FUEL,
+        rate_values=df["RATE"].tolist(),
+        suction_pressure_values=df["SUCTION_PRESSURE"].tolist(),
+        discharge_pressure_values=df["DISCHARGE_PRESSURE"].tolist(),
+        energy_usage_adjustment_constant=0,
+        energy_usage_adjustment_factor=1,
     )
 
 

--- a/tests/libecalc/core/models/test_energy_function_results.py
+++ b/tests/libecalc/core/models/test_energy_function_results.py
@@ -8,7 +8,6 @@ from libecalc.common.units import Unit
 from libecalc.domain.infrastructure.energy_components.legacy_consumer.consumer_function.compressor_consumer_function import (
     CompressorConsumerFunction,
 )
-from libecalc.domain.process.compressor import dto
 from libecalc.domain.process.compressor.core.sampled import CompressorModelSampled
 from libecalc.domain.process.core.results import (
     CompressorStageResult,
@@ -143,14 +142,12 @@ def test_extend_compressor_train_results_over_temporal_models_with_none_variable
     """
 
     compressor = CompressorModelSampled(
-        data_transfer_object=dto.CompressorSampled(
-            energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.POWER,
-            energy_usage_values=[0, 1],
-            power_interpolation_values=[0.0, 1],
-            rate_values=[0, 1],
-            energy_usage_adjustment_constant=0.0,
-            energy_usage_adjustment_factor=1.0,
-        )
+        energy_usage_type=libecalc.common.energy_usage_type.EnergyUsageType.POWER,
+        energy_usage_values=[0, 1],
+        power_interpolation_values=[0.0, 1],
+        rate_values=[0, 1],
+        energy_usage_adjustment_constant=0.0,
+        energy_usage_adjustment_factor=1.0,
     )
 
     variables_map = expression_evaluator_factory.from_time_vector(


### PR DESCRIPTION
## Why is this pull request needed?

Removing DTOs from the domain.

## What does this pull request change?

- Moves all validation logic (equal length checks, non-negative value checks, and required variable checks) from the `CompressorSampled` DTO to the `CompressorModelSampled` model.
- Refactors the model and related factory functions to directly accept and validate data attributes instead of a DTO.
- Updates relevant tests and fixtures to use the new constructor signature.
- Removes redundant validation code from the DTO, making it a simple container for data.
