### PR TITLE
feat: add yaml classes for PORTS and CONNECTIONS-based STREAM_DISTRIBUTION

### DIFF
--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
@@ -17,36 +17,12 @@ PortReference = str  # hierarchical: "target.stage.port" or "stage.port" (single
 
 class YamlPortType(enum.StrEnum):
     INLET = "INLET"
-    OUTLET = "OUTLET"
 
 
 class YamlPort(YamlBase):
     type: Annotated[
         YamlPortType,
-        Field(
-            title="TYPE",
-            description="Port direction: INLET (stream enters the stage) or OUTLET (stream leaves the stage).",
-        ),
-    ]
-
-
-class YamlStreamConnection(YamlBase):
-    port: Annotated[
-        PortReference,
-        Field(
-            title="PORT",
-            description=(
-                "Hierarchical reference to a port declared on a stage: 'target.stage.port'. "
-                "The 'target.' prefix may be omitted when the simulation has a single target."
-            ),
-        ),
-    ]
-    stream: Annotated[
-        StreamRef,
-        Field(
-            title="STREAM",
-            description="Reference to a stream declared in INLET_STREAMS.",
-        ),
+        Field(title="TYPE", description="Port direction. Currently only INLET is supported (stream enters the stage)."),
     ]
 
 
@@ -137,9 +113,102 @@ class YamlSerialProcessSystem(YamlBase):
     items: list[YamlItem[YamlCompressorStageProcessSystem]]
 
 
+class YamlRateDistributionEntry(YamlBase):
+    port: Annotated[
+        PortReference,
+        Field(
+            title="PORT",
+            description="Hierarchical reference to a port: 'target.stage.port'. The 'target.' prefix may be omitted when the simulation has a single target.",
+        ),
+    ]
+    rate_fraction: Annotated[
+        float,
+        Field(
+            title="RATE_FRACTION",
+            description="Fraction of the source stream's rate routed to this port. Fractions across all entries in a RATE_DISTRIBUTION must sum to 1.0.",
+        ),
+    ]
+
+
 class YamlOverflow(YamlBase):
     from_reference: ProcessSystemReference
     to_reference: ProcessSystemReference
+
+
+class YamlPortOverflow(YamlBase):
+    from_reference: Annotated[
+        PortReference,
+        Field(
+            title="FROM_REFERENCE",
+            description="Source port from which excess rate is redirected when its capacity is exceeded.",
+        ),
+    ]
+    to_reference: Annotated[
+        PortReference,
+        Field(
+            title="TO_REFERENCE",
+            description="Destination port that receives the redirected excess rate.",
+        ),
+    ]
+
+
+class YamlIndividualStreamConnection(YamlBase):
+    type: Literal["INDIVIDUAL_STREAM"]
+    stream: Annotated[
+        StreamRef,
+        Field(
+            title="STREAM",
+            description="Reference to a stream declared in INLET_STREAMS. The full stream is routed to the specified port.",
+        ),
+    ]
+    port: Annotated[
+        PortReference,
+        Field(
+            title="PORT",
+            description="Hierarchical reference to a port that receives the stream: 'target.stage.port'. The 'target.' prefix may be omitted when the simulation has a single target.",
+        ),
+    ]
+
+
+class YamlCommonStreamConnection(YamlBase):
+    type: Literal["COMMON_STREAM"]
+    stream: Annotated[
+        StreamRef,
+        Field(
+            title="STREAM",
+            description="Reference to a stream declared in INLET_STREAMS. The stream is distributed across the ports listed in RATE_DISTRIBUTION.",
+        ),
+    ]
+    rate_distribution: Annotated[
+        list[YamlRateDistributionEntry],
+        Field(
+            title="RATE_DISTRIBUTION",
+            description="Distribution of the source stream across one or more destination ports. Each entry specifies a port and the fraction of the stream's rate routed to it.",
+        ),
+    ]
+    overflow: Annotated[
+        list[YamlPortOverflow] | None,
+        Field(
+            title="OVERFLOW",
+            description="Optional rules for redirecting excess rate between ports when a destination's capacity is exceeded.",
+        ),
+    ] = None
+
+
+YamlConnection = Annotated[
+    YamlIndividualStreamConnection | YamlCommonStreamConnection,
+    Field(discriminator="type"),
+]
+
+
+class YamlStreamDistributionPriority(YamlBase):
+    connections: Annotated[
+        list[YamlConnection],
+        Field(
+            title="CONNECTIONS",
+            description="Set of stream connections that together make up one complete stream-distribution configuration. Each entry routes one stream to one or more ports.",
+        ),
+    ]
 
 
 class YamlCommonStreamSetting(YamlBase):
