### PR TITLE
refactor(process): rename SolverFailure to PropagationFailure

### DIFF
--- a/src/libecalc/process/process_pipeline/ids.py
+++ b/src/libecalc/process/process_pipeline/ids.py
@@ -1,0 +1,13 @@
+"""Identifier types for process pipeline entities.
+
+Kept in a dependency-free module so other modules (notably
+``propagation_failure``) can reference these identifier types without
+pulling in ``process_unit`` / ``process_pipeline`` and creating import
+cycles.
+"""
+
+from typing import NewType
+from uuid import UUID
+
+ProcessUnitId = NewType("ProcessUnitId", UUID)
+ProcessPipelineId = NewType("ProcessPipelineId", UUID)

--- a/src/libecalc/process/process_pipeline/process_pipeline.py
+++ b/src/libecalc/process/process_pipeline/process_pipeline.py
@@ -1,12 +1,10 @@
 from collections.abc import Sequence
-from typing import Final, NewType, Self
-from uuid import UUID
+from typing import Final, Self
 
 from libecalc.common.ddd.entity import Entity
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
+from libecalc.process.process_pipeline.ids import ProcessPipelineId
 from libecalc.process.process_pipeline.process_unit import ProcessUnit
-
-ProcessPipelineId = NewType("ProcessPipelineId", UUID)
 
 
 class ProcessPipeline(Entity[ProcessPipelineId]):

--- a/src/libecalc/process/process_pipeline/process_unit.py
+++ b/src/libecalc/process/process_pipeline/process_unit.py
@@ -1,12 +1,10 @@
 import abc
-from typing import NewType, Self
-from uuid import UUID
+from typing import Self
 
 from libecalc.common.ddd.entity import Entity
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
+from libecalc.process.process_pipeline.ids import ProcessUnitId
 from libecalc.process.process_pipeline.stream_propagator import StreamPropagator
-
-ProcessUnitId = NewType("ProcessUnitId", UUID)
 
 
 class ProcessUnit(Entity[ProcessUnitId], StreamPropagator, abc.ABC):

