### PR TITLE
refactor: move tabulated model mapping

### DIFF
--- a/src/libecalc/presentation/yaml/domain/reference_service.py
+++ b/src/libecalc/presentation/yaml/domain/reference_service.py
@@ -2,13 +2,13 @@ import abc
 from collections.abc import Iterable
 from typing import Protocol
 
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularEnergyFunction
 from libecalc.domain.process.pump.pump import PumpModel
 from libecalc.dto import FuelType
 from libecalc.presentation.yaml.mappers.yaml_path import YamlPath
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import (
     YamlCompressorTabularModel,
     YamlGeneratorSetModel,
+    YamlTabularModel,
 )
 from libecalc.presentation.yaml.yaml_types.models import (
     YamlCompressorChart,
@@ -69,4 +69,4 @@ class ReferenceService(Protocol):
     def get_pump_model(self, reference: str) -> PumpModel: ...
 
     @abc.abstractmethod
-    def get_tabulated_model(self, reference: str) -> TabularEnergyFunction: ...
+    def get_tabulated_model(self, reference: str) -> YamlTabularModel: ...

--- a/src/libecalc/presentation/yaml/mappers/facility_input.py
+++ b/src/libecalc/presentation/yaml/mappers/facility_input.py
@@ -1,7 +1,6 @@
 from libecalc.common.errors.exceptions import InvalidResourceException
 from libecalc.common.serializable_chart import ChartCurveDTO, SingleSpeedChartDTO, VariableSpeedChartDTO
 from libecalc.domain.infrastructure.energy_components.generator_set import GeneratorSetModel
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularEnergyFunction
 from libecalc.domain.process.pump.pump import PumpSingleSpeed, PumpVariableSpeed
 from libecalc.domain.process.value_objects.chart import SingleSpeedChart, VariableSpeedChart
 from libecalc.domain.resource import Resource
@@ -118,16 +117,4 @@ def _create_generator_set_model(
         resource=resource,
         energy_usage_adjustment_constant=adjustment_constant,
         energy_usage_adjustment_factor=adjustment_factor,
-    )
-
-
-def _create_tabulated_model(resource: Resource, facility_data: YamlFacilityModelBase) -> TabularEnergyFunction:
-    resource_headers = resource.get_headers()
-    resource_data = [resource.get_float_column(header) for header in resource_headers]
-
-    return TabularEnergyFunction(
-        headers=resource_headers,
-        data=resource_data,
-        energy_usage_adjustment_factor=_get_adjustment_factor(data=facility_data),
-        energy_usage_adjustment_constant=_get_adjustment_constant(data=facility_data),
     )

--- a/src/libecalc/presentation/yaml/mappers/model.py
+++ b/src/libecalc/presentation/yaml/mappers/model.py
@@ -15,7 +15,6 @@ from libecalc.presentation.yaml.file_context import FileContext, FileMark
 from libecalc.presentation.yaml.mappers.facility_input import (
     _create_pump_chart_variable_speed_dto_model_data,
     _create_pump_model_single_speed_dto_model_data,
-    _create_tabulated_model,
 )
 from libecalc.presentation.yaml.mappers.utils import (
     YAML_UNIT_MAPPING,
@@ -315,12 +314,10 @@ class ModelMapper:
             | YamlCompressorWithTurbine
             | YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures
             | YamlCompressorTabularModel
-            | YamlGeneratorSetModel,
+            | YamlGeneratorSetModel
+            | YamlTabularModel,
         ):
             return None
-        elif isinstance(model, YamlTabularModel):
-            resource = self._get_resource(model.file)
-            return _create_tabulated_model(resource=resource, facility_data=model)
         elif isinstance(model, YamlPumpChartSingleSpeed):
             resource = self._get_resource(model.file)
             return _create_pump_model_single_speed_dto_model_data(resource=resource, facility_data=model)

--- a/src/libecalc/presentation/yaml/yaml_reference_service.py
+++ b/src/libecalc/presentation/yaml/yaml_reference_service.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable
 from typing import Any, get_args
 
 from libecalc.common.errors.exceptions import EcalcError
-from libecalc.domain.infrastructure.energy_components.legacy_consumer.tabulated import TabularEnergyFunction
 from libecalc.domain.process.pump.pump import PumpModel
 from libecalc.domain.resource import Resources
 from libecalc.dto import FuelType
@@ -22,6 +21,7 @@ from libecalc.presentation.yaml.yaml_models.yaml_model import YamlValidator
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import (
     YamlFacilityModelType,
     YamlGeneratorSetModel,
+    YamlTabularModel,
 )
 from libecalc.presentation.yaml.yaml_types.models import YamlCompressorChart, YamlFluidModel, YamlTurbine
 from libecalc.presentation.yaml.yaml_types.models.yaml_enums import YamlModelType
@@ -170,8 +170,8 @@ class YamlReferenceService(ReferenceService):
             raise InvalidReferenceException("pump model", reference)
         return model
 
-    def get_tabulated_model(self, reference: str) -> TabularEnergyFunction:
-        model = self._get_model_reference(reference, "tabulated")
-        if not isinstance(model, TabularEnergyFunction):
+    def get_tabulated_model(self, reference: str) -> YamlTabularModel:
+        model = self._resolve_yaml_reference(reference, "tabulated")
+        if not isinstance(model, YamlTabularModel):
             raise InvalidReferenceException("tabulated", reference)
         return model


### PR DESCRIPTION
Return Yaml-class from reference service, map in consumer function
mapper for consistency.
