### PR TITLE
fix: harden compressor PH flashes

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -396,38 +396,6 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 75,
-                    "endColumn": 80,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 62,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 62,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
                     "startColumn": 35,
                     "endColumn": 42,
                     "lineCount": 1

--- a/docs/drafts/next.draft.md
+++ b/docs/drafts/next.draft.md
@@ -13,6 +13,12 @@ STP: "flare" column has been added to STP Export - for `FIXED` installations onl
 
 ## Bug Fixes
 
+- Hardened compressor PH flash handling so invalid thermodynamic states are no longer used in compressor outlet calculations.
+
 ## Breaking changes
+
+### Compressor calculations
+
+- Compressor calculations now validate PH flash results more strictly. Existing models that previously completed with invalid or non-physical PH flash states may now fail or report invalid compressor/capacity results instead.
 
 ### CLI

--- a/src/ecalc_neqsim_wrapper/exceptions.py
+++ b/src/ecalc_neqsim_wrapper/exceptions.py
@@ -1,3 +1,14 @@
+from jpype import JException  # pyright: ignore[reportMissingTypeStubs]
+from py4j.protocol import Py4JError  # pyright: ignore[reportMissingTypeStubs]
+
+from libecalc.process.fluid_stream.exceptions import FluidFlashCalculationError
+
+# Unified tuple of Java bridge exception types for except clauses.
+# Py4JError is the base for all Py4J exceptions (including Py4JJavaError, Py4JNetworkError).
+# JException is the base for all Java exceptions when using JPype.
+JAVA_ERRORS: tuple[type[Exception], ...] = (Py4JError, JException)
+
+
 class NeqsimError(Exception):
     """Base class for NeqSim related errors"""
 
@@ -16,4 +27,11 @@ class NeqsimComponentError(NeqsimError):
     def __init__(self, component_name: str):
         self.component_name = component_name
         message = f"Unknown component '{component_name}' from NeqSim. Check if the component is supported in eCalc."
+        super().__init__(message)
+
+
+class NeqsimFlashCalculationError(NeqsimError, FluidFlashCalculationError):
+    """Error raised when a NeqSim flash calculation fails or returns an unusable state."""
+
+    def __init__(self, message: str):
         super().__init__(message)

--- a/src/ecalc_neqsim_wrapper/fluid_service.py
+++ b/src/ecalc_neqsim_wrapper/fluid_service.py
@@ -13,11 +13,13 @@ import logging
 from typing import ClassVar
 
 from ecalc_neqsim_wrapper.cache_service import CacheConfig, CacheName, CacheService, LRUCache
+from ecalc_neqsim_wrapper.exceptions import NeqsimFlashCalculationError
 from ecalc_neqsim_wrapper.thermo import NeqsimFluid
 from libecalc.process.fluid_stream.constants import ThermodynamicConstants
 from libecalc.process.fluid_stream.fluid import Fluid
 from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
 from libecalc.process.fluid_stream.fluid_properties import FluidProperties
+from libecalc.process.fluid_stream.fluid_property_validation import validate_ph_flash_result
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 
@@ -56,7 +58,7 @@ class NeqSimFluidService(FluidService):
     Usage:
         service = NeqSimFluidService.instance()
         props = service.flash_pt(fluid_model, pressure_bara, temperature_kelvin)
-        props = service.flash_ph(fluid_model, pressure_bara, target_enthalpy)
+        props = service.flash_ph(fluid_model, pressure_bara, target_enthalpy_joule_per_kg)
     """
 
     _instance: ClassVar[NeqSimFluidService | None] = None
@@ -200,7 +202,7 @@ class NeqSimFluidService(FluidService):
         )
 
     def _make_ph_cache_key(
-        self, composition_key: tuple, eos_model: EoSModel, pressure: float, target_enthalpy: float
+        self, composition_key: tuple, eos_model: EoSModel, pressure: float, target_enthalpy_joule_per_kg: float
     ) -> tuple:
         """Create cache key for PH flash with proper rounding.
 
@@ -209,13 +211,15 @@ class NeqSimFluidService(FluidService):
             ("PH", composition_key, eos_model, rounded_pressure, rounded_enthalpy)
 
             This ensures unique cache entries for each distinct thermodynamic state.
+            The temperature guess is intentionally not part of this key; it is
+            a convergence aid, not part of the PH target state.
         """
         return (
             "PH",
             composition_key,
             eos_model,
             round(pressure, _PRESSURE_DECIMALS),
-            round(target_enthalpy, _ENTHALPY_DECIMALS),
+            round(target_enthalpy_joule_per_kg, _ENTHALPY_DECIMALS),
         )
 
     def _get_standard_density(self, fluid_model: FluidModel) -> float:
@@ -310,12 +314,13 @@ class NeqSimFluidService(FluidService):
         self,
         fluid_model: FluidModel,
         pressure_bara: float,
-        target_enthalpy: float,
+        target_enthalpy_joule_per_kg: float,
+        temperature_guess_kelvin: float | None = None,
     ) -> FluidProperties:
         """PH flash to target pressure and enthalpy.
 
-        Note: The target_enthalpy is reference-state dependent. NeqSim uses an arbitrary
-        enthalpy reference state, so the caller must ensure that target_enthalpy was
+        Note: The target_enthalpy_joule_per_kg is reference-state dependent. NeqSim uses an arbitrary
+        enthalpy reference state, so the caller must ensure that target_enthalpy_joule_per_kg was
         computed from enthalpy values obtained from the same EoS/fluid model session.
         Mixing enthalpy values from different thermodynamic packages or sessions may
         produce incorrect results.
@@ -323,14 +328,24 @@ class NeqSimFluidService(FluidService):
         Args:
             fluid_model: The fluid model (composition + EoS)
             pressure_bara: Target pressure in bara
