### PR TITLE
fix: reset recirculation before computing pressure control boundary

### DIFF
--- a/src/libecalc/domain/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/domain/process/process_solver/pressure_control/common_asv.py
@@ -51,6 +51,15 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
             return self._simulator.run(inlet_stream=inlet_stream)
 
         # Check feasibility: can we reach target pressure at maximum recirculation?
+        # Reset recirculation before computing the boundary — the mixer may carry
+        # residual state from anti-surge, which inflates the inlet rate and
+        # shrinks the recirculation range.
+        self._simulator.apply_configuration(
+            Configuration(
+                configuration_handler_id=self._recirculation_loop_id,
+                value=RecirculationConfiguration(recirculation_rate=0.0),
+            )
+        )
         compressor_inlet_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=self._first_compressor.get_id())
         boundary = self._first_compressor.get_recirculation_range(compressor_inlet_stream)
         min_configuration = RecirculationConfiguration(recirculation_rate=boundary.max)

--- a/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
+++ b/tests/libecalc/domain/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
@@ -156,3 +156,61 @@ def test_find_solution_returns_failure_when_rate_above_stonewall(
     )
 
     assert not solution.success
+
+
+def test_pressure_control_boundary_not_affected_by_residual_anti_surge_recirculation(
+    shaft,
+    small_chart_compressor,
+    stream_factory,
+    with_common_asv,
+    process_pipeline_factory,
+    process_runner_factory,
+    common_asv_anti_surge_strategy_factory,
+    common_asv_pressure_control_strategy_factory,
+    outlet_pressure_solver_factory,
+):
+    """Regression test: pressure control must reset recirculation before computing
+    the recirculation boundary.
+
+    When the inlet rate is well below the chart minimum, anti-surge sets a large
+    recirculation to reach the minimum flow. If pressure control does not reset
+    that recirculation before computing the boundary, the mixer inflates the
+    inlet rate, shrinking the available recirculation range. This can cause the
+    solver to report the target pressure as unreachable even though the
+    compressor can handle it at full recirculation.
+    """
+    common_asv, process_units = with_common_asv([small_chart_compressor])
+
+    runner = process_runner_factory(units=process_units, configuration_handlers=[shaft, common_asv])
+    process_pipeline = process_pipeline_factory(units=process_units)
+    anti_surge = common_asv_anti_surge_strategy_factory(
+        runner=runner, recirculation_loop_id=common_asv.get_id(), first_compressor=small_chart_compressor
+    )
+    pressure_control = common_asv_pressure_control_strategy_factory(
+        runner=runner, recirculation_loop_id=common_asv.get_id(), first_compressor=small_chart_compressor
+    )
+    solver = outlet_pressure_solver_factory(
+        shaft=shaft,
+        runner=runner,
+        anti_surge_strategy=anti_surge,
+        pressure_control_strategy=pressure_control,
+        process_pipeline_id=process_pipeline.get_id(),
+    )
+
+    # Inlet rate well below the chart minimum of 50 m³/h — forces large anti-surge recirculation.
+    inlet_stream = stream_factory(standard_rate_m3_per_day=5_000, pressure_bara=30.0, temperature_kelvin=300.0)
+    assert inlet_stream.volumetric_rate_m3_per_hour < 50.0
+
+    # A moderate target pressure that the compressor can deliver at high recirculation.
+    solution = solver.find_solution(
+        pressure_constraint=FloatConstraint(60.0),
+        inlet_stream=inlet_stream,
+    )
+
+    # Without the fix, the shrunken boundary could cause this to fail.
+    assert solution.success
+
+    # Verify the solution actually achieves the target pressure.
+    runner.apply_configurations(solution.configuration)
+    outlet_stream = runner.run(inlet_stream=inlet_stream)
+    assert outlet_stream.pressure_bara == pytest.approx(60.0, abs=0.5)


### PR DESCRIPTION
## Problem

`CommonASVPressureControlStrategy.apply()` computes the recirculation boundary via `run(inlet_stream, to_id=unit)` which passes through the `DirectMixer`. When anti-surge had previously set a non-zero recirculation rate, the mixer inflated the unit's inlet rate, shrinking the available recirculation range.

This is a latent bug introduced by #1508 (which changed boundary computation to use `run(to_id=...)` instead of the raw inlet stream). It's hard to trigger with compressors because their anti-surge recirculation is typically small relative to the chart range, but it becomes visible when the anti-surge fraction is large — e.g., when inlet rate is well below the chart minimum.

## Fix

Reset recirculation to zero before the boundary computation, so the range is always based on the base inlet rate. This matches the pattern anti-surge already uses (`reset()` is called before `apply()` in `OutletPressureSolver`).

## Testing

- Added regression test: `test_pressure_control_boundary_not_affected_by_residual_anti_surge_recirculation`
- Uses a compressor with chart min 50 m³/h and a very low inlet rate (5,000 sm³/day ≈ 7 m³/h), forcing large anti-surge recirculation
- Verified the test **fails without the fix** (solver reports achievable=60.4 vs target=60.0) and **passes with it**
- All 46 process solver tests pass