### PR TITLE
refactor(solver): extract rate-recovery helpers

### DIFF
--- a/src/libecalc/process/process_solver/solvers/recirculation_solver.py
+++ b/src/libecalc/process/process_solver/solvers/recirculation_solver.py
@@ -29,36 +29,12 @@ class RecirculationSolver(Solver):
         self._root_finding_strategy = root_finding_strategy
 
     def solve(self, func: Callable[[RecirculationConfiguration], FluidStream]) -> Solution[RecirculationConfiguration]:
-        def bool_func(x: float, mode: Literal["minimize", "maximize"]) -> tuple[bool, bool]:
-            """
-            Return a tuple where first bool is True for higher value,
-            the second bool says if the solution is accepted or not.
-
-            Need to separate these to avoid accepting a solution which is outside capacity. I.e. when minimizing we
-            want to return True for a higher value, but we don't want to accept the solution.
-            """
-            try:
-                func(RecirculationConfiguration(recirculation_rate=x))
-                return False if mode == "minimize" else True, True
-            except RateTooLowError:
-                return True, False
-            except RateTooHighError:
-                return False, False
-
         try:
-            minimum_rate = self._recirculation_rate_boundary.min
-            func(RecirculationConfiguration(recirculation_rate=minimum_rate))
-            # No error for minimum rate, no need to find min boundary
-        except RateTooLowError:
-            # Min boundary is too low, find solution
-            minimum_rate = self._search_strategy.search(
-                boundary=self._recirculation_rate_boundary,
-                func=lambda x: bool_func(x, mode="minimize"),
-            )
+            minimum_rate = self._find_min_within_capacity_rate(func)
         except RateTooHighError as e:
             # Flow is above stonewall at zero recirculation; adding recirculation cannot help.
             return Solution.from_rate_too_high(
-                e, configuration=RecirculationConfiguration(recirculation_rate=minimum_rate)
+                e, configuration=RecirculationConfiguration(recirculation_rate=self._recirculation_rate_boundary.min)
             )
 
         target_pressure = self._target_pressure
@@ -66,16 +42,7 @@ class RecirculationSolver(Solver):
             # Recirc used to get within capacity, but not to meet constraints
             return Solution(success=True, configuration=RecirculationConfiguration(recirculation_rate=minimum_rate))
 
-        try:
-            maximum_rate = self._recirculation_rate_boundary.max
-            func(RecirculationConfiguration(recirculation_rate=maximum_rate))
-            # No error for max rate, no need to find max boundary
-        except RateTooHighError:
-            # Max boundary is too high, find solution
-            maximum_rate = self._search_strategy.search(
-                boundary=self._recirculation_rate_boundary,
-                func=lambda x: bool_func(x, mode="maximize"),
-            )
+        maximum_rate = self._find_max_within_capacity_rate(func)
 
         minimum_outlet_stream = func(RecirculationConfiguration(recirculation_rate=minimum_rate))
         if minimum_outlet_stream.pressure_bara <= target_pressure:
@@ -113,3 +80,54 @@ class RecirculationSolver(Solver):
             func=lambda x: func(RecirculationConfiguration(recirculation_rate=x)).pressure_bara - target_pressure.value,
         )
         return Solution(success=True, configuration=RecirculationConfiguration(recirculation_rate=recirculation_rate))
+
+    def _find_min_within_capacity_rate(self, func: Callable[[RecirculationConfiguration], FluidStream]) -> float:
+        """Return the smallest recirculation rate that keeps every stage within flow capacity.
+
+        ``RateTooLowError`` at the boundary minimum is recoverable (more recirculation adds
+        flow); ``RateTooHighError`` is not (more recirculation only adds more flow) and
+        propagates.
+        """
+        minimum_rate = self._recirculation_rate_boundary.min
+        try:
+            func(RecirculationConfiguration(recirculation_rate=minimum_rate))
+            return minimum_rate
+        except RateTooLowError:
+            return self._search_strategy.search(
+                boundary=self._recirculation_rate_boundary,
+                func=lambda x: self._bool_func(func, x, mode="minimize"),
+            )
+
+    def _find_max_within_capacity_rate(self, func: Callable[[RecirculationConfiguration], FluidStream]) -> float:
+        """Return the largest recirculation rate that keeps every stage within flow capacity.
+
+        ``RateTooHighError`` at the boundary maximum is recoverable: search downward.
+        """
+        maximum_rate = self._recirculation_rate_boundary.max
+        try:
+            func(RecirculationConfiguration(recirculation_rate=maximum_rate))
+            return maximum_rate
+        except RateTooHighError:
+            return self._search_strategy.search(
+                boundary=self._recirculation_rate_boundary,
+                func=lambda x: self._bool_func(func, x, mode="maximize"),
+            )
+
+    @staticmethod
+    def _bool_func(
+        func: Callable[[RecirculationConfiguration], FluidStream],
+        x: float,
+        mode: Literal["minimize", "maximize"],
+    ) -> tuple[bool, bool]:
+        """Probe a candidate rate for the search strategy.
+
+        Returns ``(is_higher, is_accepted)``. The two booleans are decoupled so an
+        out-of-capacity candidate can never be accepted as a solution.
+        """
+        try:
+            func(RecirculationConfiguration(recirculation_rate=x))
+            return False if mode == "minimize" else True, True
+        except RateTooLowError:
+            return True, False
+        except RateTooHighError:
+            return False, False

