### PR TITLE
fix(solver): handle infeasible pressure from PressureDropper/Choke

### DIFF
--- a/src/libecalc/process/process_pipeline/process_error.py
+++ b/src/libecalc/process/process_pipeline/process_error.py
@@ -13,6 +13,18 @@ class OutsideCapacityError(ProcessError):
         super().__init__(reason)
 
 
+class InfeasiblePressureError(OutsideCapacityError):
+    def __init__(
+        self,
+        process_unit_id: ProcessUnitId,
+        achieved_pressure_bara: float | None = None,
+        reason: str = "Computed outlet pressure is non-positive.",
+    ):
+        self.process_unit_id = process_unit_id
+        self.achieved_pressure_bara = achieved_pressure_bara
+        super().__init__(reason)
+
+
 class RateTooLowError(OutsideCapacityError):
     def __init__(
         self,

--- a/src/libecalc/process/process_solver/anti_surge/common_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/common_asv.py
@@ -1,11 +1,12 @@
 from collections.abc import Sequence
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_error import InfeasiblePressureError
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
-from libecalc.process.process_solver.solver import Solution
+from libecalc.process.process_solver.solver import InfeasiblePressureFailure, Solution
 from libecalc.process.process_solver.solvers.recirculation_solver import (
     RecirculationConfiguration,
     RecirculationSolver,
@@ -38,7 +39,6 @@ class CommonASVAntiSurgeStrategy(AntiSurgeStrategy):
         self._simulator = simulator
 
     def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
-        # Increase recirculation to give minimum feasible flow and return outlet.
         recirculation_solution = self._increase_recirculation_to_minimum_feasible(inlet_stream)
         return Solution(
             success=recirculation_solution.success,
@@ -48,6 +48,7 @@ class CommonASVAntiSurgeStrategy(AntiSurgeStrategy):
                     value=recirculation_solution.configuration,
                 )
             ],
+            failure=recirculation_solution.failure,
         )
 
     def _apply_configuration(self, cfg: RecirculationConfiguration):
@@ -59,7 +60,16 @@ class CommonASVAntiSurgeStrategy(AntiSurgeStrategy):
         self, inlet_stream: FluidStream
     ) -> Solution[RecirculationConfiguration]:
         # The recirculation boundary depends on the inlet stream (and implicitly current speed).
-        compressor_inlet_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=self._first_compressor.get_id())
+        try:
+            compressor_inlet_stream = self._simulator.run(
+                inlet_stream=inlet_stream, to_id=self._first_compressor.get_id()
+            )
+        except InfeasiblePressureError as e:
+            return Solution(
+                success=False,
+                configuration=RecirculationConfiguration(recirculation_rate=0),
+                failure=InfeasiblePressureFailure.from_error(e),
+            )
         boundary = self._first_compressor.get_recirculation_range(compressor_inlet_stream)
 
         def recirculation_func(cfg: RecirculationConfiguration) -> FluidStream:

--- a/src/libecalc/process/process_solver/anti_surge/individual_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/individual_asv.py
@@ -2,11 +2,12 @@ from collections.abc import Sequence
 from typing import override
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import RateTooHighError
+from libecalc.process.process_pipeline.process_error import InfeasiblePressureError, RateTooHighError
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.solver import (
+    InfeasiblePressureFailure,
     RateTooHighFailure,
     Solution,
 )
@@ -64,6 +65,12 @@ class IndividualASVAntiSurgeStrategy(AntiSurgeStrategy):
                     success=False,
                     configuration=configurations,
                     failure=RateTooHighFailure.from_error(e),
+                )
+            except InfeasiblePressureError as e:
+                return Solution(
+                    success=False,
+                    configuration=configurations,
+                    failure=InfeasiblePressureFailure.from_error(e),
                 )
             boundary = compressor.get_recirculation_range(inlet_stream=inlet_stream_compressor)
             configuration: Configuration[RecirculationConfiguration] = Configuration(

--- a/src/libecalc/process/process_solver/anti_surge/individual_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/individual_asv.py
@@ -7,9 +7,8 @@ from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiS
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.solver import (
-    OutsideCapacityEvent,
+    RateTooHighFailure,
     Solution,
-    SolverFailureStatus,
 )
 from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.process.process_units.compressor import Compressor
@@ -53,28 +52,18 @@ class IndividualASVAntiSurgeStrategy(AntiSurgeStrategy):
         for loop_id, compressor in zip(self._recirculation_loop_ids, self._compressors, strict=True):
             try:
                 inlet_stream_compressor = self._simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
+                max_actual_rate = compressor.maximum_flow_rate
+                if inlet_stream_compressor.volumetric_rate_m3_per_hour > max_actual_rate:
+                    raise RateTooHighError(
+                        process_unit_id=compressor.get_id(),
+                        actual_rate=inlet_stream_compressor.volumetric_rate_m3_per_hour,
+                        boundary_rate=max_actual_rate,
+                    )
             except RateTooHighError as e:
                 return Solution(
                     success=False,
                     configuration=configurations,
-                    failure_event=OutsideCapacityEvent(
-                        status=SolverFailureStatus.ABOVE_MAXIMUM_FLOW_RATE,
-                        actual_value=e.actual_rate,
-                        boundary_value=e.boundary_rate,
-                        source_id=e.process_unit_id,
-                    ),
-                )
-            max_actual_rate = compressor.maximum_flow_rate
-            if inlet_stream_compressor.volumetric_rate_m3_per_hour > max_actual_rate:
-                return Solution(
-                    success=False,
-                    configuration=configurations,
-                    failure_event=OutsideCapacityEvent(
-                        status=SolverFailureStatus.ABOVE_MAXIMUM_FLOW_RATE,
-                        actual_value=inlet_stream_compressor.volumetric_rate_m3_per_hour,
-                        boundary_value=max_actual_rate,
-                        source_id=compressor.get_id(),
-                    ),
+                    failure=RateTooHighFailure.from_error(e),
                 )
             boundary = compressor.get_recirculation_range(inlet_stream=inlet_stream_compressor)
             configuration: Configuration[RecirculationConfiguration] = Configuration(

--- a/src/libecalc/process/process_solver/multi_pressure_solver.py
+++ b/src/libecalc/process/process_solver/multi_pressure_solver.py
@@ -95,7 +95,7 @@ class MultiPressureSolver:
 
             anti_surge_solution = segment.anti_surge_strategy.apply(inlet_stream=current_inlet)
             segment.runner.apply_configurations(anti_surge_solution.configuration)
-            solution = solution.combine(anti_surge_solution)
+            solution = solution.combine(anti_surge_solution)  # type: ignore[arg-type]
 
             outlet = segment.runner.run(inlet_stream=current_inlet)
 

--- a/src/libecalc/process/process_solver/multi_pressure_solver.py
+++ b/src/libecalc/process/process_solver/multi_pressure_solver.py
@@ -8,7 +8,7 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
 from libecalc.process.process_solver.pressure_control.downstream_choke import DownstreamChokePressureControlStrategy
 from libecalc.process.process_solver.pressure_control.upstream_choke import UpstreamChokePressureControlStrategy
-from libecalc.process.process_solver.solver import Solution, SolverFailureStatus, TargetNotAchievableEvent
+from libecalc.process.process_solver.solver import Solution, TargetDirection, TargetPressureUnreachableFailure
 
 
 class MultiPressureSolver:
@@ -111,11 +111,11 @@ class MultiPressureSolver:
                 solution = Solution(
                     success=False,
                     configuration=solution.configuration,
-                    failure_event=TargetNotAchievableEvent(
-                        status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
-                        achievable_value=outlet.pressure_bara,
-                        target_value=target.value,
+                    failure=TargetPressureUnreachableFailure(
+                        achievable_pressure_bara=outlet.pressure_bara,
+                        target_pressure_bara=target.value,
                         source_id=segment.process_pipeline_id,
+                        direction=TargetDirection.MAX_BELOW_TARGET,
                     ),
                 )
 

--- a/src/libecalc/process/process_solver/multi_shaft_equal_ratio_solver.py
+++ b/src/libecalc/process/process_solver/multi_shaft_equal_ratio_solver.py
@@ -29,7 +29,7 @@ class MultiShaftEqualRatioSolver:
         """Split overall pressure target into equal per-pipeline ratios and delegate."""
         n = len(self._process_pipelines)
         if n == 0:
-            return Solution(success=True, configuration=[], failure_event=None)
+            return Solution(success=True, configuration=[], failure=None)
 
         pressure_ratio = (pressure_constraint.value / inlet_stream.pressure_bara) ** (1.0 / n)
 

--- a/src/libecalc/process/process_solver/multi_shaft_solver.py
+++ b/src/libecalc/process/process_solver/multi_shaft_solver.py
@@ -35,11 +35,11 @@ class MultiShaftSolver:
         )
 
         if not self._process_pipelines:
-            return Solution(success=True, configuration=[], failure_event=None)
+            return Solution(success=True, configuration=[], failure=None)
 
         current_inlet = inlet_stream
         all_configurations: list[Configuration[OperatingConfiguration]] = []
-        failure_event = None
+        failure = None
         overall_success = True
 
         for i, (pipeline, target) in enumerate(zip(self._process_pipelines, pressure_targets)):
@@ -48,8 +48,8 @@ class MultiShaftSolver:
 
             if not solution.success:
                 overall_success = False
-                if failure_event is None:
-                    failure_event = solution.failure_event
+                if failure is None:
+                    failure = solution.failure
                 logger.debug("Process pipeline %d failed to reach target %.1f bara.", i, target.value)
 
             pipeline.runner.apply_configurations(solution.configuration)
@@ -58,5 +58,5 @@ class MultiShaftSolver:
         return Solution(
             success=overall_success,
             configuration=all_configurations,
-            failure_event=failure_event,
+            failure=failure,
         )

--- a/src/libecalc/process/process_solver/outlet_pressure_solver.py
+++ b/src/libecalc/process/process_solver/outlet_pressure_solver.py
@@ -16,7 +16,11 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
-from libecalc.process.process_solver.solver import Solution, SolverFailureStatus, TargetNotAchievableEvent
+from libecalc.process.process_solver.solver import (
+    Solution,
+    TargetDirection,
+    TargetPressureUnreachableFailure,
+)
 from libecalc.process.process_solver.solvers.speed_solver import SpeedSolver
 
 
@@ -142,7 +146,7 @@ class OutletPressureSolver:
             return Solution(
                 success=False,
                 configuration=list(configurations.values()),
-                failure_event=self._anti_surge_solution.failure_event,
+                failure=self._anti_surge_solution.failure,
             )
 
         outlet_at_chosen_speed = self._get_outlet_stream(
@@ -154,11 +158,11 @@ class OutletPressureSolver:
             return Solution(
                 success=False,
                 configuration=list(configurations.values()),
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
-                    achievable_value=outlet_at_chosen_speed.pressure_bara,
-                    target_value=pressure_constraint.value,
+                failure=TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=outlet_at_chosen_speed.pressure_bara,
+                    target_pressure_bara=pressure_constraint.value,
                     source_id=self._process_pipeline_id,
+                    direction=TargetDirection.MAX_BELOW_TARGET,
                 ),
             )
 
@@ -170,12 +174,12 @@ class OutletPressureSolver:
         for pressure_control_configuration in pressure_control_solution.configuration:
             configurations[pressure_control_configuration.configuration_handler_id] = pressure_control_configuration
 
-        failure_event = pressure_control_solution.failure_event
-        if isinstance(failure_event, TargetNotAchievableEvent) and failure_event.source_id is None:
-            failure_event = failure_event.with_source_id(self._process_pipeline_id)
+        failure = pressure_control_solution.failure
+        if isinstance(failure, TargetPressureUnreachableFailure) and failure.source_id is None:
+            failure = failure.with_source_id(self._process_pipeline_id)
 
         return Solution(
             success=pressure_control_solution.success,
             configuration=list(configurations.values()),
-            failure_event=failure_event,
+            failure=failure,
         )

--- a/src/libecalc/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/common_asv.py
@@ -8,8 +8,8 @@ from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     Solution,
-    SolverFailureStatus,
-    TargetNotAchievableEvent,
+    TargetDirection,
+    TargetPressureUnreachableFailure,
 )
 from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.recirculation_solver import (
@@ -74,10 +74,10 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
                         value=min_configuration,
                     )
                 ],
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=min_pressure_stream.pressure_bara,
-                    target_value=target_pressure.value,
+                failure=TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=min_pressure_stream.pressure_bara,
+                    target_pressure_bara=target_pressure.value,
+                    direction=TargetDirection.MIN_ABOVE_TARGET,
                 ),
             )
 

