### PR TITLE
refactor: consolidate conditions

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -224,15 +224,14 @@ class ProcessSimulationMapper:
             return ref
 
     def _map_conditions(
-        self, condition: YamlExpressionType | None, conditions: list[YamlExpressionType] | None
+        self, conditions: YamlExpressionType | list[YamlExpressionType] | None
     ) -> YamlExpressionType | None:
-        if condition is not None:
-            assert isinstance(condition, ExpressionType)
-            return condition
-        if conditions is not None:
-            assert isinstance(conditions, list)
+        if conditions is None:
+            return None
+        if isinstance(conditions, list):
             return handle_condition_list(conditions)
-        return None
+        assert isinstance(conditions, ExpressionType)
+        return conditions
 
     def _get_regularity(self) -> Regularity:
         return Regularity(
@@ -247,7 +246,9 @@ class ProcessSimulationMapper:
             time_series_expression=TimeSeriesExpression(
                 expression_evaluator=self._expression_evaluator,
                 expression=yaml_rate.value,
-                condition=self._map_conditions(yaml_rate.condition, yaml_rate.conditions),
+                condition=self._map_conditions(
+                    yaml_rate.conditions if yaml_rate.conditions is not None else yaml_rate.condition
+                ),
             ),
             consumption_rate_type=yaml_rate.type,
             regularity=self._get_regularity(),


### PR DESCRIPTION
Consolidates `_map_conditions` to take a single argument instead of two mutually exclusive ones. `_map_rate` picks the right YAML field via `conditions if conditions is not None else condition`.

Closes equinor/ecalc-internal#1814

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