-            target_enthalpy: Target specific enthalpy in J/kg (must be from same EoS session)
-
+            target_enthalpy_joule_per_kg: Target specific enthalpy in J/kg (must be from same EoS session)
+            temperature_guess_kelvin: Optional initial temperature for PH. When provided, the cached reference fluid is
+                first TP-flashed at the target pressure and this temperature before the same PH target is solved. This
+                is a convergence aid for callers with a physically relevant temperature estimate
+                (or a T closer to target T than T_standard at least); it will not change
+                a correctly converged PH result and is intentionally not part of the PH cache key.
+                note: this can avoid some bad initial states for the PH flash in some edge cases
         Returns:
             FluidProperties at the specified conditions.
         """
         composition = fluid_model.composition.normalized()
         composition_key = _make_composition_key(composition)
-        cache_key = self._make_ph_cache_key(composition_key, fluid_model.eos_model, pressure_bara, target_enthalpy)
+        cache_key = self._make_ph_cache_key(
+            composition_key,
+            fluid_model.eos_model,
+            pressure_bara,
+            target_enthalpy_joule_per_kg,
+        )
 
         # Check cache first
         cached = self._flash_cache.get(cache_key)
@@ -338,12 +353,28 @@ class NeqSimFluidService(FluidService):
             return cached
 
         ref = self._get_reference_fluid(fluid_model)
-        flashed = ref.set_new_pressure_and_enthalpy(
-            new_pressure=pressure_bara,
-            new_enthalpy_joule_per_kg=target_enthalpy,
-        )
+        if temperature_guess_kelvin is not None:
+            seeded_fluid = ref.set_new_pressure_and_temperature(
+                new_pressure_bara=pressure_bara,
+                new_temperature_kelvin=temperature_guess_kelvin,
+            )
+            flashed = seeded_fluid.set_new_pressure_and_enthalpy(
+                new_pressure=pressure_bara,
+                new_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+            )
+        else:
+            flashed = ref.set_new_pressure_and_enthalpy(
+                new_pressure=pressure_bara,
+                new_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+            )
 
         result = self._extract_properties(flashed, fluid_model)
+        validate_ph_flash_result(
+            result,
+            target_enthalpy_joule_per_kg,
+            "NeqSimFluidService.flash_ph",
+            error_factory=NeqsimFlashCalculationError,
+        )
         self._flash_cache.put(cache_key, result)
         return result
 

--- a/src/ecalc_neqsim_wrapper/thermo.py
+++ b/src/ecalc_neqsim_wrapper/thermo.py
@@ -6,12 +6,17 @@ from collections import defaultdict
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Protocol, assert_never
+from typing import Any, Protocol, assert_never
 
 from pydantic import BaseModel
 
 from ecalc_neqsim_wrapper.components import COMPONENTS
-from ecalc_neqsim_wrapper.exceptions import NeqsimComponentError, NeqsimPhaseError
+from ecalc_neqsim_wrapper.exceptions import (
+    JAVA_ERRORS,
+    NeqsimComponentError,
+    NeqsimFlashCalculationError,
+    NeqsimPhaseError,
+)
 from ecalc_neqsim_wrapper.java_service import NeqsimService
 from ecalc_neqsim_wrapper.mappings import (
     NeqsimComposition,
@@ -31,7 +36,7 @@ NEQSIM_MIXING_RULE = 2
 
 
 class ThermodynamicSystem(Protocol):
-    pass
+    def clone(self) -> Any: ...
 
 
 class ThermodynamicOperations(Protocol):
@@ -368,14 +373,20 @@ class NeqsimFluid:
 
         Use clone_gas_phase() on the result if you need gas phase only.
         """
-        new_thermodynamic_system = self._thermodynamic_system.clone()
-        new_thermodynamic_system.setPressure(float(new_pressure), "bara")
+        try:
+            new_thermodynamic_system = self._thermodynamic_system.clone()
+            new_thermodynamic_system.setPressure(float(new_pressure), "bara")
 
-        new_thermodynamic_system = NeqsimFluid._ph_flash(
-            thermodynamic_system=new_thermodynamic_system,
-            enthalpy=new_enthalpy_joule_per_kg,
-            use_gerg=self._use_gerg,
-        )
+            new_thermodynamic_system = NeqsimFluid._ph_flash(
+                thermodynamic_system=new_thermodynamic_system,
+                enthalpy=new_enthalpy_joule_per_kg,
+                use_gerg=self._use_gerg,
+            )
+        except JAVA_ERRORS as error:
+            raise NeqsimFlashCalculationError(
+                "NeqSim PH flash failed. "
+                f"pressure_bara={new_pressure}, target_enthalpy_joule_per_kg={new_enthalpy_joule_per_kg}."
+            ) from error
 
         return NeqsimFluid(thermodynamic_system=new_thermodynamic_system, use_gerg=self._use_gerg)
 