--- a/src/libecalc/process/process_solver/solvers/speed_solver.py
+++ b/src/libecalc/process/process_solver/solvers/speed_solver.py
@@ -29,11 +29,8 @@ class SpeedSolver(Solver[SpeedConfiguration]):
         self._root_finding_strategy = root_finding_strategy
 
     def solve(self, func: Callable[[SpeedConfiguration], FluidStream]) -> Solution[SpeedConfiguration]:
-        def get_outlet_stream(speed: float) -> FluidStream:
-            return func(SpeedConfiguration(speed=speed))
-
-        max_speed_configuration = SpeedConfiguration(speed=self._boundary.max)
         try:
+            max_speed_configuration = SpeedConfiguration(speed=self._boundary.max)
             maximum_speed_outlet_stream = func(max_speed_configuration)
         except RateTooHighError as e:
             logger.debug(f"No solution found for maximum speed: {max_speed_configuration}", exc_info=e)
@@ -50,28 +47,7 @@ class SpeedSolver(Solver[SpeedConfiguration]):
                 direction=TargetDirection.MAX_BELOW_TARGET,
             )
 
-        try:
-            minimum_speed_configuration = SpeedConfiguration(speed=self._boundary.min)
-            minimum_speed_outlet_stream = func(minimum_speed_configuration)
-        except RateTooHighError as e:
-            logger.debug(f"No solution found for minimum speed: {self._boundary.min}", exc_info=e)
-
-            # rate is above maximum rate for minimum speed. Find the lowest minimum speed which gives a valid result
-            def bool_speed_func(x: float):
-                try:
-                    get_outlet_stream(speed=x)
-                    return False, True
-                except RateTooHighError:
-                    return True, False
-                except RateTooLowError:
-                    return False, False
-
-            minimum_speed_within_capacity = self._search_strategy.search(
-                boundary=self._boundary,
-                func=bool_speed_func,
-            )
-            minimum_speed_configuration = SpeedConfiguration(speed=minimum_speed_within_capacity)
-            minimum_speed_outlet_stream = func(minimum_speed_configuration)
+        minimum_speed_configuration, minimum_speed_outlet_stream = self._find_min_within_capacity_speed(func)
 
         if minimum_speed_outlet_stream.pressure_bara > self._target_pressure:
             # Solution 2, target pressure is too low
@@ -92,7 +68,7 @@ class SpeedSolver(Solver[SpeedConfiguration]):
         def root_speed_func(x: float) -> float:
             # We should be able to produce an outlet stream since we adjust minimum speed above,
             # or exit if max speed is not enough
-            out = get_outlet_stream(speed=x)
+            out = func(SpeedConfiguration(speed=x))
             return out.pressure_bara - self._target_pressure
 
         speed = self._root_finding_strategy.find_root(
@@ -100,3 +76,33 @@ class SpeedSolver(Solver[SpeedConfiguration]):
             func=root_speed_func,
         )
         return Solution(success=True, configuration=SpeedConfiguration(speed=speed))
+
+    def _find_min_within_capacity_speed(
+        self, func: Callable[[SpeedConfiguration], FluidStream]
+    ) -> tuple[SpeedConfiguration, FluidStream]:
+        """Return the lowest speed configuration within flow capacity, and its outlet stream.
+
+        ``RateTooHighError`` at the boundary minimum is recoverable: higher speed raises the
+        stonewall limit; search upward.
+        """
+        minimum_speed_configuration = SpeedConfiguration(speed=self._boundary.min)
+        try:
+            return minimum_speed_configuration, func(minimum_speed_configuration)
+        except RateTooHighError as e:
+            logger.debug(f"No solution found for minimum speed: {self._boundary.min}", exc_info=e)
+
+            def bool_speed_func(x: float) -> tuple[bool, bool]:
+                try:
+                    func(SpeedConfiguration(speed=x))
+                    return False, True
+                except RateTooHighError:
+                    return True, False
+                except RateTooLowError:
+                    return False, False
+
+            minimum_speed_within_capacity = self._search_strategy.search(
+                boundary=self._boundary,
+                func=bool_speed_func,
+            )
+            minimum_speed_configuration = SpeedConfiguration(speed=minimum_speed_within_capacity)
+            return minimum_speed_configuration, func(minimum_speed_configuration)


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why) — pure refactor, covered by existing solver tests
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

Extract the per-boundary "probe + recover from `RateTooHighError`" logic out of `RecirculationSolver.solve` and `SpeedSolver.solve` into named helpers:

- `RecirculationSolver._find_min_within_capacity_rate` / `_find_max_within_capacity_rate`
- `SpeedSolver._find_min_within_capacity_speed`
- `RecirculationSolver._bool_func` lifted to a `@staticmethod`

The `solve()` bodies become a linear sequence of named steps. Each step's failure maps to one event at the top level, instead of a `try` whose `except` runs another search that can itself raise.

No behaviour change.

## What else did you consider?

## Between the lines?

Prerequisite for cleanly landing infeasible pressure handling in a later PR. With the flat `solve()` shape introduced here, the `InfeasiblePressureError` handling collapses into a sibling `except` clause instead of an outer `try/except` wrapped around a body that already contains nested `try/except`.

Also makes `RecirculationSolver` and `SpeedSolver` structurally symmetric, which should make any future shared-base extraction straightforward.
