### PR TITLE
refactor: drop FluidService from RecirculationLoop, DirectSplitter an…

### DIFF
--- a/src/libecalc/domain/process/entities/process_units/recirculation_loop.py
+++ b/src/libecalc/domain/process/entities/process_units/recirculation_loop.py
@@ -1,30 +1,28 @@
 from collections.abc import Sequence
 
+from libecalc.common.units import UnitConstants
 from libecalc.domain.component_validation_error import DomainValidationException
 from libecalc.domain.process.entities.process_units.compressor import Compressor
 from libecalc.domain.process.entities.process_units.mixer import Mixer
 from libecalc.domain.process.entities.process_units.splitter import Splitter
 from libecalc.domain.process.process_system.process_system import ProcessSystem, ProcessSystemId
 from libecalc.domain.process.process_system.process_unit import ProcessUnit, ProcessUnitId, create_process_unit_id
-from libecalc.domain.process.value_objects.fluid_stream import FluidService, FluidStream
+from libecalc.domain.process.value_objects.fluid_stream import FluidStream
 
 
 class DirectMixer(ProcessUnit):
-    def __init__(self, process_unit_id: ProcessUnitId, mix_rate: float, fluid_service: FluidService):
+    def __init__(self, process_unit_id: ProcessUnitId, mix_rate: float):
         self._id = process_unit_id
-        self._fluid_service = fluid_service
         self._mix_rate = mix_rate
 
     def get_id(self) -> ProcessUnitId:
         return self._id
 
     def propagate_stream(self, inlet_stream: FluidStream) -> FluidStream:
-        return self._fluid_service.create_stream_from_standard_rate(
-            fluid_model=inlet_stream.fluid_model,
-            pressure_bara=inlet_stream.pressure_bara,
-            temperature_kelvin=inlet_stream.temperature_kelvin,
-            standard_rate_m3_per_day=inlet_stream.standard_rate_sm3_per_day + self._mix_rate,
+        added_mass_kg_per_h = (
+            self._mix_rate * inlet_stream.standard_density_gas_phase_after_flash / UnitConstants.HOURS_PER_DAY
         )
+        return inlet_stream.with_mass_rate(inlet_stream.mass_rate_kg_per_h + added_mass_kg_per_h)
 
     def get_mix_rate(self) -> float:
         return self._mix_rate
@@ -34,21 +32,18 @@ class DirectMixer(ProcessUnit):
 
 
 class DirectSplitter(ProcessUnit):
-    def __init__(self, process_unit_id: ProcessUnitId, split_rate: float, fluid_service: FluidService):
+    def __init__(self, process_unit_id: ProcessUnitId, split_rate: float):
         self._id = process_unit_id
-        self._fluid_service = fluid_service
         self._split_rate = split_rate
 
     def get_id(self) -> ProcessUnitId:
         return self._id
 
     def propagate_stream(self, inlet_stream: FluidStream) -> FluidStream:
-        return self._fluid_service.create_stream_from_standard_rate(
-            fluid_model=inlet_stream.fluid_model,
-            pressure_bara=inlet_stream.pressure_bara,
-            temperature_kelvin=inlet_stream.temperature_kelvin,
-            standard_rate_m3_per_day=inlet_stream.standard_rate_sm3_per_day - self._split_rate,
+        removed_mass_kg_per_h = (
+            self._split_rate * inlet_stream.standard_density_gas_phase_after_flash / UnitConstants.HOURS_PER_DAY
         )
+        return inlet_stream.with_mass_rate(inlet_stream.mass_rate_kg_per_h - removed_mass_kg_per_h)
 
     def set_split_rate(self, split_rate: float):
         self._split_rate = split_rate
@@ -59,21 +54,17 @@ class RecirculationLoop(ProcessSystem):
         self,
         process_system_id: ProcessSystemId,
         inner_process: ProcessSystem | ProcessUnit,
-        fluid_service: FluidService,
         recirculation_rate: float = 0,
     ):
         self._id = process_system_id
         self._inner_process = inner_process
-        self._fluid_service = fluid_service
         self._validate_inner_process()
         self._mixer = DirectMixer(
             process_unit_id=create_process_unit_id(),
-            fluid_service=fluid_service,
             mix_rate=recirculation_rate,
         )
         self._splitter = DirectSplitter(
             process_unit_id=create_process_unit_id(),
-            fluid_service=fluid_service,
             split_rate=recirculation_rate,
         )
 

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -105,9 +105,7 @@ class CompressorTrainBuilder:
     def with_individual_asv(self) -> list[ProcessSystemId]:
         recirculation_loop_ids = [create_process_system_id() for _ in range(len(self._compressor_ids))]
         process_units = [
-            RecirculationLoop(
-                process_system_id=recirculation_loop_id, inner_process=compressor, fluid_service=self._fluid_service
-            )
+            RecirculationLoop(process_system_id=recirculation_loop_id, inner_process=compressor)
             for recirculation_loop_id, compressor in zip(
                 recirculation_loop_ids, self._process_system.get_process_units(), strict=True
             )
@@ -122,7 +120,6 @@ class CompressorTrainBuilder:
         recirculation_loop = RecirculationLoop(
             process_system_id=recirculation_loop_id,
             inner_process=self._process_system,
-            fluid_service=self._fluid_service,
         )
         self._process_system = SerialProcessSystem(
             process_system_id=create_process_system_id(), propagators=[recirculation_loop]

--- a/tests/libecalc/conftest.py
+++ b/tests/libecalc/conftest.py
@@ -240,7 +240,7 @@ def process_runner_factory(shaft_factory):
 
 
 @pytest.fixture
-def recirculation_loop_factory(fluid_service, process_system_factory):
+def recirculation_loop_factory(process_system_factory):
     def create_recirculation_loop(
         inner_process: ProcessSystem | ProcessUnit,
         process_system_id: ProcessSystemId = None,
@@ -251,7 +251,6 @@ def recirculation_loop_factory(fluid_service, process_system_factory):
         return RecirculationLoop(
             inner_process=inner_process,
             process_system_id=process_system_id or create_process_system_id(),
-            fluid_service=fluid_service,
             recirculation_rate=recirculation_rate,
         )
 


### PR DESCRIPTION
…d DirectMixer

FluidStream.with_mass_rate() already exists and is the right tool here. In a recirculation loop the recirculated gas is assumed to have the same composition, P, T as the stream it mixes into — no re-flash is needed. The standard density is already available on the stream itself. The RecirculationLoop can just add/remove the same mass rate in the DirectMixer and DirectSplitter.

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
