### PR TITLE
refactor: update boundary calculations for Common ASV strategies

### DIFF
--- a/src/libecalc/domain/process/process_solver/anti_surge/common_asv.py
+++ b/src/libecalc/domain/process/process_solver/anti_surge/common_asv.py
@@ -62,7 +62,8 @@ class CommonASVAntiSurgeStrategy(AntiSurgeStrategy):
         self, inlet_stream: FluidStream
     ) -> Solution[RecirculationConfiguration]:
         # The recirculation boundary depends on the inlet stream (and implicitly current speed).
-        boundary = self._first_compressor.get_recirculation_range(inlet_stream)
+        compressor_inlet_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=self._first_compressor.get_id())
+        boundary = self._first_compressor.get_recirculation_range(compressor_inlet_stream)
 
         def recirculation_func(cfg: RecirculationConfiguration) -> FluidStream:
             self._apply_configuration(cfg)

--- a/src/libecalc/domain/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/domain/process/process_solver/pressure_control/common_asv.py
@@ -51,7 +51,8 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
             return self._simulator.run(inlet_stream=inlet_stream)
 
         # Check feasibility: can we reach target pressure at maximum recirculation?
-        boundary = self._first_compressor.get_recirculation_range(inlet_stream)
+        compressor_inlet_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=self._first_compressor.get_id())
+        boundary = self._first_compressor.get_recirculation_range(compressor_inlet_stream)
         min_configuration = RecirculationConfiguration(recirculation_rate=boundary.max)
         min_pressure_stream = recirculation_func(min_configuration)
 

--- a/tests/libecalc/domain/process/process_solver/anti_surge/test_common_asv_anti_surge_strategy.py
+++ b/tests/libecalc/domain/process/process_solver/anti_surge/test_common_asv_anti_surge_strategy.py
@@ -66,16 +66,14 @@ def test_common_asv_anti_surge_uses_compressor_inlet_for_boundary(
         first_compressor=compressor,
     )
 
-    # Compute both candidate boundaries independently, so the test documents the
-    # physical difference it relies on.
+    # Compute both candidate boundaries independently, to verify difference
     boundary_on_train_inlet = compressor.get_recirculation_range(inlet_stream)
     compressor_inlet = runner.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
     boundary_on_compressor_inlet = compressor.get_recirculation_range(compressor_inlet)
 
     # Sanity: TemperatureSetter actually changed the stream the compressor sees.
     assert inlet_stream.temperature_kelvin != compressor_inlet.temperature_kelvin
-    # Sanity: the two candidate boundaries differ — otherwise the test cannot tell
-    # which stream the strategy used.
+    # Sanity: the two candidate boundaries differ.
     assert boundary_on_train_inlet.min != pytest.approx(boundary_on_compressor_inlet.min, rel=1e-3)
 
     # Capture the stream that the strategy passes into get_recirculation_range.

