### PR TITLE
fix(neqsim): re-flash gas-only system after liquid removal

### DIFF
--- a/src/ecalc_neqsim_wrapper/thermo.py
+++ b/src/ecalc_neqsim_wrapper/thermo.py
@@ -347,9 +347,11 @@ class NeqsimFluid:
         return thermodynamic_system
 
     @staticmethod
-    def _remove_liquid(thermodynamic_system: ThermodynamicSystem) -> ThermodynamicSystem:
-        """Remove liquid part of thermodynamic_system, return new NeqsimFluid object with only gas part."""
-        return thermodynamic_system.clone().phaseToSystem("gas")
+    def _remove_liquid(thermodynamic_system: ThermodynamicSystem, use_gerg: bool) -> ThermodynamicSystem:
+        """Return a gas-only thermodynamic system, re-flashed at the current (P, T)."""
+        gas_only_system = thermodynamic_system.clone().phaseToSystem("gas")
+        gas_only_system = NeqsimFluid._tp_flash(thermodynamic_system=gas_only_system, use_gerg=use_gerg)
+        return gas_only_system
 
     def clone_gas_phase(self) -> NeqsimFluid:
         """Clone this fluid, extracting only the gas phase.
@@ -360,7 +362,7 @@ class NeqsimFluid:
         Returns:
             New NeqsimFluid with gas phase only.
         """
-        gas_only_system = NeqsimFluid._remove_liquid(self._thermodynamic_system)
+        gas_only_system = NeqsimFluid._remove_liquid(self._thermodynamic_system, use_gerg=self._use_gerg)
         return NeqsimFluid(thermodynamic_system=gas_only_system, use_gerg=self._use_gerg)
 
     def copy(self) -> NeqsimFluid:

--- a/tests/ecalc_neqsim_wrapper/integration_tests/test_remove_liquid.py
+++ b/tests/ecalc_neqsim_wrapper/integration_tests/test_remove_liquid.py
@@ -122,5 +122,49 @@ def test_liquid_takeoff(inlet_fluid, outlet_fluid) -> None:
     assert math.isclose(outlet_fluid.pressure_bara, fluid_after_liquid_takeoff.pressure_bara, rel_tol=0.01)
     assert math.isclose(outlet_fluid.molar_mass, fluid_after_liquid_takeoff.molar_mass, rel_tol=0.01)
     assert math.isclose(
-        outlet_fluid.enthalpy_joule_per_kg, fluid_after_liquid_takeoff.enthalpy_joule_per_kg, rel_tol=0.5
+        outlet_fluid.enthalpy_joule_per_kg, fluid_after_liquid_takeoff.enthalpy_joule_per_kg, rel_tol=0.02
     )
+
+
+# Propane-rich composition that is ~97% liquid at the probe (P, T) below.
+DENSE_LIQUID_COMPOSITION = FluidComposition(
+    water=0.003,
+    nitrogen=2.447,
+    CO2=0.64,
+    methane=41.91,
+    ethane=19.9,
+    propane=24.29,
+    i_butane=3.64,
+    n_butane=5.40,
+    i_pentane=0.83,
+    n_pentane=0.68,
+    n_hexane=0.26,
+).normalized()
+
+
+def test_clone_gas_phase_returns_initialized_properties() -> None:
+    """clone_gas_phase() on a two-phase fluid must return properties matching a clean PT-flash of the gas-only composition."""
+    two_phase = NeqsimFluid.create_thermo_system(
+        composition=DENSE_LIQUID_COMPOSITION,
+        temperature_kelvin=301.45,
+        pressure_bara=91.476,
+    )
+    assert two_phase.vapor_fraction_molar < 0.1, (
+        f"Test precondition: expected mostly-liquid state, got vap={two_phase.vapor_fraction_molar}"
+    )
+
+    gas_only = two_phase.clone_gas_phase()
+
+    assert math.isclose(gas_only.vapor_fraction_molar, 1.0, rel_tol=1e-3)
+    # Uninitialized systems return the sentinel kappa==1.0.
+    assert gas_only.kappa > 1.02, f"Suspicious kappa (uninitialized?): {gas_only.kappa}"
+
+    reference = NeqsimFluid.create_thermo_system(
+        composition=gas_only.composition,
+        temperature_kelvin=gas_only.temperature_kelvin,
+        pressure_bara=gas_only.pressure_bara,
+    )
+    assert math.isclose(gas_only.kappa, reference.kappa, rel_tol=1e-3)
+    assert math.isclose(gas_only.z, reference.z, rel_tol=1e-3)
+    assert math.isclose(gas_only.density, reference.density, rel_tol=1e-3)
+    assert math.isclose(gas_only.enthalpy_joule_per_kg, reference.enthalpy_joule_per_kg, rel_tol=1e-3)


### PR DESCRIPTION
## Summary

`NeqsimFluid._remove_liquid` returned the result of `phaseToSystem("gas")` without re-flashing or re-initializing the resulting system. Reading thermodynamic properties from that uninitialized system produced garbage — notably `kappa == 1.0` exactly (the uninitialized sentinel from `getGamma2()`) and an enthalpy off by orders of magnitude.

## Reproducer

A propane-rich composition (~24% C3) at 91.476 bara, 301.45 K is ~97% liquid:

| | h [J/kg] | kappa | z |
|---|---|---|---|
| Before `remove_liquid` (two-phase) | -2.28e+05 | 1.071 | 0.349 |
| After `remove_liquid` (buggy) | **-7.75e+07** | **1.000001** | 0.560 |
| Clean PT-flash of resulting gas-only composition | -1.24e+05 | 1.088 | 0.560 |

The bogus enthalpy and kappa propagate into the variable-speed compressor train stage 2 inlet stream. The downstream PH flash in `calculate_outlet_pressure_and_stream` then returns NaN enthalpy, surfacing as `CompressorOutletCalculationError`.

## Fix

Run a fresh `TPflash` on the gas-only system before returning, mirroring what `_tp_flash` / `_ph_flash` already do (`TPflash` + `init(3)` + `initProperties()`).

## Tests

- New `test_clone_gas_phase_returns_initialized_properties`: constructs a two-phase fluid, calls `clone_gas_phase()`, and asserts that the resulting properties match a clean PT-flash of the gas-only composition (kappa within 0.1%, z within 0.1%). Without this fix the test fails with `kappa ≈ 1.000003`.
- Tightened the existing `test_liquid_takeoff` enthalpy tolerance from `rel_tol=0.5` to `rel_tol=0.02`. The 50% tolerance had been masking this bug.