@@ -387,13 +398,19 @@ class NeqsimFluid:
 
         Use clone_gas_phase() on the result if you need gas phase only.
         """
-        new_thermodynamic_system = self._thermodynamic_system.clone()
-        new_thermodynamic_system.setPressure(float(new_pressure_bara), "bara")
-        new_thermodynamic_system.setTemperature(float(new_temperature_kelvin), "K")
+        try:
+            new_thermodynamic_system = self._thermodynamic_system.clone()
+            new_thermodynamic_system.setPressure(float(new_pressure_bara), "bara")
+            new_thermodynamic_system.setTemperature(float(new_temperature_kelvin), "K")
 
-        new_thermodynamic_system = NeqsimFluid._tp_flash(
-            thermodynamic_system=new_thermodynamic_system, use_gerg=self._use_gerg
-        )
+            new_thermodynamic_system = NeqsimFluid._tp_flash(
+                thermodynamic_system=new_thermodynamic_system, use_gerg=self._use_gerg
+            )
+        except JAVA_ERRORS as error:
+            raise NeqsimFlashCalculationError(
+                "NeqSim TP flash failed. "
+                f"pressure_bara={new_pressure_bara}, temperature_kelvin={new_temperature_kelvin}."
+            ) from error
 
         return NeqsimFluid(thermodynamic_system=new_thermodynamic_system, use_gerg=self._use_gerg)
 

--- a/src/libecalc/domain/process/compressor/core/exceptions.py
+++ b/src/libecalc/domain/process/compressor/core/exceptions.py
@@ -1,0 +1,28 @@
+from collections.abc import Mapping
+
+
+class CompressorThermodynamicCalculationError(Exception):
+    """Raised when compressor thermodynamics cannot produce a usable state."""
+
+    def __init__(
+        self,
+        operation: str,
+        reason: str,
+        details: Mapping[str, object | None] | None = None,
+    ):
+        self.operation = operation
+        self.reason = reason
+        self.details = {name: value for name, value in (details or {}).items() if value is not None}
+        super().__init__(self._format_message())
+
+    def _format_message(self) -> str:
+        message = f"Compressor thermodynamic calculation failed during {self.operation}: {self.reason}"
+        if not self.details:
+            return message
+
+        formatted_details = ", ".join(f"{name}={value}" for name, value in self.details.items())
+        return f"{message} Context: {formatted_details}."
+
+
+class CompressorOutletCalculationError(CompressorThermodynamicCalculationError):
+    """Raised when compressor outlet thermodynamics cannot produce a usable state."""

--- a/src/libecalc/domain/process/compressor/core/train/simplified_train/simplified_train.py
+++ b/src/libecalc/domain/process/compressor/core/train/simplified_train/simplified_train.py
@@ -3,12 +3,14 @@ import numpy as np
 from libecalc.common.errors.exceptions import IllegalStateException
 from libecalc.common.logger import logger
 from libecalc.common.units import UnitConstants
+from libecalc.domain.process.compressor.core.exceptions import CompressorThermodynamicCalculationError
 from libecalc.domain.process.compressor.core.results import (
     CompressorTrainResultSingleTimeStep,
 )
 from libecalc.domain.process.compressor.core.train.base import CompressorTrainModel
 from libecalc.domain.process.compressor.core.train.stage import CompressorTrainStage
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
+from libecalc.domain.process.compressor.core.train.utils.common import flash_ph_for_compressor_calculation
 from libecalc.domain.process.compressor.core.train.utils.enthalpy_calculations import (
     calculate_polytropic_head_campbell,
 )
@@ -243,6 +245,7 @@ class CompressorTrainSimplified(CompressorTrainModel):
             raise IllegalStateException(error_message)
 
         maximum_rate_function = compressor_chart.get_maximum_rate
+        maximum_head_on_maximum_speed_curve = float(np.max(compressor_chart.maximum_speed_curve.head_values))
         polytropic_head = float(
             np.mean(compressor_chart.maximum_speed_curve.head_values)
         )  # Initial guess for polytropic head
@@ -278,8 +281,44 @@ class CompressorTrainSimplified(CompressorTrainModel):
             )
             enthalpy_change_joule_per_kg = polytropic_head / polytropic_efficiency
 
-            target_enthalpy = inlet_stream.enthalpy_joule_per_kg + enthalpy_change_joule_per_kg
-            props = fluid_service.flash_ph(inlet_stream.fluid_model, outlet_pressure, target_enthalpy)
+            target_enthalpy_joule_per_kg = inlet_stream.enthalpy_joule_per_kg + enthalpy_change_joule_per_kg
+            try:
+                props = flash_ph_for_compressor_calculation(
+                    fluid_service=fluid_service,
+                    inlet_stream=inlet_stream,
+                    outlet_pressure_bara=outlet_pressure,
+                    target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+                    operation="simplified compressor train maximum-rate PH flash",
+                    details={
+                        "pressure_ratio": pressure_ratio,
+                        "polytropic_head_joule_per_kg": polytropic_head,
+                        "polytropic_efficiency": polytropic_efficiency,
+                        "maximum_head_on_maximum_speed_curve": maximum_head_on_maximum_speed_curve,
+                    },
+                )
+            except CompressorThermodynamicCalculationError:
+                is_above_chart_maximum_head = polytropic_head > maximum_head_on_maximum_speed_curve
+                if not is_above_chart_maximum_head:
+                    raise
+
+                logger.debug(
+                    "Simplified train: outlet PH flash failed while estimating maximum rate above chart maximum head. "
+                    "Using chart-limited maximum rate. pressure_ratio=%s, outlet_pressure=%s, polytropic_head=%s, "
+                    "maximum_head_on_maximum_speed_curve=%s",
+                    pressure_ratio,
+                    outlet_pressure,
+                    polytropic_head,
+                    maximum_head_on_maximum_speed_curve,
+                    exc_info=True,
+                )
+                chart_limited_maximum_actual_volume_rate = float(
+                    maximum_rate_function(
+                        heads=polytropic_head,  # type: ignore[arg-type]
+                        extrapolate_heads_below_minimum=False,
+                    )
+                )
+                maximum_actual_volume_rate = chart_limited_maximum_actual_volume_rate
+                break
             outlet_fluid = Fluid(fluid_model=inlet_stream.fluid_model, properties=props)
             outlet_stream = inlet_stream.with_new_fluid(outlet_fluid)
 

--- a/src/libecalc/domain/process/compressor/core/train/stage.py
+++ b/src/libecalc/domain/process/compressor/core/train/stage.py
@@ -410,8 +410,15 @@ class CompressorTrainStage:
             head_exceeds_maximum = False
             exceeds_capacity = False
 
-        target_enthalpy = float(inlet_stream.enthalpy_joule_per_kg + polytropic_enthalpy_change_to_use_joule_per_kg)
-        props = self._fluid_service.flash_ph(inlet_stream.fluid_model, float(outlet_pressure), target_enthalpy)
+        target_enthalpy_joule_per_kg = float(
+            inlet_stream.enthalpy_joule_per_kg + polytropic_enthalpy_change_to_use_joule_per_kg
+        )
+        props = self._fluid_service.flash_ph(
+            fluid_model=inlet_stream.fluid_model,
+            pressure_bara=float(outlet_pressure),
+            target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+            temperature_guess_kelvin=inlet_stream.temperature_kelvin,
+        )
         outlet_fluid = Fluid(fluid_model=inlet_stream.fluid_model, properties=props)
         outlet_stream = inlet_stream.with_new_fluid(outlet_fluid)
 

--- a/src/libecalc/domain/process/compressor/core/train/utils/common.py
+++ b/src/libecalc/domain/process/compressor/core/train/utils/common.py
@@ -1,8 +1,15 @@
 from libecalc.common.logger import logger
 from libecalc.common.numeric_methods import DampState, adaptive_pressure_update
 from libecalc.common.units import UnitConstants
+from libecalc.domain.process.compressor.core.exceptions import (
+    CompressorOutletCalculationError,
+    CompressorThermodynamicCalculationError,
+)
 from libecalc.domain.process.compressor.core.train.utils.enthalpy_calculations import calculate_outlet_pressure_campbell
+from libecalc.process.fluid_stream.exceptions import FluidFlashCalculationError
 from libecalc.process.fluid_stream.fluid import Fluid
+from libecalc.process.fluid_stream.fluid_properties import FluidProperties
+from libecalc.process.fluid_stream.fluid_property_validation import require_positive_finite, validate_ph_flash_result
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 
@@ -14,9 +21,66 @@ RATE_CALCULATION_TOLERANCE = 1e-3
 RECIRCULATION_BOUNDARY_TOLERANCE = 1e-6
 # -----------------------------------------------------------------------------
 # Impossible pressure sanity cap.  Protects the PH flash when the first
-# Campbell estimate is evaluated for an artificial max‑speed head in edge cases.
+# Campbell estimate is evaluated for an artificial max-speed head in edge cases.
 # -----------------------------------------------------------------------------
 MAX_FIRST_GUESS_BAR = 2_000.0  # [bara]
+
+
+def flash_ph_for_compressor_calculation(
+    fluid_service: FluidService,
+    inlet_stream: FluidStream,
+    outlet_pressure_bara: float,
+    target_enthalpy_joule_per_kg: float,
+    operation: str,
+    error_class: type[CompressorThermodynamicCalculationError] = CompressorThermodynamicCalculationError,
+    details: dict[str, object | None] | None = None,
+) -> FluidProperties:
+    error_details = {
+        "outlet_pressure_bara": outlet_pressure_bara,
+        "target_enthalpy_joule_per_kg": target_enthalpy_joule_per_kg,
+        "temperature_guess_kelvin": inlet_stream.temperature_kelvin,
+        "inlet_pressure_bara": inlet_stream.pressure_bara,
+        "inlet_temperature_kelvin": inlet_stream.temperature_kelvin,
+        **(details or {}),
+    }
+    try:
+        properties = fluid_service.flash_ph(
+            fluid_model=inlet_stream.fluid_model,
+            pressure_bara=outlet_pressure_bara,
+            target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+            temperature_guess_kelvin=inlet_stream.temperature_kelvin,
+        )
+    except CompressorThermodynamicCalculationError:
+        raise
+    except FluidFlashCalculationError as error:
+        raise error_class(operation=operation, reason=f"PH flash failed: {error}", details=error_details) from error
+
+    validate_ph_flash_result(
+        properties,
+        target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+        context="PH flash result validation",
+        error_factory=lambda reason: error_class(operation=operation, reason=reason, details=error_details),
+    )
+    return properties
+
+
+def _flash_ph_for_compressor_outlet(
+    fluid_service: FluidService,
+    inlet_stream: FluidStream,
+    outlet_pressure_bara: float,
+    target_enthalpy_joule_per_kg: float,
+    operation: str,
+    details: dict[str, object | None] | None = None,
+) -> FluidProperties:
+    return flash_ph_for_compressor_calculation(
+        fluid_service=fluid_service,
+        inlet_stream=inlet_stream,
+        outlet_pressure_bara=outlet_pressure_bara,
+        target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+        operation=operation,
+        error_class=CompressorOutletCalculationError,
+        details=details,
+    )
 
 
 def calculate_asv_corrected_rate(
@@ -99,8 +163,23 @@ def calculate_outlet_pressure_and_stream(
         inlet_temperature_K=inlet_stream.temperature_kelvin,
         inlet_pressure_bara=inlet_stream.pressure_bara,
     )
+    require_positive_finite(
+        outlet_pressure_this_stage_bara_based_on_inlet_z_and_kappa,
+        "initial Campbell outlet pressure",
+        "calculate_outlet_pressure_and_stream",
+        error_factory=lambda reason: CompressorOutletCalculationError(
+            operation="compressor outlet pressure calculation",
+            reason=reason,
+            details={
+                "polytropic_efficiency": polytropic_efficiency,
+                "polytropic_head_joule_per_kg": polytropic_head_joule_per_kg,
+                "inlet_pressure_bara": inlet_stream.pressure_bara,
+                "inlet_temperature_kelvin": inlet_stream.temperature_kelvin,
+            },
+        ),
+    )
 
-    # Hard cap to protect the PH flash / EOS (primarily during non‑physical max‑speed probe)
+    # Hard cap to protect the PH flash / EOS (primarily during non-physical max-speed probe)
     if outlet_pressure_this_stage_bara_based_on_inlet_z_and_kappa > MAX_FIRST_GUESS_BAR:
         logger.warning(
             "Campbell first guess %.0f bar discharge pressure exceeds cap of %.0f bar; "
@@ -114,11 +193,17 @@ def calculate_outlet_pressure_and_stream(
         outlet_pressure_this_stage_bara_based_on_inlet_z_and_kappa = MAX_FIRST_GUESS_BAR
 
     enthalpy_change = polytropic_head_joule_per_kg / polytropic_efficiency
-    target_enthalpy = inlet_stream.enthalpy_joule_per_kg + enthalpy_change
-    props = fluid_service.flash_ph(
-        inlet_stream.fluid_model,
-        float(outlet_pressure_this_stage_bara_based_on_inlet_z_and_kappa),
-        target_enthalpy,
+    target_enthalpy_joule_per_kg = inlet_stream.enthalpy_joule_per_kg + enthalpy_change
+    props = _flash_ph_for_compressor_outlet(
+        fluid_service=fluid_service,
+        inlet_stream=inlet_stream,
+        outlet_pressure_bara=float(outlet_pressure_this_stage_bara_based_on_inlet_z_and_kappa),
+        target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+        operation="compressor outlet initial PH flash",
+        details={
+            "polytropic_efficiency": polytropic_efficiency,
+            "polytropic_head_joule_per_kg": polytropic_head_joule_per_kg,
+        },
     )
     outlet_fluid = Fluid(fluid_model=inlet_stream.fluid_model, properties=props)
     outlet_stream_compressor_current_iteration = inlet_stream.with_new_fluid(outlet_fluid)
@@ -141,17 +226,53 @@ def calculate_outlet_pressure_and_stream(
             inlet_temperature_K=inlet_stream.temperature_kelvin,
             inlet_pressure_bara=inlet_stream.pressure_bara,
         )
+        require_positive_finite(
+            p_raw,
+            "Campbell outlet pressure",
+            f"calculate_outlet_pressure_and_stream iteration {i}",
+            error_factory=lambda reason: CompressorOutletCalculationError(
+                operation=f"compressor outlet pressure iteration {i}",
+                reason=reason,
+                details={
+                    "polytropic_efficiency": polytropic_efficiency,
+                    "polytropic_head_joule_per_kg": polytropic_head_joule_per_kg,
+                    "inlet_pressure_bara": inlet_stream.pressure_bara,
+                    "inlet_temperature_kelvin": inlet_stream.temperature_kelvin,
+                },
+            ),
+        )
         # Adaptive damping for cases where needed (non-invasive for normal cases)
         outlet_pressure_this_stage_bara, state = adaptive_pressure_update(
             p_prev=outlet_pressure_this_stage_bara,
             p_raw=p_raw,
             state=state,
         )
-
-        props = fluid_service.flash_ph(
-            inlet_stream.fluid_model,
+        require_positive_finite(
             outlet_pressure_this_stage_bara,
-            target_enthalpy,
+            "damped outlet pressure",
+            f"calculate_outlet_pressure_and_stream iteration {i}",
+            error_factory=lambda reason: CompressorOutletCalculationError(
+                operation=f"compressor outlet pressure iteration {i}",
+                reason=reason,
+                details={
+                    "polytropic_efficiency": polytropic_efficiency,
+                    "polytropic_head_joule_per_kg": polytropic_head_joule_per_kg,
+                    "inlet_pressure_bara": inlet_stream.pressure_bara,
+                    "inlet_temperature_kelvin": inlet_stream.temperature_kelvin,
+                },
+            ),
+        )
+
+        props = _flash_ph_for_compressor_outlet(
+            fluid_service=fluid_service,
+            inlet_stream=inlet_stream,
+            outlet_pressure_bara=outlet_pressure_this_stage_bara,
+            target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+            operation=f"compressor outlet PH flash iteration {i}",
+            details={
+                "polytropic_efficiency": polytropic_efficiency,
+                "polytropic_head_joule_per_kg": polytropic_head_joule_per_kg,
+            },
         )
         outlet_fluid = Fluid(fluid_model=inlet_stream.fluid_model, properties=props)
         outlet_stream_compressor_current_iteration = inlet_stream.with_new_fluid(outlet_fluid)

--- a/src/libecalc/domain/process/compressor/core/train/utils/enthalpy_calculations.py
+++ b/src/libecalc/domain/process/compressor/core/train/utils/enthalpy_calculations.py
@@ -101,8 +101,13 @@ def calculate_enthalpy_change_head_iteration(
         # Update outlet streams using fluid_service
         outlet_streams = []
         for stream, pressure, enthalpy_change in zip(inlet_streams, outlet_pressure, enthalpy_change_joule_per_kg):
-            target_enthalpy = stream.enthalpy_joule_per_kg + enthalpy_change
-            props = fluid_service.flash_ph(stream.fluid_model, pressure, target_enthalpy)
+            target_enthalpy_joule_per_kg = stream.enthalpy_joule_per_kg + enthalpy_change
+            props = fluid_service.flash_ph(
+                fluid_model=stream.fluid_model,
+                pressure_bara=pressure,
+                target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+                temperature_guess_kelvin=stream.temperature_kelvin,
+            )
             outlet_fluid = Fluid(fluid_model=stream.fluid_model, properties=props)
             outlet_streams.append(stream.with_new_fluid(outlet_fluid))
 

--- a/src/libecalc/domain/process/entities/process_units/legacy_compressor/legacy_compressor.py
+++ b/src/libecalc/domain/process/entities/process_units/legacy_compressor/legacy_compressor.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from libecalc.common.errors.ecalc_validation_error import ProcessCompressorEfficiencyValidationException
 from libecalc.common.errors.exceptions import IllegalStateException
 from libecalc.common.logger import logger
+from libecalc.domain.process.compressor.core.exceptions import CompressorOutletCalculationError
 from libecalc.domain.process.compressor.core.train.utils.common import calculate_outlet_pressure_and_stream
 from libecalc.domain.process.value_objects.chart.chart import ChartData
 from libecalc.domain.process.value_objects.chart.chart_area_flag import ChartAreaFlag
@@ -130,9 +131,23 @@ class LegacyCompressor:
 
         assert self.operational_point is not None, "Operational point must be set before compression."
 
-        return calculate_outlet_pressure_and_stream(
-            polytropic_efficiency=self.operational_point.polytropic_efficiency,
-            polytropic_head_joule_per_kg=self.operational_point.polytropic_head_joule_per_kg,
-            inlet_stream=inlet_stream,
-            fluid_service=self._fluid_service,
-        )
+        try:
+            return calculate_outlet_pressure_and_stream(
+                polytropic_efficiency=self.operational_point.polytropic_efficiency,
+                polytropic_head_joule_per_kg=self.operational_point.polytropic_head_joule_per_kg,
+                inlet_stream=inlet_stream,
+                fluid_service=self._fluid_service,
+            )
+        except CompressorOutletCalculationError:
+            if self.operational_point.is_valid:
+                raise
+
+            logger.debug(
+                "Skipping compressor outlet flash for invalid chart point. "
+                "chart_area_flag=%s, speed=%s, rate_before_asv_m3_per_h=%s",
+                self.chart_area_flag,
+                self.speed,
+                self._rate_before_asv_m3_per_h,
+                exc_info=True,
+            )
+            return inlet_stream

--- a/src/libecalc/process/fluid_stream/exceptions.py
+++ b/src/libecalc/process/fluid_stream/exceptions.py
@@ -63,3 +63,7 @@ class IncompatibleThermoSystemProvidersException(StreamMixingException):
 
     def __init__(self, provider1: str, provider2: str):
         super().__init__(f"Cannot mix streams with different thermo system providers: {provider1} vs {provider2}")
+
+
+class FluidFlashCalculationError(Exception):
+    """Base exception for fluid-service flash calculation failures."""

--- a/src/libecalc/process/fluid_stream/fluid_property_validation.py
+++ b/src/libecalc/process/fluid_stream/fluid_property_validation.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+
+from libecalc.process.fluid_stream.fluid_properties import FluidProperties
+
+PH_ENTHALPY_REL_TOLERANCE = 1e-4
+PH_ENTHALPY_ABS_TOLERANCE_JOULE_PER_KG = 10.0
+VAPOR_FRACTION_TOLERANCE = 1e-5
+# Defensive PH-result validation tolerances. These are not process-model tolerances.
+# They only guard against thermodynamic backend failures where a PH flash returns
+# an unusable or wrong target state instead of raising. The absolute tolerance
+# covers low-enthalpy states; the relative tolerance scales with compressor
+# enthalpy levels.
+
+
+def _default_error_factory(message: str) -> ValueError:
+    return ValueError(message)
+
+
+def require_positive_finite(
+    value: float,
+    name: str,
+    context: str,
+    error_factory: Callable[[str], Exception] = _default_error_factory,
+) -> None:
+    if not math.isfinite(value) or value <= 0:
+        raise error_factory(f"{context}: expected finite positive {name}, got {value}.")
+
+
+def validate_ph_flash_result(
+    properties: FluidProperties,
+    target_enthalpy_joule_per_kg: float,
+    context: str,
+    error_factory: Callable[[str], Exception] = _default_error_factory,
+) -> None:
+    """Validate a PH flash result against the caller's target enthalpy.
+
+    This is intentionally not a ``FluidProperties`` invariant: the enthalpy
+    target and acceptable tolerance belong to the flash operation, not to a raw
+    immutable fluid-state snapshot.
+    """
+    require_positive_finite(properties.pressure_bara, "pressure_bara", context, error_factory)
+    require_positive_finite(properties.temperature_kelvin, "temperature_kelvin", context, error_factory)
+    require_positive_finite(properties.density, "density", context, error_factory)
+    require_positive_finite(properties.z, "z", context, error_factory)
+    require_positive_finite(properties.kappa, "kappa", context, error_factory)
+    require_positive_finite(properties.standard_density, "standard_density", context, error_factory)
+
+    if (
+        not math.isfinite(properties.vapor_fraction_molar)
+        or not -VAPOR_FRACTION_TOLERANCE <= properties.vapor_fraction_molar <= 1 + VAPOR_FRACTION_TOLERANCE
+    ):
+        raise error_factory(
+            f"{context}: expected finite vapor_fraction_molar in [0, 1], got {properties.vapor_fraction_molar}."
+        )
+
+    if not math.isfinite(properties.enthalpy_joule_per_kg):
+        raise error_factory(
+            f"{context}: expected finite enthalpy_joule_per_kg, got {properties.enthalpy_joule_per_kg}."
+        )
+    if not math.isfinite(target_enthalpy_joule_per_kg):
+        raise error_factory(
+            f"{context}: expected finite target_enthalpy_joule_per_kg, got {target_enthalpy_joule_per_kg}."
+        )
+
+    enthalpy_error = abs(properties.enthalpy_joule_per_kg - target_enthalpy_joule_per_kg)
+    enthalpy_tolerance = max(
+        PH_ENTHALPY_ABS_TOLERANCE_JOULE_PER_KG,
+        abs(target_enthalpy_joule_per_kg) * PH_ENTHALPY_REL_TOLERANCE,
+    )
+    if enthalpy_error > enthalpy_tolerance:
+        raise error_factory(
+            f"{context}: PH flash did not satisfy target enthalpy. "
+            f"target={target_enthalpy_joule_per_kg}, result={properties.enthalpy_joule_per_kg}, "
+            f"error={enthalpy_error}, tolerance={enthalpy_tolerance}."
+        )

--- a/src/libecalc/process/fluid_stream/fluid_service.py
+++ b/src/libecalc/process/fluid_stream/fluid_service.py
@@ -52,20 +52,27 @@ class FluidService(abc.ABC):
         self,
         fluid_model: FluidModel,
         pressure_bara: float,
-        target_enthalpy: float,
+        target_enthalpy_joule_per_kg: float,
+        temperature_guess_kelvin: float | None = None,
     ) -> FluidProperties:
         """PH flash to target pressure and enthalpy.
 