--- a/tests/libecalc/domain/process/process_solver/anti_surge/test_common_asv_anti_surge_strategy.py
+++ b/tests/libecalc/domain/process/process_solver/anti_surge/test_common_asv_anti_surge_strategy.py
@@ -1,0 +1,102 @@
+import pytest
+
+from libecalc.domain.process.entities.shaft import VariableSpeedShaft
+from libecalc.domain.process.value_objects.chart import ChartCurve
+
+
+def test_common_asv_anti_surge_uses_compressor_inlet_for_boundary(
+    stream_factory,
+    chart_data_factory,
+    fluid_service,
+    compressor_factory,
+    stage_units_factory,
+    with_common_asv,
+    process_runner_factory,
+    common_asv_anti_surge_strategy_factory,
+):
+    """
+    COMMON ASV anti-surge must compute the recirculation boundary on the compressor-inlet
+    stream (after TemperatureSetter / Choke / LiquidRemover), not the train-inlet stream.
+
+    A TemperatureSetter is placed before the compressor so the two streams differ measurably,
+    making it observable which one the strategy uses.
+    """
+
+    # Two clearly different temperatures, so train-inlet and compressor-inlet streams
+    # produce different densities — and therefore different boundaries.
+    train_inlet_temperature_kelvin = 280.0  # train inlet
+    stage_inlet_temperature_kelvin = 320.0  # enforced by TemperatureSetter
+
+    inlet_stream = stream_factory(
+        standard_rate_m3_per_day=500_000.0,
+        pressure_bara=30.0,
+        temperature_kelvin=train_inlet_temperature_kelvin,
+    )
+    q0 = float(inlet_stream.volumetric_rate_m3_per_hour)
+
+    # Wide chart so boundary.min/max are non-degenerate; otherwise the strategy
+    # would short-circuit and never query get_recirculation_range meaningfully.
+    chart_data = chart_data_factory.from_curves(
+        curves=[
+            ChartCurve(
+                speed_rpm=75.0,
+                rate_actual_m3_hour=[q0 * 2, q0 * 8],
+                polytropic_head_joule_per_kg=[150_000.0, 40_000.0],
+                efficiency_fraction=[0.75, 0.75],
+            ),
+        ],
+        control_margin=0.0,
+    )
+
+    shaft = VariableSpeedShaft()
+    compressor = compressor_factory(chart_data=chart_data)
+    units = stage_units_factory(
+        compressor=compressor,
+        shaft=shaft,
+        temperature_kelvin=stage_inlet_temperature_kelvin,
+    )
+    shaft.set_speed(75.0)
+
+    recirculation_loop, wrapped_units = with_common_asv(units)
+    runner = process_runner_factory(units=wrapped_units, configuration_handlers=[shaft, recirculation_loop])
+
+    strategy = common_asv_anti_surge_strategy_factory(
+        runner=runner,
+        recirculation_loop_id=recirculation_loop.get_id(),
+        first_compressor=compressor,
+    )
+
+    # Compute both candidate boundaries independently, so the test documents the
+    # physical difference it relies on.
+    boundary_on_train_inlet = compressor.get_recirculation_range(inlet_stream)
+    compressor_inlet = runner.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
+    boundary_on_compressor_inlet = compressor.get_recirculation_range(compressor_inlet)
+
+    # Sanity: TemperatureSetter actually changed the stream the compressor sees.
+    assert inlet_stream.temperature_kelvin != compressor_inlet.temperature_kelvin
+    # Sanity: the two candidate boundaries differ — otherwise the test cannot tell
+    # which stream the strategy used.
+    assert boundary_on_train_inlet.min != pytest.approx(boundary_on_compressor_inlet.min, rel=1e-3)
+
+    # Capture the stream that the strategy passes into get_recirculation_range.
+    captured_streams = []
+    original = compressor.get_recirculation_range
+
+    def spy(inlet_stream):
+        captured_streams.append(inlet_stream)
+        return original(inlet_stream)
+
+    compressor.get_recirculation_range = spy
+
+    # Trigger the strategy. Anti-surge calls get_recirculation_range as the very
+    # first step inside apply(), so we just need to invoke it.
+    strategy.apply(inlet_stream=inlet_stream)
+
+    # Verify the strategy used the compressor-inlet stream, not the train-inlet stream.
+    assert captured_streams, "Strategy never queried get_recirculation_range"
+    used_stream = captured_streams[0]
+    assert used_stream.temperature_kelvin == pytest.approx(stage_inlet_temperature_kelvin), (
+        f"Strategy used stream at T={used_stream.temperature_kelvin:.1f} K for boundary; "
+        f"expected compressor-inlet stream at T={stage_inlet_temperature_kelvin:.1f} K "
+        f"(train-inlet was T={train_inlet_temperature_kelvin:.1f} K)."
+    )

--- a/tests/libecalc/domain/process/process_solver/pressure_control/test_common_asv_pressure_control_strategy.py
+++ b/tests/libecalc/domain/process/process_solver/pressure_control/test_common_asv_pressure_control_strategy.py
@@ -67,8 +67,7 @@ def test_common_asv_pressure_control_uses_compressor_inlet_for_boundary(
         first_compressor=compressor,
     )
 
-    # Compute both candidate boundaries independently, so the test documents the
-    # physical difference it relies on.
+    # Compute both candidate boundaries independently, to verify difference
     boundary_on_train_inlet = compressor.get_recirculation_range(inlet_stream)
     compressor_inlet = runner.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
     boundary_on_compressor_inlet = compressor.get_recirculation_range(compressor_inlet)
