### PR TITLE
refactor(process): add DidNotConverge variant; search strategies return float | DidNotConverge

### DIFF
--- a/src/libecalc/process/process_pipeline/propagation_failure.py
+++ b/src/libecalc/process/process_pipeline/propagation_failure.py
@@ -61,3 +61,21 @@ class TargetPressureUnreachable(PropagationFailure):
 
     def with_source_id(self, source_id: ProcessPipelineId) -> Self:
         return dataclasses.replace(self, source_id=source_id)
+
+
+@dataclass
+class DidNotConverge(PropagationFailure):
+    """Numerical root-finder exhausted its iteration budget without bracketing
+    a solution within tolerance.
+
+    This is a *numerical outcome*, not a programmer mistake: the operating
+    point may have no solution in the bracket given the requested tolerance.
+    Callers should react (tighten tolerance, widen bracket, accept that this
+    time-step has no solution), not catch-and-translate an exception.
+    """
+
+    iterations: int
+    tolerance: float
+    lower_bound: float | None = None
+    upper_bound: float | None = None
+    source_id: ProcessUnitId | ProcessPipelineId | None = None

--- a/src/libecalc/process/process_solver/feasibility_solver.py
+++ b/src/libecalc/process/process_solver/feasibility_solver.py
@@ -1,10 +1,10 @@
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.propagation_failure import DidNotConverge
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
 from libecalc.process.process_solver.search_strategies import (
     BinarySearchStrategy,
-    DidNotConvergeError,
     SearchStrategy,
 )
 
@@ -58,19 +58,16 @@ class FeasibilitySolver:
         upper_bound_sm3_per_day: float,
     ) -> float:
         boundary = Boundary(min=0.0, max=upper_bound_sm3_per_day)
-        try:
-            return self._search_strategy.search(
-                boundary=boundary,
-                func=lambda rate: (
-                    self._is_feasible(inlet_stream.with_standard_rate(rate), target_pressure),
-                    True,
-                ),
-            )
-        except DidNotConvergeError:
+        result = self._search_strategy.search(
+            boundary=boundary,
+            func=lambda rate: (
+                self._is_feasible(inlet_stream.with_standard_rate(rate), target_pressure),
+                True,
+            ),
+        )
+        if isinstance(result, DidNotConverge):
             return 0.0
+        return result
 
     def _is_feasible(self, inlet_stream: FluidStream, target_pressure: FloatConstraint) -> bool:
-        try:
-            return self._solver.find_solution(target_pressure, inlet_stream).success
-        except DidNotConvergeError:
-            return False
+        return self._solver.find_solution(target_pressure, inlet_stream).success

--- a/src/libecalc/process/process_solver/search_strategies.py
+++ b/src/libecalc/process/process_solver/search_strategies.py
@@ -3,29 +3,15 @@ from collections.abc import Callable
 
 from scipy.optimize import root_scalar
 
-from libecalc.common.errors.exceptions import EcalcError
+from libecalc.process.process_pipeline.propagation_failure import DidNotConverge
 from libecalc.process.process_solver.boundary import Boundary
 
 CONVERGENCE_TOLERANCE = 1e-5
 
 
-class DidNotConvergeError(EcalcError):
-    def __init__(
-        self,
-        boundary: Boundary,
-        tolerance: float,
-        iterations: int,
-    ):
-        super().__init__(
-            title="No solution found",
-            message=f"Did not reach convergence after maximum number of iterations: {iterations}."
-            f" lower bound: {boundary.min}, upper bound: {boundary.max}, convergence_tolerance: {tolerance}.",
-        )
-
-
 class SearchStrategy(abc.ABC):
     @abc.abstractmethod
-    def search(self, boundary: Boundary, func: Callable[[float], tuple[bool, bool]]) -> float: ...
+    def search(self, boundary: Boundary, func: Callable[[float], tuple[bool, bool]]) -> float | DidNotConverge: ...
 
 
 class BinarySearchStrategy(SearchStrategy):
@@ -39,7 +25,7 @@ class BinarySearchStrategy(SearchStrategy):
         self._tolerance = tolerance
         self._max_iterations = max_iterations
 