--- a/src/libecalc/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/common_asv.py
@@ -1,12 +1,15 @@
 from collections.abc import Sequence
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_error import InfeasiblePressureError
+from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
+    InfeasiblePressureFailure,
     Solution,
     TargetDirection,
     TargetPressureUnreachableFailure,
@@ -50,7 +53,6 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
             )
             return self._simulator.run(inlet_stream=inlet_stream)
 
-        # Check feasibility: can we reach target pressure at maximum recirculation?
         # Reset recirculation before computing the boundary — the mixer may carry
         # residual state from anti-surge, which inflates the inlet rate and
         # shrinks the recirculation range.
@@ -60,8 +62,12 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
                 value=RecirculationConfiguration(recirculation_rate=0.0),
             )
         )
-        compressor_inlet_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=self._first_compressor.get_id())
-        boundary = self._first_compressor.get_recirculation_range(compressor_inlet_stream)
+
+        boundary_solution = self._compute_recirculation_boundary(inlet_stream)
+        if not boundary_solution.success:
+            return Solution(success=False, configuration=[], failure=boundary_solution.failure)
+        boundary = boundary_solution.configuration
+
         min_configuration = RecirculationConfiguration(recirculation_rate=boundary.max)
         min_pressure_stream = recirculation_func(min_configuration)
 
@@ -97,4 +103,19 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
                     value=solution.configuration,
                 )
             ],
+            failure=solution.failure,
         )
+
+    def _compute_recirculation_boundary(self, inlet_stream: FluidStream) -> Solution[Boundary]:
+        try:
+            compressor_inlet_stream = self._simulator.run(
+                inlet_stream=inlet_stream, to_id=self._first_compressor.get_id()
+            )
+        except InfeasiblePressureError as e:
+            return Solution(
+                success=False,
+                configuration=Boundary(min=0, max=0),
+                failure=InfeasiblePressureFailure.from_error(e),
+            )
+        boundary = self._first_compressor.get_recirculation_range(compressor_inlet_stream)
+        return Solution(success=True, configuration=boundary)

--- a/src/libecalc/process/process_solver/pressure_control/downstream_choke.py
+++ b/src/libecalc/process/process_solver/pressure_control/downstream_choke.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_error import InfeasiblePressureError
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
@@ -40,7 +41,10 @@ class DownstreamChokePressureControlStrategy(PressureControlStrategy):
 
         # 1) Baseline (no choking)
         baseline_config = ChokeConfiguration(delta_pressure=0.0)
-        baseline_outlet_stream = outlet_with_choke(baseline_config)
+        try:
+            baseline_outlet_stream = outlet_with_choke(baseline_config)
+        except InfeasiblePressureError as e:
+            return Solution.from_infeasible_pressure(e, configuration=[])
 
         # If already at/below target, don't choke (can't increase pressure anyway).
         if baseline_outlet_stream.pressure_bara <= target_pressure:

--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 
 from libecalc.common.numeric_methods import find_root
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_error import InfeasiblePressureError
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
@@ -41,22 +42,34 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
         self._compressors = compressors
         self._root_finding_strategy = root_finding_strategy
 
+    def _compute_minimum_achievable_pressure(
+        self, inlet_stream: FluidStream
+    ) -> Solution[Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]]:
+        """Compute maximum-recirculation configurations, catching InfeasiblePressureError."""
+        try:
+            configurations = _minimum_achievable_pressure(
+                simulator=self._simulator,
+                recirculation_loop_ids=self._recirculation_loop_ids,
+                compressors=self._compressors,
+                inlet_stream=inlet_stream,
+            )
+            return Solution(success=True, configuration=configurations)
+        except InfeasiblePressureError as e:
+            return Solution.from_infeasible_pressure(e, configuration=[])
+
     def apply(
         self,
         target_pressure: FloatConstraint,
         inlet_stream: FluidStream,
     ) -> Solution[Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]]:
-        minimum_achievable_pressure_configurations = _minimum_achievable_pressure(
-            simulator=self._simulator,
-            recirculation_loop_ids=self._recirculation_loop_ids,
-            compressors=self._compressors,
-            inlet_stream=inlet_stream,
-        )
+        min_pressure_solution = self._compute_minimum_achievable_pressure(inlet_stream)
+        if not min_pressure_solution.success:
+            return Solution(success=False, configuration=[], failure=min_pressure_solution.failure)
+
+        minimum_achievable_pressure_configurations = min_pressure_solution.configuration
         self._simulator.apply_configurations(minimum_achievable_pressure_configurations)
         minimum_achievable_pressure_stream = self._simulator.run(inlet_stream=inlet_stream)
         if minimum_achievable_pressure_stream.pressure_bara > target_pressure.value:
-            # Even at maximum recirculation, the outlet pressure is still above the target.
-            # The compressor train cannot deliver a pressure this low at the current speed.
             return Solution(
                 success=False,
                 configuration=minimum_achievable_pressure_configurations,
@@ -73,7 +86,6 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
         configurations: list[Configuration[RecirculationConfiguration | ChokeConfiguration]] = []
 
         for i, (recirculation_loop_id, compressor) in enumerate(zip(self._recirculation_loop_ids, self._compressors)):
-            # Target pressure for this stage: cumulative from original inlet
             stage_target_pressure = inlet_stream.pressure_bara * (pressure_ratio_per_stage ** (i + 1))
 
             self._simulator.apply_configuration(
@@ -82,7 +94,10 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
                     value=RecirculationConfiguration(recirculation_rate=0.0),
                 )
             )
-            current_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
+            try:
+                current_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
+            except InfeasiblePressureError as e:
+                return Solution.from_infeasible_pressure(e, configuration=configurations)
             boundary = compressor.get_recirculation_range(inlet_stream=current_stream)
 
             def recirculation_func(config: RecirculationConfiguration) -> FluidStream:
@@ -163,22 +178,34 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
             )
         return configurations
 
