### PR TITLE
refactor: remove final dto simplified train

### DIFF
--- a/src/libecalc/domain/process/compressor/core/factory.py
+++ b/src/libecalc/domain/process/compressor/core/factory.py
@@ -1,8 +1,4 @@
 from libecalc.domain.process.compressor.core.sampled import CompressorModelSampled
-from libecalc.domain.process.compressor.core.train.simplified_train import (
-    CompressorTrainSimplifiedKnownStages,
-    CompressorTrainSimplifiedUnknownStages,
-)
 from libecalc.domain.process.compressor.core.train.types import FluidStreamObjectForMultipleStreams
 from libecalc.domain.process.compressor.core.train.variable_speed_compressor_train_common_shaft import (
     VariableSpeedCompressorTrainCommonShaft,
@@ -13,8 +9,6 @@ from libecalc.domain.process.compressor.core.train.variable_speed_compressor_tra
 from libecalc.domain.process.compressor.core.utils import map_compressor_train_stage_to_domain
 from libecalc.domain.process.compressor.dto import (
     CompressorSampled,
-    CompressorTrainSimplifiedWithKnownStages,
-    CompressorTrainSimplifiedWithUnknownStages,
     VariableSpeedCompressorTrain,
     VariableSpeedCompressorTrainMultipleStreamsAndPressures,
 )
@@ -44,25 +38,6 @@ def _create_variable_speed_compressor_train_multiple_streams_and_pressures_strea
         fluid_model=stream_data.fluid_model,
         is_inlet_stream=is_inlet_stream,
         connected_to_stage_no=stream_references[stream_data.name],
-    )
-
-
-def _create_compressor_train_simplified_with_known_stages(
-    compressor_model_dto: CompressorTrainSimplifiedWithKnownStages,
-) -> CompressorTrainSimplifiedKnownStages:
-    # Energy usage adjustment not supported for this model (yet)
-    # Issue error if factors are not default (and not changing the energy usage result)
-
-    fluid_factory = _create_fluid_factory(compressor_model_dto.fluid_model)
-    if fluid_factory is None:
-        raise ValueError("Fluid model is required for compressor train")
-    return CompressorTrainSimplifiedKnownStages(
-        fluid_factory=fluid_factory,
-        energy_usage_adjustment_constant=compressor_model_dto.energy_usage_adjustment_constant,
-        energy_usage_adjustment_factor=compressor_model_dto.energy_usage_adjustment_factor,
-        stages=compressor_model_dto.stages,
-        calculate_max_rate=compressor_model_dto.calculate_max_rate,
-        maximum_power=compressor_model_dto.maximum_power,
     )
 
 
@@ -123,23 +98,6 @@ def _create_variable_speed_compressor_train_multiple_streams_and_pressures(
         maximum_power=compressor_model_dto.maximum_power,
         pressure_control=compressor_model_dto.pressure_control,
         stage_number_interstage_pressure=stage_number_interstage_pressure,
-    )
-
-
-def _create_compressor_train_simplified_with_unknown_stages(
-    compressor_model_dto: CompressorTrainSimplifiedWithUnknownStages,
-) -> CompressorTrainSimplifiedUnknownStages:
-    fluid_factory = _create_fluid_factory(compressor_model_dto.fluid_model)
-    if fluid_factory is None:
-        raise ValueError("Fluid model is required for compressor train")
-    return CompressorTrainSimplifiedUnknownStages(
-        fluid_factory=fluid_factory,
-        energy_usage_adjustment_constant=compressor_model_dto.energy_usage_adjustment_constant,
-        energy_usage_adjustment_factor=compressor_model_dto.energy_usage_adjustment_factor,
-        stage=compressor_model_dto.stage,
-        maximum_pressure_ratio_per_stage=compressor_model_dto.maximum_pressure_ratio_per_stage,
-        calculate_max_rate=compressor_model_dto.calculate_max_rate,
-        maximum_power=compressor_model_dto.maximum_power,
     )
 
 

--- a/src/libecalc/domain/process/compressor/core/train/simplified_train.py
+++ b/src/libecalc/domain/process/compressor/core/train/simplified_train.py
@@ -20,8 +20,6 @@ from libecalc.domain.process.compressor.core.train.utils.enthalpy_calculations i
     calculate_enthalpy_change_head_iteration,
     calculate_polytropic_head_campbell,
 )
