### PR TITLE
feat: multi-shaft solver for independently-shafted compressor trains

### DIFF
--- a/src/libecalc/process/process_solver/multi_shaft_equal_ratio_solver.py
+++ b/src/libecalc/process/process_solver/multi_shaft_equal_ratio_solver.py
@@ -1,0 +1,45 @@
+"""Equal-ratio pressure solver for a train of independently-shafted compressors."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_solver.configuration import Configuration, OperatingConfiguration
+from libecalc.process.process_solver.float_constraint import FloatConstraint
+from libecalc.process.process_solver.multi_shaft_solver import MultiShaftSolver
+from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.solver import Solution
+
+
+class MultiShaftEqualRatioSolver:
+    """Wrapper around MultiShaftSolver that computes per-pipeline pressure targets
+    using equal pressure ratio: target_i = P_in × ratio^(i+1).
+    """
+
+    def __init__(self, process_pipelines: Sequence[OutletPressureSolver]) -> None:
+        self._process_pipelines = list(process_pipelines)
+        self._solver = MultiShaftSolver(list(process_pipelines))
+
+    def find_solution(
+        self,
+        pressure_constraint: FloatConstraint,
+        inlet_stream: FluidStream,
+    ) -> Solution[Sequence[Configuration[OperatingConfiguration]]]:
+        """Split overall pressure target into equal per-pipeline ratios and delegate."""
+        n = len(self._process_pipelines)
+        if n == 0:
+            return Solution(success=True, configuration=[], failure_event=None)
+
+        pressure_ratio = (pressure_constraint.value / inlet_stream.pressure_bara) ** (1.0 / n)
+
+        # Rolling targets: each pipeline targets its actual inlet × ratio.
+        # The final target is always the exact requested constraint.
+        current_p = inlet_stream.pressure_bara
+        targets: list[FloatConstraint] = []
+        for _i in range(n):
+            current_p *= pressure_ratio
+            targets.append(FloatConstraint(current_p, abs_tol=pressure_constraint.abs_tol))
+        targets[-1] = pressure_constraint
+
+        return self._solver.find_solution(targets, inlet_stream)

--- a/src/libecalc/process/process_solver/multi_shaft_solver.py
+++ b/src/libecalc/process/process_solver/multi_shaft_solver.py
@@ -1,0 +1,62 @@
+"""Sequential solver with caller-supplied pressure targets per process pipeline."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_solver.configuration import Configuration, OperatingConfiguration
+from libecalc.process.process_solver.float_constraint import FloatConstraint
+from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.solver import Solution
+
+logger = logging.getLogger(__name__)
+
+
+class MultiShaftSolver:
+    """Sequences independently-shafted process pipelines, each driven toward a
+    caller-supplied pressure target.  The outlet of one pipeline feeds the
+    inlet of the next.
+    """
+
+    def __init__(self, process_pipelines: Sequence[OutletPressureSolver]) -> None:
+        self._process_pipelines = list(process_pipelines)
+
+    def find_solution(
+        self,
+        pressure_targets: Sequence[FloatConstraint],
+        inlet_stream: FluidStream,
+    ) -> Solution[Sequence[Configuration[OperatingConfiguration]]]:
+        """Run each process pipeline in flow order against its supplied pressure target."""
+        assert len(pressure_targets) == len(self._process_pipelines), (
+            f"Number of pressure targets ({len(pressure_targets)}) must match "
+            f"number of process pipelines ({len(self._process_pipelines)})."
+        )
+
+        if not self._process_pipelines:
+            return Solution(success=True, configuration=[], failure_event=None)
+
+        current_inlet = inlet_stream
+        all_configurations: list[Configuration[OperatingConfiguration]] = []
+        failure_event = None
+        overall_success = True
+
+        for i, (pipeline, target) in enumerate(zip(self._process_pipelines, pressure_targets)):
+            solution = pipeline.find_solution(target, current_inlet)
+            all_configurations.extend(solution.configuration)
+
+            if not solution.success:
+                overall_success = False
+                if failure_event is None:
+                    failure_event = solution.failure_event
+                logger.debug("Process pipeline %d failed to reach target %.1f bara.", i, target.value)
+
+            pipeline.runner.apply_configurations(solution.configuration)
+            current_inlet = pipeline.runner.run(current_inlet)
+
+        return Solution(
+            success=overall_success,
+            configuration=all_configurations,
+            failure_event=failure_event,
+        )

