### PR TITLE
chore: use global period instead of global time vector

### DIFF
--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -13,6 +13,7 @@ from libecalc.ecalc_model.time_series_configuration import (
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration import ConfigurationHandlerId
 from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
 from libecalc.process.stream_distribution.common_stream_distribution import Overflow
@@ -112,11 +113,14 @@ class ProcessSimulation(Entity[ProcessSimulationId]):  # process_model?
         process_problems: list[ProcessProblem],
         process_timesteps: Sequence[datetime],
         process_simulation_id: ProcessSimulationId | None = None,
+        process_configurations: dict[ProcessPipelineId, dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration]]
+        | None = None,
     ):
         self._name = name
         self.stream_distribution = stream_distribution
         self.process_problems = process_problems
         self.process_timesteps = process_timesteps
+        self.process_configurations = process_configurations
         self._id: Final[ProcessSimulationId] = process_simulation_id or ProcessSimulation._create_id()
 
     def get_id(self) -> ProcessSimulationId:

--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -1,10 +1,10 @@
 from collections.abc import Sequence
-from datetime import datetime
 from typing import Final, Literal, NewType, Self, assert_never
 from uuid import UUID
 
 from libecalc.common.ddd import value_object
 from libecalc.common.ddd.entity import Entity
+from libecalc.common.time_utils import Periods
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.ecalc_model.time_series_configuration import (
     TimeSeriesPressureDropperConfiguration,
@@ -105,7 +105,7 @@ class ProcessSimulation(Entity[ProcessSimulationId]):  # process_model?
         name: str,
         stream_distribution: CommonStreamDistributionConfig | IndividualStreamDistributionConfig,
         process_problems: list[ProcessProblem],
-        process_timesteps: Sequence[datetime],
+        process_periods: Periods,
         process_simulation_id: ProcessSimulationId | None = None,
         process_configurations: dict[
             ProcessPipelineId,
@@ -116,18 +116,17 @@ class ProcessSimulation(Entity[ProcessSimulationId]):  # process_model?
         self._name = name
         self.stream_distribution = stream_distribution
         self.process_problems = process_problems
-        self.process_timesteps = process_timesteps
+        self.process_periods = process_periods
         self.process_configurations = process_configurations
         self._id: Final[ProcessSimulationId] = process_simulation_id or ProcessSimulation._create_id()
 
     def get_id(self) -> ProcessSimulationId:
         return self._id
 
+    def get_process_periods(self) -> Periods:
+        return self.process_periods
     def get_name(self) -> str:
         return self._name
-
-    def get_process_timesteps(self) -> Sequence[datetime]:
-        return self.process_timesteps
 
     @classmethod
     def _create_id(cls: type[Self]) -> ProcessSimulationId:

--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -125,6 +125,7 @@ class ProcessSimulation(Entity[ProcessSimulationId]):  # process_model?
 
     def get_process_periods(self) -> Periods:
         return self.process_periods
+
     def get_name(self) -> str:
         return self._name
 

--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -7,14 +7,13 @@ from libecalc.common.ddd import value_object
 from libecalc.common.ddd.entity import Entity
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.ecalc_model.time_series_configuration import (
-    TimeSeriesChokeConfiguration,
+    TimeSeriesPressureDropperConfiguration,
     TimeSeriesTemperatureSetterConfiguration,
 )
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
-from libecalc.process.process_solver.configuration import ConfigurationHandlerId
 from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
 from libecalc.process.stream_distribution.common_stream_distribution import Overflow
 
@@ -66,10 +65,6 @@ class ProcessProblem(Entity[ProcessProblemId]):  # TODO: Rename to subproblem?
         constraint: Constraint,
         configuration_handlers: Sequence[ConfigurationHandler],
         process_pipeline_id: ProcessPipelineId,
-        configurations: dict[
-            ConfigurationHandlerId, TimeSeriesChokeConfiguration | TimeSeriesTemperatureSetterConfiguration
-        ]
-        | None = None,
         process_problem_id: ProcessProblemId | None = None,
     ):
         self.pressure_control_strategy = pressure_control_strategy
@@ -77,7 +72,6 @@ class ProcessProblem(Entity[ProcessProblemId]):  # TODO: Rename to subproblem?
         self.constraint = constraint
         self.process_pipeline_id = process_pipeline_id
         self.configuration_handlers = configuration_handlers
-        self.configurations = configurations or []
         self._id: Final[ProcessProblemId] = process_problem_id or ProcessProblem._create_id()
 
     def get_id(self) -> ProcessProblemId:
@@ -113,7 +107,10 @@ class ProcessSimulation(Entity[ProcessSimulationId]):  # process_model?
         process_problems: list[ProcessProblem],
         process_timesteps: Sequence[datetime],
         process_simulation_id: ProcessSimulationId | None = None,
-        process_configurations: dict[ProcessPipelineId, dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration]]
+        process_configurations: dict[
+            ProcessPipelineId,
+            dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration | TimeSeriesPressureDropperConfiguration],
+        ]
         | None = None,
     ):
         self._name = name

