### PR TITLE
refactor: introduce YamlProcessUnit types and rename to YamlProcessPipeline

### DIFF
--- a/src/libecalc/presentation/yaml/domain/reference_service.py
+++ b/src/libecalc/presentation/yaml/domain/reference_service.py
@@ -7,7 +7,7 @@ from libecalc.presentation.yaml.mappers.yaml_path import YamlPath
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_system import (
     YamlCompressor,
     YamlCompressorStageProcessSystem,
-    YamlSerialProcessSystem,
+    YamlProcessPipeline,
 )
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import (
     YamlCompressorTabularModel,
@@ -80,7 +80,7 @@ class ReferenceService(Protocol):
     def get_tabulated_model(self, reference: str) -> YamlTabularModel: ...
 
     @abc.abstractmethod
-    def get_process_system(self, reference: str) -> YamlSerialProcessSystem: ...
+    def get_process_system(self, reference: str) -> YamlProcessPipeline: ...
 
     @abc.abstractmethod
     def get_compressor_stage(self, reference: str) -> YamlCompressorStageProcessSystem: ...

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -37,12 +37,11 @@ from libecalc.presentation.yaml.mappers.fluid_mapper import (
 from libecalc.presentation.yaml.mappers.model import InvalidChartResourceException
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_system import (
-    YamlCompressor,
-    YamlCompressorModelChart,
     YamlCompressorStageProcessSystem,
     YamlProcessSimulation,
     YamlSerialProcessSystem,
 )
+from libecalc.presentation.yaml.yaml_types.components.yaml_process_units import YamlCompressor, YamlCompressorModelChart
 from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
 from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import YamlCompositionFluidModel, YamlPredefinedFluidModel

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -38,8 +38,8 @@ from libecalc.presentation.yaml.mappers.model import InvalidChartResourceExcepti
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_system import (
     YamlCompressorStageProcessSystem,
+    YamlProcessPipeline,
     YamlProcessSimulation,
-    YamlSerialProcessSystem,
 )
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_units import YamlCompressor, YamlCompressorModelChart
 from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
@@ -145,7 +145,7 @@ class ProcessSimulationMapper:
         self._reference_service = reference_service
         self._resources = resources
 
-    def _resolve_train_reference(self, ref: str | YamlSerialProcessSystem) -> YamlSerialProcessSystem:
+    def _resolve_train_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
         if isinstance(ref, str):
             return self._reference_service.get_process_system(reference=ref)
         else:

--- a/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
@@ -31,8 +31,8 @@ from libecalc.presentation.yaml.yaml_types.components.yaml_installation import Y
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_system import (
     YamlProcessSimulation,
     YamlProcessSystem,
-    YamlProcessUnit,
 )
+from libecalc.presentation.yaml.yaml_types.components.yaml_process_units import YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import YamlFacilityModel
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel

--- a/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
@@ -16,8 +16,8 @@ from libecalc.presentation.yaml.yaml_types.components.yaml_installation import Y
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_system import (
     YamlProcessSimulation,
     YamlProcessSystem,
-    YamlProcessUnit,
 )
+from libecalc.presentation.yaml.yaml_types.components.yaml_process_units import YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import YamlFacilityModel
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel

--- a/src/libecalc/presentation/yaml/yaml_reference_service.py
+++ b/src/libecalc/presentation/yaml/yaml_reference_service.py
@@ -10,13 +10,12 @@ from libecalc.presentation.yaml.domain.reference_service import (
 from libecalc.presentation.yaml.mappers.yaml_path import YamlPath
 from libecalc.presentation.yaml.yaml_models.yaml_model import YamlValidator
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_system import (
-    YamlCompressor,
     YamlCompressorStageProcessSystem,
     YamlProcessSimulation,
     YamlProcessSystem,
-    YamlProcessUnit,
     YamlSerialProcessSystem,
 )
+from libecalc.presentation.yaml.yaml_types.components.yaml_process_units import YamlCompressor, YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import (
     YamlFacilityModel,
     YamlGeneratorSetModel,
@@ -108,8 +107,9 @@ class YamlReferenceService(ReferenceService):
         process_units_path = YamlPath(keys=("PROCESS_UNITS",))
         for process_unit_key, process_unit in configuration.process_units.items():
             process_unit_path = process_units_path.append(process_unit_key)
-            references[process_unit.name] = process_unit
-            reference_yaml_context[process_unit.name] = process_unit_path
+            if isinstance(process_unit, YamlCompressor):
+                references[process_unit.name] = process_unit
+                reference_yaml_context[process_unit.name] = process_unit_path
 
         process_systems_path = YamlPath(keys=("PROCESS_SYSTEMS",))
         for process_system_key, process_system in configuration.process_systems.items():

--- a/src/libecalc/presentation/yaml/yaml_reference_service.py
+++ b/src/libecalc/presentation/yaml/yaml_reference_service.py
@@ -11,9 +11,9 @@ from libecalc.presentation.yaml.mappers.yaml_path import YamlPath
 from libecalc.presentation.yaml.yaml_models.yaml_model import YamlValidator
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_system import (
     YamlCompressorStageProcessSystem,
+    YamlProcessPipeline,
     YamlProcessSimulation,
     YamlProcessSystem,
-    YamlSerialProcessSystem,
 )
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_units import YamlCompressor, YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import (
@@ -192,9 +192,9 @@ class YamlReferenceService(ReferenceService):
             raise InvalidReferenceException("tabulated", reference)
         return model
 
-    def get_process_system(self, reference: str) -> YamlSerialProcessSystem:
+    def get_process_system(self, reference: str) -> YamlProcessPipeline:
         model = self._resolve_yaml_reference(reference, "process system")
-        if not isinstance(model, YamlSerialProcessSystem):
+        if not isinstance(model, YamlProcessPipeline):
             raise InvalidReferenceException("process system", reference)
         return model
 

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
@@ -7,8 +7,8 @@ from libecalc.presentation.yaml.yaml_types.components.yaml_installation import Y
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_system import (
     YamlProcessSimulation,
     YamlProcessSystem,
-    YamlProcessUnit,
 )
+from libecalc.presentation.yaml.yaml_types.components.yaml_process_units import YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import YamlFacilityModel
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
@@ -4,50 +4,13 @@ from pydantic import Field
 
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
-from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_chart import UnitsField, YamlCurve, YamlUnits
-from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
+from libecalc.presentation.yaml.yaml_types.components.yaml_process_units import (
+    ProcessUnitReference,
+    YamlCompressor,
+)
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
-from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import DataOrFile
 
 StreamRef = str
-
-
-class YamlControlMargin(YamlBase):
-    unit: YamlControlMarginUnits
-    value: float
-
-
-class YamlCompressorChart(YamlBase):
-    curves: Annotated[
-        DataOrFile[list[YamlCurve]],
-        Field(description="Compressor chart curves, one per speed.", title="CURVES"),
-    ]
-    units: YamlUnits = UnitsField()
-
-
-class YamlCompressorModelChart(YamlBase):
-    type: Literal["COMPRESSOR_CHART"]
-    chart: YamlCompressorChart
-    control_margin: YamlControlMargin
-
-
-ProcessUnitReference = str
-
-
-class YamlCompressor(YamlBase):
-    """
-    A Compressor process unit
-    """
-
-    type: Literal["COMPRESSOR"]
-    name: Annotated[
-        ProcessUnitReference,
-        Field(
-            description="Name of the model. See documentation for more information.",
-            title="NAME",
-        ),
-    ]
-    compressor_model: YamlCompressorModelChart
 
 
 type ProcessSystemReference = str  # TODO: validate correct reference
@@ -151,11 +114,6 @@ class YamlProcessSimulation(YamlBase):
         ),
     ]
 
-
-YamlProcessUnit = Annotated[
-    YamlCompressor,
-    Field(discriminator="type"),
-]
 
 YamlProcessSystem = Annotated[
     YamlSerialProcessSystem | YamlCompressorStageProcessSystem,

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_system.py
@@ -45,7 +45,7 @@ class YamlItem[TTarget](YamlBase):
     target: TTarget | ProcessSystemReference
 
 
-class YamlSerialProcessSystem(YamlBase):
+class YamlProcessPipeline(YamlBase):
     type: Literal["SERIAL"]
     name: ProcessSystemReference
     items: list[YamlItem[YamlCompressorStageProcessSystem]]
@@ -90,7 +90,7 @@ class YamlProcessConstraints(YamlBase):
 class YamlProcessSimulation(YamlBase):
     name: str
     targets: Annotated[
-        list[YamlItem[YamlSerialProcessSystem]],
+        list[YamlItem[YamlProcessPipeline]],
         Field(title="TARGETS"),
     ]
     stream_distribution: YamlStreamDistribution
@@ -116,6 +116,6 @@ class YamlProcessSimulation(YamlBase):
 
 
 YamlProcessSystem = Annotated[
-    YamlSerialProcessSystem | YamlCompressorStageProcessSystem,
+    YamlProcessPipeline | YamlCompressorStageProcessSystem,
     Field(discriminator="type"),
 ]

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_units.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_process_units.py
@@ -1,0 +1,88 @@
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from libecalc.presentation.yaml.yaml_types import YamlBase
+from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
+from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_chart import UnitsField, YamlCurve, YamlUnits
+from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
+from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import DataOrFile
+
+ProcessUnitReference = str
+
+
+class YamlControlMargin(YamlBase):
+    unit: YamlControlMarginUnits
+    value: float
+
+
+class YamlCompressorChart(YamlBase):
+    curves: Annotated[
+        DataOrFile[list[YamlCurve]],
+        Field(description="Compressor chart curves, one per speed.", title="CURVES"),
+    ]
+    units: YamlUnits = UnitsField()
+
+
+class YamlCompressorModelChart(YamlBase):
+    type: Literal["COMPRESSOR_CHART"]
+    chart: YamlCompressorChart
+    control_margin: YamlControlMargin
+
+
+class YamlCompressor(YamlBase):
+    """
+    A Compressor process unit
+    """
+
+    type: Literal["COMPRESSOR"]
+    name: Annotated[
+        ProcessUnitReference,
+        Field(
+            description="Name of the model. See documentation for more information.",
+            title="NAME",
+        ),
+    ]
+    compressor_model: YamlCompressorModelChart
+
+
+class YamlPressureDropper(YamlBase):
+    """A pressure dropper unit — reduces stream pressure by a fixed amount."""
+
+    type: Literal["PRESSURE_DROPPER"]
+    pressure_drop: Annotated[
+        YamlExpressionType,
+        Field(
+            description="Pressure drop across the unit [bar].",
+            title="PRESSURE_DROP",
+        ),
+    ]
+
+
+class YamlTemperatureSetter(YamlBase):
+    """A temperature setter unit — forces the stream to a specified temperature."""
+
+    type: Literal["TEMPERATURE_SETTER"]
+    temperature: Annotated[
+        YamlExpressionType,
+        Field(
+            description="Target temperature [Celsius].",
+            title="TEMPERATURE",
+        ),
+    ]
+
+
+class YamlLiquidRemover(YamlBase):
+    """A liquid remover (scrubber) unit — removes any condensed liquid from
+    the stream, leaving only the gas phase.
+
+    No-op if the stream is already pure vapor.
+    """
+
+    type: Literal["LIQUID_REMOVER"]
+
+
+YamlProcessUnit = Annotated[
+    YamlCompressor | YamlPressureDropper | YamlTemperatureSetter | YamlLiquidRemover,
+    Field(discriminator="type"),
+]

--- a/tests/libecalc/input/mappers/test_model_mapper.py
+++ b/tests/libecalc/input/mappers/test_model_mapper.py
@@ -11,7 +11,7 @@ from libecalc.presentation.yaml.yaml_entities import MemoryResource
 from libecalc.presentation.yaml.yaml_types.components.yaml_process_system import (
     YamlCompressor,
     YamlCompressorStageProcessSystem,
-    YamlSerialProcessSystem,
+    YamlProcessPipeline,
 )
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import (
     YamlGeneratorSetModel,
@@ -57,7 +57,7 @@ class DirectReferenceService(ReferenceService):
     def get_tabulated_model(self, reference: str) -> YamlTabularModel:
         raise NotImplementedError()
 
-    def get_process_system(self, reference: str) -> YamlSerialProcessSystem:
+    def get_process_system(self, reference: str) -> YamlProcessPipeline:
         raise NotImplementedError()
 
     def get_compressor_stage(self, reference: str) -> YamlCompressorStageProcessSystem:


### PR DESCRIPTION
Introduce `YamlProcessUnit` (`YamlPressureDropper`, `YamlTemperatureSetter`,
`YamlLiquidRemover`, `YamlCompressor`) in a new `yaml_process_units.py`
module, and rename `YamlSerialProcessSystem` → `YamlProcessPipeline`.

Preparation for removing `YamlCompressorStageProcessSystem` and letting
units stand directly in the pipeline. The mapper and `items` field are
not yet updated — that follows in a separate PR.

Refs:
equinor/ecalc-internal#1831

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