--- a/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
@@ -1,0 +1,214 @@
+"""Tests for MultiShaftEqualRatioSolver."""
+
+import pytest
+
+from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
+from libecalc.domain.process.value_objects.chart import ChartCurve
+from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
+from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
+from libecalc.process.process_solver.configuration import ConfigurationHandlerId, SpeedConfiguration
+from libecalc.process.process_solver.float_constraint import FloatConstraint
+from libecalc.process.process_solver.multi_shaft_equal_ratio_solver import MultiShaftEqualRatioSolver
+from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pressure_control.individual_asv import IndividualASVPressureControlStrategy
+from libecalc.process.process_solver.process_pipeline_runner import ProcessPipelineRunner
+from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
+from libecalc.process.process_units.compressor import Compressor
+from libecalc.process.process_units.direct_mixer import DirectMixer
+from libecalc.process.process_units.direct_splitter import DirectSplitter
+from libecalc.process.process_units.temperature_setter import TemperatureSetter
+from libecalc.process.shaft import VariableSpeedShaft
+from libecalc.testing.chart_data_factory import ChartDataFactory
+
+
+def make_variable_speed_chart(min_rate: float, max_rate: float, head_hi: float, head_lo: float, eff: float = 0.75):
+    """Five affinity-law-scaled speed curves (60–100 rpm)."""
+    curves = []
+    for n in [60.0, 70.0, 80.0, 90.0, 100.0]:
+        f = n / 100.0
+        curves.append(
+            ChartCurve(
+                speed_rpm=n,
+                rate_actual_m3_hour=[min_rate * f, max_rate * f],
+                polytropic_head_joule_per_kg=[head_hi * f**2, head_lo * f**2],
+                efficiency_fraction=[eff, eff],
+            )
+        )
+    return ChartDataFactory.from_curves(curves, control_margin=0.0)
+
+
+def make_process_pipeline(
+    *,
+    min_rate: float,
+    max_rate: float,
+    head_hi: float,
+    head_lo: float,
+    inlet_temperature_kelvin: float,
+    fluid_service,
+    root_finding_strategy,
+) -> OutletPressureSolver:
+    """One independently-shafted process pipeline: TemperatureSetter → Compressor with individual ASV."""
+    chart_data = make_variable_speed_chart(min_rate, max_rate, head_hi, head_lo)
+
+    compressor = Compressor(
+        compressor_chart=chart_data,
+        fluid_service=fluid_service,
+        process_unit_id=ProcessUnitId(ecalc_id_generator()),
+    )
+
+    shaft = VariableSpeedShaft(configuration_handler_id=ConfigurationHandlerId(ecalc_id_generator()))
+    shaft.connect(compressor)
+
+    mixer = DirectMixer()
+    splitter = DirectSplitter()
+    loop = RecirculationLoop(
+        mixer=mixer,
+        splitter=splitter,
+        configuration_handler_id=ConfigurationHandlerId(ecalc_id_generator()),
+    )
+
+    runner = ProcessPipelineRunner(
+        configuration_handlers=[shaft, loop],
+        units=[
+            TemperatureSetter(required_temperature_kelvin=inlet_temperature_kelvin, fluid_service=fluid_service),
+            mixer,
+            compressor,
+            splitter,
+        ],
+    )
+
+    anti_surge = IndividualASVAntiSurgeStrategy(
+        recirculation_loop_ids=[loop.get_id()],
+        compressors=[compressor],
+        simulator=runner,
+    )
+    pressure_control = IndividualASVPressureControlStrategy(
+        simulator=runner,
+        recirculation_loop_ids=[loop.get_id()],
+        compressors=[compressor],
+        root_finding_strategy=root_finding_strategy,
+    )
+
+    return OutletPressureSolver(
+        shaft_id=shaft.get_id(),
+        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
+        runner=runner,
+        anti_surge_strategy=anti_surge,
+        pressure_control_strategy=pressure_control,
+        root_finding_strategy=root_finding_strategy,
+        speed_boundary=shaft.get_speed_boundary(),
+    )
+
+
+@pytest.fixture
+def pipeline_kwargs(fluid_service, root_finding_strategy):
+    return {
+        "head_hi": 200_000,
+        "head_lo": 140_000,
+        "inlet_temperature_kelvin": 303.15,
+        "fluid_service": fluid_service,
+        "root_finding_strategy": root_finding_strategy,
+    }
+
+
+def test_three_shaft_train_hits_target_pressure(stream_factory, pipeline_kwargs):
+    pipelines = [
+        make_process_pipeline(min_rate=200, max_rate=5000, **pipeline_kwargs),
+        make_process_pipeline(min_rate=150, max_rate=3500, **pipeline_kwargs),
+        make_process_pipeline(min_rate=100, max_rate=2500, **pipeline_kwargs),
+    ]
+    solver = MultiShaftEqualRatioSolver(process_pipelines=pipelines)
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+
+    solution = solver.find_solution(FloatConstraint(270.0, abs_tol=5.0), inlet)
+
+    assert solution.success, f"Expected success; failure: {solution.failure_event}"
+
+
+def test_each_shaft_runs_at_different_speed(stream_factory, pipeline_kwargs):
+    """Real-gas effects cause each pipeline to need a different shaft speed."""
+    pipelines = [
+        make_process_pipeline(min_rate=200, max_rate=5000, **pipeline_kwargs),
+        make_process_pipeline(min_rate=150, max_rate=3500, **pipeline_kwargs),
+        make_process_pipeline(min_rate=100, max_rate=2500, **pipeline_kwargs),
+    ]
+    solver = MultiShaftEqualRatioSolver(process_pipelines=pipelines)
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+
+    solution = solver.find_solution(FloatConstraint(270.0, abs_tol=5.0), inlet)
+
+    speeds = [c.value.speed for c in solution.configuration if isinstance(c.value, SpeedConfiguration)]
+    assert len(speeds) == 3
+    assert len(set(speeds)) == 3, f"expected three distinct speeds, got {speeds}"
+
+
+def test_intercooler_changes_stage_speed(stream_factory, fluid_service, root_finding_strategy):
+    """Warmer inlet temperature changes the required shaft speed."""
+    common = {
+        "min_rate": 200,
+        "max_rate": 5000,
+        "head_hi": 200_000,
+        "head_lo": 140_000,
+        "fluid_service": fluid_service,
+        "root_finding_strategy": root_finding_strategy,
+    }
+
+    cool = [make_process_pipeline(**common, inlet_temperature_kelvin=303.15) for _ in range(3)]
+    warm = [make_process_pipeline(**common, inlet_temperature_kelvin=360.0) for _ in range(3)]
+
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+    constraint = FloatConstraint(270.0, abs_tol=5.0)
+
+    sol_cool = MultiShaftEqualRatioSolver(process_pipelines=cool).find_solution(constraint, inlet)
+    sol_warm = MultiShaftEqualRatioSolver(process_pipelines=warm).find_solution(constraint, inlet)
+
+    assert sol_cool.success and sol_warm.success
+
+    speeds_cool = [c.value.speed for c in sol_cool.configuration if isinstance(c.value, SpeedConfiguration)]
+    speeds_warm = [c.value.speed for c in sol_warm.configuration if isinstance(c.value, SpeedConfiguration)]
+
+    assert speeds_cool[0] != speeds_warm[0]
+    assert speeds_cool[1] != speeds_warm[1]
+
+
+def test_empty_pipelines(stream_factory):
+    solver = MultiShaftEqualRatioSolver(process_pipelines=[])
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+
+    solution = solver.find_solution(FloatConstraint(270.0, abs_tol=5.0), inlet)
+
+    assert solution.success
+    assert solution.configuration == []
+    assert solution.failure_event is None
+
+
+def test_single_pipeline_hits_exact_target(stream_factory, pipeline_kwargs):
+    """With one pipeline the target is the exact constraint (no intermediate splitting)."""
+    pipeline = make_process_pipeline(min_rate=200, max_rate=5000, **pipeline_kwargs)
+    solver = MultiShaftEqualRatioSolver(process_pipelines=[pipeline])
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+
+    solution = solver.find_solution(FloatConstraint(60.0, abs_tol=0.5), inlet)
+
+    assert solution.success
+    pipeline.runner.apply_configurations(solution.configuration)
+    outlet = pipeline.runner.run(inlet)
+    assert outlet.pressure_bara == pytest.approx(60.0, abs=0.5)
+
+
+def test_two_pipeline_intermediate_target_is_geometric_mean(stream_factory, pipeline_kwargs):
+    """With two pipelines the intermediate target should be sqrt(P_in * P_out)."""
+    pipelines = [
+        make_process_pipeline(min_rate=200, max_rate=5000, **pipeline_kwargs),
+        make_process_pipeline(min_rate=150, max_rate=3500, **pipeline_kwargs),
+    ]
+    solver = MultiShaftEqualRatioSolver(process_pipelines=pipelines)
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+
+    solution = solver.find_solution(FloatConstraint(120.0, abs_tol=1.0), inlet)
+
+    assert solution.success
+    # First pipeline should target sqrt(30 * 120) ≈ 60 bara
+    intermediate = pipelines[0].runner.run(inlet)
+    assert intermediate.pressure_bara == pytest.approx(60.0, abs=1.0)

