### PR TITLE
fix: upstream choke solver reports false success when choking exceeds rate capacity

### DIFF
--- a/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
+++ b/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 
+from libecalc.domain.process.compressor.core.train.utils.common import PRESSURE_CALCULATION_TOLERANCE
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooHighError
 from libecalc.process.process_solver.boundary import Boundary
@@ -9,6 +10,11 @@ from libecalc.process.process_solver.solver import Solution, Solver, SolverFailu
 
 
 class UpstreamChokeSolver(Solver):
+    """Find the upstream ΔP that makes outlet pressure match a target.
+
+    Precondition: unchoked outlet pressure must exceed target (caller guarantees this).
+    """
+
     def __init__(
         self,
         root_finding_strategy: RootFindingStrategy,
@@ -16,50 +22,53 @@ class UpstreamChokeSolver(Solver):
         delta_pressure_boundary: Boundary,
     ):
         self._target_pressure = target_pressure
-        self._delta_pressure_boundary = delta_pressure_boundary
+        self._boundary = delta_pressure_boundary
         self._root_finding_strategy = root_finding_strategy
 
     def solve(self, func: Callable[[ChokeConfiguration], FluidStream]) -> Solution[ChokeConfiguration]:
-        def outlet_pressure(config: ChokeConfiguration) -> float:
-            """Evaluate outlet pressure, treating RateTooHighError as infeasible (pressure = 0).
+        def outlet_pressure(delta_pressure: float) -> float:
+            return func(ChokeConfiguration(delta_pressure=delta_pressure)).pressure_bara
 
-            A large upstream pressure drop drives suction pressure towards zero, causing actual
-            volumetric flow to exceed the maximum rate the compressor chart can handle.
-            When the process signals RateTooHighError the operating point is infeasible;
-            returning 0 tells the solver that maximum choking brackets
-            the target from below, so the algorithm converges in the feasible region.
-            """
-            try:
-                return func(config).pressure_bara
-            except RateTooHighError:
-                return 0.0
+        assert outlet_pressure(0) > self._target_pressure
 
-        choke_configuration = ChokeConfiguration(delta_pressure=0)
-        if outlet_pressure(choke_configuration) <= self._target_pressure:
-            # Don't use choke if outlet pressure is below target
-            return Solution(
-                success=outlet_pressure(choke_configuration) == self._target_pressure,
-                configuration=choke_configuration,
-            )
+        search_boundary = self._feasible_boundary(func)
+        max_pressure = outlet_pressure(search_boundary.max)
 
-        # Evaluate outlet pressure at maximum allowed upstream ΔP (within boundary).
-        max_cfg = ChokeConfiguration(delta_pressure=self._delta_pressure_boundary.max)
-        max_cfg_pressure = outlet_pressure(max_cfg)
-        if max_cfg_pressure > self._target_pressure:
-            # If we are still above target even at max choking, then no solution exists within the boundary.
+        if max_pressure > self._target_pressure:
             return Solution(
                 success=False,
-                configuration=max_cfg,
+                configuration=ChokeConfiguration(delta_pressure=search_boundary.max),
                 failure_event=TargetNotAchievableEvent(
                     status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=max_cfg_pressure,
+                    achievable_value=max_pressure,
                     target_value=self._target_pressure,
                 ),
             )
 
