### PR TITLE
chore: expose properties explicitly

### DIFF
--- a/src/libecalc/process/process_solver/choke_configuration_handler.py
+++ b/src/libecalc/process/process_solver/choke_configuration_handler.py
@@ -1,5 +1,6 @@
 from typing import Final
 
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration import ChokeConfiguration, Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
 from libecalc.process.process_units.choke import Choke
@@ -12,6 +13,9 @@ class ChokeConfigurationHandler(ConfigurationHandler):
 
     def get_id(self) -> ConfigurationHandlerId:
         return self._id
+
+    def get_choke_id(self) -> ProcessUnitId:
+        return self._choke.get_id()
 
     def handle_configuration(self, configuration: Configuration) -> None:
         assert configuration.configuration_handler_id == self._id, (

--- a/src/libecalc/process/process_solver/recirculation_loop.py
+++ b/src/libecalc/process/process_solver/recirculation_loop.py
@@ -1,5 +1,6 @@
 from typing import Final
 
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration import (
     Configuration,
     ConfigurationHandlerId,
@@ -23,6 +24,12 @@ class RecirculationLoop(ConfigurationHandler):
 
     def get_id(self) -> ConfigurationHandlerId:
         return self._id
+
+    def get_mixer_id(self) -> ProcessUnitId:
+        return self._mixer.get_id()
+
+    def get_splitter_id(self) -> ProcessUnitId:
+        return self._splitter.get_id()
 
     def set_recirculation_rate(self, rate: float):
         self._mixer.set_mix_rate(rate)

--- a/src/libecalc/process/process_solver/temperature_setter_configuration_handler.py
+++ b/src/libecalc/process/process_solver/temperature_setter_configuration_handler.py
@@ -1,5 +1,6 @@
 from typing import Final
 
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration import (
     Configuration,
     ConfigurationHandlerId,
@@ -18,6 +19,9 @@ class TemperatureSetterConfigurationHandler(ConfigurationHandler):
 
     def get_id(self) -> ConfigurationHandlerId:
         return self._id
+
+    def get_temperature_setter_id(self) -> ProcessUnitId:
+        return self._temperature_setter.get_id()
 
     def handle_configuration(self, configuration: Configuration) -> None:
         assert configuration.configuration_handler_id == self._id, (

--- a/src/libecalc/process/shaft.py
+++ b/src/libecalc/process/shaft.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Final
 
 from libecalc.common.errors.exceptions import ProgrammingError
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId, SpeedConfiguration
 from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
@@ -39,6 +40,9 @@ class Shaft(ConfigurationHandler, ABC):
 
     def reset(self) -> None:
         self.reset_speed()
+
+    def get_compressor_ids(self) -> list[ProcessUnitId]:
+        return [compressor.get_id() for compressor in self._compressors]
 
     @abstractmethod
     def set_speed(self, value: float) -> None:


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