--- a/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
@@ -1,0 +1,94 @@
+"""Tests for MultiShaftSolver edge cases."""
+
+import pytest
+
+from libecalc.process.process_solver.float_constraint import FloatConstraint
+from libecalc.process.process_solver.multi_shaft_solver import MultiShaftSolver
+from tests.libecalc.process.process_solver.test_multi_shaft_equal_ratio_solver import make_process_pipeline
+
+
+def test_mismatched_targets_raises(stream_factory, fluid_service, root_finding_strategy):
+    pipelines = [
+        make_process_pipeline(
+            min_rate=200,
+            max_rate=5000,
+            head_hi=200_000,
+            head_lo=140_000,
+            inlet_temperature_kelvin=303.15,
+            fluid_service=fluid_service,
+            root_finding_strategy=root_finding_strategy,
+        )
+    ]
+    solver = MultiShaftSolver(process_pipelines=pipelines)
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+
+    with pytest.raises(AssertionError, match="must match"):
+        solver.find_solution([FloatConstraint(50.0), FloatConstraint(100.0)], inlet)
+
+
+def test_empty_pipelines(stream_factory):
+    solver = MultiShaftSolver(process_pipelines=[])
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+
+    solution = solver.find_solution([], inlet)
+
+    assert solution.success
+    assert solution.configuration == []
+    assert solution.failure_event is None
+
+
+def test_unreachable_target_reports_failure(stream_factory, fluid_service, root_finding_strategy):
+    """A target far beyond the chart capability should return success=False."""
+    pipelines = [
+        make_process_pipeline(
+            min_rate=200,
+            max_rate=5000,
+            head_hi=200_000,
+            head_lo=140_000,
+            inlet_temperature_kelvin=303.15,
+            fluid_service=fluid_service,
+            root_finding_strategy=root_finding_strategy,
+        )
+    ]
+    solver = MultiShaftSolver(process_pipelines=pipelines)
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+
+    # 9000 bara from 30 bara inlet is far beyond what a single stage can deliver
+    solution = solver.find_solution([FloatConstraint(9000.0)], inlet)
+
+    assert not solution.success
+    assert solution.failure_event is not None
+
+
+def test_second_pipeline_failure_preserves_first_failure(stream_factory, fluid_service, root_finding_strategy):
+    """When multiple pipelines fail, the first failure_event is preserved."""
+    pipelines = [
+        make_process_pipeline(
+            min_rate=200,
+            max_rate=5000,
+            head_hi=200_000,
+            head_lo=140_000,
+            inlet_temperature_kelvin=303.15,
+            fluid_service=fluid_service,
+            root_finding_strategy=root_finding_strategy,
+        ),
+        make_process_pipeline(
+            min_rate=200,
+            max_rate=5000,
+            head_hi=200_000,
+            head_lo=140_000,
+            inlet_temperature_kelvin=303.15,
+            fluid_service=fluid_service,
+            root_finding_strategy=root_finding_strategy,
+        ),
+    ]
+    solver = MultiShaftSolver(process_pipelines=pipelines)
+    inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
+
+    # Both targets unreachable
+    solution = solver.find_solution([FloatConstraint(9000.0), FloatConstraint(90000.0)], inlet)
+
+    assert not solution.success
+    assert solution.failure_event is not None
+    # Configurations are still collected (best-effort from each pipeline)
+    assert len(solution.configuration) > 0

