### PR TITLE
fix(process): scale LiquidRemover mass rate by gas mass fraction

### DIFF
--- a/docs/drafts/next.draft.md
+++ b/docs/drafts/next.draft.md
@@ -14,6 +14,7 @@ STP: "flare" column has been added to STP Export - for `FIXED` installations onl
 ## Bug Fixes
 
 - Hardened compressor PH flash handling so invalid thermodynamic states are no longer used in compressor outlet calculations.
+- `LiquidRemover` now scales the outlet mass rate by the gas mass fraction when liquid is dropped, so the removed liquid mass is no longer carried by the gas stream downstream.
 
 ## Breaking changes
 

--- a/src/libecalc/process/process_units/liquid_remover.py
+++ b/src/libecalc/process/process_units/liquid_remover.py
@@ -1,6 +1,7 @@
 from typing import Final
 
 from libecalc.process.fluid_stream.constants import ThermodynamicConstants
+from libecalc.process.fluid_stream.exceptions import InvalidStreamException
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
@@ -16,7 +17,14 @@ class LiquidRemover(ProcessUnit):
 
     def propagate_stream(self, inlet_stream: FluidStream) -> FluidStream:
         """
-        Removes liquid from the fluid stream.
+        Removes liquid from the fluid stream. The new stream's mass rate is scaled
+        down by the gas mass fraction so the dropped-out liquid isn't re-injected
+        into the gas phase.
+
+        The removed liquid (mass = inlet.mass_rate * (1 - gas_mass_fraction),
+        composition = inlet - new_fluid) is currently discarded. It could later
+        be exposed as a separate outlet stream — e.g. routed to an oil pump,
+        accounted for in emissions, or reported back to the user.
 
         Args:
             inlet_stream: The fluid stream to be scrubbed.
@@ -26,6 +34,13 @@ class LiquidRemover(ProcessUnit):
         """
         if inlet_stream.vapor_fraction_molar < ThermodynamicConstants.PURE_VAPOR_THRESHOLD:
             new_fluid = self._fluid_service.remove_liquid(inlet_stream.fluid)
-            return inlet_stream.with_new_fluid(new_fluid)
+            inlet_molar_mass = inlet_stream.fluid.molar_mass
+            if inlet_molar_mass <= 0.0:
+                raise InvalidStreamException(
+                    f"Cannot remove liquid from a degenerate stream with non-positive molar mass: {inlet_molar_mass}"
+                )
+            gas_mass_fraction = inlet_stream.vapor_fraction_molar * new_fluid.molar_mass / inlet_molar_mass
+            new_mass_rate = inlet_stream.mass_rate_kg_per_h * gas_mass_fraction
+            return inlet_stream.with_new_fluid(new_fluid).with_mass_rate(new_mass_rate)
         else:
             return inlet_stream

--- a/tests/libecalc/process/process_units/test_liquid_remover.py
+++ b/tests/libecalc/process/process_units/test_liquid_remover.py
@@ -1,6 +1,12 @@
+from unittest.mock import MagicMock
+
+import pytest
+
 from ecalc_neqsim_wrapper.thermo import STANDARD_PRESSURE_BARA, STANDARD_TEMPERATURE_KELVIN
+from libecalc.process.fluid_stream.exceptions import InvalidStreamException
 from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_units.liquid_remover import LiquidRemover
 
 
 def test_liquid_remover_removes_liquid(fluid_service, liquid_remover_factory):
@@ -33,3 +39,48 @@ def test_liquid_remover_removes_liquid(fluid_service, liquid_remover_factory):
 
     assert inlet_stream.vapor_fraction_molar < 1.0
     assert outlet_stream.vapor_fraction_molar == 1.0
+
+    expected_gas_mass_fraction = (
+        inlet_stream.vapor_fraction_molar * outlet_stream.fluid.molar_mass / inlet_stream.fluid.molar_mass
+    )
+    expected_mass_rate = inlet_stream.mass_rate_kg_per_h * expected_gas_mass_fraction
+    assert outlet_stream.mass_rate_kg_per_h < inlet_stream.mass_rate_kg_per_h
+    assert outlet_stream.mass_rate_kg_per_h == expected_mass_rate
+
+
+def test_liquid_remover_passthrough_when_no_liquid(fluid_service, liquid_remover_factory):
+    composition = FluidComposition(
+        nitrogen=3,
+        CO2=1,
+        methane=80,
+        ethane=10,
+        propane=6,
+    )
+    fluid_model = FluidModel(eos_model=EoSModel.SRK, composition=composition)
+    fluid = fluid_service.create_fluid(
+        fluid_model=fluid_model,
+        pressure_bara=STANDARD_PRESSURE_BARA,
+        temperature_kelvin=STANDARD_TEMPERATURE_KELVIN,
+    )
+    inlet_stream = FluidStream.from_standard_rate(
+        standard_rate_m3_per_day=100000,
+        fluid_model=fluid.fluid_model,
+        fluid_properties=fluid.properties,
+    )
+    remover = liquid_remover_factory()
+    outlet_stream = remover.propagate_stream(inlet_stream)
+
+    assert inlet_stream.vapor_fraction_molar == 1.0
+    assert outlet_stream.mass_rate_kg_per_h == inlet_stream.mass_rate_kg_per_h
+
+
+def test_liquid_remover_raises_on_non_positive_inlet_molar_mass():
+    inlet_stream = MagicMock()
+    inlet_stream.vapor_fraction_molar = 0.5
+    inlet_stream.fluid.molar_mass = 0.0
+
+    fluid_service = MagicMock()
+    remover = LiquidRemover(fluid_service=fluid_service)
+
+    with pytest.raises(InvalidStreamException, match="non-positive molar mass"):
+        remover.propagate_stream(inlet_stream)


### PR DESCRIPTION
## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [x] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [x] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Github issue nr in the footer!

## What is this PR all about?

When `LiquidRemover` activates on a two-phase inlet, it removes the liquid phase from the composition but previously kept the total mass rate unchanged — so the dropped-out liquid mass was effectively re-injected into the gas stream downstream.

This PR scales the outlet mass rate by the gas mass fraction so the removed liquid is no longer carried by the gas:

```
gas_mass_fraction = vapor_fraction_molar * outlet_molar_mass / inlet_molar_mass
new_mass_rate     = inlet.mass_rate * gas_mass_fraction
```

Pure-vapor inlets are unchanged.

## What else did you consider?

Also exposing the removed liquid as a separate outlet stream (e.g. for routing to an oil pump or emissions accounting). Left as a docstring note — it would change `propagate_stream`'s contract and there is no consumer for it yet.

## Between the lines?

Resolves equinor/ecalc-internal#1767