@@ -76,8 +75,7 @@ def test_common_asv_pressure_control_uses_compressor_inlet_for_boundary(
     # Sanity: TemperatureSetter actually changed the stream the compressor sees.
     assert compressor_inlet.temperature_kelvin == pytest.approx(stage_inlet_temperature_kelvin)
     assert inlet_stream.temperature_kelvin != compressor_inlet.temperature_kelvin
-    # Sanity: the two candidate boundaries differ — otherwise the test cannot tell
-    # which stream the strategy used.
+    # Sanity: the two candidate boundaries differ.
     assert boundary_on_train_inlet.min != pytest.approx(boundary_on_compressor_inlet.min, rel=1e-3)
 
     # Capture the stream that the strategy passes into get_recirculation_range.

--- a/tests/libecalc/domain/process/process_solver/pressure_control/test_common_asv_pressure_control_strategy.py
+++ b/tests/libecalc/domain/process/process_solver/pressure_control/test_common_asv_pressure_control_strategy.py
@@ -1,0 +1,104 @@
+import pytest
+
+from libecalc.domain.process.entities.shaft import VariableSpeedShaft
+from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
+from libecalc.domain.process.value_objects.chart import ChartCurve
+
+
+def test_common_asv_pressure_control_uses_compressor_inlet_for_boundary(
+    stream_factory,
+    chart_data_factory,
+    fluid_service,
+    compressor_factory,
+    stage_units_factory,
+    with_common_asv,
+    process_runner_factory,
+    common_asv_pressure_control_strategy_factory,
+):
+    """
+    COMMON ASV pressure control must compute the recirculation boundary on the compressor-inlet
+    stream (after TemperatureSetter / Choke / LiquidRemover), not the train-inlet stream.
+
+    A TemperatureSetter is placed before the compressor so the two streams differ measurably,
+    making it observable which one the strategy uses.
+    """
+
+    # Two clearly different temperatures, so train-inlet and compressor-inlet streams
+    # produce different densities — and therefore different boundaries.
+    train_inlet_temperature_kelvin = 280.0  # train inlet
+    stage_inlet_temperature_kelvin = 320.0  # enforced by TemperatureSetter
+
+    inlet_stream = stream_factory(
+        standard_rate_m3_per_day=500_000.0,
+        pressure_bara=30.0,
+        temperature_kelvin=train_inlet_temperature_kelvin,
+    )
+    q0 = float(inlet_stream.volumetric_rate_m3_per_hour)
+
+    # Wide chart boundary.min/max so the strategy don't
+    # short-circuit (early return) and never need to query get_recirculation_range meaningfully.
+    chart_data = chart_data_factory.from_curves(
+        curves=[
+            ChartCurve(
+                speed_rpm=75.0,
+                rate_actual_m3_hour=[q0 * 2, q0 * 8],
+                polytropic_head_joule_per_kg=[150_000.0, 40_000.0],
+                efficiency_fraction=[0.75, 0.75],
+            ),
+        ],
+        control_margin=0.0,
+    )
+
+    shaft = VariableSpeedShaft()
+    compressor = compressor_factory(chart_data=chart_data)
+    units = stage_units_factory(
+        compressor=compressor,
+        shaft=shaft,
+        temperature_kelvin=stage_inlet_temperature_kelvin,
+    )
+    shaft.set_speed(75.0)
+
+    recirculation_loop, wrapped_units = with_common_asv(units)
+    runner = process_runner_factory(units=wrapped_units, configuration_handlers=[shaft, recirculation_loop])
+
+    strategy = common_asv_pressure_control_strategy_factory(
+        runner=runner,
+        recirculation_loop_id=recirculation_loop.get_id(),
+        first_compressor=compressor,
+    )
+
+    # Compute both candidate boundaries independently, so the test documents the
+    # physical difference it relies on.
+    boundary_on_train_inlet = compressor.get_recirculation_range(inlet_stream)
+    compressor_inlet = runner.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
+    boundary_on_compressor_inlet = compressor.get_recirculation_range(compressor_inlet)
+
+    # Sanity: TemperatureSetter actually changed the stream the compressor sees.
+    assert compressor_inlet.temperature_kelvin == pytest.approx(stage_inlet_temperature_kelvin)
+    assert inlet_stream.temperature_kelvin != compressor_inlet.temperature_kelvin
+    # Sanity: the two candidate boundaries differ — otherwise the test cannot tell
+    # which stream the strategy used.
+    assert boundary_on_train_inlet.min != pytest.approx(boundary_on_compressor_inlet.min, rel=1e-3)
+
+    # Capture the stream that the strategy passes into get_recirculation_range.
+    captured_streams = []
+    original = compressor.get_recirculation_range
+
+    def spy(inlet_stream):
+        captured_streams.append(inlet_stream)
+        return original(inlet_stream)
+
+    compressor.get_recirculation_range = spy
+
+    # Trigger the strategy. get_recirculation_range is called on the very first line
+    # of apply(), so the target value does not affect what we are asserting on.
+    strategy.apply(target_pressure=FloatConstraint(80.0), inlet_stream=inlet_stream)
+
+    # Verify the strategy used the compressor-inlet stream, not the train-inlet stream.
+    assert captured_streams, "Strategy never queried get_recirculation_range"
+    used_stream = captured_streams[0]
+    assert used_stream.temperature_kelvin == pytest.approx(stage_inlet_temperature_kelvin), (
+        f"Strategy used stream at T={used_stream.temperature_kelvin:.1f} K for boundary; "
+        f"expected compressor-inlet stream at T={stage_inlet_temperature_kelvin:.1f} K "
+        f"(train-inlet was T={train_inlet_temperature_kelvin:.1f} K)."
+    )


### PR DESCRIPTION
Compute the recirculation boundary on the compressor's actual inlet stream (after `TemperatureSetter` +  `LiquidRemover`) instead of the train-inlet stream, matching what the Individual ASV strategies already do.

#### Changes

anti_surge/common_asv.py: propagate to first compressor inlet before calling `get_recirculation_range`.
pressure_control/common_asv.py: same.
No behavioural change expected for converged cases; eliminates fallback searches in `RecirculationSolver` for `COMMON_ASV`.

Refs: equinor/ecalc-internal#1721

## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