--- a/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
@@ -1,0 +1,82 @@
+"""Compare MultiShaftEqualRatioSolver outlet against CompressorTrainSimplified (legacy).
+
+Both models split the overall pressure target into equal per-stage ratios.
+"""
+
+import pytest
+
+from libecalc.domain.process.compressor.core.train.simplified_train.simplified_train import CompressorTrainSimplified
+from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
+from libecalc.process.process_solver.float_constraint import FloatConstraint
+from libecalc.process.process_solver.multi_shaft_equal_ratio_solver import MultiShaftEqualRatioSolver
+from tests.libecalc.process.process_solver.test_multi_shaft_equal_ratio_solver import (
+    make_process_pipeline,
+    make_variable_speed_chart,
+)
+
+_RATE_SM3_DAY = 1_500_000.0
+_P_IN_BARA = 30.0
+_P_OUT_BARA = 270.0
+_T_IN_KELVIN = 303.15
+_N_STAGES = 3
+_HEAD_HI = 200_000.0
+_HEAD_LO = 140_000.0
+_MIN_RATE = 200.0
+_MAX_RATE = 5_000.0
+
+
+def test_multi_shaft_outlet_pressure_matches_simplified_train(
+    stream_factory,
+    fluid_service,
+    root_finding_strategy,
+    compressor_stage_factory,
+):
+    """Outlet pressure should match within 1% relative tolerance."""
+    # Legacy: CompressorTrainSimplified
+    chart_data = make_variable_speed_chart(_MIN_RATE, _MAX_RATE, _HEAD_HI, _HEAD_LO)
+    legacy_stages = [
+        compressor_stage_factory(compressor_chart_data=chart_data, inlet_temperature_kelvin=_T_IN_KELVIN)
+        for _ in range(_N_STAGES)
+    ]
+    legacy_train = CompressorTrainSimplified(stages=legacy_stages, fluid_service=fluid_service)
+    inlet_stream = stream_factory(
+        standard_rate_m3_per_day=_RATE_SM3_DAY,
+        pressure_bara=_P_IN_BARA,
+        temperature_kelvin=_T_IN_KELVIN,
+    )
+    legacy_train._fluid_model = [inlet_stream.fluid_model]
+    legacy_result = legacy_train.evaluate_given_constraints(
+        CompressorTrainEvaluationInput(
+            suction_pressure=_P_IN_BARA,
+            discharge_pressure=_P_OUT_BARA,
+            rates=[_RATE_SM3_DAY],
+        )
+    )
+    legacy_outlet = legacy_result.outlet_stream
+
+    # New: MultiShaftEqualRatioSolver
+    solver_pipelines = [
+        make_process_pipeline(
+            min_rate=_MIN_RATE,
+            max_rate=_MAX_RATE,
+            head_hi=_HEAD_HI,
+            head_lo=_HEAD_LO,
+            inlet_temperature_kelvin=_T_IN_KELVIN,
+            fluid_service=fluid_service,
+            root_finding_strategy=root_finding_strategy,
+        )
+        for _ in range(_N_STAGES)
+    ]
+    solver = MultiShaftEqualRatioSolver(process_pipelines=solver_pipelines)
+    solution = solver.find_solution(FloatConstraint(_P_OUT_BARA, abs_tol=1.0), inlet_stream)
+
+    assert solution.success, f"Solver failed: {solution.failure_event}"
+
+    current = inlet_stream
+    for pipeline in solver_pipelines:
+        current = pipeline.runner.run(current)
+    new_outlet = current
+
+    assert new_outlet.pressure_bara == pytest.approx(legacy_outlet.pressure_bara, rel=0.01)
+    assert new_outlet.temperature_kelvin == pytest.approx(legacy_outlet.temperature_kelvin, rel=0.01)
+    assert new_outlet.density == pytest.approx(legacy_outlet.density, rel=0.01)