-        Note: The target_enthalpy is reference-state dependent. Thermodynamic packages
+        Note: The target_enthalpy_joule_per_kg is reference-state dependent. Thermodynamic packages
         may use arbitrary enthalpy reference states, so the caller must ensure that
-        target_enthalpy was computed from enthalpy values obtained from the same
+        target_enthalpy_joule_per_kg was computed from enthalpy values obtained from the same
         EoS/fluid model session. Mixing enthalpy values from different thermodynamic
         packages or sessions may produce incorrect results.
 
         Args:
             fluid_model: The fluid model (composition + EoS)
             pressure_bara: Target pressure in bara
-            target_enthalpy: Target specific enthalpy in J/kg (must be from same EoS session)
+            target_enthalpy_joule_per_kg: Target specific enthalpy in J/kg (must be from same EoS session)
+            temperature_guess_kelvin: Optional initial temperature for the PH flash. Implementations may use this
+                as a convergence aid by preconditioning the underlying thermodynamic system at
+                (pressure_bara, temperature_guess_kelvin) before solving the same PH target. Use it when the caller
+                has a physically relevant temperature estimate closer to the expected final state than the reference
+                fluid temperature. It should not change a correctly converged PH result, but may improve robustness
+                for difficult states by avoiding intermediate low-temperature/high-pressure guesses.
 
         Returns:
             FluidProperties at the specified conditions.

