### PR TITLE
feat: expose compressor operating point properties

### DIFF
--- a/src/libecalc/process/process_units/compressor.py
+++ b/src/libecalc/process/process_units/compressor.py
@@ -24,6 +24,11 @@ class Compressor(ProcessUnit):
         self._compressor_chart = CompressorChart(compressor_chart)
         self._fluid_service = fluid_service
         self._speed: float | None = None
+        self._polytropic_head_joule_per_kg: float | None = None
+        self._polytropic_efficiency: float | None = None
+        self._enthalpy_change_joule_per_kg: float | None = None
+        self._power_megawatt: float | None = None
+        self._actual_rate_m3_per_hour: float | None = None
 
     def get_id(self) -> ProcessUnitId:
         return self._id
@@ -56,12 +61,20 @@ class Compressor(ProcessUnit):
                 rate=actual_rate,
             )
 
-        return calculate_outlet_pressure_and_stream(
+        self._polytropic_head_joule_per_kg = polytropic_head
+        self._polytropic_efficiency = polytropic_efficiency
+        self._actual_rate_m3_per_hour = actual_rate
+
+        outlet_stream = calculate_outlet_pressure_and_stream(
             polytropic_efficiency=polytropic_efficiency,
             polytropic_head_joule_per_kg=polytropic_head,
             inlet_stream=inlet_stream,
             fluid_service=self._fluid_service,
         )
+        enthalpy_change = polytropic_head / polytropic_efficiency
+        self._enthalpy_change_joule_per_kg = enthalpy_change
+        self._power_megawatt = enthalpy_change * inlet_stream.mass_rate_kg_per_h / 1e6 / 3600
+        return outlet_stream
 
     @property
     def compressor_chart(self) -> CompressorChart:
@@ -72,6 +85,38 @@ class Compressor(ProcessUnit):
         if self._speed is None:
             raise ValueError("Speed not set. Compressor must be registered on a Shaft.")
         return self._speed
+
+    @property
+    def polytropic_head_joule_per_kg(self) -> float:
+        if self._polytropic_head_joule_per_kg is None:
+            raise ValueError("No propagation result. Call propagate_stream() first.")
+        return self._polytropic_head_joule_per_kg
+
+    @property
+    def polytropic_efficiency(self) -> float:
+        if self._polytropic_efficiency is None:
+            raise ValueError("No propagation result. Call propagate_stream() first.")
+        return self._polytropic_efficiency
+
+    @property
+    def enthalpy_change_joule_per_kg(self) -> float:
+        if self._enthalpy_change_joule_per_kg is None:
+            raise ValueError("No propagation result. Call propagate_stream() first.")
+        return self._enthalpy_change_joule_per_kg
+
+    @property
+    def power_megawatt(self) -> float:
+        """Power consumed by this compressor stage [MW]."""
+        if self._power_megawatt is None:
+            raise ValueError("No propagation result. Call propagate_stream() first.")
+        return self._power_megawatt
+
+    @property
+    def actual_rate_m3_per_hour(self) -> float:
+        """Volumetric rate at inlet conditions [m3/h]."""
+        if self._actual_rate_m3_per_hour is None:
+            raise ValueError("No propagation result. Call propagate_stream() first.")
+        return self._actual_rate_m3_per_hour
 
     @property
     def minimum_flow_rate(self) -> float:

--- a/tests/libecalc/process/process_units/test_compressor_properties.py
+++ b/tests/libecalc/process/process_units/test_compressor_properties.py
@@ -1,0 +1,47 @@
+import pytest
+
+from tests.libecalc.process.process_units import test_compressor
+
+_inlet_at_midpoint = test_compressor._inlet_at_midpoint
+compressor = test_compressor.compressor
+shaft = test_compressor.shaft
+
+
+def test_properties_populated_after_propagation(stream_factory, compressor, shaft):
+    speed = (shaft.get_speed_boundary().min + shaft.get_speed_boundary().max) / 2
+    shaft.set_speed(speed)
+    inlet = _inlet_at_midpoint(stream_factory, compressor)
+    compressor.propagate_stream(inlet_stream=inlet)
+
+    assert compressor.polytropic_head_joule_per_kg > 0
+    assert 0 < compressor.polytropic_efficiency <= 1.0
+    assert compressor.enthalpy_change_joule_per_kg > 0
+    assert compressor.power_megawatt > 0
+    assert compressor.actual_rate_m3_per_hour == pytest.approx(inlet.volumetric_rate_m3_per_hour)
+
+
+def test_power_is_consistent_with_stream_enthalpy_change_and_mass_rate(stream_factory, compressor, shaft):
+    speed = (shaft.get_speed_boundary().min + shaft.get_speed_boundary().max) / 2
+    shaft.set_speed(speed)
+    inlet = _inlet_at_midpoint(stream_factory, compressor)
+    outlet = compressor.propagate_stream(inlet_stream=inlet)
+
+    expected_enthalpy_change = outlet.enthalpy_joule_per_kg - inlet.enthalpy_joule_per_kg
+    expected_power = expected_enthalpy_change * inlet.mass_rate_kg_per_h / 1e6 / 3600
+    assert compressor.enthalpy_change_joule_per_kg == pytest.approx(expected_enthalpy_change, rel=1e-6)
+    assert compressor.power_megawatt == pytest.approx(expected_power, rel=1e-6)
+
+
+@pytest.mark.parametrize(
+    "property_name",
+    [
+        "polytropic_head_joule_per_kg",
+        "polytropic_efficiency",
+        "enthalpy_change_joule_per_kg",
+        "power_megawatt",
+        "actual_rate_m3_per_hour",
+    ],
+)
+def test_properties_raise_before_propagation(compressor, property_name):
+    with pytest.raises(ValueError, match="propagate_stream"):
+        getattr(compressor, property_name)


### PR DESCRIPTION
## Summary
- store the latest compressor operating-point values computed during `propagate_stream()`
- expose scalar read-only properties for polytropic head, polytropic efficiency, enthalpy change, power, and actual inlet rate
- add focused process-unit tests for populated properties, thermodynamic power consistency, and pre-propagation access errors

## Notes
- intentionally does not expose raw inlet/outlet `FluidStream` objects; tests use the local inlet and returned outlet for independent consistency checks
- Keeping power, enthalpy change, head, efficiency, and actual rate on `Compressor` avoids pushing compressor-domain calculations into callers. Some values can be derived from inlet/outlet streams, but head and efficiency belong to the compressor/chart calculation and are 
otherwise lost after propagation.