--- a/src/libecalc/process/process_pipeline/propagation_failure.py
+++ b/src/libecalc/process/process_pipeline/propagation_failure.py
@@ -1,0 +1,80 @@
+"""Typed reasons that propagating a stream through a process unit did not
+produce an outlet stream.
+
+A process-unit propagation function returns ``FluidStream | PropagationFailure``:
+either a stream came out, or here is the structured reason none did.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from enum import Enum
+from typing import Self
+
+from libecalc.process.process_pipeline.ids import ProcessPipelineId, ProcessUnitId
+from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
+
+
+class PropagationFailure:
+    """Base class for the typed reason a propagation did not succeed.
+
+    Subclasses carry the data relevant to a specific outcome (e.g. above
+    stonewall, below surge, target pressure unreachable). Consumers should
+    branch on subclass with ``isinstance`` or ``match`` rather than
+    inspecting flag fields.
+    """
+
+
+@dataclass
+class RateTooHigh(PropagationFailure):
+    source_id: ProcessUnitId
+    actual_rate_m3_per_hour: float | None = None
+    maximum_rate_m3_per_hour: float | None = None
+
+    @classmethod
+    def from_error(cls, e: RateTooHighError) -> Self:
+        return cls(
+            source_id=e.process_unit_id,
+            actual_rate_m3_per_hour=e.actual_rate,
+            maximum_rate_m3_per_hour=e.boundary_rate,
+        )
+
+
+@dataclass
+class RateTooLow(PropagationFailure):
+    source_id: ProcessUnitId
+    actual_rate_m3_per_hour: float | None = None
+    minimum_rate_m3_per_hour: float | None = None
+
+    @classmethod
+    def from_error(cls, e: RateTooLowError) -> Self:
+        return cls(
+            source_id=e.process_unit_id,
+            actual_rate_m3_per_hour=e.actual_rate,
+            minimum_rate_m3_per_hour=e.boundary_rate,
+        )
+
+
+@dataclass
+class InfeasiblePressure(PropagationFailure):
+    source_id: ProcessUnitId
+    achieved_pressure_bara: float | None = None
+
+
+class TargetDirection(Enum):
+    """Which side of the target pressure the achievable boundary lies on."""
+
+    MAX_BELOW_TARGET = "max_below_target"
+    MIN_ABOVE_TARGET = "min_above_target"
+
+
+@dataclass
+class TargetPressureUnreachable(PropagationFailure):
+    achievable_pressure_bara: float
+    target_pressure_bara: float
+    direction: TargetDirection
+    source_id: ProcessPipelineId | None = None
+
+    def with_source_id(self, source_id: ProcessPipelineId) -> Self:
+        return dataclasses.replace(self, source_id=source_id)

--- a/src/libecalc/process/process_solver/anti_surge/individual_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/individual_asv.py
@@ -6,9 +6,7 @@ from libecalc.process.process_pipeline.process_error import RateTooHighError
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.process_runner import ProcessRunner
-from libecalc.process.process_solver.solver import (
-    Solution,
-)
+from libecalc.process.process_solver.solver import Solution
 from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.process.process_units.compressor import Compressor
 

--- a/src/libecalc/process/process_solver/multi_pressure_solver.py
+++ b/src/libecalc/process/process_solver/multi_pressure_solver.py
@@ -3,12 +3,13 @@ from typing import Final
 
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.propagation_failure import TargetDirection
 from libecalc.process.process_solver.configuration import Configuration, OperatingConfiguration, SpeedConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
 from libecalc.process.process_solver.pressure_control.downstream_choke import DownstreamChokePressureControlStrategy
 from libecalc.process.process_solver.pressure_control.upstream_choke import UpstreamChokePressureControlStrategy
-from libecalc.process.process_solver.solver import Solution, TargetDirection
+from libecalc.process.process_solver.solver import Solution
 
 
 class MultiPressureSolver:

--- a/src/libecalc/process/process_solver/outlet_pressure_solver.py
+++ b/src/libecalc/process/process_solver/outlet_pressure_solver.py
@@ -4,6 +4,7 @@ from typing import Final
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooLowError
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
+from libecalc.process.process_pipeline.propagation_failure import TargetDirection, TargetPressureUnreachable
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import (
@@ -16,11 +17,7 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
-from libecalc.process.process_solver.solver import (
-    Solution,
-    TargetDirection,
-    TargetPressureUnreachableFailure,
-)
+from libecalc.process.process_solver.solver import Solution
 from libecalc.process.process_solver.solvers.speed_solver import SpeedSolver
 
 
@@ -172,7 +169,7 @@ class OutletPressureSolver:
             configurations[pressure_control_configuration.configuration_handler_id] = pressure_control_configuration
 
         failure = pressure_control_solution.failure
-        if isinstance(failure, TargetPressureUnreachableFailure) and failure.source_id is None:
+        if isinstance(failure, TargetPressureUnreachable) and failure.source_id is None:
             failure = failure.with_source_id(self._process_pipeline_id)
 
         return Solution(

--- a/src/libecalc/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/common_asv.py
@@ -1,15 +1,13 @@
 from collections.abc import Sequence
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.propagation_failure import TargetDirection
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
-from libecalc.process.process_solver.solver import (
-    Solution,
-    TargetDirection,
-)
+from libecalc.process.process_solver.solver import Solution
 from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.recirculation_solver import (
     RecirculationConfiguration,

--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -2,15 +2,13 @@ from collections.abc import Sequence
 
 from libecalc.common.numeric_methods import find_root
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.propagation_failure import TargetDirection
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
-from libecalc.process.process_solver.solver import (
-    Solution,
-    TargetDirection,
-)
+from libecalc.process.process_solver.solver import Solution
 from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.recirculation_solver import (
     RecirculationConfiguration,

--- a/src/libecalc/process/process_solver/solver.py
+++ b/src/libecalc/process/process_solver/solver.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import abc
-import dataclasses
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from enum import Enum
-from typing import Self, TypeVar
+from typing import TypeVar
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
-from libecalc.process.process_pipeline.process_unit import ProcessUnitId
+from libecalc.process.process_pipeline.propagation_failure import (
+    PropagationFailure,
+    RateTooHigh,
+    RateTooLow,
+    TargetDirection,
+    TargetPressureUnreachable,
+)
 from libecalc.process.process_solver.configuration import (
     Configuration,
     ConfigurationHandlerId,
@@ -21,84 +25,21 @@ from libecalc.process.process_solver.configuration import (
 TConfiguration = TypeVar("TConfiguration", covariant=True)
 
 
-class SolverFailure:
-    """Typed cause for an unsuccessful ``Solution``.
-
-    Subclasses carry the data relevant to a specific failure mode (e.g. above stonewall,
-    below surge, target pressure unreachable). Consumers should branch on subclass with
-    ``isinstance`` or ``match`` rather than inspecting flag fields.
-    """
-
-
-@dataclass
-class RateTooHighFailure(SolverFailure):
-    source_id: ProcessUnitId
-    actual_rate_m3_per_hour: float | None = None
-    maximum_rate_m3_per_hour: float | None = None
-
-    @classmethod
-    def from_error(cls, e: RateTooHighError) -> Self:
-        return cls(
-            source_id=e.process_unit_id,
-            actual_rate_m3_per_hour=e.actual_rate,
-            maximum_rate_m3_per_hour=e.boundary_rate,
-        )
-
-
-@dataclass
-class RateTooLowFailure(SolverFailure):
-    source_id: ProcessUnitId
-    actual_rate_m3_per_hour: float | None = None
-    minimum_rate_m3_per_hour: float | None = None
-
-    @classmethod
-    def from_error(cls, e: RateTooLowError) -> Self:
-        return cls(
-            source_id=e.process_unit_id,
-            actual_rate_m3_per_hour=e.actual_rate,
-            minimum_rate_m3_per_hour=e.boundary_rate,
-        )
-
-
-@dataclass
-class InfeasiblePressureFailure(SolverFailure):
-    source_id: ProcessUnitId
-    achieved_pressure_bara: float | None = None
-
-
-class TargetDirection(Enum):
-    """Which side of the target pressure the achievable boundary lies on."""
-
-    MAX_BELOW_TARGET = "max_below_target"
-    MIN_ABOVE_TARGET = "min_above_target"
-
-
-@dataclass
-class TargetPressureUnreachableFailure(SolverFailure):
-    achievable_pressure_bara: float
-    target_pressure_bara: float
-    direction: TargetDirection
-    source_id: ProcessPipelineId | None = None
-
-    def with_source_id(self, source_id: ProcessPipelineId) -> Self:
-        return dataclasses.replace(self, source_id=source_id)
-
-
 @dataclass(frozen=True)
 class Solution[TConfiguration]:
     success: bool
     configuration: TConfiguration
-    failure: SolverFailure | None = field(default=None)
+    failure: PropagationFailure | None = field(default=None)
 
     @classmethod
     def from_rate_too_high[T](cls, e: RateTooHighError, configuration: T) -> Solution[T]:
-        """Build an unsuccessful Solution carrying a RateTooHighFailure."""
-        return Solution(success=False, configuration=configuration, failure=RateTooHighFailure.from_error(e))
+        """Build an unsuccessful Solution carrying a RateTooHigh result."""
+        return Solution(success=False, configuration=configuration, failure=RateTooHigh.from_error(e))
 
     @classmethod
     def from_rate_too_low[T](cls, e: RateTooLowError, configuration: T) -> Solution[T]:
-        """Build an unsuccessful Solution carrying a RateTooLowFailure."""
-        return Solution(success=False, configuration=configuration, failure=RateTooLowFailure.from_error(e))
+        """Build an unsuccessful Solution carrying a RateTooLow result."""
+        return Solution(success=False, configuration=configuration, failure=RateTooLow.from_error(e))
 
     @classmethod
     def target_pressure_unreachable[T](
@@ -109,11 +50,11 @@ class Solution[TConfiguration]:
         direction: TargetDirection,
         source_id: ProcessPipelineId | None = None,
     ) -> Solution[T]:
-        """Build an unsuccessful Solution carrying a TargetPressureUnreachableFailure."""
+        """Build an unsuccessful Solution carrying a TargetPressureUnreachable result."""
         return Solution(
             success=False,
             configuration=configuration,
-            failure=TargetPressureUnreachableFailure(
+            failure=TargetPressureUnreachable(
                 achievable_pressure_bara=achievable_pressure_bara,
                 target_pressure_bara=target_pressure_bara,
                 direction=direction,

--- a/src/libecalc/process/process_solver/solvers/recirculation_solver.py
+++ b/src/libecalc/process/process_solver/solvers/recirculation_solver.py
@@ -3,16 +3,12 @@ from typing import Literal
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
+from libecalc.process.process_pipeline.propagation_failure import TargetDirection, TargetPressureUnreachable
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import RecirculationConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
-from libecalc.process.process_solver.solver import (
-    Solution,
-    Solver,
-    TargetDirection,
-    TargetPressureUnreachableFailure,
-)
+from libecalc.process.process_solver.solver import Solution, Solver
 
 
 class RecirculationSolver(Solver):
@@ -86,7 +82,7 @@ class RecirculationSolver(Solver):
                 configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
                 failure=None
                 if is_success
-                else TargetPressureUnreachableFailure(
+                else TargetPressureUnreachable(
                     achievable_pressure_bara=minimum_outlet_stream.pressure_bara,
                     target_pressure_bara=target_pressure.value,
                     direction=TargetDirection.MAX_BELOW_TARGET,
@@ -101,7 +97,7 @@ class RecirculationSolver(Solver):
                 configuration=RecirculationConfiguration(recirculation_rate=maximum_rate),
                 failure=None
                 if is_success
-                else TargetPressureUnreachableFailure(
+                else TargetPressureUnreachable(
                     achievable_pressure_bara=maximum_outlet_stream.pressure_bara,
                     target_pressure_bara=target_pressure.value,
                     direction=TargetDirection.MIN_ABOVE_TARGET,

--- a/src/libecalc/process/process_solver/solvers/speed_solver.py
+++ b/src/libecalc/process/process_solver/solvers/speed_solver.py
@@ -3,14 +3,11 @@ from collections.abc import Callable
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
+from libecalc.process.process_pipeline.propagation_failure import TargetDirection
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import SpeedConfiguration
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
-from libecalc.process.process_solver.solver import (
-    Solution,
-    Solver,
-    TargetDirection,
-)
+from libecalc.process.process_solver.solver import Solution, Solver
 
 logger = logging.getLogger(__name__)
 

--- a/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
+++ b/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
@@ -3,14 +3,11 @@ from collections.abc import Callable
 from libecalc.domain.process.compressor.core.train.utils.common import PRESSURE_CALCULATION_TOLERANCE
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooHighError
+from libecalc.process.process_pipeline.propagation_failure import TargetDirection
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import ChokeConfiguration
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy
-from libecalc.process.process_solver.solver import (
-    Solution,
-    Solver,
-    TargetDirection,
-)
+from libecalc.process.process_solver.solver import Solution, Solver
 
 
 class UpstreamChokeSolver(Solver):

--- a/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
@@ -3,10 +3,10 @@ import pytest
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl, InterstagePressureControl
 from libecalc.domain.process.compressor.core.train.compressor_train_common_shaft import CompressorTrainCommonShaft
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
+from libecalc.process.process_pipeline.propagation_failure import TargetPressureUnreachable
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_pressure_solver import MultiPressureSolver
 from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
-from libecalc.process.process_solver.solver import TargetPressureUnreachableFailure
 from libecalc.process.process_units.mixer import Mixer
 from libecalc.process.process_units.splitter import Splitter
 from libecalc.process.shaft import VariableSpeedShaft
@@ -360,7 +360,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
     root_finding_strategy,
     variable_speed_chart_data_factory,
 ):
-    """TargetPressureUnreachableFailure.source_id should identify the second segment when it fails."""
+    """TargetPressureUnreachable.source_id should identify the second segment when it fails."""
 
     temperature = 300.0
     q0 = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
@@ -433,7 +433,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
     )
 
     assert not solution.success
-    assert isinstance(solution.failure, TargetPressureUnreachableFailure)
+    assert isinstance(solution.failure, TargetPressureUnreachable)
     assert solution.failure.source_id == hp_process_pipeline.get_id()
 
 
@@ -451,7 +451,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
     root_finding_strategy,
     variable_speed_chart_data_factory,
 ):
-    """TargetPressureUnreachableFailure.source_id should identify the first segment when it fails."""
+    """TargetPressureUnreachable.source_id should identify the first segment when it fails."""
     temperature = 300.0
     q0 = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
     q0_vol = float(q0.volumetric_rate_m3_per_hour)
@@ -523,5 +523,5 @@ def test_target_not_achievable_event_when_first_segment_fails(
     )
 
     assert not solution.success
-    assert isinstance(solution.failure, TargetPressureUnreachableFailure)
+    assert isinstance(solution.failure, TargetPressureUnreachable)
     assert solution.failure.source_id == lp_process_pipeline.get_id()


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why) — pure rename; existing tests retained and renamed in lockstep
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

Pure rename and relocation of the typed-failure sum type used by the process simulator. **No behavioural change.**

- `SolverFailure` → `PropagationFailure`
- Variants lose their redundant `Failure` suffix:
  - `RateTooHighFailure` → `RateTooHigh`
  - `RateTooLowFailure` → `RateTooLow`
  - `InfeasiblePressureFailure` → `InfeasiblePressure`
  - `TargetPressureUnreachableFailure` → `TargetPressureUnreachable`
- Moved from `process_solver/solver.py` to a new module `process_pipeline/propagation_failure.py`, next to `stream_propagator.py` (where the type is actually produced).
- The `from_error(...)` constructors on the rate variants — only bridges from the legacy exception classes — are removed.
- New `process_pipeline/ids.py` extracted to hold the two `NewType` aliases (`ProcessUnitId`, `ProcessPipelineId`) so `propagation_failure.py` can import the identifiers without creating an import cycle through `process_unit` / `process_pipeline`.

This is **PR 1 of 3** in a stack that replaces exception-based failure signalling in the process simulator with typed return values. Splitting the rename out keeps the diffs in the follow-up PRs about behaviour, not naming.


## What else did you consider?


## Between the lines?

**Stack**

1. **This PR** — rename `SolverFailure` → `PropagationFailure`.
2. `typed-failures/02-process-units` — process units return `FluidStream | PropagationFailure`; legacy unit exception classes deleted.
3. `typed-failures/03-search-strategies` — add `DidNotConverge` variant; search/root-finding return `float | DidNotConverge`; `DidNotConvergeError` deleted.