-    def search(self, boundary: Boundary, func: Callable[[float], tuple[bool, bool]]) -> float:
+    def search(self, boundary: Boundary, func: Callable[[float], tuple[bool, bool]]) -> float | DidNotConverge:
         """Binary search until we reach the maximum x value constrained by x_min and x_max
         where we have a boolean constraint condition given as a function.
 
@@ -69,10 +55,11 @@ class BinarySearchStrategy(SearchStrategy):
             i += 1
 
         if i >= self._max_iterations:
-            raise DidNotConvergeError(
-                boundary=boundary,
-                tolerance=self._tolerance,
+            return DidNotConverge(
                 iterations=self._max_iterations,
+                tolerance=self._tolerance,
+                lower_bound=boundary.min,
+                upper_bound=boundary.max,
             )
         return x2
 
@@ -83,7 +70,7 @@ class RootFindingStrategy(abc.ABC):
         self,
         boundary: Boundary,
         func: Callable[[float], float],
-    ) -> float: ...
+    ) -> float | DidNotConverge: ...
 
 
 class ScipyRootFindingStrategy(RootFindingStrategy):
@@ -102,7 +89,7 @@ class ScipyRootFindingStrategy(RootFindingStrategy):
         self,
         boundary: Boundary,
         func: Callable[[float], float],
-    ) -> float:
+    ) -> float | DidNotConverge:
         """Root finding using scipy´s implementation of the brenth method.
 
         This will try to solve for the root: f(x) = 0. Another way to say this is "what x makes the function return 0"...
@@ -124,9 +111,10 @@ class ScipyRootFindingStrategy(RootFindingStrategy):
             rtol=self._tolerance,
         )
         if not result.converged:
-            raise DidNotConvergeError(
-                boundary=boundary,
-                tolerance=self._tolerance,
+            return DidNotConverge(
                 iterations=self._max_iterations,
+                tolerance=self._tolerance,
+                lower_bound=boundary.min,
+                upper_bound=boundary.max,
             )
         return result.root

--- a/src/libecalc/process/process_solver/solvers/recirculation_solver.py
+++ b/src/libecalc/process/process_solver/solvers/recirculation_solver.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from libecalc.process.process_pipeline.propagation_failure import (
+    DidNotConverge,
     PropagationFailure,
     RateTooHigh,
     RateTooLow,
@@ -48,10 +49,16 @@ class RecirculationSolver(Solver):
         minimum_result = func(RecirculationConfiguration(recirculation_rate=minimum_rate))
         if isinstance(minimum_result, RateTooLow):
             # Min boundary is too low, find solution
-            minimum_rate = self._search_strategy.search(
+            search_result = self._search_strategy.search(
                 boundary=self._recirculation_rate_boundary,
                 func=lambda x: bool_func(x, mode="minimize"),
             )
+            if isinstance(search_result, DidNotConverge):
+                return Solution.failed(
+                    configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
+                    failure=search_result,
+                )
+            minimum_rate = search_result
         elif isinstance(minimum_result, RateTooHigh):
             # Flow is above stonewall at zero recirculation; adding recirculation cannot help.
             return Solution.failed(
@@ -73,10 +80,16 @@ class RecirculationSolver(Solver):
         maximum_result = func(RecirculationConfiguration(recirculation_rate=maximum_rate))
         if isinstance(maximum_result, RateTooHigh):
             # Max boundary is too high, find solution
-            maximum_rate = self._search_strategy.search(
+            search_result = self._search_strategy.search(
                 boundary=self._recirculation_rate_boundary,
                 func=lambda x: bool_func(x, mode="maximize"),
             )
+            if isinstance(search_result, DidNotConverge):
+                return Solution.failed(
+                    configuration=RecirculationConfiguration(recirculation_rate=maximum_rate),
+                    failure=search_result,
+                )
+            maximum_rate = search_result
 
         minimum_outlet = func(RecirculationConfiguration(recirculation_rate=minimum_rate))
         if isinstance(minimum_outlet, PropagationFailure):
@@ -134,5 +147,10 @@ class RecirculationSolver(Solver):
             return Solution.failed(
                 configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
                 failure=exc.failure,
+            )
+        if isinstance(recirculation_rate, DidNotConverge):
+            return Solution.failed(
+                configuration=RecirculationConfiguration(recirculation_rate=minimum_rate),
+                failure=recirculation_rate,
             )
         return Solution(success=True, configuration=RecirculationConfiguration(recirculation_rate=recirculation_rate))

--- a/src/libecalc/process/process_solver/solvers/speed_solver.py
+++ b/src/libecalc/process/process_solver/solvers/speed_solver.py
@@ -1,6 +1,7 @@
 import logging
 
 from libecalc.process.process_pipeline.propagation_failure import (
+    DidNotConverge,
     PropagationFailure,
     RateTooHigh,
     RateTooLow,
@@ -61,6 +62,11 @@ class SpeedSolver(Solver[SpeedConfiguration]):
                 boundary=self._boundary,
                 func=bool_speed_func,
             )
+            if isinstance(minimum_speed_within_capacity, DidNotConverge):
+                return Solution.failed(
+                    configuration=SpeedConfiguration(speed=self._boundary.min),
+                    failure=minimum_speed_within_capacity,
+                )
             minimum_speed_configuration = SpeedConfiguration(speed=minimum_speed_within_capacity)
             minimum_speed_outlet = func(minimum_speed_configuration)
             if isinstance(minimum_speed_outlet, PropagationFailure):
@@ -98,4 +104,6 @@ class SpeedSolver(Solver[SpeedConfiguration]):
             )
         except InfeasibleDuringSearch as exc:
             return Solution.failed(configuration=minimum_speed_configuration, failure=exc.failure)
+        if isinstance(speed, DidNotConverge):
+            return Solution.failed(configuration=minimum_speed_configuration, failure=speed)
         return Solution(success=True, configuration=SpeedConfiguration(speed=speed))

--- a/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
+++ b/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
@@ -1,5 +1,10 @@
 from libecalc.domain.process.compressor.core.train.utils.common import PRESSURE_CALCULATION_TOLERANCE
-from libecalc.process.process_pipeline.propagation_failure import PropagationFailure, RateTooHigh, TargetDirection
+from libecalc.process.process_pipeline.propagation_failure import (
+    DidNotConverge,
+    PropagationFailure,
+    RateTooHigh,
+    TargetDirection,
+)
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import ChokeConfiguration
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy
@@ -61,6 +66,11 @@ class UpstreamChokeSolver(Solver):
             return Solution.failed(
                 configuration=ChokeConfiguration(delta_pressure=search_boundary.min),
                 failure=exc.failure,
+            )
+        if isinstance(delta_pressure, DidNotConverge):
+            return Solution.failed(
+                configuration=ChokeConfiguration(delta_pressure=search_boundary.min),
+                failure=delta_pressure,
             )
         return Solution(success=True, configuration=ChokeConfiguration(delta_pressure=delta_pressure))
 


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why) — existing feasibility / outlet-pressure tests cover the converged and non-converged paths; no new behaviour was introduced
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

Search and root-finding strategies no longer raise `DidNotConvergeError` when they exhaust their iteration budget — they return a typed `DidNotConverge` value instead. This is the final step of the typed-failures stack: every failure surface in the solver now flows through `PropagationFailure` values rather than exception control flow.

**New variant.** `DidNotConverge` joins `PropagationFailure` (in `process_pipeline/propagation_failure.py`), carrying `iterations`, `tolerance`, `lower_bound`, `upper_bound`.

**Signature change.** Both strategy interfaces now return a union:

```python
SearchStrategy.search(...)        -> float | DidNotConverge
RootFindingStrategy.find_root(...) -> float | DidNotConverge
```

`BinarySearchStrategy` and `ScipyRootFindingStrategy` return `DidNotConverge(...)` on iteration-budget exhaustion. The previous `DidNotConvergeError` exception class is deleted.

**Call-site updates.**
- `feasibility_solver` drops its two `try/except DidNotConvergeError` blocks in favour of `isinstance(result, DidNotConverge)` checks.
- `speed_solver`, `upstream_choke_solver`, `recirculation_solver` each guard the `search(...)` / `find_root(...)` return with an `isinstance(..., DidNotConverge)` check and translate to `Solution.failed(...)` when hit.

**No behavioural change.** Same inputs, same outputs, same failure outcomes — only the delivery mechanism changes.

## What else did you consider?

## Between the lines?

**Stack**

1. [#1578](https://github.com/equinor/ecalc/pull/1578) — rename `SolverFailure` → `PropagationFailure`.
2. [#1579](https://github.com/equinor/ecalc/pull/1579) — process units return `FluidStream | PropagationFailure`; unit exception classes deleted.
3. **This PR** — add `DidNotConverge` variant; search/root-finding return `float | DidNotConverge`; `DidNotConvergeError` deleted.
