### PR TITLE
feat: add EqualRatioOutletPressureCalculator

### DIFF
--- a/src/libecalc/domain/process/process_pipeline/process_unit.py
+++ b/src/libecalc/domain/process/process_pipeline/process_unit.py
@@ -1,10 +1,11 @@
 import abc
-from typing import NewType, Self
+from typing import NewType, Protocol, Self, runtime_checkable
 from uuid import UUID
 
 from libecalc.common.ddd.entity import Entity
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.domain.process.process_pipeline.stream_propagator import StreamPropagator
+from libecalc.domain.process.value_objects.fluid_stream import FluidStream
 
 ProcessUnitId = NewType("ProcessUnitId", UUID)
 
@@ -16,3 +17,12 @@ class ProcessUnit(Entity[ProcessUnitId], StreamPropagator, abc.ABC):
     @classmethod
     def _create_id(cls: type[Self]) -> ProcessUnitId:
         return ProcessUnitId(ecalc_id_generator())
+
+
+@runtime_checkable
+class RateConstrainedUnit(Protocol):
+    """Process units with a maximum inlet standard rate."""
+
+    def get_id(self) -> ProcessUnitId: ...
+
+    def get_maximum_standard_rate(self, inlet_stream: FluidStream) -> float: ...

--- a/src/libecalc/domain/process/process_solver/equal_ratio_outlet_pressure_calculator.py
+++ b/src/libecalc/domain/process/process_solver/equal_ratio_outlet_pressure_calculator.py
@@ -1,0 +1,189 @@
+from collections.abc import Sequence
+from typing import Final
+
+from libecalc.common.chart_type import ChartType
+from libecalc.domain.component_validation_error import ComponentValidationException, ProcessChartTypeValidationException
+from libecalc.domain.process.compressor.core.train.utils.enthalpy_calculations import (
+    calculate_enthalpy_change_head_iteration,
+)
+from libecalc.domain.process.entities.process_units.choke import Choke
+from libecalc.domain.process.entities.process_units.compressor import Compressor
+from libecalc.domain.process.process_pipeline.process_pipeline import ProcessPipeline
+from libecalc.domain.process.process_solver.boundary import Boundary
+from libecalc.domain.process.process_solver.configuration import Configuration, ConfigurationHandlerId
+from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
+from libecalc.domain.process.process_solver.solver import (
+    Solution,
+    SolverFailureStatus,
+    TargetNotAchievableEvent,
+)
+from libecalc.domain.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
+from libecalc.domain.process.value_objects.fluid_stream import FluidService, FluidStream
+from libecalc.domain.process.value_objects.fluid_stream.fluid import Fluid
+
+_ALLOWED_CHART_TYPES = (ChartType.GENERIC_FROM_INPUT, ChartType.GENERIC_FROM_DESIGN_POINT)
+
+
+class EqualRatioOutletPressureCalculator:
+    """Analytic outlet-pressure calculator: equal pressure ratio per stage, individual anti-surge."""
+
+    def __init__(
+        self,
+        system: ProcessPipeline,
+        fluid_service: FluidService,
+    ) -> None:
+        self._system: Final = system
+        self._fluid_service: Final = fluid_service
+        for unit in system.get_process_units():
+            if isinstance(unit, Choke):
+                raise ComponentValidationException(
+                    f"EqualRatioOutletPressureCalculator does not support pressure-dropping units; "
+                    f"found Choke {unit.get_id()} in the pipeline."
+                )
+            if isinstance(unit, Compressor):
+                origin = unit.compressor_chart.chart_data.origin_of_chart_data
+                if origin not in _ALLOWED_CHART_TYPES:
+                    raise ProcessChartTypeValidationException(
+                        f"EqualRatioOutletPressureCalculator requires a generic chart "
+                        f"for compressor {unit.get_id()}; got {origin.value}."
+                    )
+
+    def _per_stage_pressure_ratio(
+        self,
+        pressure_constraint: FloatConstraint,
+        inlet_stream: FluidStream,
+    ) -> float | None:
+        n = sum(1 for u in self._system.get_process_units() if isinstance(u, Compressor))
+        if n == 0:
+            return None
+        total_ratio = pressure_constraint.value / inlet_stream.pressure_bara
+        if total_ratio <= 0:
+            return None
+        return total_ratio ** (1.0 / n)
+
+    def _with_rate_delta(self, stream: FluidStream, delta: float) -> FluidStream:
+        if delta == 0.0:
+            return stream
+        return self._fluid_service.create_stream_from_standard_rate(
+            fluid_model=stream.fluid_model,
+            pressure_bara=stream.pressure_bara,
+            temperature_kelvin=stream.temperature_kelvin,
+            standard_rate_m3_per_day=stream.standard_rate_sm3_per_day + delta,
+        )
+
+    def _evaluate_stage(
+        self,
+        compressor: Compressor,
+        inlet_stream: FluidStream,
+        pressure_ratio: float,
+    ) -> tuple[Boundary, FluidStream]:
+        chart = compressor.compressor_chart
+        outlet_pressure = inlet_stream.pressure_bara * pressure_ratio
+        enthalpy_change, polytropic_efficiency = calculate_enthalpy_change_head_iteration(
+            outlet_pressure=outlet_pressure,
+            polytropic_efficiency_vs_rate_and_head_function=chart.efficiency_as_function_of_rate_and_head,
+            inlet_streams=inlet_stream,
+            fluid_service=self._fluid_service,
+        )
+        head_joule_per_kg = float(enthalpy_change * polytropic_efficiency)
+
+        min_actual_rate = float(chart.minimum_rate_as_function_of_head(head_joule_per_kg))
+        max_actual_rate = float(chart.maximum_rate_as_function_of_head(head_joule_per_kg))
+        density = inlet_stream.density
+        min_sm3_per_day = self._fluid_service.mass_rate_to_standard_rate(
+            fluid_model=inlet_stream.fluid_model,
+            mass_rate_kg_per_h=min_actual_rate * density,
+        )
+        max_sm3_per_day = self._fluid_service.mass_rate_to_standard_rate(
+            fluid_model=inlet_stream.fluid_model,
+            mass_rate_kg_per_h=max_actual_rate * density,
+        )
+        inlet_sm3_per_day = inlet_stream.standard_rate_sm3_per_day
+        recirc_range = Boundary(
+            min=min_sm3_per_day - inlet_sm3_per_day,
+            max=max_sm3_per_day - inlet_sm3_per_day,
+        )
+
+        target_enthalpy = float(inlet_stream.enthalpy_joule_per_kg + enthalpy_change)
+        props = self._fluid_service.flash_ph(inlet_stream.fluid_model, float(outlet_pressure), target_enthalpy)
+        outlet_fluid = Fluid(fluid_model=inlet_stream.fluid_model, properties=props)
+        outlet_stream = inlet_stream.with_new_fluid(outlet_fluid)
+
+        return recirc_range, outlet_stream
+
+    def find_solution(
+        self,
+        pressure_constraint: FloatConstraint,
+        inlet_stream: FluidStream,
+    ) -> Solution[Sequence[Configuration]]:
+        pressure_ratio_per_stage = self._per_stage_pressure_ratio(pressure_constraint, inlet_stream)
+        if pressure_ratio_per_stage is None:
+            return Solution(
+                success=False,
+                configuration=[],
+                failure_event=TargetNotAchievableEvent(
+                    status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
+                    achievable_value=inlet_stream.pressure_bara,
+                    target_value=pressure_constraint.value,
+                    source_id=self._system.get_id(),
+                ),
+            )
+
+        configurations: list[Configuration[RecirculationConfiguration]] = []
+        current_inlet = inlet_stream
+
+        for unit in self._system.get_process_units():
+            if isinstance(unit, Compressor):
+                recirc_range, _ = self._evaluate_stage(unit, current_inlet, pressure_ratio_per_stage)
+                if recirc_range.max < 0.0:
+                    return Solution(
+                        success=False,
+                        configuration=configurations,
+                        failure_event=TargetNotAchievableEvent(
+                            status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
+                            achievable_value=current_inlet.pressure_bara,
+                            target_value=pressure_constraint.value,
+                            source_id=self._system.get_id(),
+                        ),
+                    )
+                # Individual anti-surge.
+                recirculation_rate = max(0.0, recirc_range.min)
+
+                configurations.append(
+                    Configuration(
+                        configuration_handler_id=ConfigurationHandlerId(unit.get_id()),
+                        value=RecirculationConfiguration(recirculation_rate=recirculation_rate),
+                    )
+                )
+
+                inner_inlet = self._with_rate_delta(current_inlet, recirculation_rate)
+                _, outlet_with_recirc = self._evaluate_stage(unit, inner_inlet, pressure_ratio_per_stage)
+                current_inlet = self._with_rate_delta(outlet_with_recirc, -recirculation_rate)
+            else:
+                current_inlet = unit.propagate_stream(current_inlet)
+
+        return Solution(success=True, configuration=configurations)
+
+    def get_max_standard_rate(
+        self,
+        pressure_constraint: FloatConstraint,
+        inlet_stream: FluidStream,
+    ) -> float:
+        """Maximum inlet standard rate [sm³/day] meeting target pressure (bottleneck across stages)."""
+        pressure_ratio_per_stage = self._per_stage_pressure_ratio(pressure_constraint, inlet_stream)
+        if pressure_ratio_per_stage is None:
+            return 0.0
+
+        max_inlet_rate = float("inf")
+        current_inlet = inlet_stream
+
+        for unit in self._system.get_process_units():
+            if isinstance(unit, Compressor):
+                stage_inlet_rate = current_inlet.standard_rate_sm3_per_day
+                recirc_range, current_inlet = self._evaluate_stage(unit, current_inlet, pressure_ratio_per_stage)
+                stage_max = stage_inlet_rate + recirc_range.max
+                max_inlet_rate = min(max_inlet_rate, stage_max)
+            else:
+                current_inlet = unit.propagate_stream(current_inlet)
+
+        return max(0.0, max_inlet_rate)