-from libecalc.domain.process.compressor.core.utils import map_compressor_train_stage_to_domain
-from libecalc.domain.process.compressor.dto import CompressorStage
 from libecalc.domain.process.value_objects.chart.chart_area_flag import ChartAreaFlag
 from libecalc.domain.process.value_objects.chart.compressor import VariableSpeedCompressorChart
 from libecalc.domain.process.value_objects.chart.compressor.chart_creator import CompressorChartCreator
@@ -321,18 +319,17 @@ class CompressorTrainSimplifiedKnownStages(CompressorTrainSimplified):
         fluid_factory: FluidFactoryInterface,
         energy_usage_adjustment_constant: float,
         energy_usage_adjustment_factor: float,
-        stages: list[CompressorStage],
+        stages: list[CompressorTrainStage],
         calculate_max_rate: bool = False,
         maximum_power: float | None = None,
     ):
         """See CompressorTrainSimplified for explanation of a compressor train."""
         logger.debug(f"Creating CompressorTrainSimplifiedKnownStages with n_stages: {len(stages)}")
-        stages_mapped = [map_compressor_train_stage_to_domain(stage_dto) for stage_dto in stages]
         super().__init__(
             fluid_factory=fluid_factory,
             energy_usage_adjustment_constant=energy_usage_adjustment_constant,
             energy_usage_adjustment_factor=energy_usage_adjustment_factor,
-            stages=stages_mapped,
+            stages=stages,
             typ=EnergyModelType.COMPRESSOR_TRAIN_SIMPLIFIED_WITH_KNOWN_STAGES,
             maximum_power=maximum_power,
             pressure_control=None,  # Not relevant for simplified trains.
@@ -532,7 +529,7 @@ class CompressorTrainSimplifiedUnknownStages(CompressorTrainSimplified):
         fluid_factory: FluidFactoryInterface,
         energy_usage_adjustment_constant: float,
         energy_usage_adjustment_factor: float,
-        stage: CompressorStage,
+        stage: CompressorTrainStage,
         maximum_pressure_ratio_per_stage: float,
         calculate_max_rate: bool = False,
         maximum_power: float | None = None,
@@ -569,7 +566,7 @@ class CompressorTrainSimplifiedUnknownStages(CompressorTrainSimplified):
             compressor_maximum_pressure_ratio=self.maximum_pressure_ratio_per_stage,
         )
 