--- a/tests/ecalc_neqsim_wrapper/unit_tests/test_neqsim_fluid.py
+++ b/tests/ecalc_neqsim_wrapper/unit_tests/test_neqsim_fluid.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from ecalc_neqsim_wrapper import NeqsimService
-from ecalc_neqsim_wrapper.exceptions import NeqsimComponentError
+from ecalc_neqsim_wrapper.exceptions import NeqsimComponentError, NeqsimFlashCalculationError
 from ecalc_neqsim_wrapper.java_service import NeqsimPy4JService
 from ecalc_neqsim_wrapper.thermo import NeqsimFluid, mix_neqsim_streams
 from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition
@@ -298,3 +298,91 @@ def test_neqsim_component_error() -> None:
                     assert "unknown_component" in str(exc_info.value)
     else:
         assert True
+
+
+class TestJavaBridgeErrorHandling:
+    """Tests that Java exceptions from both Py4J and JPype backends
+    are caught and wrapped as NeqsimFlashCalculationError."""
+
+    @staticmethod
+    def _make_java_error_subclass(name: str = "MockJavaError") -> type[Exception]:
+        """Create a fresh Exception subclass to simulate a Java bridge error.
+
+        We can't instantiate jpype.JException without a running JVM targeting a
+        real Java class, so we dynamically inject a test subclass into JAVA_ERRORS
+        to prove the except clause catches it.
+        """
+        return type(name, (Exception,), {})
+
+    def test_ph_flash_wraps_py4j_error(self, medium_fluid: NeqsimFluid) -> None:
+        """Py4JError from PH flash is wrapped as NeqsimFlashCalculationError."""
+        from py4j.protocol import Py4JError
+
+        with patch.object(NeqsimFluid, "_ph_flash", side_effect=Py4JError("test")):
+            with pytest.raises(NeqsimFlashCalculationError, match="PH flash failed"):
+                medium_fluid.set_new_pressure_and_enthalpy(
+                    new_pressure=50.0,
+                    new_enthalpy_joule_per_kg=medium_fluid.enthalpy_joule_per_kg,
+                )
+
+    def test_tp_flash_wraps_py4j_error(self, medium_fluid: NeqsimFluid) -> None:
+        """Py4JError from TP flash is wrapped as NeqsimFlashCalculationError."""
+        from py4j.protocol import Py4JError
+
+        with patch.object(NeqsimFluid, "_tp_flash", side_effect=Py4JError("test")):
+            with pytest.raises(NeqsimFlashCalculationError, match="TP flash failed"):
+                medium_fluid.set_new_pressure_and_temperature(
+                    new_pressure_bara=50.0,
+                    new_temperature_kelvin=300.0,
+                )
+
+    def test_ph_flash_wraps_dynamic_java_error(self, medium_fluid: NeqsimFluid) -> None:
+        """Any exception type in JAVA_ERRORS is caught by the PH flash handler.
+
+        Verifies the catch clause works for dynamically added error types,
+        which is how JException (JPype) is included alongside Py4J errors.
+        """
+        import ecalc_neqsim_wrapper.exceptions as exc_mod
+        import ecalc_neqsim_wrapper.thermo as thermo_mod
+
+        MockJavaError = self._make_java_error_subclass()
+        extended_errors = (*exc_mod.JAVA_ERRORS, MockJavaError)
+
+        with (
+            patch.object(exc_mod, "JAVA_ERRORS", extended_errors),
+            patch.object(thermo_mod, "JAVA_ERRORS", extended_errors),
+            patch.object(NeqsimFluid, "_ph_flash", side_effect=MockJavaError("simulated Java error")),
+        ):
+            with pytest.raises(NeqsimFlashCalculationError, match="PH flash failed"):
+                medium_fluid.set_new_pressure_and_enthalpy(
+                    new_pressure=50.0,
+                    new_enthalpy_joule_per_kg=medium_fluid.enthalpy_joule_per_kg,
+                )
+
+    def test_tp_flash_wraps_dynamic_java_error(self, medium_fluid: NeqsimFluid) -> None:
+        """Any exception type in JAVA_ERRORS is caught by the TP flash handler."""
+        import ecalc_neqsim_wrapper.exceptions as exc_mod
+        import ecalc_neqsim_wrapper.thermo as thermo_mod
+
+        MockJavaError = self._make_java_error_subclass()
+        extended_errors = (*exc_mod.JAVA_ERRORS, MockJavaError)
+
+        with (
+            patch.object(exc_mod, "JAVA_ERRORS", extended_errors),
+            patch.object(thermo_mod, "JAVA_ERRORS", extended_errors),
+            patch.object(NeqsimFluid, "_tp_flash", side_effect=MockJavaError("simulated Java error")),
+        ):
+            with pytest.raises(NeqsimFlashCalculationError, match="TP flash failed"):
+                medium_fluid.set_new_pressure_and_temperature(
+                    new_pressure_bara=50.0,
+                    new_temperature_kelvin=300.0,
+                )
+
+    def test_non_java_exception_not_swallowed(self, medium_fluid: NeqsimFluid) -> None:
+        """Python exceptions (e.g. ValueError) must NOT be caught by the Java error handler."""
+        with patch.object(NeqsimFluid, "_ph_flash", side_effect=ValueError("pure Python bug")):
+            with pytest.raises(ValueError, match="pure Python bug"):
+                medium_fluid.set_new_pressure_and_enthalpy(
+                    new_pressure=50.0,
+                    new_enthalpy_joule_per_kg=medium_fluid.enthalpy_joule_per_kg,
+                )