--- a/src/libecalc/domain/process/process_solver/feasibility_solver.py
+++ b/src/libecalc/domain/process/process_solver/feasibility_solver.py
@@ -1,4 +1,3 @@
-from libecalc.domain.process.entities.process_units.compressor import Compressor
 from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
 from libecalc.domain.process.process_solver.outlet_pressure_solver import OutletPressureSolver
 from libecalc.domain.process.process_solver.process_runner import ProcessRunner
@@ -6,22 +5,14 @@ from libecalc.domain.process.value_objects.fluid_stream import FluidStream
 
 
 class FeasibilitySolver:
-    """
-    Calculates how much of a given inlet rate exceeds what a compressor train
-    can handle for a target pressure.
-
-    Orchestrates OutletPressureSolver and queries compressor charts to find
-    the feasible rate — the excess is redirected via stream distribution.
-    """
+    """Computes the inlet rate excess a compressor train cannot handle at a target pressure."""
 
     def __init__(
         self,
         outlet_pressure_solver: OutletPressureSolver,
-        compressors: list[Compressor],
         runner: ProcessRunner,
     ):
         self._solver = outlet_pressure_solver
-        self._compressors = compressors
         self._runner = runner
 
     def get_excess_rate(
@@ -29,45 +20,10 @@ class FeasibilitySolver:
         inlet_stream: FluidStream,
         target_pressure: FloatConstraint,
     ) -> float:
-        """
-        Rate [sm³/day] that exceeds what this train can handle.
-
-        This is the amount that must be redirected (e.g. via overflow)
-        to another train in the stream distribution.
-        """
-        feasible = self._find_feasible_rate(inlet_stream, target_pressure)
-        excess_rate = max(0.0, inlet_stream.standard_rate_sm3_per_day - feasible)
-        return excess_rate
-
-    def _find_feasible_rate(
-        self,
-        inlet_stream: FluidStream,
-        target_pressure: FloatConstraint,
-    ) -> float:
-        """Highest standard rate [sm³/day] for which the train can meet target_pressure.
-
-        Returns the full inlet rate if the solver succeeds, otherwise finds the
-        bottleneck compressor's stone wall limit at the current operating point.
-        """
+        """Rate [sm³/day] that exceeds what this train can handle."""
         solution = self._solver.find_solution(target_pressure, inlet_stream)
-
         if solution.success:
-            # The train can handle the full rate — no need to search for a bottleneck.
-            return inlet_stream.standard_rate_sm3_per_day
-
-        # Apply the configuration before querying compressor charts.
+            return 0.0
         self._runner.apply_configurations(solution.configuration)
-
-        # Search for compressor with the lowest max rate
-        min_max_rate = float("inf")
-        for compressor in self._compressors:
-            compressor_inlet = self._runner.run(
-                inlet_stream=inlet_stream,
-                to_id=compressor.get_id(),
-            )
-            max_rate = compressor.get_maximum_standard_rate(compressor_inlet)
-            min_max_rate = min(min_max_rate, max_rate)
-
-        feasible_rate = max(0.0, min_max_rate)
-
-        return feasible_rate
+        max_rate = self._runner.get_max_standard_rate(inlet_stream)
+        return max(0.0, inlet_stream.standard_rate_sm3_per_day - max_rate)

--- a/src/libecalc/domain/process/process_solver/process_pipeline_runner.py
+++ b/src/libecalc/domain/process/process_solver/process_pipeline_runner.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable, Sequence
 
