### PR TITLE
fix: guard against zero pressure in get_max_standard_rate

### DIFF
--- a/src/libecalc/domain/process/compressor/core/train/base.py
+++ b/src/libecalc/domain/process/compressor/core/train/base.py
@@ -392,6 +392,10 @@ class CompressorTrainModel(ABC):
                 discharge_pressures,
             )
         ):
+            if suction_pressure_value <= 0 or discharge_pressure_value <= 0:
+                max_standard_rate[i] = 0.0
+                continue
+
             constraints = CompressorTrainEvaluationInput(
                 suction_pressure=suction_pressure_value,
                 discharge_pressure=discharge_pressure_value,

--- a/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
@@ -260,6 +260,22 @@ def test_compressor_train_simplified_known_stages_no_indices_to_calculate(
     assert np.all(np.asarray(energy_result.energy_usage.values) == 0)
 
 
+def test_get_max_standard_rate_with_zero_pressure(simplified_compressor_train_factory, fluid_model_rich):
+    compressor_train = simplified_compressor_train_factory()
+    compressor_train.set_evaluation_input(
+        fluid_model=fluid_model_rich,
+        rate=np.asarray([5000000.0, 0.0]),
+        suction_pressure=np.asarray([30.0, 0.0]),
+        discharge_pressure=np.asarray([200.0, 0.0]),
+    )
+    max_rates = compressor_train.get_max_standard_rate(
+        suction_pressures=np.asarray([30.0, 0.0]),
+        discharge_pressures=np.asarray([200.0, 0.0]),
+    )
+    assert max_rates[0] > 0
+    assert max_rates[1] == 0.0
+
+
 # Unit tests individual methods
 def _span_variables(input_variables: list[NDArray[np.float64]]) -> tuple:
     number_of_variables = len(input_variables)


### PR DESCRIPTION
## Problem

When `END:` extends beyond the calibration interval with `TYPE: DEFAULT`, all time series are zero-filled — including suction and discharge pressure. The `get_max_standard_rate` method iterates over all timesteps and calls NeqSim `flash_pt(pressure=0)` to compute inlet density. The Peng-Robinson / SRK equation of state cannot solve the cubic equation at 0 bara, producing a NaN molar volume.

Error: `PhasePrEos:molarVolume - Variable Molar volume is NaN`

Relates to equinor/ecalc-internal#1720

## Fix

Skip timesteps where suction or discharge pressure is ≤ 0 in `get_max_standard_rate`, returning max_rate = 0 for those timesteps. Zero pressure is physically meaningless, and these timesteps correspond to periods where rate is also 0 (machine off).

## Test

Added `test_get_max_standard_rate_with_zero_pressure` — verifies that a mix of valid and zero-pressure timesteps produces a valid max rate for the first and 0 for the second, without crashing.