### PR TITLE
refactor: invert shaft-compressor relationship

### DIFF
--- a/src/libecalc/domain/process/entities/process_units/compressor.py
+++ b/src/libecalc/domain/process/entities/process_units/compressor.py
@@ -2,7 +2,6 @@ from libecalc.domain.process.compressor.core.train.utils.common import (
     RECIRCULATION_BOUNDARY_TOLERANCE,
     calculate_outlet_pressure_and_stream,
 )
-from libecalc.domain.process.entities.shaft import Shaft
 from libecalc.domain.process.process_solver.boundary import Boundary
 from libecalc.domain.process.process_system.process_error import RateTooHighError, RateTooLowError
 from libecalc.domain.process.process_system.process_unit import ProcessUnit, ProcessUnitId
@@ -17,12 +16,11 @@ class Compressor(ProcessUnit):
         process_unit_id: ProcessUnitId,
         compressor_chart: ChartData,
         fluid_service: FluidService,
-        shaft: Shaft,
     ):
         self._id = process_unit_id
         self._compressor_chart = CompressorChart(compressor_chart)
         self._fluid_service = fluid_service
-        self._shaft = shaft
+        self._speed: float | None = None
 
     def get_id(self) -> ProcessUnitId:
         return self._id
@@ -67,12 +65,10 @@ class Compressor(ProcessUnit):
         return self._compressor_chart
 
     @property
-    def shaft(self) -> Shaft:
-        return self._shaft
-
-    @property
     def speed(self) -> float:
-        return self.shaft.get_speed()
+        if self._speed is None:
+            raise ValueError("Speed not set. Compressor must be registered on a Shaft.")
+        return self._speed
 
     @property
     def minimum_flow_rate(self) -> float:
@@ -84,12 +80,9 @@ class Compressor(ProcessUnit):
         """Maximum flow rate in m3/h, as a function of speed if speed is set, otherwise the maximum flow rate at maximum speed."""
         return self.compressor_chart.maximum_rate_as_function_of_speed(self.speed)
 
