### PR TITLE
chore: improve error message for timeseries

### DIFF
--- a/src/libecalc/presentation/yaml/domain/time_series_resource.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_resource.py
@@ -219,7 +219,7 @@ class TimeSeriesResource(Resource):
         raise ValueError(
             "The provided dates doesn't match any of the accepted date formats, "
             "or contains inconsistently formatted dates. "
-            "Did you forget to name the datetime column 'DATE'?"
+            f"Did you forget to name the datetime column '{EcalcYamlKeywords.date}'?"
         )
 
     def validate(self) -> Self:


### PR DESCRIPTION
## Have you remembered and considered?

- [x] IF FEAT: I have remembered to update documentation
- [x] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [x] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [x] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

Fix calculation of whether most of the dates include time or not, only used in error messages, to make it easier for users to figure out whats wrong.
Also improve error message when no other reason is found, give user a better path to remediation (asking if they have used the wrong name for date column.

## What else did you consider?

Not a feature, not breaking.
(you can argue there are new tests, as I found the error message lacking while writing tests for api: https://github.com/equinor/ecalc-engine/pull/7349)

## Between the lines?

refs: https://github.com/equinor/ecalc-internal/issues/1094