-        return [map_compressor_train_stage_to_domain(self.stage) for _ in range(number_of_compressors)]
+        return [self.stage for _ in range(number_of_compressors)]
 
     @staticmethod
     def _calculate_number_of_compressors_needed(

--- a/src/libecalc/domain/process/compressor/dto/__init__.py
+++ b/src/libecalc/domain/process/compressor/dto/__init__.py
@@ -1,8 +1,6 @@
 from .sampled import CompressorSampled
 from .stage import CompressorStage, InterstagePressureControl
 from .train import (
-    CompressorTrainSimplifiedWithKnownStages,
-    CompressorTrainSimplifiedWithUnknownStages,
     VariableSpeedCompressorTrain,
     VariableSpeedCompressorTrainMultipleStreamsAndPressures,
 )

--- a/src/libecalc/domain/process/compressor/dto/train.py
+++ b/src/libecalc/domain/process/compressor/dto/train.py
@@ -5,7 +5,6 @@ from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureContr
 from libecalc.common.serializable_chart import VariableSpeedChartDTO
 from libecalc.domain.component_validation_error import (
     ProcessChartTypeValidationException,
-    ProcessPressureRatioValidationException,
 )
 from libecalc.domain.process.compressor.dto.stage import CompressorStage
 from libecalc.domain.process.dto.base import EnergyModel
@@ -34,80 +33,6 @@ class CompressorTrain(EnergyModel):
         self.calculate_max_rate = calculate_max_rate
         self.maximum_power = maximum_power
         self.pressure_control = pressure_control
-
-
-class CompressorTrainSimplifiedWithKnownStages(CompressorTrain):
-    typ: Literal[EnergyModelType.COMPRESSOR_TRAIN_SIMPLIFIED_WITH_KNOWN_STAGES] = (
-        EnergyModelType.COMPRESSOR_TRAIN_SIMPLIFIED_WITH_KNOWN_STAGES
-    )
-
-    # Not in use:
-    pressure_control: FixedSpeedPressureControl | None = None  # Not relevant for simplified trains.
-
-    def __init__(
-        self,
-        energy_usage_adjustment_constant: float,
-        energy_usage_adjustment_factor: float,
-        stages: list[CompressorStage],
-        fluid_model: FluidModel,
-        calculate_max_rate: bool = False,
-        maximum_power: float | None = None,
-    ):
-        super().__init__(
-            energy_usage_adjustment_constant=energy_usage_adjustment_constant,
-            energy_usage_adjustment_factor=energy_usage_adjustment_factor,
-            typ=self.typ,
-            stages=stages,
-            fluid_model=fluid_model,
-            pressure_control=self.pressure_control,
-            calculate_max_rate=calculate_max_rate,
-            maximum_power=maximum_power,
-        )
-
-
-class CompressorTrainSimplifiedWithUnknownStages(CompressorTrain):
-    """Unknown stages does not have stages, instead we have one stage that will be multiplied as many times as needed.
-    Will be constrained by a maximum pressure ratio per stage.
-    """
-
-    typ: Literal[EnergyModelType.COMPRESSOR_TRAIN_SIMPLIFIED_WITH_UNKNOWN_STAGES] = (
-        EnergyModelType.COMPRESSOR_TRAIN_SIMPLIFIED_WITH_UNKNOWN_STAGES
-    )
-
-    # Not in use:
-    stages: list[CompressorStage] = []  # Not relevant since the stage is Unknown
-    pressure_control: FixedSpeedPressureControl | None = None  # Not relevant for simplified trains.
-
-    def __init__(
-        self,
-        energy_usage_adjustment_constant: float,
-        energy_usage_adjustment_factor: float,
-        fluid_model: FluidModel,
-        stage: CompressorStage,
-        maximum_pressure_ratio_per_stage: float,
-        calculate_max_rate: bool = False,
-        maximum_power: float | None = None,
-    ):
-        super().__init__(
-            energy_usage_adjustment_constant,
-            energy_usage_adjustment_factor,
-            self.typ,
-            stages=self.stages,
-            fluid_model=fluid_model,
-            pressure_control=self.pressure_control,
-            calculate_max_rate=calculate_max_rate,
-            maximum_power=maximum_power,
-        )
-        self.stage = stage
-        self.maximum_pressure_ratio_per_stage = maximum_pressure_ratio_per_stage
-        self.fluid_model = fluid_model
-        self._validate_maximum_pressure_ratio_per_stage()
-
-    def _validate_maximum_pressure_ratio_per_stage(self):
-        if self.maximum_pressure_ratio_per_stage < 0:
-            msg = f"maximum_pressure_ratio_per_stage must be greater than or equal to 0. Invalid value: {self.maximum_pressure_ratio_per_stage}"
-
-            raise ProcessPressureRatioValidationException(message=str(msg))
 
 
 class VariableSpeedCompressorTrain(CompressorTrain):

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -43,12 +43,14 @@ from libecalc.domain.process.compressor.core import CompressorModel
 from libecalc.domain.process.compressor.core.base import CompressorWithTurbineModel
 from libecalc.domain.process.compressor.core.factory import (
     _create_compressor_sampled,
-    _create_compressor_train_simplified_with_known_stages,
-    _create_compressor_train_simplified_with_unknown_stages,
     _create_variable_speed_compressor_train,
     _create_variable_speed_compressor_train_multiple_streams_and_pressures,
 )
 from libecalc.domain.process.compressor.core.sampled import CompressorModelSampled
+from libecalc.domain.process.compressor.core.train.simplified_train import (
+    CompressorTrainSimplifiedKnownStages,
+    CompressorTrainSimplifiedUnknownStages,
+)
 from libecalc.domain.process.compressor.core.train.single_speed_compressor_train_common_shaft import (
     SingleSpeedCompressorTrainCommonShaft,
 )
@@ -62,8 +64,6 @@ from libecalc.domain.process.compressor.core.utils import map_compressor_train_s
 from libecalc.domain.process.compressor.dto import (
     CompressorSampled,
     CompressorStage,
-    CompressorTrainSimplifiedWithKnownStages,
-    CompressorTrainSimplifiedWithUnknownStages,
     InterstagePressureControl,
     VariableSpeedCompressorTrain,
     VariableSpeedCompressorTrainMultipleStreamsAndPressures,
@@ -310,56 +310,61 @@ class CompressorModelMapper:
     def _create_simplified_variable_speed_compressor_train(self, model: YamlSimplifiedVariableSpeedCompressorTrain):
         fluid_model_reference: str = model.fluid_model
         fluid_model = self._get_fluid_model(fluid_model_reference)
+        fluid_factory = _create_fluid_factory(fluid_model)
+        if fluid_factory is None:
+            raise ValueError("Fluid model is required for compressor train")
 
         train_spec = model.compressor_train
 
         if not isinstance(train_spec, YamlUnknownCompressorStages):
             # The stages are pre defined, known
-            stages = train_spec.stages
-            return _create_compressor_train_simplified_with_known_stages(
-                CompressorTrainSimplifiedWithKnownStages(
-                    fluid_model=fluid_model,
-                    stages=[
-                        CompressorStage(
-                            inlet_temperature_kelvin=convert_temperature_to_kelvin(
-                                [stage.inlet_temperature],
-                                input_unit=Unit.CELSIUS,
-                            )[0],
-                            compressor_chart=self._get_compressor_chart(stage.compressor_chart),
-                            pressure_drop_before_stage=0,
-                            control_margin=0,
-                            remove_liquid_after_cooling=True,
-                        )
-                        for stage in stages
-                    ],
-                    energy_usage_adjustment_constant=model.power_adjustment_constant,
-                    energy_usage_adjustment_factor=model.power_adjustment_factor,
-                    calculate_max_rate=model.calculate_max_rate,
-                    maximum_power=model.maximum_power,
+            yaml_stages = train_spec.stages
+            stages = [
+                CompressorStage(
+                    inlet_temperature_kelvin=convert_temperature_to_kelvin(
+                        [stage.inlet_temperature],
+                        input_unit=Unit.CELSIUS,
+                    )[0],
+                    compressor_chart=self._get_compressor_chart(stage.compressor_chart),
+                    pressure_drop_before_stage=0,
+                    control_margin=0,
+                    remove_liquid_after_cooling=True,
                 )
+                for stage in yaml_stages
+            ]
+            stages_mapped = [map_compressor_train_stage_to_domain(stage_dto) for stage_dto in stages]
+
+            return CompressorTrainSimplifiedKnownStages(
+                fluid_factory=fluid_factory,
+                stages=stages_mapped,
+                energy_usage_adjustment_constant=model.power_adjustment_constant,
+                energy_usage_adjustment_factor=model.power_adjustment_factor,
+                calculate_max_rate=model.calculate_max_rate,
+                maximum_power=model.maximum_power,
             )
         else:
             # The stages are unknown, not defined
             compressor_chart_reference = train_spec.compressor_chart
-            return _create_compressor_train_simplified_with_unknown_stages(
-                CompressorTrainSimplifiedWithUnknownStages(
-                    fluid_model=fluid_model,
-                    stage=CompressorStage(
-                        compressor_chart=self._get_compressor_chart(compressor_chart_reference),
-                        inlet_temperature_kelvin=convert_temperature_to_kelvin(
-                            [train_spec.inlet_temperature],
-                            input_unit=Unit.CELSIUS,
-                        )[0],
-                        pressure_drop_before_stage=0,
-                        remove_liquid_after_cooling=True,
-                        # control_margin=0,  # mypy needs this?
-                    ),
-                    energy_usage_adjustment_constant=model.power_adjustment_constant,
-                    energy_usage_adjustment_factor=model.power_adjustment_factor,
-                    calculate_max_rate=model.calculate_max_rate,
-                    maximum_pressure_ratio_per_stage=train_spec.maximum_pressure_ratio_per_stage,  # type: ignore[arg-type]
-                    maximum_power=model.maximum_power,
-                )
+            stage = CompressorStage(
+                compressor_chart=self._get_compressor_chart(compressor_chart_reference),
+                inlet_temperature_kelvin=convert_temperature_to_kelvin(
+                    [train_spec.inlet_temperature],
+                    input_unit=Unit.CELSIUS,
+                )[0],
+                pressure_drop_before_stage=0,
+                remove_liquid_after_cooling=True,
+                # control_margin=0,  # mypy needs this?
+            )
+            stage_mapped = map_compressor_train_stage_to_domain(stage)
+
+            return CompressorTrainSimplifiedUnknownStages(
+                fluid_factory=fluid_factory,
+                stage=stage_mapped,
+                energy_usage_adjustment_constant=model.power_adjustment_constant,
+                energy_usage_adjustment_factor=model.power_adjustment_factor,
+                calculate_max_rate=model.calculate_max_rate,
+                maximum_pressure_ratio_per_stage=train_spec.maximum_pressure_ratio_per_stage,  # type: ignore[arg-type]
+                maximum_power=model.maximum_power,
             )
 
     def _create_variable_speed_compressor_train(

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_model_vs_unisim.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_model_vs_unisim.py
@@ -9,6 +9,7 @@ from libecalc.domain.process.compressor.core.train.simplified_train import Compr
 from libecalc.domain.process.compressor.core.train.utils.enthalpy_calculations import (
     calculate_enthalpy_change_head_iteration,
 )
+from libecalc.domain.process.compressor.core.utils import map_compressor_train_stage_to_domain
 from libecalc.domain.process.value_objects.chart.generic import GenericChartFromDesignPoint
 from libecalc.domain.process.value_objects.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
 from libecalc.infrastructure.neqsim_fluid_provider.neqsim_fluid_factory import NeqSimFluidFactory
@@ -141,23 +142,25 @@ def test_simplified_compressor_train_compressor_stage_work(
     """
 
     fluid_factory = unisim_test_data.fluid_factory
+    stages = [
+        dto.CompressorStage(
+            inlet_temperature_kelvin=313.15,
+            compressor_chart=GenericChartFromDesignPoint(
+                polytropic_efficiency_fraction=unisim_test_data.compressor_data.polytropic_efficiency,
+                design_polytropic_head_J_per_kg=1,  # Dummy value
+                design_rate_actual_m3_per_hour=1,  # Dummy value
+            ),
+            pressure_drop_before_stage=0,
+            remove_liquid_after_cooling=True,
+            control_margin=0,
+        )
+    ]
+    stages_mapped = [map_compressor_train_stage_to_domain(stage) for stage in stages]
     compressor_train = CompressorTrainSimplifiedKnownStages(
         fluid_factory=fluid_factory,
         energy_usage_adjustment_factor=1,
         energy_usage_adjustment_constant=0,
-        stages=[
-            dto.CompressorStage(
-                inlet_temperature_kelvin=313.15,
-                compressor_chart=GenericChartFromDesignPoint(
-                    polytropic_efficiency_fraction=unisim_test_data.compressor_data.polytropic_efficiency,
-                    design_polytropic_head_J_per_kg=1,  # Dummy value
-                    design_rate_actual_m3_per_hour=1,  # Dummy value
-                ),
-                pressure_drop_before_stage=0,
-                remove_liquid_after_cooling=True,
-                control_margin=0,
-            )
-        ],
+        stages=stages_mapped,
     )
 
     results = []


### PR DESCRIPTION
## Why is this pull request needed?

This PR simplifies the handling of simplified compressor train models by removing unused DTO classes and factory methods, and ensures mapping between DTOs and domain models happens at the correct layer.

## What does this pull request change?

- Removes the DTO classes `CompressorTrainSimplifiedWithKnownStages` and `CompressorTrainSimplifiedWithUnknownStages`.
- Removes corresponding factory methods and related imports.
- Refactors affected tests and code to use `CompressorTrainSimplifiedKnownStages` and CompressorTrainSimplifiedUnknownStages directly with domain types.