### PR DESCRIPTION
Replaces earlier efforts: 
https://github.com/equinor/ecalc/pull/1483
https://github.com/equinor/ecalc/pull/1519


Adds two solvers for compressor trains where each rotating equipment sits on its own shaft:

**`MultiShaftSolver`** — general sequential solver. Takes a list of process pipelines (`OutletPressureSolver`) and one pressure target per pipeline. Solves each pipeline in flow order, feeding the outlet of one into the next. The caller controls how the overall pressure is distributed across pipelines.

**`MultiShaftEqualRatioSolver`** — convenience wrapper that splits the overall pressure target into equal per-pipeline ratios (`target_i = P_in × ratio^(i+1)`), matching the strategy used by the legacy `CompressorTrainSimplified`. The final target is set to the exact requested constraint to avoid floating-point drift.

**Comparison of the properties of the computed outlet stream with legacy `CompressorTrainSimplified`:**

| Property | Relative error |
|---|---|
| Pressure | 4.8 × 10⁻⁹ |
| Temperature | 1.3 × 10⁻⁵ |
| Density | 1.9 × 10⁻⁵ |

| Solver | Avg time (1000 runs) |
|---|---|
| `CompressorTrainSimplified` | 4.66 ms |
| `MultiShaftEqualRatioSolver` | 4.71 ms |