### PR TITLE
test: add test to deny import of pydantic in domain

### DIFF
--- a/src/libecalc/process/fluid_stream/constants.py
+++ b/src/libecalc/process/fluid_stream/constants.py
@@ -2,15 +2,16 @@
 Constants and properties used in thermodynamic calculations.
 """
 
-from pydantic import BaseModel, Field
+from libecalc.common.ddd import value_object
 
 
-class ComponentProperties(BaseModel):
+@value_object
+class ComponentProperties:
     """Properties for a single component including critical properties and molecular weight."""
 
-    critical_temperature_k: float = Field(..., alias="Tc")  # K
-    critical_pressure_bara: float = Field(..., alias="Pc")  # bara
-    acentric_factor: float = Field(..., alias="omega")
+    critical_temperature_k: float
+    critical_pressure_bara: float
+    acentric_factor: float
     molecular_weight_kg_per_mol: float
 
 
@@ -27,17 +28,72 @@ class ThermodynamicConstants:
 
     # Component properties combining critical properties and molecular weights
     COMPONENTS: dict[str, ComponentProperties] = {
-        "water": ComponentProperties(Tc=647.3, Pc=221.2, omega=0.344, molecular_weight_kg_per_mol=0.01801534),
-        "nitrogen": ComponentProperties(Tc=126.2, Pc=33.9, omega=0.039, molecular_weight_kg_per_mol=0.02801340),
-        "CO2": ComponentProperties(Tc=304.1, Pc=73.8, omega=0.239, molecular_weight_kg_per_mol=0.04400995),
-        "methane": ComponentProperties(Tc=190.4, Pc=46.0, omega=0.011, molecular_weight_kg_per_mol=0.01604246),
-        "ethane": ComponentProperties(Tc=305.4, Pc=48.8, omega=0.099, molecular_weight_kg_per_mol=0.03006904),
-        "propane": ComponentProperties(Tc=369.8, Pc=42.5, omega=0.153, molecular_weight_kg_per_mol=0.04409562),
-        "i_butane": ComponentProperties(Tc=408.2, Pc=36.5, omega=0.183, molecular_weight_kg_per_mol=0.05812220),
-        "n_butane": ComponentProperties(Tc=425.2, Pc=38.0, omega=0.199, molecular_weight_kg_per_mol=0.05812220),
-        "i_pentane": ComponentProperties(Tc=460.4, Pc=33.9, omega=0.227, molecular_weight_kg_per_mol=0.07214878),
-        "n_pentane": ComponentProperties(Tc=469.7, Pc=33.7, omega=0.251, molecular_weight_kg_per_mol=0.07214878),
-        "n_hexane": ComponentProperties(Tc=507.5, Pc=30.1, omega=0.299, molecular_weight_kg_per_mol=0.08617536),
+        "water": ComponentProperties(
+            critical_temperature_k=647.3,
+            critical_pressure_bara=221.2,
+            acentric_factor=0.344,
+            molecular_weight_kg_per_mol=0.01801534,
+        ),
+        "nitrogen": ComponentProperties(
+            critical_temperature_k=126.2,
+            critical_pressure_bara=33.9,
+            acentric_factor=0.039,
+            molecular_weight_kg_per_mol=0.02801340,
+        ),
+        "CO2": ComponentProperties(
+            critical_temperature_k=304.1,
+            critical_pressure_bara=73.8,
+            acentric_factor=0.239,
+            molecular_weight_kg_per_mol=0.04400995,
+        ),
+        "methane": ComponentProperties(
+            critical_temperature_k=190.4,
+            critical_pressure_bara=46.0,
+            acentric_factor=0.011,
+            molecular_weight_kg_per_mol=0.01604246,
+        ),
+        "ethane": ComponentProperties(
+            critical_temperature_k=305.4,
+            critical_pressure_bara=48.8,
+            acentric_factor=0.099,
+            molecular_weight_kg_per_mol=0.03006904,
+        ),
+        "propane": ComponentProperties(
+            critical_temperature_k=369.8,
+            critical_pressure_bara=42.5,
+            acentric_factor=0.153,
+            molecular_weight_kg_per_mol=0.04409562,
+        ),
+        "i_butane": ComponentProperties(
+            critical_temperature_k=408.2,
+            critical_pressure_bara=36.5,
+            acentric_factor=0.183,
+            molecular_weight_kg_per_mol=0.05812220,
+        ),
+        "n_butane": ComponentProperties(
+            critical_temperature_k=425.2,
+            critical_pressure_bara=38.0,
+            acentric_factor=0.199,
+            molecular_weight_kg_per_mol=0.05812220,
+        ),
+        "i_pentane": ComponentProperties(
+            critical_temperature_k=460.4,
+            critical_pressure_bara=33.9,
+            acentric_factor=0.227,
+            molecular_weight_kg_per_mol=0.07214878,
+        ),
+        "n_pentane": ComponentProperties(
+            critical_temperature_k=469.7,
+            critical_pressure_bara=33.7,
+            acentric_factor=0.251,
+            molecular_weight_kg_per_mol=0.07214878,
+        ),
+        "n_hexane": ComponentProperties(
+            critical_temperature_k=507.5,
+            critical_pressure_bara=30.1,
+            acentric_factor=0.299,
+            molecular_weight_kg_per_mol=0.08617536,
+        ),
     }
 
     @classmethod

--- a/tests/architectural_tests/conftest.py
+++ b/tests/architectural_tests/conftest.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,11 @@ def src_dir(root_dir) -> Path:
 
 
 @pytest.fixture(scope="session")
-def libecalc_architecture(root_dir, src_dir: Path) -> EvaluableArchitecture:
-    arch = get_evaluable_architecture(str(root_dir), str(src_dir))
-    return arch
+def libecalc_architecture(root_dir, src_dir: Path) -> Callable[..., EvaluableArchitecture]:
+    def __evaluable_architecture(exclude_external_libraries: bool = True):
+        arch = get_evaluable_architecture(
+            str(root_dir), str(src_dir), exclude_external_libraries=exclude_external_libraries
+        )
+        return arch
+
+    return __evaluable_architecture

--- a/tests/architectural_tests/test_enforce_hexagonal_architecture.py
+++ b/tests/architectural_tests/test_enforce_hexagonal_architecture.py
@@ -15,7 +15,7 @@ def test_common_to_not_import_process(libecalc_architecture):
         )  # TODO: What to do with expression? Is it a part of ecalc_model "domain" only?
     )
 
-    rule.assert_applies(libecalc_architecture)
+    rule.assert_applies(libecalc_architecture())
 
 
 @pytest.mark.arch
@@ -33,7 +33,12 @@ def test_process_to_import_process_or_common_only(libecalc_architecture):
         .import_modules_that()
         .are_named(allowed_process_dependencies)
     )
-    rule.assert_applies(libecalc_architecture)
+    rule.assert_applies(libecalc_architecture())
+
+    rule_excl = (
+        Rule().modules_that().are_named("libecalc.process").should_not().import_modules_that().are_named("pydantic")
+    )
+    rule_excl.assert_applies(libecalc_architecture(exclude_external_libraries=False))
 
 
 @pytest.mark.arch
@@ -51,4 +56,4 @@ def test_ecalc_model_to_import_ecalc_model_or_common_only(libecalc_architecture)
         .import_modules_that()
         .are_named(allowed_process_dependencies)
     )
-    rule.assert_applies(libecalc_architecture)
+    rule.assert_applies(libecalc_architecture())


### PR DESCRIPTION
do we want to only use pydantic in ecalc_model?

## pros/cons having pydantic in domain

### pros

- a lot of ready to use validators
- objs can be serialized using pydantic for free
- a lot for free

### cons

- external dep/infrastructure concern in domain
- serialization is not a domain concern
- pydantic validation and domain/invariant validation is not the same?
- less control of pydantic magic
- overhead wrt performance? (most likely)
- cannot use __slots__ perforamance boost (does it matter?)

or the worst that we have now: some pydantic, some dataclass ...dont know what to expect, more to think of,
etc






## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