@@ -180,17 +249,6 @@ class YamlProcessSimulation(YamlBase):
         Field(title="TARGETS"),
     ]
     stream_distribution: YamlStreamDistribution
-    stream_connections: Annotated[
-        list[YamlStreamConnection] | None,
-        Field(
-            title="STREAM_CONNECTIONS",
-            description=(
-                "Optional list of port-to-stream mappings. Each entry connects a port "
-                "(declared on a stage via PORTS) to a stream (declared in INLET_STREAMS). "
-                "INLET ports receive a stream into the train; OUTLET ports extract a stream."
-            ),
-        ),
-    ] = None
     pressure_control: Annotated[
         dict[
             ProcessSystemReference,

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
@@ -1,3 +1,4 @@
+import enum
 from typing import Annotated, Literal, TypeVar
 
 from pydantic import Field
@@ -10,6 +11,43 @@ from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import Yaml
 from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import DataOrFile
 
 StreamRef = str
+PortName = str
+PortReference = str  # hierarchical: "target.stage.port" or "stage.port" (single-target case)
+
+
+class YamlPortType(enum.StrEnum):
+    INLET = "INLET"
+    OUTLET = "OUTLET"
+
+
+class YamlPort(YamlBase):
+    type: Annotated[
+        YamlPortType,
+        Field(
+            title="TYPE",
+            description="Port direction: INLET (stream enters the stage) or OUTLET (stream leaves the stage).",
+        ),
+    ]
+
+
+class YamlStreamConnection(YamlBase):
+    port: Annotated[
+        PortReference,
+        Field(
+            title="PORT",
+            description=(
+                "Hierarchical reference to a port declared on a stage: 'target.stage.port'. "
+                "The 'target.' prefix may be omitted when the simulation has a single target."
+            ),
+        ),
+    ]
+    stream: Annotated[
+        StreamRef,
+        Field(
+            title="STREAM",
+            description="Reference to a stream declared in INLET_STREAMS.",
+        ),
+    ]
 
 
 class YamlControlMargin(YamlBase):
@@ -73,6 +111,17 @@ class YamlCompressorStageProcessSystem(YamlBase):
         ),
     ] = 0.0
     compressor: CompressorReference | YamlCompressor
+    ports: Annotated[
+        dict[PortName, YamlPort] | None,
+        Field(
+            title="PORTS",
+            description=(
+                "Optional mapping of port name → port specification. Declares physical interstage "
+                "connection points where fluid streams can be added (INLET) or extracted (OUTLET). "
+                "Wired to streams via STREAM_CONNECTIONS on the PROCESS_SIMULATION."
+            ),
+        ),
+    ] = None
 
 
 TTarget = TypeVar("TTarget")
@@ -131,6 +180,17 @@ class YamlProcessSimulation(YamlBase):
         Field(title="TARGETS"),
     ]
     stream_distribution: YamlStreamDistribution