--- a/src/libecalc/ecalc_model/time_series_configuration.py
+++ b/src/libecalc/ecalc_model/time_series_configuration.py
@@ -3,8 +3,8 @@ from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesE
 
 
 @value_object
-class TimeSeriesChokeConfiguration:
-    delta_pressure: TimeSeriesExpression
+class TimeSeriesPressureDropperConfiguration:
+    pressure_drop_in_bara: TimeSeriesExpression
 
 
 @value_object

--- a/src/libecalc/ecalc_model/time_series_configuration.py
+++ b/src/libecalc/ecalc_model/time_series_configuration.py
@@ -9,4 +9,4 @@ class TimeSeriesChokeConfiguration:
 
 @value_object
 class TimeSeriesTemperatureSetterConfiguration:
-    temperature: TimeSeriesExpression
+    temperature_in_celsius: TimeSeriesExpression

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -21,6 +21,7 @@ from libecalc.ecalc_model.process_simulation import (
     ProcessSimulation,
 )
 from libecalc.ecalc_model.time_series_configuration import (
+    TimeSeriesPressureDropperConfiguration,
     TimeSeriesTemperatureSetterConfiguration,
 )
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
@@ -75,6 +76,7 @@ from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.process_units.direct_mixer import DirectMixer
 from libecalc.process.process_units.direct_splitter import DirectSplitter
 from libecalc.process.process_units.liquid_remover import LiquidRemover
+from libecalc.process.process_units.pressure_dropper import PressureDropper
 from libecalc.process.process_units.temperature_setter import TemperatureSetter
 from libecalc.process.shaft import VariableSpeedShaft
 from libecalc.process.stream_distribution.common_stream_distribution import (
@@ -308,7 +310,7 @@ class ProcessSimulationMapper:
         configuration_handlers: dict[ProcessPipelineId, Sequence[ConfigurationHandler]] = {}
         configurations: dict[
             ProcessPipelineId,
-            dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration],
+            dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration | TimeSeriesPressureDropperConfiguration],
         ] = {}
 
         process_pipeline_reference_to_id_map: dict[str, ProcessPipelineId] = {}
@@ -319,7 +321,9 @@ class ProcessSimulationMapper:
             process_unit_map: dict[ProcessUnitId, ProcessUnit] = {}
             compressor_stages: list[list[ProcessUnitId]] = []
             compressor_ids: list[ProcessUnitId] = []
-            problem_time_series_configurations: dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration] = {}
+            problem_time_series_configurations: dict[
+                ProcessUnitId, TimeSeriesTemperatureSetterConfiguration | TimeSeriesPressureDropperConfiguration
+            ] = {}
             for yaml_serial_item in item.items:
                 yaml_compressor_stage = self._resolve_compressor_stage_reference(yaml_serial_item.target)
                 compressor = self._get_compressor(yaml_compressor_stage=yaml_compressor_stage)
@@ -331,27 +335,33 @@ class ProcessSimulationMapper:
                 temperature_setter_configuration_handler = TemperatureSetterConfigurationHandler(
                     temperature_setter=temperature_setter
                 )
