### PR TITLE
chore: construct fluid model from dict

### DIFF
--- a/src/libecalc/domain/process/value_objects/fluid_stream/fluid_model.py
+++ b/src/libecalc/domain/process/value_objects/fluid_stream/fluid_model.py
@@ -20,7 +20,7 @@ class EoSModel(str, Enum):
 
 
 class FluidComposition(BaseModel):
-    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True, from_attributes=True)
     water: float = Field(0.0, ge=0.0)
     nitrogen: float = Field(0.0, ge=0.0)
     CO2: float = Field(0.0, ge=0.0)


### PR DESCRIPTION
allow pydantic to reconstruct fluid model object from a dict.

## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