+    def _compute_minimum_achievable_pressure(
+        self, inlet_stream: FluidStream
+    ) -> Solution[Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]]:
+        """Compute maximum-recirculation configurations, catching InfeasiblePressureError."""
+        try:
+            configurations = _minimum_achievable_pressure(
+                simulator=self._simulator,
+                recirculation_loop_ids=self._recirculation_loop_ids,
+                compressors=self._compressors,
+                inlet_stream=inlet_stream,
+            )
+            return Solution(success=True, configuration=configurations)
+        except InfeasiblePressureError as e:
+            return Solution.from_infeasible_pressure(e, configuration=[])
+
     def apply(
         self,
         target_pressure: FloatConstraint,
         inlet_stream: FluidStream,
     ) -> Solution[Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]]:
-        minimum_achievable_pressure_configurations = _minimum_achievable_pressure(
-            simulator=self._simulator,
-            recirculation_loop_ids=self._recirculation_loop_ids,
-            compressors=self._compressors,
-            inlet_stream=inlet_stream,
-        )
+        min_pressure_solution = self._compute_minimum_achievable_pressure(inlet_stream)
+        if not min_pressure_solution.success:
+            return Solution(success=False, configuration=[], failure=min_pressure_solution.failure)
+
+        minimum_achievable_pressure_configurations = min_pressure_solution.configuration
         self._simulator.apply_configurations(minimum_achievable_pressure_configurations)
         minimum_achievable_pressure_stream = self._simulator.run(inlet_stream=inlet_stream)
         if minimum_achievable_pressure_stream.pressure_bara > target_pressure.value:
-            # Even at maximum recirculation, the outlet pressure is still above the target.
-            # The compressor train cannot deliver a pressure this low at the current speed.
             return Solution(
                 success=False,
                 configuration=minimum_achievable_pressure_configurations,

--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -9,8 +9,8 @@ from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     Solution,
-    SolverFailureStatus,
-    TargetNotAchievableEvent,
+    TargetDirection,
+    TargetPressureUnreachableFailure,
 )
 from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.recirculation_solver import (
@@ -60,10 +60,10 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
             return Solution(
                 success=False,
                 configuration=minimum_achievable_pressure_configurations,
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=minimum_achievable_pressure_stream.pressure_bara,
-                    target_value=target_pressure.value,
+                failure=TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=minimum_achievable_pressure_stream.pressure_bara,
+                    target_pressure_bara=target_pressure.value,
+                    direction=TargetDirection.MIN_ABOVE_TARGET,
                 ),
             )
 
@@ -109,7 +109,7 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
                 return Solution(
                     success=False,
                     configuration=configurations,
-                    failure_event=solution.failure_event,
+                    failure=solution.failure,
                 )
 
         return Solution(
@@ -182,10 +182,10 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
             return Solution(
                 success=False,
                 configuration=minimum_achievable_pressure_configurations,
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=minimum_achievable_pressure_stream.pressure_bara,
-                    target_value=target_pressure.value,
+                failure=TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=minimum_achievable_pressure_stream.pressure_bara,
+                    target_pressure_bara=target_pressure.value,
+                    direction=TargetDirection.MIN_ABOVE_TARGET,
                 ),
             )
 

