### PR TITLE
refactor: remove final dto single speed compressor train

### DIFF
--- a/src/libecalc/domain/process/compressor/core/factory.py
+++ b/src/libecalc/domain/process/compressor/core/factory.py
@@ -3,9 +3,6 @@ from libecalc.domain.process.compressor.core.train.simplified_train import (
     CompressorTrainSimplifiedKnownStages,
     CompressorTrainSimplifiedUnknownStages,
 )
-from libecalc.domain.process.compressor.core.train.single_speed_compressor_train_common_shaft import (
-    SingleSpeedCompressorTrainCommonShaft,
-)
 from libecalc.domain.process.compressor.core.train.types import FluidStreamObjectForMultipleStreams
 from libecalc.domain.process.compressor.core.train.variable_speed_compressor_train_common_shaft import (
     VariableSpeedCompressorTrainCommonShaft,
@@ -18,7 +15,6 @@ from libecalc.domain.process.compressor.dto import (
     CompressorSampled,
     CompressorTrainSimplifiedWithKnownStages,
     CompressorTrainSimplifiedWithUnknownStages,
-    SingleSpeedCompressorTrain,
     VariableSpeedCompressorTrain,
     VariableSpeedCompressorTrainMultipleStreamsAndPressures,
 )
@@ -67,24 +63,6 @@ def _create_compressor_train_simplified_with_known_stages(
         stages=compressor_model_dto.stages,
         calculate_max_rate=compressor_model_dto.calculate_max_rate,
         maximum_power=compressor_model_dto.maximum_power,
-    )
-
-
-def _create_single_speed_compressor_train(
-    compressor_model_dto: SingleSpeedCompressorTrain,
-) -> SingleSpeedCompressorTrainCommonShaft:
-    fluid_factory = _create_fluid_factory(compressor_model_dto.fluid_model)
-    if fluid_factory is None:
-        raise ValueError("Fluid model is required for compressor train")
-    return SingleSpeedCompressorTrainCommonShaft(
-        fluid_factory=fluid_factory,
-        energy_usage_adjustment_constant=compressor_model_dto.energy_usage_adjustment_constant,
-        energy_usage_adjustment_factor=compressor_model_dto.energy_usage_adjustment_factor,
-        stages=compressor_model_dto.stages,
-        pressure_control=compressor_model_dto.pressure_control,
-        calculate_max_rate=compressor_model_dto.calculate_max_rate,
-        maximum_power=compressor_model_dto.maximum_power,
-        maximum_discharge_pressure=compressor_model_dto.maximum_discharge_pressure,
     )
 
 

--- a/src/libecalc/domain/process/compressor/dto/__init__.py
+++ b/src/libecalc/domain/process/compressor/dto/__init__.py
@@ -3,7 +3,6 @@ from .stage import CompressorStage, InterstagePressureControl
 from .train import (
     CompressorTrainSimplifiedWithKnownStages,
     CompressorTrainSimplifiedWithUnknownStages,
-    SingleSpeedCompressorTrain,
     VariableSpeedCompressorTrain,
     VariableSpeedCompressorTrainMultipleStreamsAndPressures,
 )

--- a/src/libecalc/domain/process/compressor/dto/train.py
+++ b/src/libecalc/domain/process/compressor/dto/train.py
@@ -2,10 +2,9 @@ from typing import Literal
 
 from libecalc.common.energy_model_type import EnergyModelType
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
-from libecalc.common.serializable_chart import SingleSpeedChartDTO, VariableSpeedChartDTO
+from libecalc.common.serializable_chart import VariableSpeedChartDTO
 from libecalc.domain.component_validation_error import (
     ProcessChartTypeValidationException,
-    ProcessDischargePressureValidationException,
     ProcessPressureRatioValidationException,
 )
 from libecalc.domain.process.compressor.dto.stage import CompressorStage
@@ -109,53 +108,6 @@ class CompressorTrainSimplifiedWithUnknownStages(CompressorTrain):
             msg = f"maximum_pressure_ratio_per_stage must be greater than or equal to 0. Invalid value: {self.maximum_pressure_ratio_per_stage}"
 
             raise ProcessPressureRatioValidationException(message=str(msg))
-
-
-class SingleSpeedCompressorTrain(CompressorTrain):
-    """Single speed train has a control mechanism for max discharge pressure."""
-
-    typ: Literal[EnergyModelType.SINGLE_SPEED_COMPRESSOR_TRAIN_COMMON_SHAFT] = (
-        EnergyModelType.SINGLE_SPEED_COMPRESSOR_TRAIN_COMMON_SHAFT
-    )
-
-    def __init__(
-        self,
-        energy_usage_adjustment_constant: float,
-        energy_usage_adjustment_factor: float,
-        stages: list[CompressorStage],
-        fluid_model: FluidModel | None = None,
-        pressure_control: FixedSpeedPressureControl | None = None,
-        calculate_max_rate: bool = False,
-        maximum_power: float | None = None,
-        maximum_discharge_pressure: float | None = None,
-    ):
-        super().__init__(
-            energy_usage_adjustment_constant=energy_usage_adjustment_constant,
-            energy_usage_adjustment_factor=energy_usage_adjustment_factor,
-            typ=self.typ,
-            stages=stages,
-            fluid_model=fluid_model,
-            pressure_control=pressure_control,
-            calculate_max_rate=calculate_max_rate,
-            maximum_power=maximum_power,
-        )
-        self.maximum_discharge_pressure = maximum_discharge_pressure
-        self._validate_maximum_discharge_pressure()
-        self._validate_stages(stages)
-
-    def _validate_maximum_discharge_pressure(self):
-        if self.maximum_discharge_pressure is not None and self.maximum_discharge_pressure < 0:
-            msg = f"maximum_discharge_pressure must be greater than or equal to 0. Invalid value: {self.maximum_discharge_pressure}"
-
-            raise ProcessDischargePressureValidationException(message=str(msg))
-
-    def _validate_stages(self, stages):
-        for stage in stages:
-            if not isinstance(stage.compressor_chart, SingleSpeedChartDTO):
-                msg = "Single Speed Compressor train only accepts Single Speed Compressor Charts."
-                f" Given type was {type(stage.compressor_chart)}"
-
-                raise ProcessChartTypeValidationException(message=str(msg))
 
 
 class VariableSpeedCompressorTrain(CompressorTrain):

--- a/tests/libecalc/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_single_speed_compressor_train_common_shaft.py
@@ -7,6 +7,7 @@ from libecalc.domain.process.compressor.core.train.single_speed_compressor_train
 )
 from libecalc.domain.process.compressor.core.train.stage import CompressorTrainStage
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
+from libecalc.domain.process.compressor.core.utils import map_compressor_train_stage_to_domain
 from libecalc.domain.process.core.results.compressor import CompressorTrainCommonShaftFailureStatus
 from libecalc.domain.process.value_objects.chart.chart_area_flag import ChartAreaFlag
 from libecalc.domain.process.value_objects.fluid_stream.fluid_model import FluidModel