--- a/tests/ecalc_neqsim_wrapper/unit_tests/test_seeded_ph_flash.py
+++ b/tests/ecalc_neqsim_wrapper/unit_tests/test_seeded_ph_flash.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from ecalc_neqsim_wrapper.cache_service import CacheService
+from ecalc_neqsim_wrapper.fluid_service import NeqSimFluidService
+from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
+from libecalc.process.fluid_stream.fluid_properties import FluidProperties
+
+
+class NeqsimFluidSpy:
+    def __init__(self, name: str, calls: list[tuple[str, float, float, str]]) -> None:
+        self.name = name
+        self.calls = calls
+
+    def set_new_pressure_and_temperature(
+        self,
+        new_pressure_bara: float,
+        new_temperature_kelvin: float,
+    ) -> NeqsimFluidSpy:
+        self.calls.append(("tp", new_pressure_bara, new_temperature_kelvin, self.name))
+        return NeqsimFluidSpy("temperature_seeded", self.calls)
+
+    def set_new_pressure_and_enthalpy(
+        self,
+        new_pressure: float,
+        new_enthalpy_joule_per_kg: float,
+    ) -> NeqsimFluidSpy:
+        self.calls.append(("ph", new_pressure, new_enthalpy_joule_per_kg, self.name))
+        return NeqsimFluidSpy(f"ph_from_{self.name}", self.calls)
+
+
+def test_temperature_guess_preconditions_ph_flash_and_populates_target_cache(monkeypatch):
+    NeqSimFluidService.reset_instance()
+    CacheService.clear_all()
+    CacheService._caches.clear()
+    service = NeqSimFluidService.instance()
+
+    calls: list[tuple[str, float, float, str]] = []
+    reference_fluid = NeqsimFluidSpy("reference", calls)
+    fluid_model = FluidModel(composition=FluidComposition(methane=1.0), eos_model=EoSModel.PR)
+
+    monkeypatch.setattr(service, "_get_reference_fluid", lambda fluid_model: reference_fluid)
+
+    def extract_properties(neqsim_fluid: NeqsimFluidSpy, fluid_model: FluidModel) -> FluidProperties:
+        return FluidProperties(
+            temperature_kelvin=310.0 if neqsim_fluid.name == "ph_from_temperature_seeded" else 288.15,
+            pressure_bara=50.0,
+            density=1.0,
+            enthalpy_joule_per_kg=1_000.0,
+            z=0.9,
+            kappa=1.2,
+            vapor_fraction_molar=1.0,
+            molar_mass=fluid_model.composition.molar_mass_mixture,
+            standard_density=0.7,
+        )
+
+    monkeypatch.setattr(service, "_extract_properties", extract_properties)
+
+    seeded = service.flash_ph(
+        fluid_model=fluid_model,
+        pressure_bara=50.0,
+        target_enthalpy_joule_per_kg=1_000.0,
+        temperature_guess_kelvin=310.0,
+    )
+    cached_unseeded = service.flash_ph(
+        fluid_model=fluid_model,
+        pressure_bara=50.0,
+        target_enthalpy_joule_per_kg=1_000.0,
+    )
+
+    assert seeded.temperature_kelvin == 310.0
+    assert cached_unseeded == seeded
+    assert calls == [
+        ("tp", 50.0, 310.0, "reference"),
+        ("ph", 50.0, 1_000.0, "temperature_seeded"),
+    ]

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_model_vs_unisim.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_model_vs_unisim.py
@@ -266,11 +266,11 @@ def test_fluid_streams(unisim_test_data):
     fluid_service = NeqSimFluidService.instance()
     outlet_streams_enthalpy = []
     for index, s in enumerate(inlet_streams):