-from libecalc.domain.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
+from libecalc.domain.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId, RateConstrainedUnit
 from libecalc.domain.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.domain.process.process_solver.configuration_handler import ConfigurationHandler
 from libecalc.domain.process.process_solver.process_runner import ProcessRunner
@@ -55,3 +55,11 @@ class ProcessPipelineRunner(ProcessRunner):
             return current_stream
         else:
             return propagate_stream_many(process_units=list(self._units.values()), inlet_stream=inlet_stream)
+
+    def get_max_standard_rate(self, inlet_stream: FluidStream) -> float:
+        min_max_rate = float("inf")
+        for unit in self._units.values():
+            if isinstance(unit, RateConstrainedUnit):
+                unit_inlet = self.run(inlet_stream=inlet_stream, to_id=unit.get_id())
+                min_max_rate = min(min_max_rate, unit.get_maximum_standard_rate(unit_inlet))
+        return max(0.0, min_max_rate)

--- a/src/libecalc/domain/process/process_solver/process_runner.py
+++ b/src/libecalc/domain/process/process_solver/process_runner.py
@@ -29,3 +29,8 @@ class ProcessRunner(abc.ABC):
 
         """
         ...
+
+    @abc.abstractmethod
+    def get_max_standard_rate(self, inlet_stream: FluidStream) -> float:
+        """Bottleneck inlet standard rate [sm³/day] at the current configured state."""
+        ...

--- a/tests/libecalc/domain/process/process_solver/conftest.py
+++ b/tests/libecalc/domain/process/process_solver/conftest.py
@@ -2,7 +2,10 @@ from collections.abc import Sequence
 
 import pytest
 
+from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.domain.process.entities.process_units.compressor import Compressor
+from libecalc.domain.process.entities.process_units.liquid_remover import LiquidRemover
+from libecalc.domain.process.entities.process_units.temperature_setter import TemperatureSetter
 from libecalc.domain.process.entities.shaft import Shaft
 from libecalc.domain.process.process_pipeline.process_pipeline import ProcessPipelineId
 from libecalc.domain.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
@@ -25,6 +28,47 @@ from libecalc.domain.process.process_solver.pressure_control.upstream_choke impo
 from libecalc.domain.process.process_solver.process_runner import ProcessRunner
 from libecalc.domain.process.process_solver.recirculation_loop import RecirculationLoop
 from libecalc.domain.process.value_objects.chart import ChartCurve
+from libecalc.testing.chart_data_factory import ChartDataFactory
+
+
+@pytest.fixture
+def make_compressor(fluid_service):
+    def _make(min_rate=300.0, max_rate=3000.0, head_hi=80000.0, head_lo=55000.0, eff=0.75):
+        chart_data = ChartDataFactory.from_rate_and_head(
+            rate=[min_rate, max_rate],
+            head=[head_hi, head_lo],
+            efficiency=eff,
+        )
+        return Compressor(
+            process_unit_id=ProcessUnitId(ecalc_id_generator()),
+            compressor_chart=chart_data,
+            fluid_service=fluid_service,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_temperature_setter(fluid_service):
+    def _make(temperature_kelvin=303.15):
+        return TemperatureSetter(
+            process_unit_id=ProcessUnitId(ecalc_id_generator()),
+            required_temperature_kelvin=temperature_kelvin,
+            fluid_service=fluid_service,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_liquid_remover(fluid_service):
+    def _make():
+        return LiquidRemover(
+            process_unit_id=ProcessUnitId(ecalc_id_generator()),
+            fluid_service=fluid_service,
+        )
+
+    return _make
 
 
 @pytest.fixture

--- a/tests/libecalc/domain/process/process_solver/test_equal_ratio_outlet_pressure_calculator.py
+++ b/tests/libecalc/domain/process/process_solver/test_equal_ratio_outlet_pressure_calculator.py
@@ -6,8 +6,6 @@ from libecalc.domain.component_validation_error import ComponentValidationExcept
 from libecalc.domain.process.compressor.core.train.simplified_train.simplified_train import CompressorTrainSimplified
 from libecalc.domain.process.entities.process_units.choke import Choke
 from libecalc.domain.process.entities.process_units.compressor import Compressor
-from libecalc.domain.process.entities.process_units.liquid_remover import LiquidRemover
-from libecalc.domain.process.entities.process_units.temperature_setter import TemperatureSetter
 from libecalc.domain.process.process_pipeline.process_pipeline import ProcessPipeline, ProcessPipelineId
 from libecalc.domain.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.domain.process.process_solver.equal_ratio_outlet_pressure_calculator import (
@@ -15,47 +13,6 @@ from libecalc.domain.process.process_solver.equal_ratio_outlet_pressure_calculat
 )
 from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
 from libecalc.domain.process.process_solver.solver import SolverFailureStatus
-from libecalc.testing.chart_data_factory import ChartDataFactory
-
-
-@pytest.fixture
-def make_compressor(fluid_service):
-    def _make(min_rate=300.0, max_rate=3000.0, head_hi=80000.0, head_lo=55000.0, eff=0.75):
-        chart_data = ChartDataFactory.from_rate_and_head(
-            rate=[min_rate, max_rate],
-            head=[head_hi, head_lo],
-            efficiency=eff,
-        )
-        return Compressor(
-            process_unit_id=ProcessUnitId(ecalc_id_generator()),
-            compressor_chart=chart_data,
-            fluid_service=fluid_service,
-        )
-
-    return _make
-
-
-@pytest.fixture
-def make_temperature_setter(fluid_service):
-    def _make(temperature_kelvin=303.15):
-        return TemperatureSetter(
-            process_unit_id=ProcessUnitId(ecalc_id_generator()),
-            required_temperature_kelvin=temperature_kelvin,
-            fluid_service=fluid_service,
-        )
-
-    return _make
-
-
-@pytest.fixture
-def make_liquid_remover(fluid_service):
-    def _make():
-        return LiquidRemover(
-            process_unit_id=ProcessUnitId(ecalc_id_generator()),
-            fluid_service=fluid_service,
-        )
-
-    return _make
 
 
 def test_single_stage_simplified_solver_meets_target(stream_factory, fluid_service, make_compressor):

--- a/tests/libecalc/domain/process/process_solver/test_equal_ratio_outlet_pressure_calculator.py
+++ b/tests/libecalc/domain/process/process_solver/test_equal_ratio_outlet_pressure_calculator.py
@@ -1,0 +1,344 @@
+import numpy as np
+import pytest
+
+from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
+from libecalc.domain.component_validation_error import ComponentValidationException
+from libecalc.domain.process.compressor.core.train.simplified_train.simplified_train import CompressorTrainSimplified
+from libecalc.domain.process.entities.process_units.choke import Choke
+from libecalc.domain.process.entities.process_units.compressor import Compressor
+from libecalc.domain.process.entities.process_units.liquid_remover import LiquidRemover
+from libecalc.domain.process.entities.process_units.temperature_setter import TemperatureSetter
+from libecalc.domain.process.process_pipeline.process_pipeline import ProcessPipeline, ProcessPipelineId
+from libecalc.domain.process.process_pipeline.process_unit import ProcessUnitId
+from libecalc.domain.process.process_solver.equal_ratio_outlet_pressure_calculator import (
+    EqualRatioOutletPressureCalculator,
+)
+from libecalc.domain.process.process_solver.float_constraint import FloatConstraint
+from libecalc.domain.process.process_solver.solver import SolverFailureStatus
+from libecalc.testing.chart_data_factory import ChartDataFactory
+
+
+@pytest.fixture
+def make_compressor(fluid_service):
+    def _make(min_rate=300.0, max_rate=3000.0, head_hi=80000.0, head_lo=55000.0, eff=0.75):
+        chart_data = ChartDataFactory.from_rate_and_head(
+            rate=[min_rate, max_rate],
+            head=[head_hi, head_lo],
+            efficiency=eff,
+        )
+        return Compressor(
+            process_unit_id=ProcessUnitId(ecalc_id_generator()),
+            compressor_chart=chart_data,
+            fluid_service=fluid_service,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_temperature_setter(fluid_service):
+    def _make(temperature_kelvin=303.15):
+        return TemperatureSetter(
+            process_unit_id=ProcessUnitId(ecalc_id_generator()),
+            required_temperature_kelvin=temperature_kelvin,
+            fluid_service=fluid_service,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_liquid_remover(fluid_service):
+    def _make():
+        return LiquidRemover(
+            process_unit_id=ProcessUnitId(ecalc_id_generator()),
+            fluid_service=fluid_service,
+        )
+
+    return _make
+
+
+def test_single_stage_simplified_solver_meets_target(stream_factory, fluid_service, make_compressor):
+    """Single-stage simplified solver should produce outlet at target pressure."""
+    system = ProcessPipeline(
+        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()), stream_propagators=[make_compressor()]
+    )
+    solver = EqualRatioOutletPressureCalculator(system=system, fluid_service=fluid_service)
+
+    inlet = stream_factory(standard_rate_m3_per_day=400_000, pressure_bara=20.0)
+    target = FloatConstraint(50.0, abs_tol=1.0)
+
+    solution = solver.find_solution(pressure_constraint=target, inlet_stream=inlet)
+
+    assert solution.success
+
+
+def test_two_stage_simplified_solver_meets_target(stream_factory, fluid_service, make_compressor):
+    """Two-stage simplified solver should split ratio equally and produce correct outlet."""
+    system = ProcessPipeline(
+        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
+        stream_propagators=[make_compressor(), make_compressor()],
+    )
+    solver = EqualRatioOutletPressureCalculator(system=system, fluid_service=fluid_service)
+
+    inlet = stream_factory(standard_rate_m3_per_day=400_000, pressure_bara=20.0)
+    target = FloatConstraint(80.0, abs_tol=2.0)
+
+    solution = solver.find_solution(pressure_constraint=target, inlet_stream=inlet)
+
+    assert solution.success
+    assert len(solution.configuration) == 2
+
+
+def test_stonewall_on_excess_inlet_rate_reports_failure(stream_factory, fluid_service, make_compressor):
+    """When inlet actual rate exceeds the chart's max-flow at the required head, find_solution
+    must return a failure with MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET — not silently
+    succeed with bogus zero recirculation."""
+    small_compressor = make_compressor(min_rate=300.0, max_rate=1000.0)
+    pipeline_id = ProcessPipelineId(ecalc_id_generator())
+    system = ProcessPipeline(process_pipeline_id=pipeline_id, stream_propagators=[small_compressor])
+    solver = EqualRatioOutletPressureCalculator(system=system, fluid_service=fluid_service)
+
+    inlet = stream_factory(standard_rate_m3_per_day=400_000, pressure_bara=20.0)
+    target = FloatConstraint(50.0, abs_tol=1.0)
+
+    solution = solver.find_solution(pressure_constraint=target, inlet_stream=inlet)
+
+    assert not solution.success
+    assert solution.failure_event is not None
+    assert solution.failure_event.status == SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET
+    assert solution.failure_event.source_id == pipeline_id
+
+
+def test_temperature_setter_before_compressor_is_applied(
+    stream_factory, fluid_service, make_compressor, make_temperature_setter
+):
+    """TemperatureSetter before a compressor should set inlet temperature before compression.
+
+    Configuration list should contain exactly one entry (only the Compressor produces config).
+    """
+    system_with_setter = ProcessPipeline(
+        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
+        stream_propagators=[make_temperature_setter(temperature_kelvin=303.15), make_compressor()],
+    )
+    system_without_setter = ProcessPipeline(
+        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()), stream_propagators=[make_compressor()]
+    )
+
+    hot_inlet = stream_factory(standard_rate_m3_per_day=400_000, pressure_bara=20.0, temperature_kelvin=373.15)
+    target = FloatConstraint(50.0, abs_tol=1.0)
+
+    sol_with = EqualRatioOutletPressureCalculator(system=system_with_setter, fluid_service=fluid_service).find_solution(
+        pressure_constraint=target, inlet_stream=hot_inlet
+    )
+    sol_without = EqualRatioOutletPressureCalculator(
+        system=system_without_setter, fluid_service=fluid_service
+    ).find_solution(pressure_constraint=target, inlet_stream=hot_inlet)
+
+    assert sol_with.success
+    assert sol_without.success
+    assert len(sol_with.configuration) == 1
+
+
+def test_two_stage_with_liquid_remover_and_temperature_setter(
+    stream_factory,
+    fluid_service,
+    make_compressor,
+    make_temperature_setter,
+    make_liquid_remover,
+):
+    """A realistic two-stage train: TemperatureSetter + Compressor + LiquidRemover + TemperatureSetter + Compressor."""
+    system = ProcessPipeline(
+        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
+        stream_propagators=[
+            make_temperature_setter(temperature_kelvin=303.15),
+            make_compressor(),
+            make_liquid_remover(),
+            make_temperature_setter(temperature_kelvin=303.15),
+            make_compressor(),
+        ],
+    )
+    solver = EqualRatioOutletPressureCalculator(system=system, fluid_service=fluid_service)
+
+    inlet = stream_factory(standard_rate_m3_per_day=400_000, pressure_bara=20.0)
+    target = FloatConstraint(80.0, abs_tol=2.0)
+
+    solution = solver.find_solution(pressure_constraint=target, inlet_stream=inlet)
+
+    assert solution.success
+    assert len(solution.configuration) == 2
+
+
+def test_choke_in_pipeline_raises_at_construction(make_compressor, fluid_service):
+    """A Choke in the pipeline invalidates the equal-ratio assumption and must be rejected."""
+    choke = Choke(
+        process_unit_id=ProcessUnitId(ecalc_id_generator()),
+        fluid_service=fluid_service,
+        pressure_change=5.0,
+    )
+    system = ProcessPipeline(
+        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
+        stream_propagators=[make_compressor(), choke, make_compressor()],
+    )
+    with pytest.raises(ComponentValidationException, match="Choke"):
+        EqualRatioOutletPressureCalculator(system=system, fluid_service=fluid_service)
+
+
+def test_get_max_standard_rate_matches_legacy_simplified_train(
+    fluid_service,
+    fluid_model_rich,
+    chart_data_factory,
+    compressor_stages,
+    make_temperature_setter,
+    make_liquid_remover,
+):
+    """Mirror legacy `test_compressor_train_simplified_known_stages_generic_chart`:
+    EqualRatioOutletPressureCalculator.get_max_standard_rate must match
+    CompressorTrainSimplified.get_max_standard_rate for the same 2-stage generic-chart setup.
+    """
+    suction_pressures = np.asarray([36.0, 31.0, 21.0, 19.0, 18.0, 18.0, 18.0, 18.0])
+    discharge_pressures = np.asarray([250.0, 250.0, 200.0, 200.0, 200.0, 200.0, 200.0, 200.0])
+
+    chart_a = chart_data_factory.from_design_point(efficiency=0.75, rate=15848.089397866604, head=135478.5333104937)
+    chart_b = chart_data_factory.from_design_point(efficiency=0.75, rate=4539.170738284835, head=116082.08687178302)
+
+    legacy_stages = [
+        compressor_stages(chart_data=chart_a, remove_liquid_after_cooling=True)[0],
+        compressor_stages(chart_data=chart_b, remove_liquid_after_cooling=True)[0],
+    ]
+    legacy = CompressorTrainSimplified(
+        stages=legacy_stages,
+        fluid_service=fluid_service,
+        energy_usage_adjustment_constant=0,
+        energy_usage_adjustment_factor=1,
+    )
+    expected = legacy.get_max_standard_rate(
+        suction_pressures=suction_pressures,
+        discharge_pressures=discharge_pressures,
+        fluid_model=fluid_model_rich,
+    )
+
+    def _make_compressor(chart):
+        return Compressor(
+            process_unit_id=ProcessUnitId(ecalc_id_generator()),
+            compressor_chart=chart,
+            fluid_service=fluid_service,
+        )
+
+    pipeline = ProcessPipeline(
+        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
+        stream_propagators=[
+            make_temperature_setter(temperature_kelvin=303.15),
+            _make_compressor(chart_a),
+            make_liquid_remover(),
+            make_temperature_setter(temperature_kelvin=303.15),
+            _make_compressor(chart_b),
+        ],
+    )
+    calculator = EqualRatioOutletPressureCalculator(system=pipeline, fluid_service=fluid_service)
+
+    actual = []
+    for suction, discharge in zip(suction_pressures, discharge_pressures):
+        inlet = fluid_service.create_stream_from_standard_rate(
+            fluid_model=fluid_model_rich,
+            pressure_bara=float(suction),
+            temperature_kelvin=303.15,
+            standard_rate_m3_per_day=1.0,
+        )
+        actual.append(
+            calculator.get_max_standard_rate(
+                pressure_constraint=FloatConstraint(float(discharge), abs_tol=1.0),
+                inlet_stream=inlet,
+            )
+        )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-3)
+
+
+def test_find_solution_matches_legacy_simplified_train_recirculation(
+    fluid_service,
+    fluid_model_rich,
+    chart_data_factory,
+    compressor_stages,
+    make_temperature_setter,
+    make_liquid_remover,
+):
+    """Solve the same 2-stage train with both implementations and verify per-stage
+    recirculation (ASV add-back) matches at every operating point.
+
+    Legacy stage_results expose mass_rate_kg_per_hr (gross) and mass_rate_before_asv_kg_per_hr
+    (net); their difference is the recirc mass added by ASV. The new calculator's
+    RecirculationConfiguration.recirculation_rate is the same quantity in std m3/day.
+    """
+    rates = np.asarray(
+        [15478059.4, 14296851.66, 9001365.137, 7921594.316, 5857638.265, 4012786.153, 2920238.089, 2398857.123]
+    )
+    suction_pressures = np.asarray([36.0, 31.0, 21.0, 19.0, 18.0, 18.0, 18.0, 18.0])
+    discharge_pressures = np.asarray([250.0, 250.0, 200.0, 200.0, 200.0, 200.0, 200.0, 200.0])
+
+    chart_a = chart_data_factory.from_design_point(efficiency=0.75, rate=15848.089397866604, head=135478.5333104937)
+    chart_b = chart_data_factory.from_design_point(efficiency=0.75, rate=4539.170738284835, head=116082.08687178302)
+
+    legacy_stages = [
+        compressor_stages(chart_data=chart_a, remove_liquid_after_cooling=True)[0],
+        compressor_stages(chart_data=chart_b, remove_liquid_after_cooling=True)[0],
+    ]
+    legacy = CompressorTrainSimplified(
+        stages=legacy_stages,
+        fluid_service=fluid_service,
+        energy_usage_adjustment_constant=0,
+        energy_usage_adjustment_factor=1,
+    )
+    legacy.set_evaluation_input(
+        fluid_model=fluid_model_rich,
+        rate=rates,
+        suction_pressure=suction_pressures,
+        discharge_pressure=discharge_pressures,
+    )
+    legacy_results = legacy.evaluate()
+
+    def _make_compressor(chart):
+        return Compressor(
+            process_unit_id=ProcessUnitId(ecalc_id_generator()),
+            compressor_chart=chart,
+            fluid_service=fluid_service,
+        )
+
+    pipeline = ProcessPipeline(
+        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
+        stream_propagators=[
+            make_temperature_setter(temperature_kelvin=303.15),
+            _make_compressor(chart_a),
+            make_liquid_remover(),
+            make_temperature_setter(temperature_kelvin=303.15),
+            _make_compressor(chart_b),
+        ],
+    )
+    calculator = EqualRatioOutletPressureCalculator(system=pipeline, fluid_service=fluid_service)
+
+    expected_recirc_stage0_sm3 = []
+    actual_recirc_stage0_sm3 = []
+    for i, (rate, suction, discharge) in enumerate(zip(rates, suction_pressures, discharge_pressures)):
+        inlet = fluid_service.create_stream_from_standard_rate(
+            fluid_model=fluid_model_rich,
+            pressure_bara=float(suction),
+            temperature_kelvin=303.15,
+            standard_rate_m3_per_day=float(rate),
+        )
+        solution = calculator.find_solution(
+            pressure_constraint=FloatConstraint(float(discharge), abs_tol=1.0),
+            inlet_stream=inlet,
+        )
+        assert solution.success, f"point {i}: new calculator failed"
+        assert len(solution.configuration) == 2
+        actual_recirc_stage0_sm3.append(solution.configuration[0].value.recirculation_rate)
+
+        legacy_recirc_kg = (
+            legacy_results.stage_results[0].mass_rate_kg_per_hr[i]
+            - legacy_results.stage_results[0].mass_rate_before_asv_kg_per_hr[i]
+        )
+        expected_recirc_stage0_sm3.append(
+            fluid_service.mass_rate_to_standard_rate(fluid_model=fluid_model_rich, mass_rate_kg_per_h=legacy_recirc_kg)
+        )
+
+    np.testing.assert_allclose(actual_recirc_stage0_sm3, expected_recirc_stage0_sm3, rtol=1e-2, atol=1.0)


### PR DESCRIPTION
What

Adds an analytic outlet-pressure calculator for compressor trains that operate at a fixed pressure ratio per stage — no shaft speed search. Same idea as the legacy `CompressorTrainSimplified`, repackaged as a `Solution`-returning calculator that plugs into the `ProcessRunner` / configuration-handler architecture.

Why

The existing `OutletPressureSolver` searches for a shaft speed to meet a target outlet pressure. Simplified compressor trains using `GENERIC_FROM_INPUT` / `GENERIC_FROM_DESIGN_POINT` charts don't model shaft speed — they distribute the total pressure ratio equally across stages. This PR adds a calculator for that path, sitting alongside the speed-based solver.

Changes

New domain entity:

 - `EqualRatioOutletPressureCalculator` — distributes equal pressure ratio (geometric mean) across all `Compressor` units in the pipeline, applies minimum recirculation per stage (individual anti-surge), and returns a `Solution[Sequence[Configuration]]` of `RecirculationConfiguration` per stage. Exposes `get_max_standard_rate()` for stonewall-based feasibility (per-stage max → bottleneck `min`).
 - Rejects `Choke` units and non-generic compressor charts at construction time.

Refactor:

 - Moved `get_max_standard_rate` from `FeasibilitySolver` to `ProcessRunner`, so both the speed-based and ratio-based paths can share it.

Tests

 - `test_equal_ratio_outlet_pressure_calculator.py` — unit tests covering equal-ratio split, individual anti-surge, max-rate bottleneck, choke/chart-type rejection.