-    def get_speed_boundary(self) -> Boundary:
-        """Min and max shaft speed from the compressor chart."""
-        return Boundary(
-            min=self.compressor_chart.minimum_speed,
-            max=self.compressor_chart.maximum_speed,
-        )
+    def set_speed(self, speed: float) -> None:
+        """Set the rotational speed used for chart lookup."""
+        self._speed = speed
 
     def get_minimum_standard_rate(self, inlet_stream: FluidStream) -> float:
         """Minimum standard volumetric rate [sm³/day] at current speed.

--- a/src/libecalc/domain/process/entities/shaft/shaft.py
+++ b/src/libecalc/domain/process/entities/shaft/shaft.py
@@ -33,12 +33,12 @@ class Shaft(ABC):
     def set_speed(self, value: float) -> None:
         pass
 
-    def register(self, compressor) -> None:
+    def connect(self, compressor: Compressor) -> None:
         if compressor in self._compressors:
             raise ProgrammingError("Compressor is already registered on this shaft.")
         self._compressors.append(compressor)
 
-    def get_compressors(self) -> list:
+    def get_compressors(self) -> list[Compressor]:
         return list(self._compressors)
 
     def get_speed(self) -> float:

--- a/src/libecalc/domain/process/entities/shaft/shaft.py
+++ b/src/libecalc/domain/process/entities/shaft/shaft.py
@@ -38,9 +38,6 @@ class Shaft(ABC):
             raise ProgrammingError("Compressor is already registered on this shaft.")
         self._compressors.append(compressor)
 
-    def get_compressors(self) -> list[Compressor]:
-        return list(self._compressors)
-
     def get_speed(self) -> float:
         if self._speed_rpm is None:
             return float("nan")

--- a/src/libecalc/domain/process/entities/shaft/shaft.py
+++ b/src/libecalc/domain/process/entities/shaft/shaft.py
@@ -3,6 +3,10 @@ from abc import ABC, abstractmethod
 from typing import NewType
 from uuid import UUID
 
+from libecalc.common.errors.exceptions import ProgrammingError
+from libecalc.domain.process.entities.process_units.compressor import Compressor
+from libecalc.domain.process.process_solver.boundary import Boundary
+
 ShaftId = NewType("ShaftId", UUID)
 
 
@@ -20,6 +24,7 @@ class Shaft(ABC):
     def __init__(self, speed_rpm: float | None = None):
         self._id = create_shaft_id()
         self._speed_rpm = speed_rpm
+        self._compressors: list[Compressor] = []
 
     def get_id(self) -> ShaftId:
         return self._id
@@ -27,6 +32,14 @@ class Shaft(ABC):
     @abstractmethod
     def set_speed(self, value: float) -> None:
         pass
+
+    def register(self, compressor) -> None:
+        if compressor in self._compressors:
+            raise ProgrammingError("Compressor is already registered on this shaft.")
+        self._compressors.append(compressor)
+
+    def get_compressors(self) -> list:
+        return list(self._compressors)
 
     def get_speed(self) -> float:
         if self._speed_rpm is None:
@@ -40,15 +53,29 @@ class Shaft(ABC):
     def speed_is_defined(self) -> bool:
         return self._speed_rpm is not None
 
+    def get_speed_boundary(self) -> Boundary:
+        from libecalc.domain.process.process_solver.boundary import Boundary
+
+        if not self._compressors:
+            raise ValueError("No compressors registered on this shaft.")
+        min_speed = max(c.compressor_chart.minimum_speed for c in self._compressors)
+        max_speed = min(c.compressor_chart.maximum_speed for c in self._compressors)
+        return Boundary(min=min_speed, max=max_speed)
+
+    def _apply_speed(self, value: float):
+        self._speed_rpm = value
+        for compressor in self._compressors:
+            compressor.set_speed(value)
+
 
 class SingleSpeedShaft(Shaft):
     def set_speed(self, value: float):
         if self._speed_rpm is None:
-            self._speed_rpm = value
+            self._apply_speed(value)
         elif value != self._speed_rpm:
             raise AttributeError("Speed has already been set. Cannot modify speed of SingleSpeedShaft")
 
 
 class VariableSpeedShaft(Shaft):
     def set_speed(self, value: float):
-        self._speed_rpm = value
+        self._apply_speed(value)

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -349,7 +349,7 @@ class ProcessSimulationMapper:
             item = self._resolve_train_reference(yaml_compressor_train_item.target)
             compressors = self._get_compressors(item)
             for compressor in compressors:
-                shaft.register(compressor)
+                shaft.connect(compressor)
 
             try:
                 pressure_control = yaml_process_simulation.pressure_control[item.name]

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -9,7 +9,6 @@ from libecalc.domain.component_validation_error import DomainValidationException
 from libecalc.domain.process.entities.process_units.choke import Choke
 from libecalc.domain.process.entities.process_units.compressor import Compressor
 from libecalc.domain.process.entities.process_units.recirculation_loop import RecirculationLoop
-from libecalc.domain.process.entities.shaft import Shaft
 from libecalc.domain.process.entities.shaft.shaft import VariableSpeedShaft
 from libecalc.domain.process.process_simulation import (
     AntiSurgeConfig,
@@ -217,7 +216,7 @@ class ProcessSimulationMapper:
                 yaml_curves, units=yaml_chart.units, control_margin=control_margin_fraction
             )
 
-    def _get_compressor(self, yaml_compressor_stage: YamlCompressorStageProcessSystem, shaft: Shaft) -> Compressor:
+    def _get_compressor(self, yaml_compressor_stage: YamlCompressorStageProcessSystem) -> Compressor:
         # TODO: deal with stage
         yaml_compressor = self._resolve_compressor_reference(yaml_compressor_stage.compressor)
 
@@ -227,14 +226,11 @@ class ProcessSimulationMapper:
             process_unit_id=create_process_unit_id(),
             compressor_chart=chart,
             fluid_service=self._fluid_service,
-            shaft=shaft,
         )
 
-    def _get_compressors(self, target: YamlSerialProcessSystem, shaft: Shaft) -> list[Compressor]:
+    def _get_compressors(self, target: YamlSerialProcessSystem) -> list[Compressor]:
         return [
-            self._get_compressor(
-                yaml_compressor_stage=self._resolve_compressor_stage_reference(yaml_compressor.target), shaft=shaft
-            )
+            self._get_compressor(yaml_compressor_stage=self._resolve_compressor_stage_reference(yaml_compressor.target))
             for yaml_compressor in target.items
         ]
 
@@ -351,7 +347,9 @@ class ProcessSimulationMapper:
         for yaml_compressor_train_item in yaml_process_simulation.targets:
             shaft = VariableSpeedShaft()
             item = self._resolve_train_reference(yaml_compressor_train_item.target)
-            compressors = self._get_compressors(item, shaft=shaft)
+            compressors = self._get_compressors(item)
+            for compressor in compressors:
+                shaft.register(compressor)
 
             try:
                 pressure_control = yaml_process_simulation.pressure_control[item.name]

--- a/tests/libecalc/domain/process/conftest.py
+++ b/tests/libecalc/domain/process/conftest.py
@@ -213,7 +213,7 @@ def stage_units_factory(fluid_service):
             compressor_chart=chart_data,
             fluid_service=fluid_service,
         )
-        shaft.register(compressor)
+        shaft.connect(compressor)
         units.append(compressor)
 
         return units

--- a/tests/libecalc/domain/process/conftest.py
+++ b/tests/libecalc/domain/process/conftest.py
@@ -208,14 +208,13 @@ def stage_units_factory(fluid_service):
                 )
             )
 
-        units.append(
-            Compressor(
-                process_unit_id=create_process_unit_id(),
-                compressor_chart=chart_data,
-                fluid_service=fluid_service,
-                shaft=shaft,
-            )
+        compressor = Compressor(
+            process_unit_id=create_process_unit_id(),
+            compressor_chart=chart_data,
+            fluid_service=fluid_service,
         )
+        shaft.register(compressor)
+        units.append(compressor)
 
         return units
 

--- a/tests/libecalc/domain/process/entities/process_units/test_compressor.py
+++ b/tests/libecalc/domain/process/entities/process_units/test_compressor.py
@@ -19,7 +19,7 @@ def compressor(shaft, variable_speed_compressor_chart_data, fluid_service):
         compressor_chart=variable_speed_compressor_chart_data,
         fluid_service=fluid_service,
     )
-    shaft.register(compressor)
+    shaft.connect(compressor)
     return compressor
 
 

--- a/tests/libecalc/domain/process/entities/process_units/test_compressor.py
+++ b/tests/libecalc/domain/process/entities/process_units/test_compressor.py
@@ -14,12 +14,13 @@ def shaft():
 @pytest.fixture
 def compressor(shaft, variable_speed_compressor_chart_data, fluid_service):
     """A Compressor backed by the standard variable-speed chart from conftest."""
-    return Compressor(
+    compressor = Compressor(
         process_unit_id=create_process_unit_id(),
         compressor_chart=variable_speed_compressor_chart_data,
         fluid_service=fluid_service,
-        shaft=shaft,
     )
+    shaft.register(compressor)
+    return compressor
 
 
 def _inlet_at_midpoint(stream_factory, compressor, pressure_bara=30.0, temperature_kelvin=300.0):
@@ -36,21 +37,21 @@ def _inlet_at_midpoint(stream_factory, compressor, pressure_bara=30.0, temperatu
 
 
 class TestCompressorSpeedBoundary:
-    def test_speed_boundary_matches_chart(self, compressor):
-        boundary = compressor.get_speed_boundary()
+    def test_speed_boundary_matches_chart(self, compressor, shaft):
+        boundary = shaft.get_speed_boundary()
         assert boundary.min > 0
         assert boundary.max > boundary.min
 
 
 class TestCompressorFlowLimits:
     def test_raises_rate_too_low_below_minimum_flow(self, stream_factory, compressor, shaft):
-        shaft.set_speed(compressor.get_speed_boundary().min)
+        shaft.set_speed(shaft.get_speed_boundary().min)
         inlet = stream_factory(standard_rate_m3_per_day=1.0, pressure_bara=30.0, temperature_kelvin=300.0)
         with pytest.raises(RateTooLowError):
             compressor.propagate_stream(inlet_stream=inlet)
 
     def test_raises_rate_too_high_above_maximum_flow(self, stream_factory, compressor, shaft):
-        shaft.set_speed(compressor.get_speed_boundary().max)
+        shaft.set_speed(shaft.get_speed_boundary().max)
         inlet = stream_factory(standard_rate_m3_per_day=1e12, pressure_bara=30.0, temperature_kelvin=300.0)
         with pytest.raises(RateTooHighError):
             compressor.propagate_stream(inlet_stream=inlet)
@@ -58,14 +59,14 @@ class TestCompressorFlowLimits:
 
 class TestCompressorPropagation:
     def test_outlet_pressure_higher_than_inlet(self, stream_factory, compressor, shaft):
-        speed = (compressor.get_speed_boundary().min + compressor.get_speed_boundary().max) / 2
+        speed = (shaft.get_speed_boundary().min + shaft.get_speed_boundary().max) / 2
         shaft.set_speed(speed)
         inlet = _inlet_at_midpoint(stream_factory, compressor)
         outlet = compressor.propagate_stream(inlet_stream=inlet)
         assert outlet.pressure_bara > inlet.pressure_bara
 
     def test_higher_speed_gives_higher_outlet_pressure(self, stream_factory, compressor, shaft):
-        boundary = compressor.get_speed_boundary()
+        boundary = shaft.get_speed_boundary()
 
         shaft.set_speed(boundary.min * 1.05)
         inlet_low = _inlet_at_midpoint(stream_factory, compressor)
@@ -78,7 +79,7 @@ class TestCompressorPropagation:
         assert outlet_high.pressure_bara > outlet_low.pressure_bara
 
     def test_standard_rate_is_conserved(self, stream_factory, compressor, shaft):
-        speed = (compressor.get_speed_boundary().min + compressor.get_speed_boundary().max) / 2
+        speed = (shaft.get_speed_boundary().min + shaft.get_speed_boundary().max) / 2
         shaft.set_speed(speed)
         inlet = _inlet_at_midpoint(stream_factory, compressor)
         outlet = compressor.propagate_stream(inlet_stream=inlet)
@@ -88,7 +89,7 @@ class TestCompressorPropagation:
 class TestCompressorRecirculationRange:
     def test_recirculation_range_min_is_zero_when_above_surge(self, stream_factory, compressor, shaft):
         """When the inlet rate is comfortably above surge, no recirculation is needed."""
-        speed = (compressor.get_speed_boundary().min + compressor.get_speed_boundary().max) / 2
+        speed = (shaft.get_speed_boundary().min + shaft.get_speed_boundary().max) / 2
         shaft.set_speed(speed)
         inlet = _inlet_at_midpoint(stream_factory, compressor)
         boundary = compressor.get_recirculation_range(inlet_stream=inlet)
@@ -96,7 +97,7 @@ class TestCompressorRecirculationRange:
 
     def test_recirculation_range_min_positive_when_below_surge(self, stream_factory, compressor, shaft):
         """When inlet rate is below the surge limit, min recirculation must be > 0."""
-        shaft.set_speed(compressor.get_speed_boundary().max * 0.9)
+        shaft.set_speed(shaft.get_speed_boundary().max * 0.9)
         placeholder = stream_factory(standard_rate_m3_per_day=1.0, pressure_bara=30.0, temperature_kelvin=300.0)
         min_rate = compressor.get_minimum_standard_rate(placeholder)
         inlet = stream_factory(

--- a/tests/libecalc/domain/process/process_solver/conftest.py
+++ b/tests/libecalc/domain/process/process_solver/conftest.py
@@ -5,7 +5,6 @@ from libecalc.domain.process.entities.shaft import Shaft
 from libecalc.domain.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.domain.process.process_solver.anti_surge.common_asv import CommonASVAntiSurgeStrategy
 from libecalc.domain.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
-from libecalc.domain.process.process_solver.boundary import Boundary
 from libecalc.domain.process.process_solver.multi_pressure_solver import MultiPressureSolver
 from libecalc.domain.process.process_solver.outlet_pressure_solver import OutletPressureSolver
 from libecalc.domain.process.process_solver.pressure_control.common_asv import CommonASVPressureControlStrategy
@@ -69,7 +68,6 @@ def outlet_pressure_solver_factory(root_finding_strategy):
         runner: ProcessRunner,
         anti_surge_strategy: AntiSurgeStrategy,
         pressure_control_strategy: PressureControlStrategy,
-        speed_boundary: Boundary,
         process_system_id: ProcessSystemId | None = None,
     ):
         return OutletPressureSolver(
@@ -79,7 +77,7 @@ def outlet_pressure_solver_factory(root_finding_strategy):
             anti_surge_strategy=anti_surge_strategy,
             pressure_control_strategy=pressure_control_strategy,
             root_finding_strategy=root_finding_strategy,
-            speed_boundary=speed_boundary,
+            speed_boundary=shaft.get_speed_boundary(),
         )
 
     return create_outlet_pressure_solver

--- a/tests/libecalc/domain/process/process_solver/pressure_control/test_individual_asv_pressure_pressure_control_strategy.py
+++ b/tests/libecalc/domain/process/process_solver/pressure_control/test_individual_asv_pressure_pressure_control_strategy.py
@@ -51,9 +51,9 @@ def test_individual_asv_pressure_control_reaches_target_pressure(
     from libecalc.domain.process.entities.shaft import VariableSpeedShaft
 
     shaft = VariableSpeedShaft()
+    units = stage_units_factory(chart_data=chart_data, shaft=shaft, temperature_kelvin=temperature)
     shaft.set_speed(75.0)
 
-    units = stage_units_factory(chart_data=chart_data, shaft=shaft, temperature_kelvin=temperature)
     wrapped_units, loop_ids, compressors = with_individual_asv(units)
     runner = process_runner_factory(units=wrapped_units, shaft=shaft)
 

--- a/tests/libecalc/domain/process/process_solver/pressure_control/test_individual_asv_rate_control_pressure_strategy.py
+++ b/tests/libecalc/domain/process/process_solver/pressure_control/test_individual_asv_rate_control_pressure_strategy.py
@@ -51,9 +51,9 @@ def test_individual_asv_rate_control_reaches_target_pressure(
     from libecalc.domain.process.entities.shaft import VariableSpeedShaft
 
     shaft = VariableSpeedShaft()
+    units = stage_units_factory(chart_data=chart_data, shaft=shaft, temperature_kelvin=temperature)
     shaft.set_speed(75.0)
 
-    units = stage_units_factory(chart_data=chart_data, shaft=shaft, temperature_kelvin=temperature)
     wrapped_units, loop_ids, compressors = with_individual_asv(units)
     runner = process_runner_factory(units=wrapped_units, shaft=shaft)
 

--- a/tests/libecalc/domain/process/process_solver/test_common_asv_solver_vs_legacy_train.py
+++ b/tests/libecalc/domain/process/process_solver/test_common_asv_solver_vs_legacy_train.py
@@ -4,9 +4,7 @@ from inline_snapshot import snapshot
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
 from libecalc.domain.process.compressor.core.results import CompressorTrainResultSingleTimeStep
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
-from libecalc.domain.process.entities.process_units.compressor import Compressor
 from libecalc.domain.process.entities.shaft import VariableSpeedShaft
-from libecalc.domain.process.process_solver.boundary import Boundary
 from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
 from libecalc.domain.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.domain.process.value_objects.chart import ChartCurve
@@ -131,11 +129,7 @@ def test_common_asv_solver_vs_legacy_train(
     stage2_new = stage_units_factory(chart_data=stage2_chart_data, shaft=shaft_new, temperature_kelvin=temperature)
 
     common_asv, loop_id, first_compressor = with_common_asv([*stage1_new, *stage2_new])
-    compressors = [c for c in [*stage1_new, *stage2_new] if isinstance(c, Compressor)]
-    speed_boundary = Boundary(
-        min=max(c.get_speed_boundary().min for c in compressors),
-        max=min(c.get_speed_boundary().max for c in compressors),
-    )
+
     runner = process_runner_factory(units=[common_asv], shaft=shaft_new)
     anti_surge_strategy = common_asv_anti_surge_strategy_factory(
         runner=runner,
@@ -152,7 +146,6 @@ def test_common_asv_solver_vs_legacy_train(
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
         pressure_control_strategy=pressure_control_strategy,
-        speed_boundary=speed_boundary,
     )
     solution = train_solver.find_solution(
         pressure_constraint=FloatConstraint(target_pressure),

--- a/tests/libecalc/domain/process/process_solver/test_individual_asv_solver_vs_legacy_train.py
+++ b/tests/libecalc/domain/process/process_solver/test_individual_asv_solver_vs_legacy_train.py
@@ -3,7 +3,6 @@ import pytest
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
 from libecalc.domain.process.entities.shaft import VariableSpeedShaft
-from libecalc.domain.process.process_solver.boundary import Boundary
 from libecalc.domain.process.process_solver.configuration import Configuration
 from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
 from libecalc.domain.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
@@ -116,10 +115,7 @@ def test_individual_asv_rate_solver_vs_legacy_train(
     stage2_new = stage_units_factory(chart_data=stage2_chart_data, shaft=shaft_new, temperature_kelvin=temperature)
 
     units_new, recirculation_loop_ids, compressors = with_individual_asv([*stage1_new, *stage2_new])
-    speed_boundary = Boundary(
-        min=max(c.get_speed_boundary().min for c in compressors),
-        max=min(c.get_speed_boundary().max for c in compressors),
-    )
+
     runner = process_runner_factory(units=units_new, shaft=shaft_new)
     anti_surge_strategy = individual_asv_anti_surge_strategy_factory(
         runner=runner,
@@ -136,7 +132,6 @@ def test_individual_asv_rate_solver_vs_legacy_train(
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
         pressure_control_strategy=pressure_control_strategy,
-        speed_boundary=speed_boundary,
     )
     solution = train_solver.find_solution(
         pressure_constraint=FloatConstraint(target_pressure),
@@ -254,10 +249,7 @@ def test_individual_asv_pressure_solver_vs_legacy_train(
     stage2_new = stage_units_factory(chart_data=stage2_chart_data, shaft=shaft_new, temperature_kelvin=temperature)
 
     units_new, recirculation_loop_ids, compressors = with_individual_asv([*stage1_new, *stage2_new])
-    speed_boundary = Boundary(
-        min=max(c.get_speed_boundary().min for c in compressors),
-        max=min(c.get_speed_boundary().max for c in compressors),
-    )
+
     runner = process_runner_factory(units=units_new, shaft=shaft_new)
     anti_surge_strategy = individual_asv_anti_surge_strategy_factory(
         runner=runner,
@@ -274,7 +266,6 @@ def test_individual_asv_pressure_solver_vs_legacy_train(
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
         pressure_control_strategy=pressure_control_strategy,
-        speed_boundary=speed_boundary,
     )
     solution = train_solver.find_solution(
         pressure_constraint=FloatConstraint(target_pressure),
@@ -339,10 +330,7 @@ def test_individual_asv_anti_surge_returns_failure_when_rate_above_stonewall(
     stage1_units = stage_units_factory(chart_data=chart_data, shaft=shaft)
     stage2_units = stage_units_factory(chart_data=chart_data, shaft=shaft)
     individual_asvs, loop_ids, compressors = with_individual_asv([*stage1_units, *stage2_units])
-    speed_boundary = Boundary(
-        min=max(c.get_speed_boundary().min for c in compressors),
-        max=min(c.get_speed_boundary().max for c in compressors),
-    )
+
     runner = process_runner_factory(units=individual_asvs, shaft=shaft)
     anti_surge = individual_asv_anti_surge_strategy_factory(
         runner=runner, recirculation_loop_ids=loop_ids, compressors=compressors
@@ -355,7 +343,6 @@ def test_individual_asv_anti_surge_returns_failure_when_rate_above_stonewall(
         runner=runner,
         anti_surge_strategy=anti_surge,
         pressure_control_strategy=pressure_control,
-        speed_boundary=speed_boundary,
     )
 
     inlet_stream = stream_factory(standard_rate_m3_per_day=5_000_000, pressure_bara=30.0)

--- a/tests/libecalc/domain/process/process_solver/test_multi_pressure_solver.py
+++ b/tests/libecalc/domain/process/process_solver/test_multi_pressure_solver.py
@@ -8,7 +8,6 @@ from libecalc.domain.process.compressor.core.train.train_evaluation_input import
 from libecalc.domain.process.entities.process_units.mixer import Mixer
 from libecalc.domain.process.entities.process_units.splitter import Splitter
 from libecalc.domain.process.entities.shaft import VariableSpeedShaft
-from libecalc.domain.process.process_solver.boundary import Boundary
 from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
 from libecalc.domain.process.process_solver.multi_pressure_solver import MultiPressureSolver
 from libecalc.domain.process.process_solver.outlet_pressure_solver import OutletPressureSolver
@@ -115,16 +114,7 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
     )
     high_pressure_runner = process_runner_factory(units=[splitter, *high_pressure_units_wrapped], shaft=shaft_new)
 
-    speed_boundary = Boundary(
-        min=max(
-            max(c.get_speed_boundary().min for c in low_pressure_compressors),
-            max(c.get_speed_boundary().min for c in high_pressure_compressors),
-        ),
-        max=min(
-            min(c.get_speed_boundary().max for c in low_pressure_compressors),
-            min(c.get_speed_boundary().max for c in high_pressure_compressors),
-        ),
-    )
+    speed_boundary = shaft_new.get_speed_boundary()
     low_pressure_segment = OutletPressureSolver(
         shaft_id=shaft_new.get_id(),
         process_system_id=create_process_system_id(),
@@ -277,18 +267,7 @@ def test_three_stage_train_with_mixers_and_splitters_at_interstage(
     mixer1.set_stream(injection_stream)
     mixer2.set_stream(injection_stream)
 
-    speed_boundary = Boundary(
-        min=max(
-            max(c.get_speed_boundary().min for c in low_pressure_compressors),
-            max(c.get_speed_boundary().min for c in medium_pressure_compressors),
-            max(c.get_speed_boundary().min for c in high_pressure_compressors),
-        ),
-        max=min(
-            min(c.get_speed_boundary().max for c in low_pressure_compressors),
-            min(c.get_speed_boundary().max for c in medium_pressure_compressors),
-            min(c.get_speed_boundary().max for c in high_pressure_compressors),
-        ),
-    )
+    speed_boundary = shaft.get_speed_boundary()
 
     def make_segment(runner, loop_ids, compressors):
         return OutletPressureSolver(
@@ -371,10 +350,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
     hp_units, hp_loop_ids, hp_compressors = with_individual_asv(hp_units_raw)
     hp_runner = process_runner_factory(units=hp_units, shaft=shaft)
 
-    speed_boundary = Boundary(
-        min=max(c.get_speed_boundary().min for c in lp_compressors + hp_compressors),
-        max=min(c.get_speed_boundary().max for c in lp_compressors + hp_compressors),
-    )
+    speed_boundary = shaft.get_speed_boundary()
 
     lp_process_system_id = create_process_system_id()
     hp_process_system_id = create_process_system_id()

--- a/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
+++ b/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
@@ -112,7 +112,7 @@ def small_chart_compressor(fluid_service, shaft):
         compressor_chart=chart_data,
         fluid_service=fluid_service,
     )
-    shaft.register(compressor)
+    shaft.connect(compressor)
     return compressor
 
 

--- a/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
+++ b/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
@@ -3,7 +3,6 @@ from inline_snapshot import snapshot
 
 from libecalc.domain.process.entities.process_units.compressor import Compressor
 from libecalc.domain.process.entities.shaft import VariableSpeedShaft
-from libecalc.domain.process.process_solver.boundary import Boundary
 from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
 from libecalc.domain.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.domain.process.process_system.process_unit import create_process_unit_id
@@ -39,11 +38,6 @@ def test_outlet_pressure_solver_with_common_asv(
     stage2 = stage_units_factory(chart_data=stage2_chart_data, shaft=shaft)
 
     common_asv, loop_id, first_compressor = with_common_asv([*stage1, *stage2])
-    compressors = [u for u in [*stage1, *stage2] if isinstance(u, Compressor)]
-    speed_boundary = Boundary(
-        min=max(c.get_speed_boundary().min for c in compressors),
-        max=min(c.get_speed_boundary().max for c in compressors),
-    )
     runner = process_runner_factory(units=[common_asv], shaft=shaft)
     anti_surge_strategy = common_asv_anti_surge_strategy_factory(
         runner=runner,
@@ -60,7 +54,6 @@ def test_outlet_pressure_solver_with_common_asv(
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
         pressure_control_strategy=pressure_control_strategy,
-        speed_boundary=speed_boundary,
     )
 
     inlet_stream = stream_factory(
@@ -114,12 +107,13 @@ def small_chart_compressor(fluid_service, shaft):
             ),
         ]
     )
-    return Compressor(
+    compressor = Compressor(
         process_unit_id=create_process_unit_id(),
         compressor_chart=chart_data,
         fluid_service=fluid_service,
-        shaft=shaft,
     )
+    shaft.register(compressor)
+    return compressor
 
 
 def test_find_solution_returns_failure_when_rate_above_stonewall(
@@ -133,10 +127,7 @@ def test_find_solution_returns_failure_when_rate_above_stonewall(
     outlet_pressure_solver_factory,
 ):
     common_asv, loop_id, first_compressor = with_common_asv([small_chart_compressor])
-    speed_boundary = Boundary(
-        min=small_chart_compressor.get_speed_boundary().min,
-        max=small_chart_compressor.get_speed_boundary().max,
-    )
+
     runner = process_runner_factory(units=[common_asv], shaft=shaft)
     anti_surge = common_asv_anti_surge_strategy_factory(
         runner=runner, recirculation_loop_id=loop_id, first_compressor=first_compressor
@@ -149,7 +140,6 @@ def test_find_solution_returns_failure_when_rate_above_stonewall(
         runner=runner,
         anti_surge_strategy=anti_surge,
         pressure_control_strategy=pressure_control,
-        speed_boundary=speed_boundary,
     )
 
     inlet_stream = stream_factory(standard_rate_m3_per_day=5_000_000, pressure_bara=30.0, temperature_kelvin=300.0)

--- a/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_downstream_choke.py
+++ b/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_downstream_choke.py
@@ -46,7 +46,7 @@ def test_outlet_pressure_solver_applies_downstream_choke_when_speed_solution_is_
     """
     compressor = single_speed_compressor
     shaft = VariableSpeedShaft()
