### PR TITLE
refactor(solver): typed Solution failures and factories

### DIFF
--- a/src/libecalc/process/process_solver/anti_surge/individual_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/individual_asv.py
@@ -7,9 +7,7 @@ from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiS
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.solver import (
-    OutsideCapacityEvent,
     Solution,
-    SolverFailureStatus,
 )
 from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.process.process_units.compressor import Compressor
@@ -53,29 +51,15 @@ class IndividualASVAntiSurgeStrategy(AntiSurgeStrategy):
         for loop_id, compressor in zip(self._recirculation_loop_ids, self._compressors, strict=True):
             try:
                 inlet_stream_compressor = self._simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
+                max_actual_rate = compressor.maximum_flow_rate
+                if inlet_stream_compressor.volumetric_rate_m3_per_hour > max_actual_rate:
+                    raise RateTooHighError(
+                        process_unit_id=compressor.get_id(),
+                        actual_rate=inlet_stream_compressor.volumetric_rate_m3_per_hour,
+                        boundary_rate=max_actual_rate,
+                    )
             except RateTooHighError as e:
-                return Solution(
-                    success=False,
-                    configuration=configurations,
-                    failure_event=OutsideCapacityEvent(
-                        status=SolverFailureStatus.ABOVE_MAXIMUM_FLOW_RATE,
-                        actual_value=e.actual_rate,
-                        boundary_value=e.boundary_rate,
-                        source_id=e.process_unit_id,
-                    ),
-                )
-            max_actual_rate = compressor.maximum_flow_rate
-            if inlet_stream_compressor.volumetric_rate_m3_per_hour > max_actual_rate:
-                return Solution(
-                    success=False,
-                    configuration=configurations,
-                    failure_event=OutsideCapacityEvent(
-                        status=SolverFailureStatus.ABOVE_MAXIMUM_FLOW_RATE,
-                        actual_value=inlet_stream_compressor.volumetric_rate_m3_per_hour,
-                        boundary_value=max_actual_rate,
-                        source_id=compressor.get_id(),
-                    ),
-                )
+                return Solution.from_rate_too_high(e, configuration=configurations)
             boundary = compressor.get_recirculation_range(inlet_stream=inlet_stream_compressor)
             configuration: Configuration[RecirculationConfiguration] = Configuration(
                 configuration_handler_id=loop_id,

--- a/src/libecalc/process/process_solver/multi_pressure_solver.py
+++ b/src/libecalc/process/process_solver/multi_pressure_solver.py
@@ -8,7 +8,7 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
 from libecalc.process.process_solver.pressure_control.downstream_choke import DownstreamChokePressureControlStrategy
 from libecalc.process.process_solver.pressure_control.upstream_choke import UpstreamChokePressureControlStrategy
-from libecalc.process.process_solver.solver import Solution, SolverFailureStatus, TargetNotAchievableEvent
+from libecalc.process.process_solver.solver import Solution, TargetDirection
 
 
 class MultiPressureSolver:
@@ -108,15 +108,12 @@ class MultiPressureSolver:
                 segment.runner.apply_configurations(pressure_control_solution.configuration)
                 outlet = segment.runner.run(inlet_stream=current_inlet)
             elif outlet.pressure_bara < target:
-                solution = Solution(
-                    success=False,
+                solution = Solution.target_pressure_unreachable(
                     configuration=solution.configuration,
-                    failure_event=TargetNotAchievableEvent(
-                        status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
-                        achievable_value=outlet.pressure_bara,
-                        target_value=target.value,
-                        source_id=segment.process_pipeline_id,
-                    ),
+                    achievable_pressure_bara=outlet.pressure_bara,
+                    target_pressure_bara=target.value,
+                    source_id=segment.process_pipeline_id,
+                    direction=TargetDirection.MAX_BELOW_TARGET,
                 )
 
             current_inlet = outlet

--- a/src/libecalc/process/process_solver/multi_shaft_equal_ratio_solver.py
+++ b/src/libecalc/process/process_solver/multi_shaft_equal_ratio_solver.py
@@ -29,7 +29,7 @@ class MultiShaftEqualRatioSolver:
         """Split overall pressure target into equal per-pipeline ratios and delegate."""
         n = len(self._process_pipelines)
         if n == 0:
-            return Solution(success=True, configuration=[], failure_event=None)
+            return Solution(success=True, configuration=[], failure=None)
 
         pressure_ratio = (pressure_constraint.value / inlet_stream.pressure_bara) ** (1.0 / n)
 

--- a/src/libecalc/process/process_solver/multi_shaft_solver.py
+++ b/src/libecalc/process/process_solver/multi_shaft_solver.py
@@ -35,11 +35,11 @@ class MultiShaftSolver:
         )
 
         if not self._process_pipelines:
-            return Solution(success=True, configuration=[], failure_event=None)
+            return Solution(success=True, configuration=[], failure=None)
 
         current_inlet = inlet_stream
         all_configurations: list[Configuration[OperatingConfiguration]] = []
-        failure_event = None
+        failure = None
         overall_success = True
 
         for i, (pipeline, target) in enumerate(zip(self._process_pipelines, pressure_targets)):
@@ -48,8 +48,8 @@ class MultiShaftSolver:
 
             if not solution.success:
                 overall_success = False
-                if failure_event is None:
-                    failure_event = solution.failure_event
+                if failure is None:
+                    failure = solution.failure
                 logger.debug("Process pipeline %d failed to reach target %.1f bara.", i, target.value)
 
             pipeline.runner.apply_configurations(solution.configuration)
@@ -58,5 +58,5 @@ class MultiShaftSolver:
         return Solution(
             success=overall_success,
             configuration=all_configurations,
-            failure_event=failure_event,
+            failure=failure,
         )

--- a/src/libecalc/process/process_solver/outlet_pressure_solver.py
+++ b/src/libecalc/process/process_solver/outlet_pressure_solver.py
@@ -16,7 +16,11 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
-from libecalc.process.process_solver.solver import Solution, SolverFailureStatus, TargetNotAchievableEvent
+from libecalc.process.process_solver.solver import (
+    Solution,
+    TargetDirection,
+    TargetPressureUnreachableFailure,
+)
 from libecalc.process.process_solver.solvers.speed_solver import SpeedSolver
 
 
@@ -142,7 +146,7 @@ class OutletPressureSolver:
             return Solution(
                 success=False,
                 configuration=list(configurations.values()),
-                failure_event=self._anti_surge_solution.failure_event,
+                failure=self._anti_surge_solution.failure,
             )
 
         outlet_at_chosen_speed = self._get_outlet_stream(
@@ -151,15 +155,12 @@ class OutletPressureSolver:
         )
 
         if outlet_at_chosen_speed.pressure_bara < pressure_constraint:
-            return Solution(
-                success=False,
+            return Solution.target_pressure_unreachable(
                 configuration=list(configurations.values()),
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
-                    achievable_value=outlet_at_chosen_speed.pressure_bara,
-                    target_value=pressure_constraint.value,
-                    source_id=self._process_pipeline_id,
-                ),
+                achievable_pressure_bara=outlet_at_chosen_speed.pressure_bara,
+                target_pressure_bara=pressure_constraint.value,
+                source_id=self._process_pipeline_id,
+                direction=TargetDirection.MAX_BELOW_TARGET,
             )
 
         pressure_control_solution = self._pressure_control_strategy.apply(
@@ -170,12 +171,12 @@ class OutletPressureSolver:
         for pressure_control_configuration in pressure_control_solution.configuration:
             configurations[pressure_control_configuration.configuration_handler_id] = pressure_control_configuration
 
-        failure_event = pressure_control_solution.failure_event
-        if isinstance(failure_event, TargetNotAchievableEvent) and failure_event.source_id is None:
-            failure_event = failure_event.with_source_id(self._process_pipeline_id)
+        failure = pressure_control_solution.failure
+        if isinstance(failure, TargetPressureUnreachableFailure) and failure.source_id is None:
+            failure = failure.with_source_id(self._process_pipeline_id)
 
         return Solution(
             success=pressure_control_solution.success,
             configuration=list(configurations.values()),
-            failure_event=failure_event,
+            failure=failure,
         )

--- a/src/libecalc/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/common_asv.py
@@ -8,8 +8,7 @@ from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     Solution,
-    SolverFailureStatus,
-    TargetNotAchievableEvent,
+    TargetDirection,
 )
 from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.recirculation_solver import (
@@ -66,19 +65,16 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
         min_pressure_stream = recirculation_func(min_configuration)
 
         if min_pressure_stream.pressure_bara > target_pressure.value:
-            return Solution(
-                success=False,
+            return Solution.target_pressure_unreachable(
                 configuration=[
                     Configuration(
                         configuration_handler_id=self._recirculation_loop_id,
                         value=min_configuration,
                     )
                 ],
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=min_pressure_stream.pressure_bara,
-                    target_value=target_pressure.value,
-                ),
+                achievable_pressure_bara=min_pressure_stream.pressure_bara,
+                target_pressure_bara=target_pressure.value,
+                direction=TargetDirection.MIN_ABOVE_TARGET,
             )
 
         solver = RecirculationSolver(

--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -9,8 +9,7 @@ from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     Solution,
-    SolverFailureStatus,
-    TargetNotAchievableEvent,
+    TargetDirection,
 )
 from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.recirculation_solver import (
@@ -57,14 +56,11 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
         if minimum_achievable_pressure_stream.pressure_bara > target_pressure.value:
             # Even at maximum recirculation, the outlet pressure is still above the target.
             # The compressor train cannot deliver a pressure this low at the current speed.
-            return Solution(
-                success=False,
+            return Solution.target_pressure_unreachable(
                 configuration=minimum_achievable_pressure_configurations,
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=minimum_achievable_pressure_stream.pressure_bara,
-                    target_value=target_pressure.value,
-                ),
+                achievable_pressure_bara=minimum_achievable_pressure_stream.pressure_bara,
+                target_pressure_bara=target_pressure.value,
+                direction=TargetDirection.MIN_ABOVE_TARGET,
             )
 
         n_stages = len(self._recirculation_loop_ids)
@@ -109,7 +105,7 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
                 return Solution(
                     success=False,
                     configuration=configurations,
-                    failure_event=solution.failure_event,
+                    failure=solution.failure,
                 )
 
         return Solution(
@@ -179,14 +175,11 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
         if minimum_achievable_pressure_stream.pressure_bara > target_pressure.value:
             # Even at maximum recirculation, the outlet pressure is still above the target.
             # The compressor train cannot deliver a pressure this low at the current speed.
-            return Solution(
-                success=False,
+            return Solution.target_pressure_unreachable(
                 configuration=minimum_achievable_pressure_configurations,
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=minimum_achievable_pressure_stream.pressure_bara,
-                    target_value=target_pressure.value,
-                ),
+                achievable_pressure_bara=minimum_achievable_pressure_stream.pressure_bara,
+                target_pressure_bara=target_pressure.value,
+                direction=TargetDirection.MIN_ABOVE_TARGET,
             )
 
         def get_outlet_stream(rate_fraction: float) -> FluidStream:

--- a/src/libecalc/process/process_solver/solver.py
+++ b/src/libecalc/process/process_solver/solver.py
@@ -4,10 +4,11 @@ import abc
 import dataclasses
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from enum import StrEnum
+from enum import Enum
 from typing import Self, TypeVar
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration import (
@@ -20,40 +21,105 @@ from libecalc.process.process_solver.configuration import (
 TConfiguration = TypeVar("TConfiguration", covariant=True)
 
 
-class SolverFailureStatus(StrEnum):
-    ABOVE_MAXIMUM_FLOW_RATE = "ABOVE_MAXIMUM_FLOW_RATE"
-    BELOW_MINIMUM_FLOW_RATE = "BELOW_MINIMUM_FLOW_RATE"
-    MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET = "MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET"
-    MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET = "MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET"
+class SolverFailure:
+    """Typed cause for an unsuccessful ``Solution``.
+
+    Subclasses carry the data relevant to a specific failure mode (e.g. above stonewall,
+    below surge, target pressure unreachable). Consumers should branch on subclass with
+    ``isinstance`` or ``match`` rather than inspecting flag fields.
+    """
 
 
 @dataclass
-class OutsideCapacityEvent:
-    status: SolverFailureStatus
+class RateTooHighFailure(SolverFailure):
     source_id: ProcessUnitId
-    actual_value: float | None = None
-    boundary_value: float | None = None
+    actual_rate_m3_per_hour: float | None = None
+    maximum_rate_m3_per_hour: float | None = None
+
+    @classmethod
+    def from_error(cls, e: RateTooHighError) -> Self:
+        return cls(
+            source_id=e.process_unit_id,
+            actual_rate_m3_per_hour=e.actual_rate,
+            maximum_rate_m3_per_hour=e.boundary_rate,
+        )
 
 
 @dataclass
-class TargetNotAchievableEvent:
-    status: SolverFailureStatus
-    achievable_value: float
-    target_value: float
+class RateTooLowFailure(SolverFailure):
+    source_id: ProcessUnitId
+    actual_rate_m3_per_hour: float | None = None
+    minimum_rate_m3_per_hour: float | None = None
+
+    @classmethod
+    def from_error(cls, e: RateTooLowError) -> Self:
+        return cls(
+            source_id=e.process_unit_id,
+            actual_rate_m3_per_hour=e.actual_rate,
+            minimum_rate_m3_per_hour=e.boundary_rate,
+        )
+
+
+@dataclass
+class InfeasiblePressureFailure(SolverFailure):
+    source_id: ProcessUnitId
+    achieved_pressure_bara: float | None = None
+
+
+class TargetDirection(Enum):
+    """Which side of the target pressure the achievable boundary lies on."""
+
+    MAX_BELOW_TARGET = "max_below_target"
+    MIN_ABOVE_TARGET = "min_above_target"
+
+
+@dataclass
+class TargetPressureUnreachableFailure(SolverFailure):
+    achievable_pressure_bara: float
+    target_pressure_bara: float
+    direction: TargetDirection
     source_id: ProcessPipelineId | None = None
 
     def with_source_id(self, source_id: ProcessPipelineId) -> Self:
         return dataclasses.replace(self, source_id=source_id)
 
 
-SolverFailureEvent = OutsideCapacityEvent | TargetNotAchievableEvent
-
-
 @dataclass(frozen=True)
 class Solution[TConfiguration]:
     success: bool
     configuration: TConfiguration
-    failure_event: SolverFailureEvent | None = field(default=None)
+    failure: SolverFailure | None = field(default=None)
+
+    @classmethod
+    def from_rate_too_high[T](cls, e: RateTooHighError, configuration: T) -> Solution[T]:
+        """Build an unsuccessful Solution carrying a RateTooHighFailure."""
+        return Solution(success=False, configuration=configuration, failure=RateTooHighFailure.from_error(e))
+
+    @classmethod
+    def from_rate_too_low[T](cls, e: RateTooLowError, configuration: T) -> Solution[T]:
+        """Build an unsuccessful Solution carrying a RateTooLowFailure."""
+        return Solution(success=False, configuration=configuration, failure=RateTooLowFailure.from_error(e))
+
+    @classmethod
+    def target_pressure_unreachable[T](
+        cls,
+        configuration: T,
+        achievable_pressure_bara: float,
+        target_pressure_bara: float,
+        direction: TargetDirection,
+        source_id: ProcessPipelineId | None = None,
+    ) -> Solution[T]:
+        """Build an unsuccessful Solution carrying a TargetPressureUnreachableFailure."""
+        return Solution(
+            success=False,
+            configuration=configuration,
+            failure=TargetPressureUnreachableFailure(
+                achievable_pressure_bara=achievable_pressure_bara,
+                target_pressure_bara=target_pressure_bara,
+                direction=direction,
+                source_id=source_id,
+            ),
+        )
 
     def get_configuration(
         self: Solution[Sequence[Configuration[OperatingConfiguration]]],

--- a/src/libecalc/process/process_solver/solvers/recirculation_solver.py
+++ b/src/libecalc/process/process_solver/solvers/recirculation_solver.py
@@ -8,11 +8,10 @@ from libecalc.process.process_solver.configuration import RecirculationConfigura
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
 from libecalc.process.process_solver.solver import (
-    OutsideCapacityEvent,
     Solution,
     Solver,
-    SolverFailureStatus,
-    TargetNotAchievableEvent,
+    TargetDirection,
+    TargetPressureUnreachableFailure,
 )
 
 
@@ -58,15 +57,8 @@ class RecirculationSolver(Solver):
             )
         except RateTooHighError as e:
             # Flow is above stonewall at zero recirculation; adding recirculation cannot help.
-            return Solution(
-                success=False,
-                configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
-                failure_event=OutsideCapacityEvent(
-                    status=SolverFailureStatus.ABOVE_MAXIMUM_FLOW_RATE,
-                    actual_value=e.actual_rate,
-                    boundary_value=e.boundary_rate,
-                    source_id=e.process_unit_id,
-                ),
+            return Solution.from_rate_too_high(
+                e, configuration=RecirculationConfiguration(recirculation_rate=minimum_rate)
             )
 
         target_pressure = self._target_pressure
@@ -92,12 +84,12 @@ class RecirculationSolver(Solver):
             return Solution(
                 success=is_success,
                 configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
-                failure_event=None
+                failure=None
                 if is_success
-                else TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
-                    achievable_value=minimum_outlet_stream.pressure_bara,
-                    target_value=target_pressure.value,
+                else TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=minimum_outlet_stream.pressure_bara,
+                    target_pressure_bara=target_pressure.value,
+                    direction=TargetDirection.MAX_BELOW_TARGET,
                 ),
             )
         maximum_outlet_stream = func(RecirculationConfiguration(recirculation_rate=maximum_rate))
@@ -107,12 +99,12 @@ class RecirculationSolver(Solver):
             return Solution(
                 success=is_success,
                 configuration=RecirculationConfiguration(recirculation_rate=maximum_rate),
-                failure_event=None
+                failure=None
                 if is_success
-                else TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=maximum_outlet_stream.pressure_bara,
-                    target_value=target_pressure.value,
+                else TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=maximum_outlet_stream.pressure_bara,
+                    target_pressure_bara=target_pressure.value,
+                    direction=TargetDirection.MIN_ABOVE_TARGET,
                 ),
             )
 

--- a/src/libecalc/process/process_solver/solvers/speed_solver.py
+++ b/src/libecalc/process/process_solver/solvers/speed_solver.py
@@ -7,11 +7,9 @@ from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import SpeedConfiguration
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
 from libecalc.process.process_solver.solver import (
-    OutsideCapacityEvent,
     Solution,
     Solver,
-    SolverFailureStatus,
-    TargetNotAchievableEvent,
+    TargetDirection,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,38 +37,17 @@ class SpeedSolver(Solver[SpeedConfiguration]):
             maximum_speed_outlet_stream = func(max_speed_configuration)
         except RateTooHighError as e:
             logger.debug(f"No solution found for maximum speed: {max_speed_configuration}", exc_info=e)
-            return Solution(
-                success=False,
-                configuration=max_speed_configuration,
-                failure_event=OutsideCapacityEvent(
-                    status=SolverFailureStatus.ABOVE_MAXIMUM_FLOW_RATE,
-                    actual_value=e.actual_rate,
-                    boundary_value=e.boundary_rate,
-                    source_id=e.process_unit_id,
-                ),
-            )
+            return Solution.from_rate_too_high(e, configuration=max_speed_configuration)
         except RateTooLowError as e:
             logger.debug(f"No solution found for maximum speed: {max_speed_configuration}", exc_info=e)
-            return Solution(
-                success=False,
-                configuration=max_speed_configuration,
-                failure_event=OutsideCapacityEvent(
-                    status=SolverFailureStatus.BELOW_MINIMUM_FLOW_RATE,
-                    actual_value=e.actual_rate,
-                    boundary_value=e.boundary_rate,
-                    source_id=e.process_unit_id,
-                ),
-            )
+            return Solution.from_rate_too_low(e, configuration=max_speed_configuration)
 
         if maximum_speed_outlet_stream.pressure_bara < self._target_pressure:
-            return Solution(
-                success=False,
+            return Solution.target_pressure_unreachable(
                 configuration=SpeedConfiguration(self._boundary.max),
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
-                    achievable_value=maximum_speed_outlet_stream.pressure_bara,
-                    target_value=self._target_pressure,
-                ),
+                achievable_pressure_bara=maximum_speed_outlet_stream.pressure_bara,
+                target_pressure_bara=self._target_pressure,
+                direction=TargetDirection.MAX_BELOW_TARGET,
             )
 
         try:
@@ -98,14 +75,11 @@ class SpeedSolver(Solver[SpeedConfiguration]):
 
         if minimum_speed_outlet_stream.pressure_bara > self._target_pressure:
             # Solution 2, target pressure is too low
-            return Solution(
-                success=False,
+            return Solution.target_pressure_unreachable(
                 configuration=minimum_speed_configuration,
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=minimum_speed_outlet_stream.pressure_bara,
-                    target_value=self._target_pressure,
-                ),
+                achievable_pressure_bara=minimum_speed_outlet_stream.pressure_bara,
+                target_pressure_bara=self._target_pressure,
+                direction=TargetDirection.MIN_ABOVE_TARGET,
             )
 
         assert (

--- a/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
+++ b/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
@@ -6,7 +6,11 @@ from libecalc.process.process_pipeline.process_error import RateTooHighError
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import ChokeConfiguration
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy
-from libecalc.process.process_solver.solver import Solution, Solver, SolverFailureStatus, TargetNotAchievableEvent
+from libecalc.process.process_solver.solver import (
+    Solution,
+    Solver,
+    TargetDirection,
+)
 
 
 class UpstreamChokeSolver(Solver):
@@ -35,14 +39,11 @@ class UpstreamChokeSolver(Solver):
         max_pressure = outlet_pressure(search_boundary.max)
 
         if max_pressure > self._target_pressure:
-            return Solution(
-                success=False,
+            return Solution.target_pressure_unreachable(
                 configuration=ChokeConfiguration(delta_pressure=search_boundary.max),
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=max_pressure,
-                    target_value=self._target_pressure,
-                ),
+                achievable_pressure_bara=max_pressure,
+                target_pressure_bara=self._target_pressure,
+                direction=TargetDirection.MIN_ABOVE_TARGET,
             )
 
         delta_pressure = self._root_finding_strategy.find_root(

--- a/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
+++ b/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
@@ -111,9 +111,9 @@ def test_upstream_choke_solver_reports_failure_when_rate_capacity_prevents_reach
     solution = upstream_choke_solver.solve(choke_func)
 
     assert not solution.success
-    assert solution.failure_event is not None
-    assert solution.failure_event.target_value == target_pressure
-    assert solution.failure_event.achievable_value > target_pressure
+    assert solution.failure is not None
+    assert solution.failure.target_pressure_bara == target_pressure
+    assert solution.failure.achievable_pressure_bara > target_pressure
 
 
 def test_upstream_choke_solver_reports_failure_when_max_choke_still_above_target(
@@ -140,6 +140,6 @@ def test_upstream_choke_solver_reports_failure_when_max_choke_still_above_target
     solution = upstream_choke_solver.solve(choke_func)
 
     assert not solution.success
-    assert solution.failure_event is not None
-    assert solution.failure_event.target_value == target_pressure
-    assert solution.failure_event.achievable_value > target_pressure
+    assert solution.failure is not None
+    assert solution.failure.target_pressure_bara == target_pressure
+    assert solution.failure.achievable_pressure_bara > target_pressure

--- a/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
@@ -6,7 +6,7 @@ from libecalc.domain.process.compressor.core.train.train_evaluation_input import
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_pressure_solver import MultiPressureSolver
 from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
-from libecalc.process.process_solver.solver import TargetNotAchievableEvent
+from libecalc.process.process_solver.solver import TargetPressureUnreachableFailure
 from libecalc.process.process_units.mixer import Mixer
 from libecalc.process.process_units.splitter import Splitter
 from libecalc.process.shaft import VariableSpeedShaft
@@ -360,7 +360,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
     root_finding_strategy,
     variable_speed_chart_data_factory,
 ):
-    """TargetNotAchievableEvent.source_id should identify the second segment when it fails."""
+    """TargetPressureUnreachableFailure.source_id should identify the second segment when it fails."""
 
     temperature = 300.0
     q0 = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
@@ -433,8 +433,8 @@ def test_target_not_achievable_event_identifies_failing_segment(
     )
 
     assert not solution.success
-    assert isinstance(solution.failure_event, TargetNotAchievableEvent)
-    assert solution.failure_event.source_id == hp_process_pipeline.get_id()
+    assert isinstance(solution.failure, TargetPressureUnreachableFailure)
+    assert solution.failure.source_id == hp_process_pipeline.get_id()
 
 
 def test_target_not_achievable_event_when_first_segment_fails(
@@ -451,7 +451,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
     root_finding_strategy,
     variable_speed_chart_data_factory,
 ):
-    """TargetNotAchievableEvent.source_id should identify the first segment when it fails."""
+    """TargetPressureUnreachableFailure.source_id should identify the first segment when it fails."""
     temperature = 300.0
     q0 = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
     q0_vol = float(q0.volumetric_rate_m3_per_hour)
@@ -523,5 +523,5 @@ def test_target_not_achievable_event_when_first_segment_fails(
     )
 
     assert not solution.success
-    assert isinstance(solution.failure_event, TargetNotAchievableEvent)
-    assert solution.failure_event.source_id == lp_process_pipeline.get_id()
+    assert isinstance(solution.failure, TargetPressureUnreachableFailure)
+    assert solution.failure.source_id == lp_process_pipeline.get_id()

--- a/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
@@ -123,7 +123,7 @@ def test_three_shaft_train_hits_target_pressure(stream_factory, pipeline_kwargs)
 
     solution = solver.find_solution(FloatConstraint(270.0, abs_tol=5.0), inlet)
 
-    assert solution.success, f"Expected success; failure: {solution.failure_event}"
+    assert solution.success, f"Expected success; failure: {solution.failure}"
 
 
 def test_each_shaft_runs_at_different_speed(stream_factory, pipeline_kwargs):
@@ -180,7 +180,7 @@ def test_empty_pipelines(stream_factory):
 
     assert solution.success
     assert solution.configuration == []
-    assert solution.failure_event is None
+    assert solution.failure is None
 
 
 def test_single_pipeline_hits_exact_target(stream_factory, pipeline_kwargs):

--- a/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
@@ -34,7 +34,7 @@ def test_empty_pipelines(stream_factory):
 
     assert solution.success
     assert solution.configuration == []
-    assert solution.failure_event is None
+    assert solution.failure is None
 
 
 def test_unreachable_target_reports_failure(stream_factory, fluid_service, root_finding_strategy):
@@ -57,11 +57,11 @@ def test_unreachable_target_reports_failure(stream_factory, fluid_service, root_
     solution = solver.find_solution([FloatConstraint(9000.0)], inlet)
 
     assert not solution.success
-    assert solution.failure_event is not None
+    assert solution.failure is not None
 
 
 def test_second_pipeline_failure_preserves_first_failure(stream_factory, fluid_service, root_finding_strategy):
-    """When multiple pipelines fail, the first failure_event is preserved."""
+    """When multiple pipelines fail, the first failure is preserved."""
     pipelines = [
         make_process_pipeline(
             min_rate=200,
@@ -89,6 +89,6 @@ def test_second_pipeline_failure_preserves_first_failure(stream_factory, fluid_s
     solution = solver.find_solution([FloatConstraint(9000.0), FloatConstraint(90000.0)], inlet)
 
     assert not solution.success
-    assert solution.failure_event is not None
+    assert solution.failure is not None
     # Configurations are still collected (best-effort from each pipeline)
     assert len(solution.configuration) > 0

--- a/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
@@ -70,7 +70,7 @@ def test_multi_shaft_outlet_pressure_matches_simplified_train(
     solver = MultiShaftEqualRatioSolver(process_pipelines=solver_pipelines)
     solution = solver.find_solution(FloatConstraint(_P_OUT_BARA, abs_tol=1.0), inlet_stream)
 
-    assert solution.success, f"Solver failed: {solution.failure_event}"
+    assert solution.success, f"Solver failed: {solution.failure}"
 
     current = inlet_stream
     for pipeline in solver_pipelines:


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why) — pure refactor; existing tests cover the behaviour. A few test assertions updated to the new field/class names.
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

Solver failure causes were tagged twice: by class (`OutsideCapacityEvent` vs `TargetNotAchievableEvent`) and by a `SolverFailureStatus` enum field. Nothing prevented `OutsideCapacityEvent(status=MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET, …)` — a nonsense combination. Fields were generic (`actual_value`, `boundary_value`, `achievable_value`), so unit and meaning lived in the call site rather than the type.

Replace the enum + generic dataclasses with a small typed hierarchy under a shared `SolverFailure` base:

```
SolverFailure                                                     (marker base)
├── RateTooHighFailure(source_id, actual_rate_m3_per_hour, maximum_rate_m3_per_hour)
├── RateTooLowFailure (source_id, actual_rate_m3_per_hour, minimum_rate_m3_per_hour)
└── TargetPressureUnreachableFailure(
        achievable_pressure_bara, target_pressure_bara,
        direction: TargetDirection, source_id?
    )
```

- **`SolverFailure`** is a plain marker base. `Solution.failure: SolverFailure | None` types as a single base type and supports `isinstance` / `match` discrimination at consumers.
- **Rate failures** are siblings — the asymmetric field names (`maximum_…` vs `minimum_…`) make a shared base lose precision.
- **`TargetPressureUnreachableFailure`** collapses the previous empty `MaximumAchievableBelowTargetEvent` / `MinimumAchievableAboveTargetEvent` subclasses into one class with a `TargetDirection` enum field (`MAX_BELOW_TARGET` / `MIN_ABOVE_TARGET`). The two subclasses carried no data of their own, so the split was type-system noise. The direction is now an explicit, queryable field.

`SolverFailureStatus` is removed. Its `.status` field had no consumers outside one test assertion.

The `failure_event` field on `Solution` is renamed to `failure` to match the new class names.

### `from_error` classmethods

Each rate failure exposes a `from_error` classmethod that builds the failure from its corresponding exception:

```python
@classmethod
def from_error(cls, e: RateTooHighError) -> Self:
    return cls(
        source_id=e.process_unit_id,
        actual_rate_m3_per_hour=e.actual_rate,
        maximum_rate_m3_per_hour=e.boundary_rate,
    )
```

The error → failure mapping lives with the failure definition rather than being duplicated at every catch site. All call sites go through `from_error`. One pre-existing site in `IndividualASVAntiSurgeStrategy` that explicitly checked `volumetric_rate > max_actual_rate` and built the failure from local values is converted to `raise RateTooHighError(...)`, caught by the same `except` block — unifying the two failure paths.

### `Solution` factory classmethods

`Solution` exposes three factories that build the unsuccessful `Solution` + matching failure in a single call:

```python
@classmethod
def from_rate_too_high[T](cls, e: RateTooHighError, configuration: T) -> Solution[T]: ...

@classmethod
def from_rate_too_low[T](cls, e: RateTooLowError, configuration: T) -> Solution[T]: ...

@classmethod
def target_pressure_unreachable[T](
    cls, configuration: T,
    achievable_pressure_bara: float, target_pressure_bara: float,
    direction: TargetDirection, source_id: ProcessPipelineId | None = None,
) -> Solution[T]: ...
```

Call sites collapse from 5–8 lines of `Solution(success=False, configuration=..., failure=<Failure>(...))` to a single call with only the inputs that vary. The `success=False` + `failure=<matching type>` coupling is centralised so the two can't drift.

Per-method generic `[T]` is used so the new classmethod parameters don't pull `TConfiguration` into an input position on the class — that would flip the auto-inferred variance to invariant and break the (typing-correct) `Solution.combine(anti_surge_solution)` call in `MultiPressureSolver`.

## What else did you consider?

## Between the lines?