@@ -52,12 +53,13 @@ def single_speed_compressor_train_common_shaft(single_speed_stages, fluid_model_
         if stages is None:
             stages = single_speed_stages
         fluid_factory = NeqSimFluidFactory(fluid_model)
+        stages_mapped = [map_compressor_train_stage_to_domain(stage_dto) for stage_dto in stages]
 
         return SingleSpeedCompressorTrainCommonShaft(
             fluid_factory=fluid_factory,
             energy_usage_adjustment_constant=energy_usage_adjustment_constant,
             energy_usage_adjustment_factor=energy_usage_adjustment_factor,
-            stages=stages,
+            stages=stages_mapped,
             pressure_control=pressure_control,
             calculate_max_rate=calculate_max_rate,
             maximum_power=maximum_power,


### PR DESCRIPTION
## Why is this pull request needed?

The PR removes the `SingleSpeedCompressorTrain` DTO and related code, simplifying the compressor train modeling by using the core implementation directly. This reduces duplication and potential sources of confusion or errors.

## What does this pull request change?

- Deletes the `SingleSpeedCompressorTrain` class from the DTO layer and its references throughout the codebase.
- Refactors factories, mappers, and tests to use SingleSpeedCompressorTrainCommonShaft directly.
- Moves validation logic for single speed compressor trains from the DTO layer to the core implementation.
- Updates related imports, object creation, and test fixtures accordingly.