-                problem_time_series_configurations[
-                    temperature_setter_configuration_handler.get_temperature_setter_id()
-                ] = TimeSeriesTemperatureSetterConfiguration(
-                    temperature_in_celsius=self._map_temperature(yaml_compressor_stage.inlet_temperature)
+                problem_time_series_configurations[temperature_setter.get_id()] = (
+                    TimeSeriesTemperatureSetterConfiguration(
+                        temperature_in_celsius=self._map_temperature(yaml_compressor_stage.inlet_temperature)
+                    )
                 )
+                # TODO: Needed?
                 problem_configuration_handlers.append(temperature_setter_configuration_handler)
 
-                choke, choke_configuration_handler = choke_factory(fluid_service=self._fluid_service)
-                # problem_time_series_configurations[choke_configuration_handler.get_id()] = TimeSeriesChokeConfiguration(
-                #    delta_pressure=self._map_pressure(yaml_compressor_stage.pressure_drop_ahead_of_stage)
-                # )
-                problem_configuration_handlers.append(choke_configuration_handler)
+                pressure_dropper = PressureDropper(fluid_service=self._fluid_service)
+                problem_time_series_configurations[pressure_dropper.get_id()] = TimeSeriesPressureDropperConfiguration(
+                    pressure_drop_in_bara=self._map_pressure(yaml_compressor_stage.pressure_drop_ahead_of_stage)
+                )
 
                 liquid_remover = LiquidRemover(fluid_service=self._fluid_service)
                 process_unit_map[temperature_setter.get_id()] = temperature_setter
-                process_unit_map[choke.get_id()] = choke
+                process_unit_map[pressure_dropper.get_id()] = pressure_dropper
                 process_unit_map[liquid_remover.get_id()] = liquid_remover
                 process_unit_map[compressor.get_id()] = compressor
 
+                # TODO: Pressure dropper AFTER temperature setter. Correct? Should not it be before? Does it matter?
                 compressor_stages.append(
-                    [temperature_setter.get_id(), choke.get_id(), liquid_remover.get_id(), compressor.get_id()]
+                    [
+                        temperature_setter.get_id(),
+                        pressure_dropper.get_id(),
+                        liquid_remover.get_id(),
+                        compressor.get_id(),
+                    ]
                 )
 
             for compressor_id in compressor_ids:

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -334,7 +334,7 @@ class ProcessSimulationMapper:
                 problem_time_series_configurations[
                     temperature_setter_configuration_handler.get_temperature_setter_id()
                 ] = TimeSeriesTemperatureSetterConfiguration(
-                    temperature=self._map_temperature(yaml_compressor_stage.inlet_temperature)
+                    temperature_in_celsius=self._map_temperature(yaml_compressor_stage.inlet_temperature)
                 )
                 problem_configuration_handlers.append(temperature_setter_configuration_handler)
 

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -21,7 +21,6 @@ from libecalc.ecalc_model.process_simulation import (
     ProcessSimulation,
 )
 from libecalc.ecalc_model.time_series_configuration import (
-    TimeSeriesChokeConfiguration,
     TimeSeriesTemperatureSetterConfiguration,
 )
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
@@ -309,20 +308,18 @@ class ProcessSimulationMapper:
         configuration_handlers: dict[ProcessPipelineId, Sequence[ConfigurationHandler]] = {}
         configurations: dict[
             ProcessPipelineId,
-            dict[ConfigurationHandlerId, TimeSeriesChokeConfiguration | TimeSeriesTemperatureSetterConfiguration],
+            dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration],
         ] = {}
 
         process_pipeline_reference_to_id_map: dict[str, ProcessPipelineId] = {}
         for yaml_compressor_train_item in yaml_process_simulation.targets:
+            problem_configuration_handlers = []
             shaft = VariableSpeedShaft()
             item = self._resolve_train_reference(yaml_compressor_train_item.target)
             process_unit_map: dict[ProcessUnitId, ProcessUnit] = {}
             compressor_stages: list[list[ProcessUnitId]] = []
             compressor_ids: list[ProcessUnitId] = []
-            problem_configuration_handlers = []
-            problem_time_series_configurations: dict[
-                ConfigurationHandlerId, TimeSeriesChokeConfiguration | TimeSeriesTemperatureSetterConfiguration
-            ] = {}
+            problem_time_series_configurations: dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration] = {}
             for yaml_serial_item in item.items:
                 yaml_compressor_stage = self._resolve_compressor_stage_reference(yaml_serial_item.target)
                 compressor = self._get_compressor(yaml_compressor_stage=yaml_compressor_stage)
@@ -334,17 +331,17 @@ class ProcessSimulationMapper:
                 temperature_setter_configuration_handler = TemperatureSetterConfigurationHandler(
                     temperature_setter=temperature_setter
                 )
