### PR TITLE
refactor: individual asv pressure solve each stage on its own outlet

### DIFF
--- a/src/libecalc/domain/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/domain/process/process_solver/pressure_control/individual_asv.py
@@ -85,7 +85,7 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
             current_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
             boundary = compressor.get_recirculation_range(inlet_stream=current_stream)
 
-            def recirculation_func(config: RecirculationConfiguration):
+            def recirculation_func(config: RecirculationConfiguration) -> FluidStream:
                 self._simulator.apply_configuration(
                     Configuration(configuration_handler_id=recirculation_loop_id, value=config)
                 )

--- a/src/libecalc/domain/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/domain/process/process_solver/pressure_control/individual_asv.py
@@ -89,7 +89,8 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
                 self._simulator.apply_configuration(
                     Configuration(configuration_handler_id=recirculation_loop_id, value=config)
                 )
-                return self._simulator.run(inlet_stream=inlet_stream)
+                compressor_inlet_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
+                return compressor.propagate_stream(inlet_stream=compressor_inlet_stream)
 
             solver = RecirculationSolver(
                 search_strategy=BinarySearchStrategy(tolerance=10e-3),
@@ -111,10 +112,8 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
                     failure_event=solution.failure_event,
                 )
 
-        self._simulator.apply_configurations(configurations)
-        outlet_stream = self._simulator.run(inlet_stream=inlet_stream)
         return Solution(
-            success=outlet_stream.pressure_bara == target_pressure,
+            success=True,
             configuration=configurations,
         )
 
@@ -211,10 +210,8 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
             inlet_stream=inlet_stream,
             asv_rate_fraction=result_fraction,
         )
-        self._simulator.apply_configurations(configurations)
-        outlet_stream = self._simulator.run(inlet_stream=inlet_stream)
         return Solution(
-            success=outlet_stream.pressure_bara == target_pressure,
+            success=True,
             configuration=configurations,
         )
 

--- a/tests/libecalc/domain/process/process_solver/pressure_control/test_individual_asv_pressure_pressure_control_strategy.py
+++ b/tests/libecalc/domain/process/process_solver/pressure_control/test_individual_asv_pressure_pressure_control_strategy.py
@@ -1,5 +1,6 @@
 import pytest
 
+from libecalc.domain.process.entities.shaft import VariableSpeedShaft
 from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
 from libecalc.domain.process.value_objects.chart import ChartCurve
 