-        pressure_change = self._root_finding_strategy.find_root(
-            boundary=self._delta_pressure_boundary,
-            func=lambda x: outlet_pressure(ChokeConfiguration(delta_pressure=x)) - self._target_pressure,
+        delta_pressure = self._root_finding_strategy.find_root(
+            boundary=search_boundary,
+            func=lambda x: outlet_pressure(x) - self._target_pressure,
         )
+        return Solution(success=True, configuration=ChokeConfiguration(delta_pressure=delta_pressure))
 
-        return Solution(success=True, configuration=ChokeConfiguration(delta_pressure=pressure_change))
+    def _feasible_boundary(self, func: Callable[[ChokeConfiguration], FluidStream]) -> Boundary:
+        """Return the search boundary narrowed to the feasible region (no RateTooHighError).
+
+        Probes the upper bound first; if feasible, returns the original boundary immediately.
+        Otherwise bisects for the largest ΔP before rate capacity is exceeded.
+        """
+        try:
+            func(ChokeConfiguration(delta_pressure=self._boundary.max))
+            return self._boundary
+        except RateTooHighError:
+            pass
+
+        lo, hi = self._boundary.min, self._boundary.max
+        while hi - lo > PRESSURE_CALCULATION_TOLERANCE:
+            mid = (lo + hi) / 2
+            try:
+                func(ChokeConfiguration(delta_pressure=mid))
+                lo = mid
+            except RateTooHighError:
+                hi = mid
+        return Boundary(min=self._boundary.min, max=lo)

--- a/tests/libecalc/process/process_solver/pressure_control/test_upstream_choke_pressure_control_strategy.py
+++ b/tests/libecalc/process/process_solver/pressure_control/test_upstream_choke_pressure_control_strategy.py
@@ -1,10 +1,12 @@
+import pytest
+
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.upstream_choke import (
     UpstreamChokePressureControlStrategy,
 )
 
 
-def test_upstream_choke_strategy_baseline_below_target_does_not_choke(
+def test_upstream_choke_strategy_asserts_when_baseline_below_target(
     simple_process_unit_factory,
     stream_factory,
     choke_factory,
@@ -12,9 +14,7 @@ def test_upstream_choke_strategy_baseline_below_target_does_not_choke(
     root_finding_strategy,
     process_runner_factory,
 ):
-    """
-    Does not apply upstream choking when baseline outlet pressure is already below the target.
-    """
+    """Upstream choke strategy requires unchoked outlet to exceed target (caller must guard)."""
     upstream_choke = choke_factory()
     upstream_choke_configuration_handler = choke_configuration_handler_factory(choke=upstream_choke)
     process_units = [upstream_choke, simple_process_unit_factory(pressure_multiplier=1)]
@@ -29,20 +29,8 @@ def test_upstream_choke_strategy_baseline_below_target_does_not_choke(
     inlet_stream = stream_factory(standard_rate_m3_per_day=1000, pressure_bara=50)
     target_pressure = FloatConstraint(70.0, abs_tol=1e-12)
 
-    solution = strategy.apply(target_pressure=target_pressure, inlet_stream=inlet_stream)
-    assert solution.success is False
-
-    choke_configuration = [
-        config
-        for config in solution.configuration
-        if config.configuration_handler_id == upstream_choke_configuration_handler.get_id()
-    ][0]
-    assert choke_configuration.value.delta_pressure == 0
-
-    # Ensure choke is not applied (baseline-run uses delta_pressure=0.0)
-    runner.apply_configurations(solution.configuration)
-    outlet_stream_no_choke = runner.run(inlet_stream=inlet_stream)
-    assert outlet_stream_no_choke.pressure_bara < target_pressure
+    with pytest.raises(AssertionError):
+        strategy.apply(target_pressure=target_pressure, inlet_stream=inlet_stream)
 
 
 def test_upstream_choke_strategy_baseline_above_target_chokes_to_target(

--- a/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
+++ b/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
@@ -1,5 +1,3 @@
-import pytest
-
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.domain.process.compressor.core.train.utils.common import EPSILON
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
@@ -11,31 +9,21 @@ from libecalc.process.process_solver.solvers.downstream_choke_solver import Chok
 from libecalc.process.process_solver.solvers.upstream_choke_solver import UpstreamChokeSolver
 
 
-@pytest.mark.parametrize(
-    "inlet_pressure, target_pressure, expected_pressure",
-    [
-        (100, 70, 70),  # Choked
-        (50, 70, 50),  # Not choked
-    ],
-)
 def test_upstream_choke_solver(
     root_finding_strategy,
     simple_process_unit_factory,
     fluid_service,
     stream_factory,
-    inlet_pressure,
-    target_pressure,
-    expected_pressure,
     choke_factory,
 ):
     choke = choke_factory()
     process_units = [choke, simple_process_unit_factory(pressure_multiplier=1)]
 
-    inlet_stream = stream_factory(standard_rate_m3_per_day=1000, pressure_bara=inlet_pressure)
+    inlet_stream = stream_factory(standard_rate_m3_per_day=1000, pressure_bara=100)
 
     upstream_choke_solver = UpstreamChokeSolver(
         root_finding_strategy=root_finding_strategy,
-        target_pressure=target_pressure,
+        target_pressure=70,
         delta_pressure_boundary=Boundary(min=EPSILON, max=inlet_stream.pressure_bara - EPSILON),
     )
 
@@ -46,7 +34,7 @@ def test_upstream_choke_solver(
     assert upstream_choke_solver.solve(choke_func)
     outlet_stream = propagate_stream_many(process_units=process_units, inlet_stream=inlet_stream)
 
-    assert outlet_stream.pressure_bara == expected_pressure
+    assert outlet_stream.pressure_bara == 70
 
 
 def test_upstream_choke_solver_handles_rate_too_high_at_max_choke(
@@ -87,3 +75,71 @@ def test_upstream_choke_solver_handles_rate_too_high_at_max_choke(
 
     assert solution.success
     assert abs(solution.configuration.delta_pressure - 70.0) < 1e-3
+
+
+def test_upstream_choke_solver_reports_failure_when_rate_capacity_prevents_reaching_target(
+    root_finding_strategy,
+    stream_factory,
+):
+    """When RateTooHighError creates a discontinuity that prevents the outlet from reaching
+    the target, the solver must report failure rather than false success at the discontinuity boundary.
+
+    Scenario: outlet = inlet - dp + 50. RateTooHighError at dp > 40 (suction < 60).
+    Target = 80 requires dp = 70, which is in the infeasible region.
+    Root-finding converges at dp ≈ 40 (discontinuity boundary) where actual outlet = 110, not 80.
+    """
+    inlet_pressure = 100.0
+    feasible_suction_minimum = 60.0  # RateTooHighError below this
+    pressure_added = 50.0
+    target_pressure = 80.0  # Requires dp=70, infeasible (max feasible dp=40)
+
+    upstream_choke_solver = UpstreamChokeSolver(
+        root_finding_strategy=root_finding_strategy,
+        target_pressure=target_pressure,
+        delta_pressure_boundary=Boundary(min=EPSILON, max=inlet_pressure - EPSILON),
+    )
+
+    def choke_func(configuration: ChokeConfiguration) -> FluidStream:
+        suction_pressure = inlet_pressure - configuration.delta_pressure
+        if suction_pressure < feasible_suction_minimum:
+            raise RateTooHighError(process_unit_id=ProcessUnitId(ecalc_id_generator()))
+        return stream_factory(
+            standard_rate_m3_per_day=1000,
+            pressure_bara=suction_pressure + pressure_added,
+        )
+
+    solution = upstream_choke_solver.solve(choke_func)
+
+    assert not solution.success
+    assert solution.failure_event is not None
+    assert solution.failure_event.target_value == target_pressure
+    assert solution.failure_event.achievable_value > target_pressure
+
+
+def test_upstream_choke_solver_reports_failure_when_max_choke_still_above_target(
+    root_finding_strategy,
+    stream_factory,
+):
+    inlet_pressure = 100.0
+    pressure_added = 200.0
+    target_pressure = 80.0  # max choke gives ~0 + 200 = 200, still above 80
+
+    upstream_choke_solver = UpstreamChokeSolver(
+        root_finding_strategy=root_finding_strategy,
+        target_pressure=target_pressure,
+        delta_pressure_boundary=Boundary(min=EPSILON, max=inlet_pressure - EPSILON),
+    )
+
+    def choke_func(configuration: ChokeConfiguration) -> FluidStream:
+        suction_pressure = inlet_pressure - configuration.delta_pressure
+        return stream_factory(
+            standard_rate_m3_per_day=1000,
+            pressure_bara=suction_pressure + pressure_added,
+        )
+
+    solution = upstream_choke_solver.solve(choke_func)
+
+    assert not solution.success
+    assert solution.failure_event is not None
+    assert solution.failure_event.target_value == target_pressure
+    assert solution.failure_event.achievable_value > target_pressure


### PR DESCRIPTION
## Problem

The upstream choke solver uses `RateTooHighError → 0` as a surrogate to bracket the root-finding. This works when the true root lies in the feasible region of the compressor chart. But when the target pressure requires enough choking that the reduced suction pressure drives the actual volumetric flow rate beyond the chart's maximum, root-finding converges on the discontinuity instead of a real root, and the solver reports success with an outlet pressure that doesn't match the target.

## Fix

When the upper boundary of the search interval falls in the infeasible region (mapped to 0), we first binary-search (using the existing `BinarySearchStrategy`) for the feasibility edge — the largest Δp before the flow rate exceeds chart capacity. If the outlet at that edge is still above target, there is no solution and we return failure. Otherwise we clamp the search boundary to the feasible region so root-finding operates on a continuous function.

## Tests

Also adds tests to cover all viable paths through the upstream choke solver:

- **Rate capacity prevents reaching target**: target requires more choking than the compressor can tolerate before exceeding max rate. Verifies the solver returns `success=False`. Fails on main.
- **Max choke still above target**: even at near-zero suction pressure (no RTH involved), the compressor's head is too high to reach the target. Verifies the existing `max_cfg_pressure > target` early exit returns failure correctly.