### PR TITLE
refactor: have get_max_standards_rate use set_evaluation_input for co…

### DIFF
--- a/src/libecalc/domain/process/compressor/core/sampled/compressor_model_sampled.py
+++ b/src/libecalc/domain/process/compressor/core/sampled/compressor_model_sampled.py
@@ -149,15 +149,13 @@ class CompressorModelSampled:
 
     def get_max_standard_rate(
         self,
-        suction_pressures: NDArray[np.float64] | None = None,
-        discharge_pressures: NDArray[np.float64] | None = None,
     ) -> NDArray[np.float64] | None:
         """Get max rate given suction pressure and a discharge pressure.
 
         :param suction_pressures: Suction pressure [bar]
         :param discharge_pressures: Discharge pressure [bar]
         """
-        number_of_calculation_points = len(suction_pressures) if suction_pressures is not None else 1
+        number_of_calculation_points = len(self._suction_pressure) if self._suction_pressure is not None else 1
         if self.support_max_rate:
             if self._qhull_sampled.support_max_rate:
                 return np.full(

--- a/src/libecalc/domain/process/compressor/core/train/compressor_train_common_shaft_multiple_streams_and_pressures.py
+++ b/src/libecalc/domain/process/compressor/core/train/compressor_train_common_shaft_multiple_streams_and_pressures.py
@@ -111,7 +111,7 @@ class CompressorTrainCommonShaftMultipleStreamsAndPressures(CompressorTrainCommo
     def set_evaluation_input(
         self,
         rate: NDArray[np.float64],
-        fluid_factory: FluidFactoryInterface | list[FluidFactoryInterface] | None,
+        fluid_factory: FluidFactoryInterface | list[FluidFactoryInterface],
         suction_pressure: NDArray[np.float64],
         discharge_pressure: NDArray[np.float64],
         intermediate_pressure: NDArray[np.float64] | None = None,

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_train_common_shaft.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_train_common_shaft.py
@@ -869,20 +869,19 @@ def test_get_max_standard_rate_with_and_without_maximum_power(variable_speed_com
     compressor_train_max_power = variable_speed_compressor_train(maximum_power=7.0)
 
     compressor_train.set_evaluation_input(
-        fluid_factory=fluid_factory_medium, rate=1, suction_pressure=30, discharge_pressure=100
+        fluid_factory=fluid_factory_medium,
+        rate=np.asarray([1], dtype=float),
+        suction_pressure=np.asarray([30], dtype=float),
+        discharge_pressure=np.asarray([100], dtype=float),
     )
     compressor_train_max_power.set_evaluation_input(
-        fluid_factory=fluid_factory_medium, rate=1, suction_pressure=30, discharge_pressure=100
+        fluid_factory=fluid_factory_medium,
+        rate=np.asarray([1], dtype=float),
+        suction_pressure=np.asarray([30], dtype=float),
+        discharge_pressure=np.asarray([100], dtype=float),
     )
-
-    max_standard_rate_without_maximum_power = compressor_train.get_max_standard_rate(
-        suction_pressures=np.asarray([30]),
-        discharge_pressures=np.asarray([100]),
-    )
-    max_standard_rate_with_maximum_power = compressor_train_max_power.get_max_standard_rate(
-        suction_pressures=np.asarray([30]),
-        discharge_pressures=np.asarray([100]),
-    )
+    max_standard_rate_without_maximum_power = compressor_train.get_max_standard_rate()
+    max_standard_rate_with_maximum_power = compressor_train_max_power.get_max_standard_rate()
     compressor_train.set_evaluation_input(
         fluid_factory=fluid_factory_medium,
         rate=np.asarray([max_standard_rate_without_maximum_power], dtype=float),

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_with_turbine.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_with_turbine.py
@@ -49,29 +49,21 @@ def test_turbine_max_rate(turbine_factory, single_speed_compressor_train_unisim_
     fluid_factory = NeqSimFluidFactory(FluidModel(composition=FluidComposition(methane=1.0), eos_model=EoSModel.SRK))
     compressor_with_turbine_model = CompressorWithTurbineModel(
         turbine_model=turbine_factory(
-            loads=[1, 10], efficiency_fractions=[0.5, 0.5]
+            loads=[1, 12], efficiency_fractions=[0.5, 0.5]
         ),  # Max power 10, make sure above power from compressor model
         compressor_energy_function=single_speed_compressor_train_unisim_methane,
         energy_usage_adjustment_constant=0,
         energy_usage_adjustment_factor=1,
     )
-    rate = np.asarray([[1, 1, 1, 1, 1]])
-    suction_pressure = np.asarray([40, 40, 40, 35, 60])
-    discharge_pressure = np.asarray([200, 200, 200, 200, 200])
+    rate = np.asarray([[1, 1, 1]])
+    suction_pressure = np.asarray([40, 35, 60])
+    discharge_pressure = np.asarray([90, 80, 90])
     compressor_with_turbine_model.set_evaluation_input(
         fluid_factory=fluid_factory,
         rate=rate,
         suction_pressure=suction_pressure,
         discharge_pressure=discharge_pressure,
     )
-    max_rate = compressor_with_turbine_model.get_max_standard_rate(
-        suction_pressures=suction_pressure,
-        discharge_pressures=discharge_pressure,
-    )
+    max_rate = compressor_with_turbine_model.get_max_standard_rate()
 
-    assert (
-        max_rate.tolist()
-        == single_speed_compressor_train_unisim_methane.get_max_standard_rate(
-            suction_pressures=suction_pressure, discharge_pressures=discharge_pressure, fluid_factory=fluid_factory
-        ).tolist()
-    )
+    assert max_rate.tolist() == single_speed_compressor_train_unisim_methane.get_max_standard_rate().tolist()

--- a/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
@@ -214,10 +214,7 @@ def test_compressor_train_simplified_known_stages_generic_chart(
 
     assert len(results.stage_results) == 2
 
-    maximum_rates = simple_compressor_train_model.get_max_standard_rate(
-        suction_pressures=suction_pressures,
-        discharge_pressures=discharge_pressures,
-    )
+    maximum_rates = simple_compressor_train_model.get_max_standard_rate()
 
     np.testing.assert_allclose(
         maximum_rates.tolist(),


### PR DESCRIPTION
…mpressor models

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