+    stream_connections: Annotated[
+        list[YamlStreamConnection] | None,
+        Field(
+            title="STREAM_CONNECTIONS",
+            description=(
+                "Optional list of port-to-stream mappings. Each entry connects a port "
+                "(declared on a stage via PORTS) to a stream (declared in INLET_STREAMS). "
+                "INLET ports receive a stream into the train; OUTLET ports extract a stream."
+            ),
+        ),
+    ] = None
     pressure_control: Annotated[
         dict[
             ProcessSystemReference,

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
@@ -93,8 +93,7 @@ class YamlCompressorStageProcessSystem(YamlBase):
             title="PORTS",
             description=(
                 "Optional mapping of port name → port specification. Declares physical interstage "
-                "connection points where fluid streams can be added (INLET) or extracted (OUTLET). "
-                "Wired to streams via STREAM_CONNECTIONS on the PROCESS_SIMULATION."
+                "connection points where fluid streams can enter the stage."
             ),
         ),
     ] = None

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
@@ -154,7 +154,7 @@ class YamlPortOverflow(YamlBase):
 class YamlIndividualStreamConnection(YamlBase):
     type: Literal["INDIVIDUAL_STREAM"]
     stream: Annotated[
-        StreamRef,
+        StreamRef | YamlInletStream,
         Field(
             title="STREAM",
             description="Reference to a stream declared in INLET_STREAMS. The full stream is routed to the specified port.",
@@ -172,7 +172,7 @@ class YamlIndividualStreamConnection(YamlBase):
 class YamlCommonStreamConnection(YamlBase):
     type: Literal["COMMON_STREAM"]
     stream: Annotated[
-        StreamRef,
+        StreamRef | YamlInletStream,
         Field(
             title="STREAM",
             description="Reference to a stream declared in INLET_STREAMS. The stream is distributed across the ports listed in RATE_DISTRIBUTION.",


### PR DESCRIPTION
### Summary

Adds yaml classes for the upcoming CONNECTIONS-based STREAM_DISTRIBUTION structure, along with PORTS for declaring physical interstage connection points on compressor stages.

### Why

The domain already supports multiple streams and pressures, but the YAML schema only allows a single inlet stream and a single outlet pressure per train. PORTS and CONNECTIONS make it possible to express setups with multiple inlets along the train and intermediate pressure targets.

### Scope

Schema additions only. The new classes are defined but not used in any field on `YamlProcessSimulation`. The existing `stream_distribution` schema remains in place so the mapper keeps working. Switching the field, removing the legacy classes, renaming `YamlPortOverflow` to `YamlOverflow`, and migrating the mapper will follow in subsequent PRs.

### What's added

On `YamlCompressorStageProcessSystem`:
- `PORTS` — optional mapping of port name → port specification

New schema classes (defined, not yet wired up):
- `YamlPort`, `YamlPortType` — declares an INLET port on a stage
- `YamlRateDistributionEntry` — port + rate fraction
- `YamlPortOverflow` — port-to-port overflow (temporary name to avoid collision with the legacy `YamlOverflow`)
- `YamlIndividualStreamConnection` — one stream routed to one port
- `YamlCommonStreamConnection` — one stream distributed across multiple ports
- `YamlConnection` — discriminated union of the two connection types
- `YamlStreamDistributionPriority` — set of connections forming one complete configuration

<details>
<summary>YAML example (illustrates the target structure)</summary>

```yaml
# A setup with two compressor trains running in parallel, a side inlet on the second stage  
# of train A, and a common gas stream split between the two trains with overflow handling.
PROCESS_SIMULATIONS:
  - NAME: my_simulation
    TARGETS:
      - TARGET:
          NAME: train_a
          TYPE: SERIAL
          ITEMS:
            - TARGET:
                NAME: stage_1
                TYPE: COMPRESSOR_STAGE
                INLET_TEMPERATURE: 30
                COMPRESSOR: compressor_a1
            - TARGET:
                NAME: stage_2
                TYPE: COMPRESSOR_STAGE
                INLET_TEMPERATURE: 30
                COMPRESSOR: compressor_a2
                PORTS:
                  side_inlet:
                    TYPE: INLET
      - TARGET:
          NAME: train_b
          TYPE: SERIAL
          ITEMS:
            - TARGET:
                NAME: stage_1
                TYPE: COMPRESSOR_STAGE
                INLET_TEMPERATURE: 30
                COMPRESSOR: compressor_b1

    STREAM_DISTRIBUTION:
      # Priority 1 - preferred configuration:
      # - injection_stream goes to the side inlet on train A, stage 2
      # - main_gas is split 70/30 between train A and train B, with excess from
      #   train A overflowing to train B if A cannot handle its share.
      - CONNECTIONS:
          - TYPE: INDIVIDUAL_STREAM
            STREAM: injection_stream
            PORT: train_a.stage_2.side_inlet
          - TYPE: COMMON_STREAM
            STREAM: main_gas
            RATE_DISTRIBUTION:
              - PORT: train_a.stage_1.inlet
                RATE_FRACTION: 0.7
              - PORT: train_b.stage_1.inlet
                RATE_FRACTION: 0.3
            OVERFLOW:
              - FROM_REFERENCE: train_a.stage_1.inlet
                TO_REFERENCE: train_b.stage_1.inlet

      # Priority 2 - fallback configuration used if priority 1 is infeasible:
      # - injection_stream goes to the side inlet on train A, stage 2
      # - main_gas is routed entirely through train B.
      - CONNECTIONS:
          - TYPE: INDIVIDUAL_STREAM
            STREAM: injection_stream
            PORT: train_a.stage_2.side_inlet
          - TYPE: INDIVIDUAL_STREAM
            STREAM: main_gas
            PORT: train_b.stage_1.inlet
```

</details>

Refs: equinor/ecalc-internal#1809

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