-    shaft.register(compressor)
+    shaft.connect(compressor)
     downstream_choke = choke_factory()
 
     common_asv = recirculation_loop_factory(inner_process=process_system_factory(process_units=[compressor]))

--- a/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_downstream_choke.py
+++ b/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_downstream_choke.py
@@ -21,12 +21,10 @@ def single_speed_compressor(fluid_service):
             )
         ]
     )
-    shaft = VariableSpeedShaft()
     return Compressor(
         process_unit_id=create_process_unit_id(),
         compressor_chart=chart_data,
         fluid_service=fluid_service,
-        shaft=shaft,
     )
 
 
@@ -47,7 +45,8 @@ def test_outlet_pressure_solver_applies_downstream_choke_when_speed_solution_is_
     downstream choke it should be able to meet the target.
     """
     compressor = single_speed_compressor
-    shaft = compressor.shaft
+    shaft = VariableSpeedShaft()
+    shaft.register(compressor)
     downstream_choke = choke_factory()
 
     common_asv = recirculation_loop_factory(inner_process=process_system_factory(process_units=[compressor]))
@@ -66,7 +65,6 @@ def test_outlet_pressure_solver_applies_downstream_choke_when_speed_solution_is_
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
         pressure_control_strategy=pressure_control_strategy,
-        speed_boundary=compressor.get_speed_boundary(),
     )
 
     # 500_000 sm3/day at 25 bara gives ~850 m3/h actual, which fits within [500, 1500].
@@ -85,7 +83,7 @@ def test_outlet_pressure_solver_applies_downstream_choke_when_speed_solution_is_
     speed_configuration = config_dict[shaft.get_id()]
 
     # Single-speed compressor: SpeedSolver is forced to return the only available speed.
-    assert speed_configuration.speed == compressor.get_speed_boundary().min
+    assert speed_configuration.speed == shaft.get_speed_boundary().min
 
     # Overall solver should succeed via downstream choke pressure control.
     assert solution.success

--- a/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_upstream_choke.py
+++ b/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_upstream_choke.py
@@ -21,12 +21,10 @@ def single_speed_compressor(fluid_service):
             )
         ]
     )
-    shaft = VariableSpeedShaft()
     return Compressor(
         process_unit_id=create_process_unit_id(),
         compressor_chart=chart_data,
         fluid_service=fluid_service,
-        shaft=shaft,
     )
 
 
@@ -47,7 +45,8 @@ def test_outlet_pressure_solver_applies_upstream_choke_when_speed_solution_is_at
     upstream choke it should be able to meet the target.
     """
     compressor = single_speed_compressor