@@ -76,3 +77,95 @@ def test_individual_asv_pressure_control_reaches_target_pressure(
     outlet = runner.run(inlet_stream=inlet_stream)
 
     assert outlet.pressure_bara == pytest.approx(target_pressure_bara, rel=1e-3)
+
+
+def test_individual_asv_pressure_each_stage_meets_geometric_target(
+    stream_factory,
+    chart_data_factory,
+    fluid_service,
+    compressor_factory,
+    stage_units_factory,
+    with_individual_asv,
+    process_runner_factory,
+    individual_asv_pressure_control_strategy_factory,
+):
+    """Each stage's outlet must equal inlet * ratio^(i+1), where ratio = (target/inlet)^(1/n).
+
+    Per-stage solving must compare against the stage's own outlet, not the full train outlet —
+    otherwise stage 0 over-recirculates to hit the train target alone (with downstream stages
+    still at rate=0), leaving stage 0's outlet near the train target instead of the geometric
+    midpoint.
+    """
+
+    # 2 stages is the minimum that exposes the per-stage solving contract:
+    # with 1 stage, stage_target == train_target and the contract is trivially satisfied.
+    n_stages = 2
+    inlet_pressure = 30.0
+    target_pressure_bara = 60.0  # ratio per stage = sqrt(2) ≈ 1.414, stage 0 outlet ≈ 42.4 bara
+
+    inlet_stream = stream_factory(
+        standard_rate_m3_per_day=500_000.0,
+        pressure_bara=inlet_pressure,
+        temperature_kelvin=300.0,
+    )
+    q0 = float(inlet_stream.volumetric_rate_m3_per_hour)
+
+    # Wide chart so the per-stage solver has room to find an interior solution
+    # (not pinned to surge or stonewall).
+    chart_data = chart_data_factory.from_curves(
+        curves=[
+            ChartCurve(
+                speed_rpm=75.0,
+                rate_actual_m3_hour=[q0 * 2, q0 * 8],
+                polytropic_head_joule_per_kg=[150_000.0, 40_000.0],
+                efficiency_fraction=[0.75, 0.75],
+            ),
+        ],
+        control_margin=0.0,
+    )
+
+    shaft = VariableSpeedShaft()
+    compressors = [compressor_factory(chart_data=chart_data) for _ in range(n_stages)]
+    units = []
+    for compressor in compressors:
+        units.extend(stage_units_factory(compressor=compressor, shaft=shaft, temperature_kelvin=300.0))
+    shaft.set_speed(75.0)
+
+    wrapped_units, loops = with_individual_asv(units)
+    runner = process_runner_factory(units=wrapped_units, configuration_handlers=[shaft, *loops])
+
+    strategy = individual_asv_pressure_control_strategy_factory(
+        runner=runner,
+        recirculation_loop_ids=[loop.get_id() for loop in loops],
+        compressors=compressors,
+    )
+
+    # Solve and apply the resulting per-loop recirculation rates.
+    solution = strategy.apply(target_pressure=FloatConstraint(target_pressure_bara), inlet_stream=inlet_stream)
+    assert solution.success is True
+    runner.apply_configurations(solution.configuration)
+
+    # Geometrically distributed targets: stage i outlet = inlet * ratio^(i+1).
+    pressure_ratio_per_stage = (target_pressure_bara / inlet_pressure) ** (1.0 / n_stages)
+    expected_outlets = [inlet_pressure * (pressure_ratio_per_stage ** (i + 1)) for i in range(n_stages)]
+
+    # Read each stage's actual outlet by propagating up to the compressor and through it.
+    actual_outlets = []
+    for compressor in compressors:
+        compressor_inlet = runner.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
+        actual_outlets.append(compressor.propagate_stream(compressor_inlet).pressure_bara)
+
+    # Each stage must match its own geometric target.
+    for i, (actual, expected) in enumerate(zip(actual_outlets, expected_outlets)):
+        assert actual == pytest.approx(
+            expected, rel=5e-3
+        ), f"Stage {i} outlet {actual:.3f} bara != expected {expected:.3f} bara"
+
+    # Stage 0 must be at the geometric midpoint, not near the train target. If it lands close
+    # to target, the strategy is solving stage 0 against the full train outlet instead of the
+    # stage outlet — over-recirculating to compensate for downstream stages at rate=0.
+    assert actual_outlets[0] < 0.8 * target_pressure_bara, (
+        f"Stage 0 outlet {actual_outlets[0]:.3f} bara is suspiciously close to train target "
+        f"{target_pressure_bara} bara — strategy is likely solving against full train outlet "
+        f"instead of stage outlet."
+    )

--- a/tests/libecalc/domain/process/process_solver/pressure_control/test_individual_asv_pressure_pressure_control_strategy.py
+++ b/tests/libecalc/domain/process/process_solver/pressure_control/test_individual_asv_pressure_pressure_control_strategy.py
@@ -147,25 +147,18 @@ def test_individual_asv_pressure_each_stage_meets_geometric_target(
 
     # Geometrically distributed targets: stage i outlet = inlet * ratio^(i+1).
     pressure_ratio_per_stage = (target_pressure_bara / inlet_pressure) ** (1.0 / n_stages)
-    expected_outlets = [inlet_pressure * (pressure_ratio_per_stage ** (i + 1)) for i in range(n_stages)]
+    expected_outlet_pressures = [inlet_pressure * (pressure_ratio_per_stage ** (i + 1)) for i in range(n_stages)]
 
     # Read each stage's actual outlet by propagating up to the compressor and through it.
-    actual_outlets = []
+    actual_outlet_pressures = []
     for compressor in compressors:
         compressor_inlet = runner.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
-        actual_outlets.append(compressor.propagate_stream(compressor_inlet).pressure_bara)
+        actual_outlet_pressures.append(compressor.propagate_stream(compressor_inlet).pressure_bara)
 
-    # Each stage must match its own geometric target.
-    for i, (actual, expected) in enumerate(zip(actual_outlets, expected_outlets)):
+    # Each stage must match its own geometric target. Stage 0 in particular must land at
+    # sqrt(inlet*target) — landing near the train target would indicate stage 0 is solving
+    # against the full train outlet instead of its own.
+    for i, (actual, expected) in enumerate(zip(actual_outlet_pressures, expected_outlet_pressures)):
         assert actual == pytest.approx(
             expected, rel=5e-3
         ), f"Stage {i} outlet {actual:.3f} bara != expected {expected:.3f} bara"
-
-    # Stage 0 must be at the geometric midpoint, not near the train target. If it lands close
-    # to target, the strategy is solving stage 0 against the full train outlet instead of the
-    # stage outlet — over-recirculating to compensate for downstream stages at rate=0.
-    assert actual_outlets[0] < 0.8 * target_pressure_bara, (
-        f"Stage 0 outlet {actual_outlets[0]:.3f} bara is suspiciously close to train target "
-        f"{target_pressure_bara} bara — strategy is likely solving against full train outlet "
-        f"instead of stage outlet."
-    )


### PR DESCRIPTION
Refs: equinor/ecalc-internal#1722

## Description

Per-stage `recirculation_func` in `IndividualASVPressureControlStrategy` now solves against the **stage outlet** instead of the full train outlet, so each stage targets its own cumulative pressure without being skewed by downstream stages still at `recirculation_rate=0`.

Also drops the redundant `success=outlet_stream.pressure_bara == target_pressure` check in both `IndividualASVPressureControlStrategy` and `IndividualASVRateControlStrategy` — per-stage solvers / `find_root` already guarantee convergence within tolerance, so the extra full-train propagation per `apply` call not needed.

See linked issue for context and reasoning.

## Changes

- `IndividualASVPressureControlStrategy.apply`: `recirculation_func` returns `compressor.propagate_stream(compressor_inlet)` instead of `simulator.run(inlet_stream)`.
- `IndividualASVPressureControlStrategy.apply` and `IndividualASVRateControlStrategy.apply`: replace final `apply_configurations` + `run` + `success=...==target_pressure` with `Solution(success=True, ...)`.

## Test

- Existing tests pass.
- Effect first observable on 2+ stage trains; 1-stage behavior unchanged (cumulative target == train target).

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