-        target_enthalpy = s.enthalpy_joule_per_kg + compressor_data_enthalpy_change_joule_per_kg[index]
+        target_enthalpy_joule_per_kg = s.enthalpy_joule_per_kg + compressor_data_enthalpy_change_joule_per_kg[index]
         props = fluid_service.flash_ph(
-            s.fluid_model,
-            unisim_test_data.output_stream_data.pressures[index],
-            target_enthalpy,
+            fluid_model=s.fluid_model,
+            pressure_bara=unisim_test_data.output_stream_data.pressures[index],
+            target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
         )
         outlet_fluid = Fluid(fluid_model=s.fluid_model, properties=props)
         outlet_streams_enthalpy.append(s.with_new_fluid(outlet_fluid))

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_train_common_shaft_utils.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_train_common_shaft_utils.py
@@ -1,14 +1,28 @@
 import pytest
 
+from libecalc.common.errors.exceptions import IllegalStateException
 from libecalc.common.units import UnitConstants
+from libecalc.domain.process.compressor.core.exceptions import CompressorOutletCalculationError
 from libecalc.domain.process.compressor.core.train.utils.common import (
     calculate_asv_corrected_rate,
+    calculate_outlet_pressure_and_stream,
     calculate_power_in_megawatt,
 )
 from libecalc.domain.process.compressor.core.train.utils.enthalpy_calculations import (
     _calculate_polytropic_exponent_expression_n_minus_1_over_n,
     calculate_outlet_pressure_campbell,
 )
