### PR TITLE
chore(neqsim): bump bundled NeqSim.jar from 3.0.38 to 3.8.0-Java21

### DIFF
--- a/.github/workflows/test-library.yml
+++ b/.github/workflows/test-library.yml
@@ -27,6 +27,12 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
       - name: Set up Python
         run: uv python install
 

--- a/tests/libecalc/application/test_stream_distribution.py
+++ b/tests/libecalc/application/test_stream_distribution.py
@@ -57,7 +57,7 @@ class TestCommonStreamDistribution:
         streams = stream_distribution.get_streams()
 
         rates = [stream.standard_rate_sm3_per_day for stream in streams]
-        assert rates == [45, 55]
+        assert rates == pytest.approx([45, 55])
 
     def test_common_stream_with_overflow_out_of_capacity(self, stream_factory, fluid_service):
         inlet_stream = stream_factory(standard_rate_m3_per_day=110)
@@ -76,7 +76,7 @@ class TestCommonStreamDistribution:
         streams = stream_distribution.get_streams()
 
         rates = [stream.standard_rate_sm3_per_day for stream in streams]
-        assert rates == [45, 65]
+        assert rates == pytest.approx([45, 65])
 
     @pytest.mark.snapshot
     @pytest.mark.inlinesnapshot

--- a/tests/libecalc/domain/process/process_solver/test_common_asv_solver_vs_legacy_train.py
+++ b/tests/libecalc/domain/process/process_solver/test_common_asv_solver_vs_legacy_train.py
@@ -1,5 +1,4 @@
 import pytest
-from inline_snapshot import snapshot
 
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
 from libecalc.domain.process.compressor.core.results import CompressorTrainResultSingleTimeStep
@@ -182,6 +181,6 @@ def test_common_asv_solver_vs_legacy_train(
         - old_result.stage_results[1].standard_rate_sm3_per_day
     )
 
-    assert new_recirculation_rate == snapshot(250000.000001)
-    assert old_recirculation_rate_1 == snapshot(249999.99999999988)
+    assert new_recirculation_rate == pytest.approx(250000.0, rel=1e-6)
+    assert old_recirculation_rate_1 == pytest.approx(250000.0, rel=1e-6)
     assert old_recirculation_rate_2 == 0.0

--- a/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
+++ b/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
@@ -1,5 +1,4 @@
 import pytest
-from inline_snapshot import snapshot
 
 from libecalc.domain.process.entities.process_units.compressor import Compressor
 from libecalc.domain.process.entities.shaft import VariableSpeedShaft
@@ -61,7 +60,7 @@ def test_outlet_pressure_solver_with_common_asv(
     inlet_stream = stream_factory(
         standard_rate_m3_per_day=500_000.0, pressure_bara=30.0, temperature_kelvin=temperature
     )
-    assert inlet_stream.volumetric_rate_m3_per_hour == snapshot(681.2529349883239)
+    assert inlet_stream.volumetric_rate_m3_per_hour == pytest.approx(681.253, rel=1e-4)
 
     solution = common_asv_solver.find_solution(
         pressure_constraint=target_pressure,
@@ -74,7 +73,7 @@ def test_outlet_pressure_solver_with_common_asv(
     recirculation_at_capacity_solution = common_asv_solver.get_anti_surge_solution()
 
     assert solution.success
-    assert speed_configuration.speed == snapshot(94.40012312859398)
+    assert speed_configuration.speed == pytest.approx(94.40, rel=1e-3)
 
     recirculation_rate_at_capacity = recirculation_at_capacity_solution.configuration[0].value.recirculation_rate
 
@@ -83,7 +82,7 @@ def test_outlet_pressure_solver_with_common_asv(
     ][0]
     recirculation_rate_after_pressure_control = recirculation_configuration.value.recirculation_rate
 
-    assert recirculation_rate_at_capacity == snapshot(336264.90573204844)
+    assert recirculation_rate_at_capacity == pytest.approx(336264.9, rel=1e-4)
     assert recirculation_rate_after_pressure_control >= recirculation_rate_at_capacity
 
     runner.apply_configurations(solution.configuration)


### PR DESCRIPTION
Targets the Java 21 build of NeqSim (optimised bytecode, improved GC, virtual thread support). The production backend runs openjdk-21-jre-headless so this is the appropriate variant.

Relaxes float-sensitive test assertions from exact inline snapshots to pytest.approx so they do not need updating on future jar bumps.

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