--- a/src/libecalc/process/process_solver/solver.py
+++ b/src/libecalc/process/process_solver/solver.py
@@ -4,10 +4,11 @@ import abc
 import dataclasses
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from enum import StrEnum
+from enum import Enum
 from typing import Self, TypeVar
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration import (
@@ -20,40 +21,74 @@ from libecalc.process.process_solver.configuration import (
 TConfiguration = TypeVar("TConfiguration", covariant=True)
 
 
-class SolverFailureStatus(StrEnum):
-    ABOVE_MAXIMUM_FLOW_RATE = "ABOVE_MAXIMUM_FLOW_RATE"
-    BELOW_MINIMUM_FLOW_RATE = "BELOW_MINIMUM_FLOW_RATE"
-    MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET = "MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET"
-    MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET = "MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET"
+class SolverFailure:
+    """Typed cause for an unsuccessful ``Solution``.
+
+    Subclasses carry the data relevant to a specific failure mode (e.g. above stonewall,
+    below surge, target pressure unreachable). Consumers should branch on subclass with
+    ``isinstance`` or ``match`` rather than inspecting flag fields.
+    """
 
 
 @dataclass
-class OutsideCapacityEvent:
-    status: SolverFailureStatus
+class RateTooHighFailure(SolverFailure):
     source_id: ProcessUnitId
-    actual_value: float | None = None
-    boundary_value: float | None = None
+    actual_rate_m3_per_hour: float | None = None
+    maximum_rate_m3_per_hour: float | None = None
+
+    @classmethod
+    def from_error(cls, e: RateTooHighError) -> Self:
+        return cls(
+            source_id=e.process_unit_id,
+            actual_rate_m3_per_hour=e.actual_rate,
+            maximum_rate_m3_per_hour=e.boundary_rate,
+        )
 
 
 @dataclass
-class TargetNotAchievableEvent:
-    status: SolverFailureStatus
-    achievable_value: float
-    target_value: float
+class RateTooLowFailure(SolverFailure):
+    source_id: ProcessUnitId
+    actual_rate_m3_per_hour: float | None = None
+    minimum_rate_m3_per_hour: float | None = None
+
+    @classmethod
+    def from_error(cls, e: RateTooLowError) -> Self:
+        return cls(
+            source_id=e.process_unit_id,
+            actual_rate_m3_per_hour=e.actual_rate,
+            minimum_rate_m3_per_hour=e.boundary_rate,
+        )
+
+
+@dataclass
+class InfeasiblePressureFailure(SolverFailure):
+    source_id: ProcessUnitId
+    achieved_pressure_bara: float | None = None
+
+
+class TargetDirection(Enum):
+    """Which side of the target pressure the achievable boundary lies on."""
+
+    MAX_BELOW_TARGET = "max_below_target"
+    MIN_ABOVE_TARGET = "min_above_target"
+
+
+@dataclass
+class TargetPressureUnreachableFailure(SolverFailure):
+    achievable_pressure_bara: float
+    target_pressure_bara: float
+    direction: TargetDirection
     source_id: ProcessPipelineId | None = None
 
     def with_source_id(self, source_id: ProcessPipelineId) -> Self:
         return dataclasses.replace(self, source_id=source_id)
 
 
-SolverFailureEvent = OutsideCapacityEvent | TargetNotAchievableEvent
-
-
 @dataclass(frozen=True)
 class Solution[TConfiguration]:
     success: bool
     configuration: TConfiguration
-    failure_event: SolverFailureEvent | None = field(default=None)
+    failure: SolverFailure | None = field(default=None)
 
     def get_configuration(
         self: Solution[Sequence[Configuration[OperatingConfiguration]]],

--- a/src/libecalc/process/process_solver/solver.py
+++ b/src/libecalc/process/process_solver/solver.py
@@ -8,7 +8,11 @@ from enum import Enum
 from typing import Self, TypeVar
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
+from libecalc.process.process_pipeline.process_error import (
+    InfeasiblePressureError,
+    RateTooHighError,
+    RateTooLowError,
+)
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration import (
@@ -65,6 +69,13 @@ class InfeasiblePressureFailure(SolverFailure):
     source_id: ProcessUnitId
     achieved_pressure_bara: float | None = None
 
+    @classmethod
+    def from_error(cls, e: InfeasiblePressureError) -> Self:
+        return cls(
+            source_id=e.process_unit_id,
+            achieved_pressure_bara=e.achieved_pressure_bara,
+        )
+
 
 class TargetDirection(Enum):
     """Which side of the target pressure the achievable boundary lies on."""
@@ -89,6 +100,17 @@ class Solution[TConfiguration]:
     success: bool
     configuration: TConfiguration
     failure: SolverFailure | None = field(default=None)
+
+    @classmethod
+    def from_infeasible_pressure(
+        cls, e: InfeasiblePressureError, configuration: TConfiguration
+    ) -> Solution[TConfiguration]:
+        """Build an unsuccessful Solution carrying an InfeasiblePressureFailure."""
+        return cls(
+            success=False,
+            configuration=configuration,
+            failure=InfeasiblePressureFailure.from_error(e),
+        )
 
     def get_configuration(
         self: Solution[Sequence[Configuration[OperatingConfiguration]]],

--- a/src/libecalc/process/process_solver/solvers/recirculation_solver.py
+++ b/src/libecalc/process/process_solver/solvers/recirculation_solver.py
@@ -30,37 +30,13 @@ class RecirculationSolver(Solver):
         self._root_finding_strategy = root_finding_strategy
 
     def solve(self, func: Callable[[RecirculationConfiguration], FluidStream]) -> Solution[RecirculationConfiguration]:
-        def bool_func(x: float, mode: Literal["minimize", "maximize"]) -> tuple[bool, bool]:
-            """
-            Return a tuple where first bool is True for higher value,
-            the second bool says if the solution is accepted or not.
-
-            Need to separate these to avoid accepting a solution which is outside capacity. I.e. when minimizing we
-            want to return True for a higher value, but we don't want to accept the solution.
-            """
-            try:
-                func(RecirculationConfiguration(recirculation_rate=x))
-                return False if mode == "minimize" else True, True
-            except RateTooLowError:
-                return True, False
-            except RateTooHighError:
-                return False, False
-
         try:
-            minimum_rate = self._recirculation_rate_boundary.min
-            func(RecirculationConfiguration(recirculation_rate=minimum_rate))
-            # No error for minimum rate, no need to find min boundary
-        except RateTooLowError:
-            # Min boundary is too low, find solution
-            minimum_rate = self._search_strategy.search(
-                boundary=self._recirculation_rate_boundary,
-                func=lambda x: bool_func(x, mode="minimize"),
-            )
+            minimum_rate = self._find_min_within_capacity_rate(func)
         except RateTooHighError as e:
             # Flow is above stonewall at zero recirculation; adding recirculation cannot help.
             return Solution(
                 success=False,
-                configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
+                configuration=RecirculationConfiguration(recirculation_rate=self._recirculation_rate_boundary.min),
                 failure=RateTooHighFailure.from_error(e),
             )
 
@@ -69,16 +45,7 @@ class RecirculationSolver(Solver):
             # Recirc used to get within capacity, but not to meet constraints
             return Solution(success=True, configuration=RecirculationConfiguration(recirculation_rate=minimum_rate))
 
-        try:
-            maximum_rate = self._recirculation_rate_boundary.max
-            func(RecirculationConfiguration(recirculation_rate=maximum_rate))
-            # No error for max rate, no need to find max boundary
-        except RateTooHighError:
-            # Max boundary is too high, find solution
-            maximum_rate = self._search_strategy.search(
-                boundary=self._recirculation_rate_boundary,
-                func=lambda x: bool_func(x, mode="maximize"),
-            )
+        maximum_rate = self._find_max_within_capacity_rate(func)
 
         minimum_outlet_stream = func(RecirculationConfiguration(recirculation_rate=minimum_rate))
         if minimum_outlet_stream.pressure_bara <= target_pressure:
@@ -116,3 +83,54 @@ class RecirculationSolver(Solver):
             func=lambda x: func(RecirculationConfiguration(recirculation_rate=x)).pressure_bara - target_pressure.value,
         )
         return Solution(success=True, configuration=RecirculationConfiguration(recirculation_rate=recirculation_rate))
+
+    def _find_min_within_capacity_rate(self, func: Callable[[RecirculationConfiguration], FluidStream]) -> float:
+        """Return the smallest recirculation rate that keeps every stage within flow capacity.
+
+        ``RateTooLowError`` at the boundary minimum is recoverable (more recirculation adds
+        flow); ``RateTooHighError`` is not (more recirculation only adds more flow) and
+        propagates.
+        """
+        minimum_rate = self._recirculation_rate_boundary.min
+        try:
+            func(RecirculationConfiguration(recirculation_rate=minimum_rate))
+            return minimum_rate
+        except RateTooLowError:
+            return self._search_strategy.search(
+                boundary=self._recirculation_rate_boundary,
+                func=lambda x: self._bool_func(func, x, mode="minimize"),
+            )
+
+    def _find_max_within_capacity_rate(self, func: Callable[[RecirculationConfiguration], FluidStream]) -> float:
+        """Return the largest recirculation rate that keeps every stage within flow capacity.
+
+        ``RateTooHighError`` at the boundary maximum is recoverable: search downward.
+        """
+        maximum_rate = self._recirculation_rate_boundary.max
+        try:
+            func(RecirculationConfiguration(recirculation_rate=maximum_rate))
+            return maximum_rate
+        except RateTooHighError:
+            return self._search_strategy.search(
+                boundary=self._recirculation_rate_boundary,
+                func=lambda x: self._bool_func(func, x, mode="maximize"),
+            )
+
+    @staticmethod
+    def _bool_func(
+        func: Callable[[RecirculationConfiguration], FluidStream],
+        x: float,
+        mode: Literal["minimize", "maximize"],
+    ) -> tuple[bool, bool]:
+        """Probe a candidate rate for the search strategy.
+
+        Returns ``(is_higher, is_accepted)``. The two booleans are decoupled so an
+        out-of-capacity candidate can never be accepted as a solution.
+        """
+        try:
+            func(RecirculationConfiguration(recirculation_rate=x))
+            return False if mode == "minimize" else True, True
+        except RateTooLowError:
+            return True, False
+        except RateTooHighError:
+            return False, False

--- a/src/libecalc/process/process_solver/solvers/recirculation_solver.py
+++ b/src/libecalc/process/process_solver/solvers/recirculation_solver.py
@@ -8,11 +8,11 @@ from libecalc.process.process_solver.configuration import RecirculationConfigura
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
 from libecalc.process.process_solver.solver import (
-    OutsideCapacityEvent,
+    RateTooHighFailure,
     Solution,
     Solver,
-    SolverFailureStatus,
-    TargetNotAchievableEvent,
+    TargetDirection,
+    TargetPressureUnreachableFailure,
 )
 
 
@@ -61,12 +61,7 @@ class RecirculationSolver(Solver):
             return Solution(
                 success=False,
                 configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
-                failure_event=OutsideCapacityEvent(
-                    status=SolverFailureStatus.ABOVE_MAXIMUM_FLOW_RATE,
-                    actual_value=e.actual_rate,
-                    boundary_value=e.boundary_rate,
-                    source_id=e.process_unit_id,
-                ),
+                failure=RateTooHighFailure.from_error(e),
             )
 
         target_pressure = self._target_pressure
@@ -92,12 +87,12 @@ class RecirculationSolver(Solver):
             return Solution(
                 success=is_success,
                 configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
-                failure_event=None
+                failure=None
                 if is_success
-                else TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
-                    achievable_value=minimum_outlet_stream.pressure_bara,
-                    target_value=target_pressure.value,
+                else TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=minimum_outlet_stream.pressure_bara,
+                    target_pressure_bara=target_pressure.value,
+                    direction=TargetDirection.MAX_BELOW_TARGET,
                 ),
             )
         maximum_outlet_stream = func(RecirculationConfiguration(recirculation_rate=maximum_rate))
@@ -107,12 +102,12 @@ class RecirculationSolver(Solver):
             return Solution(
                 success=is_success,
                 configuration=RecirculationConfiguration(recirculation_rate=maximum_rate),
-                failure_event=None
+                failure=None
                 if is_success
-                else TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=maximum_outlet_stream.pressure_bara,
-                    target_value=target_pressure.value,
+                else TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=maximum_outlet_stream.pressure_bara,
+                    target_pressure_bara=target_pressure.value,
+                    direction=TargetDirection.MIN_ABOVE_TARGET,
                 ),
             )
 

--- a/src/libecalc/process/process_solver/solvers/recirculation_solver.py
+++ b/src/libecalc/process/process_solver/solvers/recirculation_solver.py
@@ -2,12 +2,17 @@ from collections.abc import Callable
 from typing import Literal
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
+from libecalc.process.process_pipeline.process_error import (
+    InfeasiblePressureError,
+    RateTooHighError,
+    RateTooLowError,
+)
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import RecirculationConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
 from libecalc.process.process_solver.solver import (
+    InfeasiblePressureFailure,
     RateTooHighFailure,
     Solution,
     Solver,
@@ -32,6 +37,54 @@ class RecirculationSolver(Solver):
     def solve(self, func: Callable[[RecirculationConfiguration], FluidStream]) -> Solution[RecirculationConfiguration]:
         try:
             minimum_rate = self._find_min_within_capacity_rate(func)
+
+            target_pressure = self._target_pressure
+            if target_pressure is None:
+                # Recirc used to get within capacity, but not to meet constraints
+                return Solution(success=True, configuration=RecirculationConfiguration(recirculation_rate=minimum_rate))
+
+            maximum_rate = self._find_max_within_capacity_rate(func)
+
+            minimum_outlet_stream = func(RecirculationConfiguration(recirculation_rate=minimum_rate))
+            if minimum_outlet_stream.pressure_bara <= target_pressure:
+                # Highest possible pressure is too low
+                is_success = minimum_outlet_stream.pressure_bara == target_pressure
+                return Solution(
+                    success=is_success,
+                    configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
+                    failure=None
+                    if is_success
+                    else TargetPressureUnreachableFailure(
+                        achievable_pressure_bara=minimum_outlet_stream.pressure_bara,
+                        target_pressure_bara=target_pressure.value,
+                        direction=TargetDirection.MAX_BELOW_TARGET,
+                    ),
+                )
+            maximum_outlet_stream = func(RecirculationConfiguration(recirculation_rate=maximum_rate))
+            if maximum_outlet_stream.pressure_bara >= target_pressure:
+                # Lowest possible pressure is too high
+                is_success = maximum_outlet_stream.pressure_bara == self._target_pressure
+                return Solution(
+                    success=is_success,
+                    configuration=RecirculationConfiguration(recirculation_rate=maximum_rate),
+                    failure=None
+                    if is_success
+                    else TargetPressureUnreachableFailure(
+                        achievable_pressure_bara=maximum_outlet_stream.pressure_bara,
+                        target_pressure_bara=target_pressure.value,
+                        direction=TargetDirection.MIN_ABOVE_TARGET,
+                    ),
+                )
+
+            recirculation_rate = self._root_finding_strategy.find_root(
+                boundary=Boundary(min=minimum_rate, max=maximum_rate),
+                func=lambda x: (
+                    func(RecirculationConfiguration(recirculation_rate=x)).pressure_bara - target_pressure.value
+                ),
+            )
+            return Solution(
+                success=True, configuration=RecirculationConfiguration(recirculation_rate=recirculation_rate)
+            )
         except RateTooHighError as e:
             # Flow is above stonewall at zero recirculation; adding recirculation cannot help.
             return Solution(
@@ -39,50 +92,12 @@ class RecirculationSolver(Solver):
                 configuration=RecirculationConfiguration(recirculation_rate=self._recirculation_rate_boundary.min),
                 failure=RateTooHighFailure.from_error(e),
             )
-
-        target_pressure = self._target_pressure
-        if target_pressure is None:
-            # Recirc used to get within capacity, but not to meet constraints
-            return Solution(success=True, configuration=RecirculationConfiguration(recirculation_rate=minimum_rate))
-
-        maximum_rate = self._find_max_within_capacity_rate(func)
-
-        minimum_outlet_stream = func(RecirculationConfiguration(recirculation_rate=minimum_rate))
-        if minimum_outlet_stream.pressure_bara <= target_pressure:
-            # Highest possible pressure is too low
-            is_success = minimum_outlet_stream.pressure_bara == target_pressure
+        except InfeasiblePressureError as e:
             return Solution(
-                success=is_success,
-                configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
-                failure=None
-                if is_success
-                else TargetPressureUnreachableFailure(
-                    achievable_pressure_bara=minimum_outlet_stream.pressure_bara,
-                    target_pressure_bara=target_pressure.value,
-                    direction=TargetDirection.MAX_BELOW_TARGET,
-                ),
+                success=False,
+                configuration=RecirculationConfiguration(recirculation_rate=self._recirculation_rate_boundary.min),
+                failure=InfeasiblePressureFailure.from_error(e),
             )
-        maximum_outlet_stream = func(RecirculationConfiguration(recirculation_rate=maximum_rate))
-        if maximum_outlet_stream.pressure_bara >= target_pressure:
-            # Lowest possible pressure is too high
-            is_success = maximum_outlet_stream.pressure_bara == self._target_pressure
-            return Solution(
-                success=is_success,
-                configuration=RecirculationConfiguration(recirculation_rate=maximum_rate),
-                failure=None
-                if is_success
-                else TargetPressureUnreachableFailure(
-                    achievable_pressure_bara=maximum_outlet_stream.pressure_bara,
-                    target_pressure_bara=target_pressure.value,
-                    direction=TargetDirection.MIN_ABOVE_TARGET,
-                ),
-            )
-
-        recirculation_rate = self._root_finding_strategy.find_root(
-            boundary=Boundary(min=minimum_rate, max=maximum_rate),
-            func=lambda x: func(RecirculationConfiguration(recirculation_rate=x)).pressure_bara - target_pressure.value,
-        )
-        return Solution(success=True, configuration=RecirculationConfiguration(recirculation_rate=recirculation_rate))
 
     def _find_min_within_capacity_rate(self, func: Callable[[RecirculationConfiguration], FluidStream]) -> float:
         """Return the smallest recirculation rate that keeps every stage within flow capacity.

--- a/src/libecalc/process/process_solver/solvers/speed_solver.py
+++ b/src/libecalc/process/process_solver/solvers/speed_solver.py
@@ -32,11 +32,8 @@ class SpeedSolver(Solver[SpeedConfiguration]):
         self._root_finding_strategy = root_finding_strategy
 
     def solve(self, func: Callable[[SpeedConfiguration], FluidStream]) -> Solution[SpeedConfiguration]:
-        def get_outlet_stream(speed: float) -> FluidStream:
-            return func(SpeedConfiguration(speed=speed))
-
-        max_speed_configuration = SpeedConfiguration(speed=self._boundary.max)
         try:
+            max_speed_configuration = SpeedConfiguration(speed=self._boundary.max)
             maximum_speed_outlet_stream = func(max_speed_configuration)
         except RateTooHighError as e:
             logger.debug(f"No solution found for maximum speed: {max_speed_configuration}", exc_info=e)
@@ -64,28 +61,7 @@ class SpeedSolver(Solver[SpeedConfiguration]):
                 ),
             )
 
-        try:
-            minimum_speed_configuration = SpeedConfiguration(speed=self._boundary.min)
-            minimum_speed_outlet_stream = func(minimum_speed_configuration)
-        except RateTooHighError as e:
-            logger.debug(f"No solution found for minimum speed: {self._boundary.min}", exc_info=e)
-
-            # rate is above maximum rate for minimum speed. Find the lowest minimum speed which gives a valid result
-            def bool_speed_func(x: float):
-                try:
-                    get_outlet_stream(speed=x)
-                    return False, True
-                except RateTooHighError:
-                    return True, False
-                except RateTooLowError:
-                    return False, False
-
-            minimum_speed_within_capacity = self._search_strategy.search(
-                boundary=self._boundary,
-                func=bool_speed_func,
-            )
-            minimum_speed_configuration = SpeedConfiguration(speed=minimum_speed_within_capacity)
-            minimum_speed_outlet_stream = func(minimum_speed_configuration)
+        minimum_speed_configuration, minimum_speed_outlet_stream = self._find_min_within_capacity_speed(func)
 
         if minimum_speed_outlet_stream.pressure_bara > self._target_pressure:
             # Solution 2, target pressure is too low
@@ -109,7 +85,7 @@ class SpeedSolver(Solver[SpeedConfiguration]):
         def root_speed_func(x: float) -> float:
             # We should be able to produce an outlet stream since we adjust minimum speed above,
             # or exit if max speed is not enough
-            out = get_outlet_stream(speed=x)
+            out = func(SpeedConfiguration(speed=x))
             return out.pressure_bara - self._target_pressure
 
         speed = self._root_finding_strategy.find_root(
@@ -117,3 +93,33 @@ class SpeedSolver(Solver[SpeedConfiguration]):
             func=root_speed_func,
         )
         return Solution(success=True, configuration=SpeedConfiguration(speed=speed))
+
+    def _find_min_within_capacity_speed(
+        self, func: Callable[[SpeedConfiguration], FluidStream]
+    ) -> tuple[SpeedConfiguration, FluidStream]:
+        """Return the lowest speed configuration within flow capacity, and its outlet stream.
+
+        ``RateTooHighError`` at the boundary minimum is recoverable: higher speed raises the
+        stonewall limit; search upward.
+        """
+        minimum_speed_configuration = SpeedConfiguration(speed=self._boundary.min)
+        try:
+            return minimum_speed_configuration, func(minimum_speed_configuration)
+        except RateTooHighError as e:
+            logger.debug(f"No solution found for minimum speed: {self._boundary.min}", exc_info=e)
+
+            def bool_speed_func(x: float) -> tuple[bool, bool]:
+                try:
+                    func(SpeedConfiguration(speed=x))
+                    return False, True
+                except RateTooHighError:
+                    return True, False
+                except RateTooLowError:
+                    return False, False
+
+            minimum_speed_within_capacity = self._search_strategy.search(
+                boundary=self._boundary,
+                func=bool_speed_func,
+            )
+            minimum_speed_configuration = SpeedConfiguration(speed=minimum_speed_within_capacity)
+            return minimum_speed_configuration, func(minimum_speed_configuration)

--- a/src/libecalc/process/process_solver/solvers/speed_solver.py
+++ b/src/libecalc/process/process_solver/solvers/speed_solver.py
@@ -7,11 +7,12 @@ from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import SpeedConfiguration
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
 from libecalc.process.process_solver.solver import (
-    OutsideCapacityEvent,
+    RateTooHighFailure,
+    RateTooLowFailure,
     Solution,
     Solver,
-    SolverFailureStatus,
-    TargetNotAchievableEvent,
+    TargetDirection,
+    TargetPressureUnreachableFailure,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,34 +43,24 @@ class SpeedSolver(Solver[SpeedConfiguration]):
             return Solution(
                 success=False,
                 configuration=max_speed_configuration,
-                failure_event=OutsideCapacityEvent(
-                    status=SolverFailureStatus.ABOVE_MAXIMUM_FLOW_RATE,
-                    actual_value=e.actual_rate,
-                    boundary_value=e.boundary_rate,
-                    source_id=e.process_unit_id,
-                ),
+                failure=RateTooHighFailure.from_error(e),
             )
         except RateTooLowError as e:
             logger.debug(f"No solution found for maximum speed: {max_speed_configuration}", exc_info=e)
             return Solution(
                 success=False,
                 configuration=max_speed_configuration,
-                failure_event=OutsideCapacityEvent(
-                    status=SolverFailureStatus.BELOW_MINIMUM_FLOW_RATE,
-                    actual_value=e.actual_rate,
-                    boundary_value=e.boundary_rate,
-                    source_id=e.process_unit_id,
-                ),
+                failure=RateTooLowFailure.from_error(e),
             )
 
         if maximum_speed_outlet_stream.pressure_bara < self._target_pressure:
             return Solution(
                 success=False,
                 configuration=SpeedConfiguration(self._boundary.max),
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MAXIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_BELOW_TARGET,
-                    achievable_value=maximum_speed_outlet_stream.pressure_bara,
-                    target_value=self._target_pressure,
+                failure=TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=maximum_speed_outlet_stream.pressure_bara,
+                    target_pressure_bara=self._target_pressure,
+                    direction=TargetDirection.MAX_BELOW_TARGET,
                 ),
             )
 
@@ -101,10 +92,10 @@ class SpeedSolver(Solver[SpeedConfiguration]):
             return Solution(
                 success=False,
                 configuration=minimum_speed_configuration,
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=minimum_speed_outlet_stream.pressure_bara,
-                    target_value=self._target_pressure,
+                failure=TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=minimum_speed_outlet_stream.pressure_bara,
+                    target_pressure_bara=self._target_pressure,
+                    direction=TargetDirection.MIN_ABOVE_TARGET,
                 ),
             )
 

--- a/src/libecalc/process/process_solver/solvers/speed_solver.py
+++ b/src/libecalc/process/process_solver/solvers/speed_solver.py
@@ -2,11 +2,16 @@ import logging
 from collections.abc import Callable
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
+from libecalc.process.process_pipeline.process_error import (
+    InfeasiblePressureError,
+    RateTooHighError,
+    RateTooLowError,
+)
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import SpeedConfiguration
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
 from libecalc.process.process_solver.solver import (
+    InfeasiblePressureFailure,
     RateTooHighFailure,
     RateTooLowFailure,
     Solution,
@@ -32,9 +37,53 @@ class SpeedSolver(Solver[SpeedConfiguration]):
         self._root_finding_strategy = root_finding_strategy
 
     def solve(self, func: Callable[[SpeedConfiguration], FluidStream]) -> Solution[SpeedConfiguration]:
+        max_speed_configuration = SpeedConfiguration(speed=self._boundary.max)
         try:
-            max_speed_configuration = SpeedConfiguration(speed=self._boundary.max)
             maximum_speed_outlet_stream = func(max_speed_configuration)
+
+            if maximum_speed_outlet_stream.pressure_bara < self._target_pressure:
+                return Solution(
+                    success=False,
+                    configuration=max_speed_configuration,
+                    failure=TargetPressureUnreachableFailure(
+                        achievable_pressure_bara=maximum_speed_outlet_stream.pressure_bara,
+                        target_pressure_bara=self._target_pressure,
+                        direction=TargetDirection.MAX_BELOW_TARGET,
+                    ),
+                )
+
+            minimum_speed_configuration, minimum_speed_outlet_stream = self._find_min_within_capacity_speed(func)
+
+            if minimum_speed_outlet_stream.pressure_bara > self._target_pressure:
+                # Solution 2, target pressure is too low
+                return Solution(
+                    success=False,
+                    configuration=minimum_speed_configuration,
+                    failure=TargetPressureUnreachableFailure(
+                        achievable_pressure_bara=minimum_speed_outlet_stream.pressure_bara,
+                        target_pressure_bara=self._target_pressure,
+                        direction=TargetDirection.MIN_ABOVE_TARGET,
+                    ),
+                )
+
+            assert (
+                minimum_speed_outlet_stream.pressure_bara
+                <= self._target_pressure
+                <= maximum_speed_outlet_stream.pressure_bara
+            )
+
+            # Solution 1, iterate on speed until target discharge pressure is found
+            def root_speed_func(x: float) -> float:
+                # We should be able to produce an outlet stream since we adjust minimum speed above,
+                # or exit if max speed is not enough
+                out = func(SpeedConfiguration(speed=x))
+                return out.pressure_bara - self._target_pressure
+
+            speed = self._root_finding_strategy.find_root(
+                boundary=Boundary(min=minimum_speed_configuration.speed, max=self._boundary.max),
+                func=root_speed_func,
+            )
+            return Solution(success=True, configuration=SpeedConfiguration(speed=speed))
         except RateTooHighError as e:
             logger.debug(f"No solution found for maximum speed: {max_speed_configuration}", exc_info=e)
             return Solution(
@@ -49,50 +98,13 @@ class SpeedSolver(Solver[SpeedConfiguration]):
                 configuration=max_speed_configuration,
                 failure=RateTooLowFailure.from_error(e),
             )
-
-        if maximum_speed_outlet_stream.pressure_bara < self._target_pressure:
+        except InfeasiblePressureError as e:
+            logger.debug(f"Infeasible pressure encountered in SpeedSolver: {e}", exc_info=e)
             return Solution(
                 success=False,
-                configuration=SpeedConfiguration(self._boundary.max),
-                failure=TargetPressureUnreachableFailure(
-                    achievable_pressure_bara=maximum_speed_outlet_stream.pressure_bara,
-                    target_pressure_bara=self._target_pressure,
-                    direction=TargetDirection.MAX_BELOW_TARGET,
-                ),
+                configuration=SpeedConfiguration(speed=self._boundary.min),
+                failure=InfeasiblePressureFailure.from_error(e),
             )
-
-        minimum_speed_configuration, minimum_speed_outlet_stream = self._find_min_within_capacity_speed(func)
-
-        if minimum_speed_outlet_stream.pressure_bara > self._target_pressure:
-            # Solution 2, target pressure is too low
-            return Solution(
-                success=False,
-                configuration=minimum_speed_configuration,
-                failure=TargetPressureUnreachableFailure(
-                    achievable_pressure_bara=minimum_speed_outlet_stream.pressure_bara,
-                    target_pressure_bara=self._target_pressure,
-                    direction=TargetDirection.MIN_ABOVE_TARGET,
-                ),
-            )
-
-        assert (
-            minimum_speed_outlet_stream.pressure_bara
-            <= self._target_pressure
-            <= maximum_speed_outlet_stream.pressure_bara
-        )
-
-        # Solution 1, iterate on speed until target discharge pressure is found
-        def root_speed_func(x: float) -> float:
-            # We should be able to produce an outlet stream since we adjust minimum speed above,
-            # or exit if max speed is not enough
-            out = func(SpeedConfiguration(speed=x))
-            return out.pressure_bara - self._target_pressure
-
-        speed = self._root_finding_strategy.find_root(
-            boundary=Boundary(min=minimum_speed_configuration.speed, max=self._boundary.max),
-            func=root_speed_func,
-        )
-        return Solution(success=True, configuration=SpeedConfiguration(speed=speed))
 
     def _find_min_within_capacity_speed(
         self, func: Callable[[SpeedConfiguration], FluidStream]

--- a/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
+++ b/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
@@ -6,7 +6,12 @@ from libecalc.process.process_pipeline.process_error import RateTooHighError
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import ChokeConfiguration
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy
-from libecalc.process.process_solver.solver import Solution, Solver, SolverFailureStatus, TargetNotAchievableEvent
+from libecalc.process.process_solver.solver import (
+    Solution,
+    Solver,
+    TargetDirection,
+    TargetPressureUnreachableFailure,
+)
 
 
 class UpstreamChokeSolver(Solver):
@@ -38,10 +43,10 @@ class UpstreamChokeSolver(Solver):
             return Solution(
                 success=False,
                 configuration=ChokeConfiguration(delta_pressure=search_boundary.max),
-                failure_event=TargetNotAchievableEvent(
-                    status=SolverFailureStatus.MINIMUM_ACHIEVABLE_DISCHARGE_PRESSURE_ABOVE_TARGET,
-                    achievable_value=max_pressure,
-                    target_value=self._target_pressure,
+                failure=TargetPressureUnreachableFailure(
+                    achievable_pressure_bara=max_pressure,
+                    target_pressure_bara=self._target_pressure,
+                    direction=TargetDirection.MIN_ABOVE_TARGET,
                 ),
             )
 

--- a/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
+++ b/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 
 from libecalc.domain.process.compressor.core.train.utils.common import PRESSURE_CALCULATION_TOLERANCE
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import RateTooHighError
+from libecalc.process.process_pipeline.process_error import InfeasiblePressureError, RateTooHighError
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import ChokeConfiguration
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy
@@ -34,38 +34,43 @@ class UpstreamChokeSolver(Solver):
         def outlet_pressure(delta_pressure: float) -> float:
             return func(ChokeConfiguration(delta_pressure=delta_pressure)).pressure_bara
 
-        assert outlet_pressure(0) > self._target_pressure
+        try:
+            assert outlet_pressure(0) > self._target_pressure
 
-        search_boundary = self._feasible_boundary(func)
-        max_pressure = outlet_pressure(search_boundary.max)
+            search_boundary = self._feasible_boundary(func)
+            max_pressure = outlet_pressure(search_boundary.max)
 
-        if max_pressure > self._target_pressure:
-            return Solution(
-                success=False,
-                configuration=ChokeConfiguration(delta_pressure=search_boundary.max),
-                failure=TargetPressureUnreachableFailure(
-                    achievable_pressure_bara=max_pressure,
-                    target_pressure_bara=self._target_pressure,
-                    direction=TargetDirection.MIN_ABOVE_TARGET,
-                ),
+            if max_pressure > self._target_pressure:
+                return Solution(
+                    success=False,
+                    configuration=ChokeConfiguration(delta_pressure=search_boundary.max),
+                    failure=TargetPressureUnreachableFailure(
+                        achievable_pressure_bara=max_pressure,
+                        target_pressure_bara=self._target_pressure,
+                        direction=TargetDirection.MIN_ABOVE_TARGET,
+                    ),
+                )
+
+            delta_pressure = self._root_finding_strategy.find_root(
+                boundary=search_boundary,
+                func=lambda x: outlet_pressure(x) - self._target_pressure,
+            )
+            return Solution(success=True, configuration=ChokeConfiguration(delta_pressure=delta_pressure))
+        except InfeasiblePressureError as e:
+            return Solution.from_infeasible_pressure(
+                e, configuration=ChokeConfiguration(delta_pressure=self._boundary.min)
             )
 
-        delta_pressure = self._root_finding_strategy.find_root(
-            boundary=search_boundary,
-            func=lambda x: outlet_pressure(x) - self._target_pressure,
-        )
-        return Solution(success=True, configuration=ChokeConfiguration(delta_pressure=delta_pressure))
-
     def _feasible_boundary(self, func: Callable[[ChokeConfiguration], FluidStream]) -> Boundary:
-        """Return the search boundary narrowed to the feasible region (no RateTooHighError).
+        """Return the search boundary narrowed to the feasible region.
 
         Probes the upper bound first; if feasible, returns the original boundary immediately.
-        Otherwise bisects for the largest ΔP before rate capacity is exceeded.
+        Otherwise bisects for the largest ΔP before rate capacity or pressure feasibility is exceeded.
         """
         try:
             func(ChokeConfiguration(delta_pressure=self._boundary.max))
             return self._boundary
-        except RateTooHighError:
+        except (RateTooHighError, InfeasiblePressureError):
             pass
 
         lo, hi = self._boundary.min, self._boundary.max
@@ -74,6 +79,6 @@ class UpstreamChokeSolver(Solver):
             try:
                 func(ChokeConfiguration(delta_pressure=mid))
                 lo = mid
-            except RateTooHighError:
+            except (RateTooHighError, InfeasiblePressureError):
                 hi = mid
         return Boundary(min=self._boundary.min, max=lo)

--- a/src/libecalc/process/process_units/choke.py
+++ b/src/libecalc/process/process_units/choke.py
@@ -2,7 +2,7 @@ from typing import Final
 
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import OutsideCapacityError
+from libecalc.process.process_pipeline.process_error import InfeasiblePressureError
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
@@ -33,7 +33,16 @@ class Choke(ProcessUnit):
         if self._pressure_change > 0.0:
             pressure_bara = inlet_stream.pressure_bara - self._pressure_change
             if pressure_bara < 0.0:
-                raise OutsideCapacityError("Trying to choke to negative pressure.")
+                raise InfeasiblePressureError(
+                    process_unit_id=self.get_id(),
+                    achieved_pressure_bara=pressure_bara,
+                    reason=(
+                        f"Choke would reduce pressure below 0 bara "
+                        f"(inlet={inlet_stream.pressure_bara}, "
+                        f"change={self._pressure_change}, "
+                        f"result={pressure_bara})."
+                    ),
+                )
         else:
             # Delta pressure = 0, i.e. don't do anything
             return inlet_stream

--- a/src/libecalc/process/process_units/pressure_dropper.py
+++ b/src/libecalc/process/process_units/pressure_dropper.py
@@ -2,7 +2,7 @@ from typing import Final
 
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import OutsideCapacityError
+from libecalc.process.process_pipeline.process_error import InfeasiblePressureError
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
@@ -33,7 +33,16 @@ class PressureDropper(ProcessUnit):
         if self._pressure_drop_bara > 0.0:
             new_pressure_bara = inlet_stream.pressure_bara - self._pressure_drop_bara
             if new_pressure_bara < 0.0:
-                raise OutsideCapacityError(f"Pressure cannot drop below 0 (Given: {new_pressure_bara})")
+                raise InfeasiblePressureError(
+                    process_unit_id=self.get_id(),
+                    achieved_pressure_bara=new_pressure_bara,
+                    reason=(
+                        f"PressureDropper would drop pressure below 0 bara "
+                        f"(inlet={inlet_stream.pressure_bara}, "
+                        f"drop={self._pressure_drop_bara}, "
+                        f"result={new_pressure_bara})."
+                    ),
+                )
         else:
             # Delta pressure = 0, i.e. don't do anything
             return inlet_stream

--- a/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
+++ b/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
@@ -111,9 +111,9 @@ def test_upstream_choke_solver_reports_failure_when_rate_capacity_prevents_reach
     solution = upstream_choke_solver.solve(choke_func)
 
     assert not solution.success
-    assert solution.failure_event is not None
-    assert solution.failure_event.target_value == target_pressure
-    assert solution.failure_event.achievable_value > target_pressure
+    assert solution.failure is not None
+    assert solution.failure.target_pressure_bara == target_pressure
+    assert solution.failure.achievable_pressure_bara > target_pressure
 
 
 def test_upstream_choke_solver_reports_failure_when_max_choke_still_above_target(
@@ -140,6 +140,6 @@ def test_upstream_choke_solver_reports_failure_when_max_choke_still_above_target
     solution = upstream_choke_solver.solve(choke_func)
 
     assert not solution.success
-    assert solution.failure_event is not None
-    assert solution.failure_event.target_value == target_pressure
-    assert solution.failure_event.achievable_value > target_pressure
+    assert solution.failure is not None
+    assert solution.failure.target_pressure_bara == target_pressure
+    assert solution.failure.achievable_pressure_bara > target_pressure

--- a/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
+++ b/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
@@ -5,6 +5,7 @@ from libecalc.process.process_pipeline.process_error import RateTooHighError
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.process_pipeline_runner import propagate_stream_many
+from libecalc.process.process_solver.solver import TargetPressureUnreachableFailure
 from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.upstream_choke_solver import UpstreamChokeSolver
 
@@ -112,6 +113,7 @@ def test_upstream_choke_solver_reports_failure_when_rate_capacity_prevents_reach
 
     assert not solution.success
     assert solution.failure is not None
+    assert isinstance(solution.failure, TargetPressureUnreachableFailure)
     assert solution.failure.target_pressure_bara == target_pressure
     assert solution.failure.achievable_pressure_bara > target_pressure
 
@@ -141,5 +143,6 @@ def test_upstream_choke_solver_reports_failure_when_max_choke_still_above_target
 
     assert not solution.success
     assert solution.failure is not None
+    assert isinstance(solution.failure, TargetPressureUnreachableFailure)
     assert solution.failure.target_pressure_bara == target_pressure
     assert solution.failure.achievable_pressure_bara > target_pressure

--- a/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
@@ -176,9 +176,11 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
     assert solution.success
     assert interstage_stream.pressure_bara == pytest.approx(interstage_pressure_target, rel=0.001)
     assert new_outlet_stream.pressure_bara == pytest.approx(target_pressure, rel=0.001)
+    assert old_result.stage_results[0].outlet_stream is not None
     assert interstage_stream.pressure_bara == pytest.approx(
         old_result.stage_results[0].outlet_stream.pressure_bara, rel=0.001
     )
+    assert old_result.outlet_stream is not None
     assert new_outlet_stream.pressure_bara == pytest.approx(old_result.outlet_stream.pressure_bara, rel=0.001)
 
 

--- a/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
@@ -6,7 +6,7 @@ from libecalc.domain.process.compressor.core.train.train_evaluation_input import
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_pressure_solver import MultiPressureSolver
 from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
-from libecalc.process.process_solver.solver import TargetNotAchievableEvent
+from libecalc.process.process_solver.solver import TargetPressureUnreachableFailure
 from libecalc.process.process_units.mixer import Mixer
 from libecalc.process.process_units.splitter import Splitter
 from libecalc.process.shaft import VariableSpeedShaft
@@ -360,7 +360,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
     root_finding_strategy,
     variable_speed_chart_data_factory,
 ):
-    """TargetNotAchievableEvent.source_id should identify the second segment when it fails."""
+    """TargetPressureUnreachableFailure.source_id should identify the second segment when it fails."""
 
     temperature = 300.0
     q0 = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
@@ -433,8 +433,8 @@ def test_target_not_achievable_event_identifies_failing_segment(
     )
 
     assert not solution.success
-    assert isinstance(solution.failure_event, TargetNotAchievableEvent)
-    assert solution.failure_event.source_id == hp_process_pipeline.get_id()
+    assert isinstance(solution.failure, TargetPressureUnreachableFailure)
+    assert solution.failure.source_id == hp_process_pipeline.get_id()
 
 
 def test_target_not_achievable_event_when_first_segment_fails(
@@ -451,7 +451,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
     root_finding_strategy,
     variable_speed_chart_data_factory,
 ):
-    """TargetNotAchievableEvent.source_id should identify the first segment when it fails."""
+    """TargetPressureUnreachableFailure.source_id should identify the first segment when it fails."""
     temperature = 300.0
     q0 = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
     q0_vol = float(q0.volumetric_rate_m3_per_hour)
@@ -523,5 +523,5 @@ def test_target_not_achievable_event_when_first_segment_fails(
     )
 
     assert not solution.success
-    assert isinstance(solution.failure_event, TargetNotAchievableEvent)
-    assert solution.failure_event.source_id == lp_process_pipeline.get_id()
+    assert isinstance(solution.failure, TargetPressureUnreachableFailure)
+    assert solution.failure.source_id == lp_process_pipeline.get_id()

--- a/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
@@ -123,7 +123,7 @@ def test_three_shaft_train_hits_target_pressure(stream_factory, pipeline_kwargs)
 
     solution = solver.find_solution(FloatConstraint(270.0, abs_tol=5.0), inlet)
 
-    assert solution.success, f"Expected success; failure: {solution.failure_event}"
+    assert solution.success, f"Expected success; failure: {solution.failure}"
 
 
 def test_each_shaft_runs_at_different_speed(stream_factory, pipeline_kwargs):
@@ -180,7 +180,7 @@ def test_empty_pipelines(stream_factory):
 
     assert solution.success
     assert solution.configuration == []
-    assert solution.failure_event is None
+    assert solution.failure is None
 
 
 def test_single_pipeline_hits_exact_target(stream_factory, pipeline_kwargs):

--- a/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
@@ -34,7 +34,7 @@ def test_empty_pipelines(stream_factory):
 
     assert solution.success
     assert solution.configuration == []
-    assert solution.failure_event is None
+    assert solution.failure is None
 
 
 def test_unreachable_target_reports_failure(stream_factory, fluid_service, root_finding_strategy):
@@ -57,11 +57,11 @@ def test_unreachable_target_reports_failure(stream_factory, fluid_service, root_
     solution = solver.find_solution([FloatConstraint(9000.0)], inlet)
 
     assert not solution.success
-    assert solution.failure_event is not None
+    assert solution.failure is not None
 
 
 def test_second_pipeline_failure_preserves_first_failure(stream_factory, fluid_service, root_finding_strategy):
-    """When multiple pipelines fail, the first failure_event is preserved."""
+    """When multiple pipelines fail, the first failure is preserved."""
     pipelines = [
         make_process_pipeline(
             min_rate=200,
@@ -89,6 +89,6 @@ def test_second_pipeline_failure_preserves_first_failure(stream_factory, fluid_s
     solution = solver.find_solution([FloatConstraint(9000.0), FloatConstraint(90000.0)], inlet)
 
     assert not solution.success
-    assert solution.failure_event is not None
+    assert solution.failure is not None
     # Configurations are still collected (best-effort from each pipeline)
     assert len(solution.configuration) > 0

--- a/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
@@ -70,7 +70,7 @@ def test_multi_shaft_outlet_pressure_matches_simplified_train(
     solver = MultiShaftEqualRatioSolver(process_pipelines=solver_pipelines)
     solution = solver.find_solution(FloatConstraint(_P_OUT_BARA, abs_tol=1.0), inlet_stream)
 
-    assert solution.success, f"Solver failed: {solution.failure_event}"
+    assert solution.success, f"Solver failed: {solution.failure}"
 
     current = inlet_stream
     for pipeline in solver_pipelines:

--- a/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
@@ -53,6 +53,7 @@ def test_multi_shaft_outlet_pressure_matches_simplified_train(
         )
     )
     legacy_outlet = legacy_result.outlet_stream
+    assert legacy_outlet is not None
 
     # New: MultiShaftEqualRatioSolver
     solver_pipelines = [

--- a/tests/libecalc/process/process_solver/test_outlet_pressure_solver_infeasible_pressure.py
+++ b/tests/libecalc/process/process_solver/test_outlet_pressure_solver_infeasible_pressure.py
@@ -1,0 +1,94 @@
+"""Regression: InfeasiblePressureError from a PressureDropper / Choke must
+not propagate out of OutletPressureSolver."""
+
+import pytest
+
+from libecalc.domain.process.value_objects.chart import ChartCurve
+from libecalc.process.process_solver.float_constraint import FloatConstraint
+from libecalc.process.process_solver.solver import InfeasiblePressureFailure
+from libecalc.process.process_units.compressor import Compressor
+from libecalc.process.process_units.pressure_dropper import PressureDropper
+from libecalc.process.shaft import VariableSpeedShaft
+from libecalc.testing.chart_data_factory import ChartDataFactory
+
+
+@pytest.fixture
+def single_speed_compressor(fluid_service):
+    chart_data = ChartDataFactory.from_curves(
+        [
+            ChartCurve(
+                rate_actual_m3_hour=[500.0, 1500.0],
+                polytropic_head_joule_per_kg=[70000.0, 50000.0],
+                efficiency_fraction=[0.75, 0.75],
+                speed_rpm=100.0,
+            )
+        ]
+    )
+    return Compressor(
+        compressor_chart=chart_data,
+        fluid_service=fluid_service,
+    )
+
+
+def test_outlet_pressure_solver_handles_infeasible_pressure_from_pressure_dropper(
+    stream_factory,
+    fluid_service,
+    single_speed_compressor,
+    process_pipeline_factory,
+    process_runner_factory,
+    with_common_asv,
+    common_asv_anti_surge_strategy_factory,
+    downstream_choke_pressure_control_strategy_factory,
+    choke_factory,
+    choke_configuration_handler_factory,
+    outlet_pressure_solver_factory,
+):
+    compressor = single_speed_compressor
+    shaft = VariableSpeedShaft()
+    shaft.connect(compressor)
+
+    inlet_pressure = 25.0
+    misconfigured_dropper = PressureDropper(
+        fluid_service=fluid_service,
+        pressure_drop_bara=inlet_pressure + 50.0,
+    )
+
+    downstream_choke = choke_factory()
+    downstream_choke_handler = choke_configuration_handler_factory(choke=downstream_choke)
+
+    recirculation_loop, looped_units = with_common_asv([compressor])
+    units = [misconfigured_dropper, *looped_units, downstream_choke]
+    runner = process_runner_factory(
+        units=units,
+        configuration_handlers=[shaft, recirculation_loop, downstream_choke_handler],
+    )
+    pipeline = process_pipeline_factory(units=units)
+    anti_surge_strategy = common_asv_anti_surge_strategy_factory(
+        runner=runner,
+        recirculation_loop_id=recirculation_loop.get_id(),
+        first_compressor=compressor,
+    )
+    pressure_control_strategy = downstream_choke_pressure_control_strategy_factory(
+        runner=runner,
+        choke_id=downstream_choke_handler.get_id(),
+    )
+    solver = outlet_pressure_solver_factory(
+        shaft=shaft,
+        runner=runner,
+        anti_surge_strategy=anti_surge_strategy,
+        pressure_control_strategy=pressure_control_strategy,
+        process_pipeline_id=pipeline.get_id(),
+    )
+
+    inlet_stream = stream_factory(standard_rate_m3_per_day=500_000, pressure_bara=inlet_pressure)
+
+    solution = solver.find_solution(
+        pressure_constraint=FloatConstraint(40.0),
+        inlet_stream=inlet_stream,
+    )
+
+    assert solution.success is False
+    assert isinstance(solution.failure, InfeasiblePressureFailure)
+    assert solution.failure.source_id == misconfigured_dropper.get_id()
+    assert solution.failure.achieved_pressure_bara is not None
+    assert solution.failure.achieved_pressure_bara < 0.0


### PR DESCRIPTION
## Type of Work

- [ ] Patch
- [x] Minor (`fix:`)
- [ ] Major

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [x] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: ...
- [x] I have added tests
- [x] I have used conventional commits syntax

> Stacked on top of #1575 (typed solver failures) and #1577 (rate-recovery helpers). The first two commits drop out of this PR's diff once those merge.

## What is this PR all about?

`PressureDropper` and `Choke` raise `OutsideCapacityError` when the configured pressure change drives the outlet pressure to zero or below. The solver layer only caught the rate-flavoured subclasses (`RateTooHighError` / `RateTooLowError`), so this exception propagated out of `OutletPressureSolver` uncaught and crashed the caller instead of being reported as a structured solver failure.

The base `OutsideCapacityError` also carried no attribution — catch sites had no way to tell which process unit was responsible.

### Changes

- New `InfeasiblePressureError(OutsideCapacityError)` carrying `process_unit_id` and the resulting non-positive
  `achieved_pressure_bara`. `PressureDropper` and `Choke` raise it.
- New `InfeasiblePressureFailure(source_id, achieved_pressure_bara)` — a sibling of `RateTooHighFailure` / `RateTooLowFailure` under the `SolverFailure` base introduced in #1575. Exposes `from_error(e)` for one-line translation at catch sites.
- Catch sites updated to convert `InfeasiblePressureError` → `Solution(success=False, failure=InfeasiblePressureFailure.from_error(e))` with attribution preserved:
  - `SpeedSolver.solve` (sibling `except` on the flat body introduced by #1577)
  - `RecirculationSolver.solve` (sibling `except` on the flat body introduced by #1577)
  - `UpstreamChokeSolver.solve` (outer wrap)
  - `CommonASVAntiSurgeStrategy.apply`
  - `IndividualASVAntiSurgeStrategy.apply` (per-stage)
  - `CommonASVPressureControlStrategy.apply`
  - `DownstreamChokePressureControlStrategy.apply`
  - `IndividualASVPressureControlStrategy.apply` (both pressure- and
    rate-control variants)
- `UpstreamChokeSolver._feasible_boundary` additionally treats
  `InfeasiblePressureError` the same as `RateTooHighError`: it
  brackets the choke ΔP downward, since increasing ΔP further can
  only make pressure feasibility worse.

### Drive-by fixes

- `CommonASVAntiSurgeStrategy.apply` was silently dropping `recirculation_solution.failure`. Now forwarded.
- `CommonASVPressureControlStrategy.apply` was likewise dropping the inner `RecirculationSolver`'s `failure`. Now forwarded.

## What else did you consider?

## Between the lines?