-                problem_time_series_configurations[temperature_setter_configuration_handler.get_id()] = (
-                    TimeSeriesTemperatureSetterConfiguration(
-                        temperature=self._map_temperature(yaml_compressor_stage.inlet_temperature)
-                    )
+                problem_time_series_configurations[
+                    temperature_setter_configuration_handler.get_temperature_setter_id()
+                ] = TimeSeriesTemperatureSetterConfiguration(
+                    temperature=self._map_temperature(yaml_compressor_stage.inlet_temperature)
                 )
                 problem_configuration_handlers.append(temperature_setter_configuration_handler)
 
                 choke, choke_configuration_handler = choke_factory(fluid_service=self._fluid_service)
-                problem_time_series_configurations[choke_configuration_handler.get_id()] = TimeSeriesChokeConfiguration(
-                    delta_pressure=self._map_pressure(yaml_compressor_stage.pressure_drop_ahead_of_stage)
-                )
+                # problem_time_series_configurations[choke_configuration_handler.get_id()] = TimeSeriesChokeConfiguration(
+                #    delta_pressure=self._map_pressure(yaml_compressor_stage.pressure_drop_ahead_of_stage)
+                # )
                 problem_configuration_handlers.append(choke_configuration_handler)
 
                 liquid_remover = LiquidRemover(fluid_service=self._fluid_service)
@@ -362,17 +359,18 @@ class ProcessSimulationMapper:
                 assert isinstance(compressor, Compressor)
                 shaft.connect(compressor)
 
+            problem_configuration_handlers.append(shaft)
+
             try:
                 pressure_control = yaml_process_simulation.pressure_control[item.name]
             except KeyError as e:
                 raise EcalcValidationException(f"Missing pressure control for process system '{item.name}'") from e
 
+            process_units = []
             if pressure_control == "COMMON_ASV":
                 recirculation_loop, process_units = with_asv(units=list(process_unit_map.values()))
                 problem_configuration_handlers.append(recirculation_loop)
-            else:
-                process_units = []
-                problem_configuration_handlers = []
+            else:  # INDIVIDUAL ASV (ASV per stage) assumed if not COMMON ASV explicitly set
                 for compressor_stage_ids in compressor_stages:
                     stage_units = [process_unit_map[stage_unit_id] for stage_unit_id in compressor_stage_ids]
                     recirculation_loop, stage_process_units = with_asv(units=stage_units)
@@ -500,7 +498,6 @@ class ProcessSimulationMapper:
                 anti_surge_strategy=anti_surge_configs[process_pipeline.get_id()],
                 pressure_control_strategy=pressure_control_configs[process_pipeline.get_id()],
                 configuration_handlers=configuration_handlers[process_pipeline.get_id()],
-                configurations=configurations[process_pipeline.get_id()],
             )
             for process_pipeline in process_pipelines
         ]
@@ -512,5 +509,6 @@ class ProcessSimulationMapper:
                 process_problems=process_problems,
                 stream_distribution=stream_distribution,
                 process_timesteps=process_timesteps,
+                process_configurations=configurations,
             ),
         )

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -353,11 +353,10 @@ class ProcessSimulationMapper:
                 process_unit_map[liquid_remover.get_id()] = liquid_remover
                 process_unit_map[compressor.get_id()] = compressor
 