+from libecalc.domain.process.entities.process_units.legacy_compressor import legacy_compressor
+from libecalc.domain.process.entities.process_units.legacy_compressor.legacy_compressor import (
+    LegacyCompressor,
+    OperationalPoint,
+)
+from libecalc.domain.process.value_objects.chart.chart_area_flag import ChartAreaFlag
+from libecalc.process.fluid_stream.fluid import Fluid
+from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
+from libecalc.process.fluid_stream.fluid_properties import FluidProperties
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.shaft import SingleSpeedShaft
 
 
 def test_calculate_polytropic_exponent_expression(
@@ -60,6 +74,141 @@ def test_calculate_outlet_pressure_campbell(
         polytropic_head_fluid_Joule_per_kg=polytropic_head_fluid_Joule_per_kg,
     )
     assert result == pytest.approx(expected_outlet_pressure)
+
+
+def test_calculate_outlet_pressure_and_stream_rejects_invalid_ph_result():
+    fluid_model = FluidModel(
+        composition=FluidComposition(methane=1.0),
+        eos_model=EoSModel.PR,
+    )
+    inlet_properties = FluidProperties(
+        temperature_kelvin=300.0,
+        pressure_bara=20.0,
+        density=30.0,
+        enthalpy_joule_per_kg=1000.0,
+        z=0.9,
+        kappa=1.3,
+        vapor_fraction_molar=1.0,
+        molar_mass=0.016,
+        standard_density=0.7,
+    )
+    inlet_stream = FluidStream(
+        fluid=Fluid(fluid_model=fluid_model, properties=inlet_properties),
+        mass_rate_kg_per_h=1.0,
+    )
+
+    class InvalidPhFlashService:
+        temperature_guesses: list[float | None]
+
+        def __init__(self) -> None:
+            self.temperature_guesses = []
+
+        def flash_ph(
+            self,
+            fluid_model: FluidModel,
+            pressure_bara: float,
+            target_enthalpy_joule_per_kg: float,
+            temperature_guess_kelvin: float | None = None,
+        ) -> FluidProperties:
+            self.temperature_guesses.append(temperature_guess_kelvin)
+            return FluidProperties(
+                temperature_kelvin=288.15,
+                pressure_bara=pressure_bara,
+                density=100.0,
+                enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+                z=0.6,
+                kappa=float("nan"),
+                vapor_fraction_molar=0.3,
+                molar_mass=0.016,
+                standard_density=0.7,
+            )
+
+    fluid_service = InvalidPhFlashService()
+
+    with pytest.raises(CompressorOutletCalculationError, match="kappa"):
+        calculate_outlet_pressure_and_stream(
+            polytropic_efficiency=0.75,
+            polytropic_head_joule_per_kg=10_000.0,
+            inlet_stream=inlet_stream,
+            fluid_service=fluid_service,  # type: ignore[arg-type]
+        )
+
+    assert fluid_service.temperature_guesses == [inlet_stream.temperature_kelvin]
+
+
+def _make_compressor_with_invalid_chart_point(
+    monkeypatch, single_speed_chart_data, outlet_error: Exception
+) -> tuple[LegacyCompressor, FluidStream]:
+    """Set up a LegacyCompressor whose chart point is invalid (ABOVE_MAXIMUM_FLOW_RATE)
+    and whose outlet calculation raises *outlet_error*."""
+    inlet_stream = FluidStream(
+        fluid=Fluid(
+            fluid_model=FluidModel(composition=FluidComposition(methane=1.0), eos_model=EoSModel.PR),
+            properties=FluidProperties(
+                temperature_kelvin=300.0,
+                pressure_bara=20.0,
+                density=30.0,
+                enthalpy_joule_per_kg=1000.0,
+                z=0.9,
+                kappa=1.3,
+                vapor_fraction_molar=1.0,
+                molar_mass=0.016,
+                standard_density=0.7,
+            ),
+        ),
+        mass_rate_kg_per_h=1.0,
+    )
+    compressor = LegacyCompressor(
+        compressor_chart=single_speed_chart_data,
+        fluid_service=object(),  # type: ignore[arg-type]
+        shaft=SingleSpeedShaft(),
+    )
+    compressor.set_rate_before_asv(rate_before_asv_m3_per_h=10_000.0)
+
+    def set_invalid_operational_point(actual_rate_m3_per_h_including_asv: float) -> None:
+        compressor._operational_point = OperationalPoint(
+            actual_rate_m3_per_h=actual_rate_m3_per_h_including_asv,
+            polytropic_head_joule_per_kg=100_000.0,
+            polytropic_efficiency=0.75,
+            is_valid=False,
+        )
+        compressor._chart_area_flag = ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE
+
+    def fail_outlet_calculation(**kwargs) -> FluidStream:
+        raise outlet_error
+
+    monkeypatch.setattr(compressor, "set_chart_area_flag_and_operational_point", set_invalid_operational_point)
+    monkeypatch.setattr(legacy_compressor, "calculate_outlet_pressure_and_stream", fail_outlet_calculation)
+    return compressor, inlet_stream
+
+
+def test_invalid_compressor_chart_point_returns_inlet_when_outlet_calculation_fails(
+    monkeypatch, single_speed_chart_data
+):
+    compressor, inlet_stream = _make_compressor_with_invalid_chart_point(
+        monkeypatch,
+        single_speed_chart_data,
+        outlet_error=CompressorOutletCalculationError(
+            operation="test compressor outlet calculation",
+            reason="thermodynamic outlet calculation failed",
+        ),
+    )
+
+    assert compressor.compress(inlet_stream) is inlet_stream
+    assert compressor.operational_point is not None
+    assert not compressor.operational_point.is_valid
+    assert compressor.chart_area_flag == ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE
+
+
+def test_invalid_compressor_chart_point_does_not_swallow_unrelated_illegal_state(monkeypatch, single_speed_chart_data):
+    compressor, inlet_stream = _make_compressor_with_invalid_chart_point(
+        monkeypatch,
+        single_speed_chart_data,
+        outlet_error=IllegalStateException("unrelated illegal state"),
+    )
+
+    with pytest.raises(IllegalStateException, match="unrelated illegal state"):
+        compressor.compress(inlet_stream)
 
 
 def test_calculate_asv_corrected_rate():

--- a/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_simplified_compressor_train.py
@@ -735,8 +735,12 @@ def test_calculate_enthalpy_change_head_iteration_and_outlet_stream(fluid_servic
     )
     outlet_streams = []
     for stream, pressure, enthalpy_change in zip(inlet_streams, outlet_pressure, enthalpy_change_joule_per_kg):
-        target_enthalpy = stream.enthalpy_joule_per_kg + enthalpy_change
-        props = fluid_service.flash_ph(stream.fluid_model, pressure, target_enthalpy)
+        target_enthalpy_joule_per_kg = stream.enthalpy_joule_per_kg + enthalpy_change
+        props = fluid_service.flash_ph(
+            fluid_model=stream.fluid_model,
+            pressure_bara=pressure,
+            target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+        )
         outlet_fluid = Fluid(fluid_model=stream.fluid_model, properties=props)
         outlet_streams.append(stream.with_new_fluid(outlet_fluid))
 

--- a/tests/libecalc/process/fluid_stream/test_stream.py
+++ b/tests/libecalc/process/fluid_stream/test_stream.py
@@ -77,14 +77,14 @@ class TestStream:
 
         new_pressure = 5.0
         enthalpy_change = -5000.0
-        target_enthalpy = stream.enthalpy_joule_per_kg + enthalpy_change
+        target_enthalpy_joule_per_kg = stream.enthalpy_joule_per_kg + enthalpy_change
         expected_temp = 300.0 + (enthalpy_change / 1000.0)
 
         # Create mock properties for the result
         new_props = mock_fluid_properties_factory(
             pressure_bara=new_pressure,
             temperature_kelvin=expected_temp,
-            enthalpy_joule_per_kg=target_enthalpy,
+            enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
         )
 
         # Mock the service
@@ -92,7 +92,11 @@ class TestStream:
         mock_service.flash_ph.return_value = new_props
 
         # Call the pattern: flash_ph + construct Fluid + with_new_fluid
-        result_props = mock_service.flash_ph(stream.fluid_model, new_pressure, target_enthalpy)
+        result_props = mock_service.flash_ph(
+            fluid_model=stream.fluid_model,
+            pressure_bara=new_pressure,
+            target_enthalpy_joule_per_kg=target_enthalpy_joule_per_kg,
+        )
         new_fluid = Fluid(fluid_model=stream.fluid_model, properties=result_props)
         new_stream = stream.with_new_fluid(new_fluid)
 


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [x] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!


## Summary
Note: BREAKING!

This PR hardens compressor PH flash handling after debugging a production compressor model crash.

The work happened in three steps:

1. **Fix the original compressor PH crash**
   - The original failure came from a compressor outlet PH flash where NeqSim returned an invalid outlet state near the phase envelope.
   - That invalid state contained bad thermodynamic properties, including non-finite `kappa`.
   - eCalc then used those properties in the Campbell pressure iteration, which produced a non-finite outlet pressure and eventually crashed in NeqSim.
   - The fix is to seed compressor PH flashes from the compressor inlet temperature instead of starting from the cached standard-condition reference state.

2. **Add validation so bad PH results cannot silently propagate**
   - PH flash results are now validated before they are cached or used.
   - Validation checks finite/positive pressure, temperature, density, `z`, `kappa`, standard density, finite vapor fraction and enthalpy, and that the resulting enthalpy matches the PH target within tolerance.
   - Compressor outlet calculations now also reject non-finite Campbell pressure guesses before they are sent back into NeqSim.

3. **Handle additional invalid/non-physical states exposed by validation**
   - After validation was added, the full model exposed another failure in a max-speed/capacity probe: the chart point was already invalid/outside capacity, but the code still required a physical outlet PH state for the extrapolated probe.
   - That PH target was not physically reachable, causing NeqSim to drive temperature toward near-zero K and fail. The code now preserves the original invalid chart/capacity result instead of crashing on the outlet flash for an already-invalid chart point.
   - Validation also exposed an existing simplified-train test case where extreme pressure ratios produced an invalid near-zero-temperature PH result. The simplified max-rate helper now avoids using those invalid PH properties once the required head is already above the maximum-speed chart head, preserving the existing chart-limited scalar result.

## Changes

- Add optional `temperature_guess_kelvin` to `FluidService.flash_ph(...)`.
- Seed compressor PH flashes from inlet stream temperature.
- Validate NeqSim PH flash results before cache insertion/use.
- Add `CompressorOutletCalculationError` for compressor outlet thermodynamic failures.
- Reject invalid/non-finite compressor PH results and Campbell pressure guesses.
- In legacy compressor evaluation, skip failed outlet PH only when the chart point is already invalid; valid chart points still raise.
- Preserve simplified max-rate behavior for above-chart-head estimates without relying on invalid NeqSim properties.

## Testing

Added and updated tests for seeded PH flash cache behavior, compressor outlet PH validation, invalid-chart outlet failure handling, and simplified max-rate behavior for invalid high-head PH states.

All tests pass.

## Verification

- All UAT models run successfully with no validation triggers — the new guards are targeted and do not affect existing production models.
- Unified Java bridge error handling: PH/TP flash handlers now catch both Py4J and JPype exceptions via a shared `JAVA_ERRORS` tuple.

## Githus projects issue
refs.:
https://github.com/equinor/ecalc-internal/issues/1765