-    shaft = compressor.shaft
+    shaft = VariableSpeedShaft()
+    shaft.register(compressor)
     upstream_choke = choke_factory()
 
     common_asv = recirculation_loop_factory(inner_process=process_system_factory(process_units=[compressor]))
@@ -66,7 +65,6 @@ def test_outlet_pressure_solver_applies_upstream_choke_when_speed_solution_is_at
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
         pressure_control_strategy=pressure_control_strategy,
-        speed_boundary=compressor.get_speed_boundary(),
     )
 
     # 500_000 sm3/day at 25 bara gives ~850 m3/h actual, which fits within [500, 1500].
@@ -86,7 +84,7 @@ def test_outlet_pressure_solver_applies_upstream_choke_when_speed_solution_is_at
     speed_configuration = config_dict[shaft.get_id()]
 
     # Single-speed compressor: SpeedSolver is forced to return the only available speed.
-    assert speed_configuration.speed == compressor.get_speed_boundary().min
+    assert speed_configuration.speed == shaft.get_speed_boundary().min
 
     # Overall solver should succeed via upstream choke pressure control.
     assert solution.success

--- a/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_upstream_choke.py
+++ b/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_upstream_choke.py
@@ -46,7 +46,7 @@ def test_outlet_pressure_solver_applies_upstream_choke_when_speed_solution_is_at
     """
     compressor = single_speed_compressor
     shaft = VariableSpeedShaft()
-    shaft.register(compressor)
+    shaft.connect(compressor)
     upstream_choke = choke_factory()
 
     common_asv = recirculation_loop_factory(inner_process=process_system_factory(process_units=[compressor]))

--- a/tests/libecalc/domain/process/process_solver/test_two_stage_train_with_interstage_splitter_vs_legacy.py
+++ b/tests/libecalc/domain/process/process_solver/test_two_stage_train_with_interstage_splitter_vs_legacy.py
@@ -6,7 +6,6 @@ from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureContr
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
 from libecalc.domain.process.entities.process_units.splitter import Splitter
 from libecalc.domain.process.entities.shaft import VariableSpeedShaft
-from libecalc.domain.process.process_solver.boundary import Boundary
 from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
 from libecalc.domain.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 
@@ -98,10 +97,7 @@ def test_two_stage_train_with_interstage_splitter_vs_legacy(
     )
     all_units = [*low_pressure_stage_new, interstage_splitter, *high_pressure_stage_new]
     units_new, recirculation_loop_ids, compressors = with_individual_asv(all_units)
-    speed_boundary = Boundary(
-        min=max(c.get_speed_boundary().min for c in compressors),
-        max=min(c.get_speed_boundary().max for c in compressors),
-    )
+
     runner = process_runner_factory(units=units_new, shaft=shaft_new)
     anti_surge_strategy = individual_asv_anti_surge_strategy_factory(
         runner=runner,
@@ -118,7 +114,6 @@ def test_two_stage_train_with_interstage_splitter_vs_legacy(
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
         pressure_control_strategy=pressure_control_strategy,
-        speed_boundary=speed_boundary,
     )
     solution = train_solver.find_solution(
         pressure_constraint=FloatConstraint(target_pressure),


### PR DESCRIPTION
Previously each `Compressor` received a `Shaft` via its constructor and read speed through `self._shaft.get_speed()`. The ownership was implicit — multiple compressors shared a mutable reference.

Now `Shaft` explicitly owns its compressors. Speed is propagated to all registered units when `set_speed()` is called, enforcing the invariant (same speed on every compressor) in one place.

---

### Changes

**`shaft.py`**
- Added `register(unit)` — registers a compressor (or any object with `set_speed()`) on the shaft
- Added `get_speed_boundary()` — returns the overlapping speed range across all registered compressors
- `set_speed()` now propagates speed to all registered units via `_apply_speed()`

**`compressor.py`**
- Removed `shaft` from constructor
- Removed `shaft` property and `get_speed_boundary()`
- Added public `set_speed(speed)` — called by Shaft when speed changes
- `speed` property now reads from internal `_speed` instead of `self._shaft.get_speed()`

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