-                # TODO: Pressure dropper AFTER temperature setter. Correct? Should not it be before? Does it matter?
                 compressor_stages.append(
                     [
-                        temperature_setter.get_id(),
                         pressure_dropper.get_id(),
+                        temperature_setter.get_id(),
                         liquid_remover.get_id(),
                         compressor.get_id(),
                     ]

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -1,10 +1,9 @@
 from collections.abc import Sequence
-from datetime import datetime
 from typing import Literal, assert_never
 
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
 from libecalc.common.errors.exceptions import InvalidResourceException
-from libecalc.common.time_utils import Period
+from libecalc.common.time_utils import Period, Periods
 from libecalc.common.units import Unit
 from libecalc.common.variables import ExpressionEvaluator
 from libecalc.domain.process.value_objects.chart.chart import ChartData
@@ -301,7 +300,7 @@ class ProcessSimulationMapper:
                 assert_never(recirculation_type)
 
     def map_process_simulation(
-        self, yaml_process_simulation: YamlProcessSimulation, process_timesteps: list[datetime]
+        self, yaml_process_simulation: YamlProcessSimulation, process_periods: Periods
     ) -> tuple[list[ProcessPipeline], ProcessSimulation]:
         process_pipelines: list[ProcessPipeline] = []
         constraints: dict[ProcessPipelineId, Constraint] = {}
@@ -518,7 +517,7 @@ class ProcessSimulationMapper:
                 name=yaml_process_simulation.name,
                 process_problems=process_problems,
                 stream_distribution=stream_distribution,
-                process_timesteps=process_timesteps,
+                process_periods=process_periods,
                 process_configurations=configurations,
             ),
         )

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -156,7 +156,7 @@ class YamlModel:
         process_pipelines = []
         for yaml_process_simulation in self._configuration.process_simulations:
             process_pipeline, process_simulation = mapper.map_process_simulation(
-                yaml_process_simulation=yaml_process_simulation, process_timesteps=self.get_periods().start_dates
+                yaml_process_simulation=yaml_process_simulation, process_periods=self.get_periods()
             )
             process_pipelines.extend(process_pipeline)
             process_simulations.append(process_simulation)

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -156,19 +156,19 @@ class YamlModel:
         process_pipelines = []
         for yaml_process_simulation in self._configuration.process_simulations:
             process_pipeline, process_simulation = mapper.map_process_simulation(
-                yaml_process_simulation=yaml_process_simulation, process_timesteps=self.get_timesteps()
+                yaml_process_simulation=yaml_process_simulation, process_timesteps=self.get_periods().start_dates
             )
             process_pipelines.extend(process_pipeline)
             process_simulations.append(process_simulation)
 
         return process_pipelines, process_simulations
 
-    def get_timesteps(self) -> list[datetime]:
+    def get_periods(self) -> Periods:
         """
         Get the global timevector for this model
         """
         self.validate_for_run()
-        return self._global_time_vector
+        return self._global_periods
 
     def get_emitter(self, container_id: uuid.UUID) -> Emitter | None:
         for installation in self.get_installations():
@@ -271,9 +271,9 @@ class YamlModel:
                 end=self._configuration.end,
                 additional_dates=set(self._configuration.dates),
             )
-            # Temporary side effect to set the global time vector in parsing
-            self._global_time_vector = time_vector
-            return Periods.create_periods(time_vector, include_before=False, include_after=False)
+            periods = Periods.create_periods(time_vector, include_before=False, include_after=False)
+            self._global_periods = periods
+            return periods
         except InvalidEndDate as e:
             location_keys = ("END",)
             raise ModelValidationException(

--- a/src/libecalc/process/process_units/pressure_dropper.py
+++ b/src/libecalc/process/process_units/pressure_dropper.py
@@ -1,0 +1,46 @@
+from typing import Final
+
+from libecalc.process.fluid_stream.fluid_service import FluidService
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_error import OutsideCapacityError
+from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
+
+
+class PressureDropper(ProcessUnit):
+    def __init__(
+        self,
+        fluid_service: FluidService,
+        process_unit_id: ProcessUnitId | None = None,
+        pressure_drop_bara: float = 0.0,
+    ):
+        self._id: Final[ProcessUnitId] = process_unit_id or ProcessUnit._create_id()
+        self._pressure_drop_bara = pressure_drop_bara
+        self._fluid_service = fluid_service
+
+    def get_id(self) -> ProcessUnitId:
+        return self._id
+
+    @property
+    def pressure_drop(self) -> float:
+        return self._pressure_drop_bara
+
+    def set_pressure_drop(self, pressure_drop_bara: float) -> None:
+        if pressure_drop_bara < 0:
+            raise ValueError("Pressure drop cannot be negative")
+        self._pressure_drop_bara = pressure_drop_bara
+
+    def propagate_stream(self, inlet_stream: FluidStream) -> FluidStream:
+        if self._pressure_drop_bara > 0.0:
+            new_pressure_bara = inlet_stream.pressure_bara - self._pressure_drop_bara
+            if new_pressure_bara < 0.0:
+                raise OutsideCapacityError(f"Pressure cannot drop below 0 (Given: {new_pressure_bara})")
+        else:
+            # Delta pressure = 0, i.e. don't do anything
+            return inlet_stream
+
+        return self._fluid_service.create_stream_from_standard_rate(
+            fluid_model=inlet_stream.fluid_model,
+            pressure_bara=new_pressure_bara,
+            temperature_kelvin=inlet_stream.temperature_kelvin,
+            standard_rate_m3_per_day=inlet_stream.standard_rate_sm3_per_day,
+        )


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
