### PR TITLE
refactor: consolidate state reset via ProcessRunner.reset_to

### DIFF
--- a/src/libecalc/domain/process/entities/shaft/shaft.py
+++ b/src/libecalc/domain/process/entities/shaft/shaft.py
@@ -39,6 +39,9 @@ class Shaft(ConfigurationHandler, ABC):
         )
         self.set_speed(configuration.value.speed)
 
+    def reset(self) -> None:
+        self.reset_speed()
+
     @abstractmethod
     def set_speed(self, value: float) -> None:
         pass

--- a/src/libecalc/domain/process/process_solver/anti_surge/anti_surge_strategy.py
+++ b/src/libecalc/domain/process/process_solver/anti_surge/anti_surge_strategy.py
@@ -26,8 +26,3 @@ class AntiSurgeStrategy(ABC):
             Outlet stream after applying anti-surge adjustments (e.g. setting ASV recirculation).
         """
         ...
-
-    @abstractmethod
-    def reset(self) -> None:
-        """Reset mutable control state used by the strategy (e.g. ASV recirculation)."""
-        ...

--- a/src/libecalc/domain/process/process_solver/anti_surge/common_asv.py
+++ b/src/libecalc/domain/process/process_solver/anti_surge/common_asv.py
@@ -37,9 +37,6 @@ class CommonASVAntiSurgeStrategy(AntiSurgeStrategy):
         self._root_finding_strategy = root_finding_strategy
         self._simulator = simulator
 
-    def reset(self) -> None:
-        self._apply_configuration(RecirculationConfiguration(recirculation_rate=0.0))
-
     def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
         # Increase recirculation to give minimum feasible flow and return outlet.
         recirculation_solution = self._increase_recirculation_to_minimum_feasible(inlet_stream)

--- a/src/libecalc/domain/process/process_solver/anti_surge/individual_asv.py
+++ b/src/libecalc/domain/process/process_solver/anti_surge/individual_asv.py
@@ -48,18 +48,6 @@ class IndividualASVAntiSurgeStrategy(AntiSurgeStrategy):
         )
 
     @override
-    def reset(self) -> None:
-        for loop_id in self._recirculation_loop_ids:
-            self._simulator.apply_configuration(
-                Configuration(
-                    configuration_handler_id=loop_id,
-                    value=RecirculationConfiguration(
-                        recirculation_rate=0.0,
-                    ),
-                )
-            )
-
-    @override
     def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
         configurations: Sequence[Configuration[RecirculationConfiguration]] = []
         for loop_id, compressor in zip(self._recirculation_loop_ids, self._compressors, strict=True):

--- a/src/libecalc/domain/process/process_solver/choke_configuration_handler.py
+++ b/src/libecalc/domain/process/process_solver/choke_configuration_handler.py
@@ -27,3 +27,6 @@ class ChokeConfigurationHandler(ConfigurationHandler):
             f"Expected configuration value to be of type 'ChokeConfiguration', got '{type(configuration.value)}'"
         )
         self._choke.set_pressure_change(configuration.value.delta_pressure)
+
+    def reset(self) -> None:
+        self._choke.set_pressure_change(0.0)

--- a/src/libecalc/domain/process/process_solver/configuration_handler.py
+++ b/src/libecalc/domain/process/process_solver/configuration_handler.py
@@ -15,6 +15,11 @@ class ConfigurationHandler(Entity[ConfigurationHandlerId], abc.ABC):
         """Handle the given configuration."""
         ...
 
+    @abc.abstractmethod
+    def reset(self) -> None:
+        """Restore handler to its default/unconfigured state."""
+        ...
+
     @classmethod
     def _create_id(cls: type[Self]) -> ConfigurationHandlerId:
         return ConfigurationHandlerId(ecalc_id_generator())

--- a/src/libecalc/domain/process/process_solver/feasibility_solver.py
+++ b/src/libecalc/domain/process/process_solver/feasibility_solver.py
@@ -56,7 +56,7 @@ class FeasibilitySolver:
             return inlet_stream.standard_rate_sm3_per_day
 
         # Apply the configuration before querying compressor charts.
-        self._runner.apply_configurations(solution.configuration)
+        self._runner.reset_to(configurations=solution.configuration)
 
         # Search for compressor with the lowest max rate
         min_max_rate = float("inf")

--- a/src/libecalc/domain/process/process_solver/multi_pressure_solver.py
+++ b/src/libecalc/domain/process/process_solver/multi_pressure_solver.py
@@ -96,9 +96,8 @@ class MultiPressureSolver:
         current_inlet = inlet_stream
 
         for segment, target in zip(self._segments, pressure_targets):
-            segment.runner.apply_configuration(shaft_config)
+            segment.runner.reset_to(configurations=[shaft_config])
 
-            segment.anti_surge_strategy.reset()
             anti_surge_solution = segment.anti_surge_strategy.apply(inlet_stream=current_inlet)
             segment.runner.apply_configurations(anti_surge_solution.configuration)
             solution = solution.combine(anti_surge_solution)

--- a/src/libecalc/domain/process/process_solver/outlet_pressure_solver.py
+++ b/src/libecalc/domain/process/process_solver/outlet_pressure_solver.py
@@ -91,14 +91,12 @@ class OutletPressureSolver:
         )
 
         def speed_func(configuration: SpeedConfiguration) -> FluidStream:
-            self._simulator.apply_configuration(
-                Configuration(configuration_handler_id=self._shaft_id, value=configuration)
+            self._simulator.reset_to(
+                configurations=[Configuration(configuration_handler_id=self._shaft_id, value=configuration)],
             )
-            self._anti_surge_strategy.reset()
             try:
                 return self._simulator.run(inlet_stream=inlet_stream)
             except RateTooLowError:
-                # Reset anti-surge control state before applying the strategy.
                 solution = self._anti_surge_strategy.apply(inlet_stream=inlet_stream)
                 self._simulator.apply_configurations(solution.configuration)
                 return self._simulator.run(inlet_stream=inlet_stream)
@@ -123,6 +121,7 @@ class OutletPressureSolver:
         """
         Finds the speed and recirculation rates for each compressor to meet the pressure constraint.
         """
+        self._simulator.reset_to()
         configurations: dict[ConfigurationHandlerId, Configuration] = {}
         speed_solution = self._find_speed_solution(pressure_constraint=pressure_constraint, inlet_stream=inlet_stream)
         configurations[self._shaft_id] = Configuration(
@@ -130,8 +129,7 @@ class OutletPressureSolver:
             value=speed_solution.configuration,
         )
 
-        self._simulator.apply_configurations(list(configurations.values()))
-        self._anti_surge_strategy.reset()
+        self._simulator.reset_to(configurations=list(configurations.values()))
         self._anti_surge_solution = self._anti_surge_strategy.apply(inlet_stream=inlet_stream)
         for anti_surge_configuration in self._anti_surge_solution.configuration:
             configurations[anti_surge_configuration.configuration_handler_id] = anti_surge_configuration

--- a/src/libecalc/domain/process/process_solver/process_pipeline_runner.py
+++ b/src/libecalc/domain/process/process_solver/process_pipeline_runner.py
@@ -29,6 +29,16 @@ class ProcessPipelineRunner(ProcessRunner):
         self._configurations[configuration.configuration_handler_id] = configuration
         self._apply_config_for_unit(configuration_handler=unit, configuration=configuration)
 
+    def reset_to(
+        self,
+        configurations: Sequence[Configuration] = (),
+    ) -> None:
+        self._configurations.clear()
+        for handler in self._configuration_handlers.values():
+            handler.reset()
+        if configurations:
+            self.apply_configurations(configurations)
+
     def _get_configuration_handler(self, configuration_handler_id: ConfigurationHandlerId) -> ConfigurationHandler:
         return self._configuration_handlers[configuration_handler_id]
 

--- a/src/libecalc/domain/process/process_solver/process_runner.py
+++ b/src/libecalc/domain/process/process_solver/process_runner.py
@@ -18,6 +18,22 @@ class ProcessRunner(abc.ABC):
             self.apply_configuration(configuration)
 
     @abc.abstractmethod
+    def reset_to(
+        self,
+        configurations: Sequence[Configuration] = (),
+    ) -> None:
+        """Establish a clean starting state for the next evaluation.
+
+        Clears all configuration-handler state on the runner (e.g. shaft speed,
+        recirculation rates, choke pressure changes) and then applies the given
+        configurations as the new starting point.
+
+        Call this whenever a solver begins a new attempt so that no state from a
+        previous run leaks into the next one.
+        """
+        ...
+
+    @abc.abstractmethod
     def run(self, inlet_stream: FluidStream, to_id: ProcessUnitId | None = None) -> FluidStream:
         """
         Simulate the process

--- a/src/libecalc/domain/process/process_solver/recirculation_loop.py
+++ b/src/libecalc/domain/process/process_solver/recirculation_loop.py
@@ -33,6 +33,9 @@ class RecirculationLoop(ConfigurationHandler):
     def get_recirculation_rate(self) -> float:
         return self._mixer.get_mix_rate()
 
+    def reset(self) -> None:
+        self.set_recirculation_rate(0.0)
+
     def handle_configuration(self, configuration: Configuration):
         if configuration.configuration_handler_id != self._id:
             raise ValueError(


### PR DESCRIPTION
Adds a single `ProcessRunner.reset_to(configurations=())` method that solvers call at the start of every evaluation: it clears all configuration-handler state and applies the given configurations as the new starting point.

Replaces the previous two-step clear → re-apply pattern in `OutletPressureSolver`, `MultiPressureSolver`, and `FeasibilitySolver`. Each `ConfigurationHandler` now implements `reset()`.