### PR TITLE
refactor: add compressor solver-path matrix tests

### DIFF
--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -40,9 +40,18 @@ class Constraint:  # should this instead be more flexible wrt. matching one or m
     outlet_pressure: TimeSeriesExpression
 
 
+PressureControlType = Literal[
+    "UPSTREAM_CHOKE",
+    "DOWNSTREAM_CHOKE",
+    "COMMON_ASV",
+    "INDIVIDUAL_ASV_RATE",
+    "INDIVIDUAL_ASV_PRESSURE",
+]
+
+
 @value_object
 class PressureControlConfig:  # Spec
-    type: Literal["UPSTREAM_CHOKE", "DOWNSTREAM_CHOKE", "COMMON_ASV", "INDIVIDUAL_ASV_RATE", "INDIVIDUAL_ASV_PRESSURE"]
+    type: PressureControlType
 
 
 @value_object

--- a/tests/libecalc/process/conftest.py
+++ b/tests/libecalc/process/conftest.py
@@ -2,7 +2,6 @@ from typing import Final
 
 import pytest
 
-from ecalc_neqsim_wrapper import NeqSimFluidService
 from libecalc.domain.process.value_objects.chart.chart import ChartData
 from libecalc.process.fluid_stream.fluid import Fluid
 from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
@@ -189,7 +188,6 @@ def stage_units_factory(fluid_service):
         remove_liquid_after_cooling: bool = False,
     ) -> list[ProcessUnit]:
         assert isinstance(compressor, Compressor)
-        fluid_service = NeqSimFluidService.instance()
         units: list[ProcessUnit] = []
 
         if pressure_drop_ahead_of_stage:

--- a/tests/libecalc/process/helpers/__init__.py
+++ b/tests/libecalc/process/helpers/__init__.py
@@ -1,0 +1,4 @@
+from tests.libecalc.process.helpers.process_solver_builder import ProcessSolverBuilder
+from tests.libecalc.process.helpers.process_solver_system import ProcessSolverSystem, StageConfig
+
+__all__ = ["ProcessSolverBuilder", "ProcessSolverSystem", "StageConfig"]

--- a/tests/libecalc/process/helpers/process_solver_builder.py
+++ b/tests/libecalc/process/helpers/process_solver_builder.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import assert_never
+
+from libecalc.ecalc_model.process_simulation import PressureControlConfig, PressureControlType
+from libecalc.process.fluid_stream.fluid_service import FluidService
+from libecalc.process.process_pipeline.process_pipeline import ProcessPipeline
+from libecalc.process.process_pipeline.process_unit import ProcessUnit
+from libecalc.process.process_solver.anti_surge.common_asv import CommonASVAntiSurgeStrategy
+from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
+from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
+from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pressure_control.common_asv import CommonASVPressureControlStrategy
+from libecalc.process.process_solver.pressure_control.downstream_choke import DownstreamChokePressureControlStrategy
+from libecalc.process.process_solver.pressure_control.individual_asv import (
+    IndividualASVPressureControlStrategy,
+    IndividualASVRateControlStrategy,
+)
+from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
+from libecalc.process.process_solver.pressure_control.upstream_choke import UpstreamChokePressureControlStrategy
+from libecalc.process.process_solver.process_pipeline_runner import ProcessPipelineRunner
+from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
+from libecalc.process.process_solver.search_strategies import RootFindingStrategy, ScipyRootFindingStrategy
+from libecalc.process.process_units.choke import Choke
+from libecalc.process.process_units.compressor import Compressor
+from libecalc.process.process_units.direct_mixer import DirectMixer
+from libecalc.process.process_units.direct_splitter import DirectSplitter
+from libecalc.process.process_units.liquid_remover import LiquidRemover
+from libecalc.process.process_units.temperature_setter import TemperatureSetter
+from libecalc.process.shaft import VariableSpeedShaft
+from tests.libecalc.process.helpers.process_solver_system import ProcessSolverSystem, StageConfig
+
+
+class ProcessSolverBuilder:
+    """Build fully-wired process solver systems for tests.
+
+    This mirrors the production process-simulation assembly without YAML,
+    expressions, or time-series concerns.
+    """
+
+    def __init__(
+        self,
+        *,
+        stages: Sequence[StageConfig],
+        pressure_control_type: PressureControlType,
+        fluid_service: FluidService,
+        root_finding_strategy: RootFindingStrategy | None = None,
+    ) -> None:
+        if not stages:
+            raise ValueError("At least one stage is required")
+        self._stages = tuple(stages)
+        self._pressure_control_config = PressureControlConfig(type=pressure_control_type)
+        self._fluid_service = fluid_service
+        self._root_finding_strategy = root_finding_strategy or ScipyRootFindingStrategy()
+
+    def build(self) -> ProcessSolverSystem:
+        shaft = VariableSpeedShaft()
+        compressors: list[Compressor] = []
+        stage_units = [
+            self._create_stage_units(stage=stage, shaft=shaft, compressors=compressors) for stage in self._stages
+        ]
+
+        process_units, recirculation_loops = self._wrap_with_recirculation(stage_units=stage_units)
+        choke: Choke | None = None
+        choke_configuration_handler: ChokeConfigurationHandler | None = None
+        configuration_handlers = [shaft, *recirculation_loops]
+
+        if self._pressure_control_config.type in {"DOWNSTREAM_CHOKE", "UPSTREAM_CHOKE"}:
+            choke = Choke(fluid_service=self._fluid_service)
+            choke_configuration_handler = ChokeConfigurationHandler(choke=choke)
+            configuration_handlers.append(choke_configuration_handler)
+            if self._pressure_control_config.type == "DOWNSTREAM_CHOKE":
+                process_units = [*process_units, choke]
+            else:
+                process_units = [choke, *process_units]
+
+        pipeline = ProcessPipeline(name="test-pipeline", stream_propagators=process_units)
+        runner = ProcessPipelineRunner(units=process_units, configuration_handlers=configuration_handlers)
+        anti_surge_strategy = self._create_anti_surge_strategy(
+            runner=runner,
+            recirculation_loops=recirculation_loops,
+            compressors=compressors,
+        )
+        pressure_control_strategy = self._create_pressure_control_strategy(
+            runner=runner,
+            recirculation_loops=recirculation_loops,
+            compressors=compressors,
+            choke_configuration_handler=choke_configuration_handler,
+        )
+        solver = OutletPressureSolver(
+            shaft_id=shaft.get_id(),
+            process_pipeline_id=pipeline.get_id(),
+            runner=runner,
+            anti_surge_strategy=anti_surge_strategy,
+            pressure_control_strategy=pressure_control_strategy,
+            root_finding_strategy=self._root_finding_strategy,
+            speed_boundary=shaft.get_speed_boundary(),
+        )
+
+        return ProcessSolverSystem(
+            solver=solver,
+            runner=runner,
+            pipeline=pipeline,
+            shaft=shaft,
+            compressors=tuple(compressors),
+            recirculation_loops=tuple(recirculation_loops),
+            choke=choke,
+        )
+
+    def _create_stage_units(
+        self,
+        *,
+        stage: StageConfig,
+        shaft: VariableSpeedShaft,
+        compressors: list[Compressor],
+    ) -> list[ProcessUnit]:
+        compressor = Compressor(compressor_chart=stage.chart_data, fluid_service=self._fluid_service)
+        shaft.connect(compressor)
+        compressors.append(compressor)
+
+        units: list[ProcessUnit] = [
+            TemperatureSetter(
+                required_temperature_kelvin=stage.inlet_temperature_kelvin,
+                fluid_service=self._fluid_service,
+            ),
+            Choke(
+                fluid_service=self._fluid_service,
+                pressure_change=stage.pressure_drop_ahead_of_stage,
+            ),
+        ]
+        if stage.remove_liquid_after_cooling:
+            units.append(LiquidRemover(fluid_service=self._fluid_service))
+        units.append(compressor)
+        return units
+
+    def _wrap_with_recirculation(
+        self,
+        *,
+        stage_units: Sequence[Sequence[ProcessUnit]],
+    ) -> tuple[list[ProcessUnit], list[RecirculationLoop]]:
+        if self._pressure_control_config.type == "COMMON_ASV":
+            recirculation_loop, process_units = self._wrap_units_with_asv(
+                [unit for units in stage_units for unit in units]
+            )
+            return process_units, [recirculation_loop]
+
+        process_units: list[ProcessUnit] = []
+        recirculation_loops: list[RecirculationLoop] = []
+        for units in stage_units:
+            recirculation_loop, stage_process_units = self._wrap_units_with_asv(units)
+            recirculation_loops.append(recirculation_loop)
+            process_units.extend(stage_process_units)
+        return process_units, recirculation_loops
+
+    @staticmethod
+    def _wrap_units_with_asv(units: Sequence[ProcessUnit]) -> tuple[RecirculationLoop, list[ProcessUnit]]:
+        mixer = DirectMixer()
+        splitter = DirectSplitter()
+        recirculation_loop = RecirculationLoop(mixer=mixer, splitter=splitter)
+        return recirculation_loop, [mixer, *units, splitter]
+
+    def _create_anti_surge_strategy(
+        self,
+        *,
+        runner: ProcessPipelineRunner,
+        recirculation_loops: Sequence[RecirculationLoop],
+        compressors: Sequence[Compressor],
+    ) -> CommonASVAntiSurgeStrategy | IndividualASVAntiSurgeStrategy:
+        match self._pressure_control_config.type:
+            case "COMMON_ASV":
+                return CommonASVAntiSurgeStrategy(
+                    simulator=runner,
+                    root_finding_strategy=self._root_finding_strategy,
+                    first_compressor=compressors[0],
+                    recirculation_loop_id=recirculation_loops[0].get_id(),
+                )
+            case "DOWNSTREAM_CHOKE" | "UPSTREAM_CHOKE" | "INDIVIDUAL_ASV_RATE" | "INDIVIDUAL_ASV_PRESSURE":
+                return IndividualASVAntiSurgeStrategy(
+                    simulator=runner,
+                    recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
+                    compressors=compressors,
+                )
+            case _:
+                assert_never(self._pressure_control_config.type)
+
+    def _create_pressure_control_strategy(
+        self,
+        *,
+        runner: ProcessPipelineRunner,
+        recirculation_loops: Sequence[RecirculationLoop],
+        compressors: Sequence[Compressor],
+        choke_configuration_handler: ChokeConfigurationHandler | None,
+    ) -> PressureControlStrategy:
+        match self._pressure_control_config.type:
+            case "DOWNSTREAM_CHOKE":
+                assert choke_configuration_handler is not None
+                return DownstreamChokePressureControlStrategy(
+                    simulator=runner,
+                    choke_configuration_handler_id=choke_configuration_handler.get_id(),
+                )
+            case "UPSTREAM_CHOKE":
+                assert choke_configuration_handler is not None
+                return UpstreamChokePressureControlStrategy(
+                    simulator=runner,
+                    choke_configuration_handler_id=choke_configuration_handler.get_id(),
+                    root_finding_strategy=self._root_finding_strategy,
+                )
+            case "COMMON_ASV":
+                return CommonASVPressureControlStrategy(
+                    simulator=runner,
+                    recirculation_loop_id=recirculation_loops[0].get_id(),
+                    first_compressor=compressors[0],
+                    root_finding_strategy=self._root_finding_strategy,
+                )
+            case "INDIVIDUAL_ASV_RATE":
+                return IndividualASVRateControlStrategy(
+                    simulator=runner,
+                    recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
+                    compressors=compressors,
+                )
+            case "INDIVIDUAL_ASV_PRESSURE":
+                return IndividualASVPressureControlStrategy(
+                    simulator=runner,
+                    recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
+                    compressors=compressors,
+                    root_finding_strategy=self._root_finding_strategy,
+                )
+            case _:
+                assert_never(self._pressure_control_config.type)

--- a/tests/libecalc/process/helpers/process_solver_system.py
+++ b/tests/libecalc/process/helpers/process_solver_system.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from libecalc.domain.process.value_objects.chart.chart import ChartData
+from libecalc.process.process_pipeline.process_pipeline import ProcessPipeline
+from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.process_runner import ProcessRunner
+from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
+from libecalc.process.process_units.choke import Choke
+from libecalc.process.process_units.compressor import Compressor
+from libecalc.process.shaft import VariableSpeedShaft
+
+
+@dataclass(frozen=True)
+class StageConfig:
+    chart_data: ChartData
+    inlet_temperature_kelvin: float = 303.15
+    remove_liquid_after_cooling: bool = True
+    pressure_drop_ahead_of_stage: float = 0.0
+
+
+@dataclass(frozen=True)
+class ProcessSolverSystem:
+    solver: OutletPressureSolver
+    runner: ProcessRunner
+    pipeline: ProcessPipeline
+    shaft: VariableSpeedShaft
+    compressors: tuple[Compressor, ...]
+    recirculation_loops: tuple[RecirculationLoop, ...]
+    choke: Choke | None

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/assertions.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/assertions.py
@@ -1,0 +1,81 @@
+"""Shared assertion helpers for solver-path matrix tests."""
+
+from __future__ import annotations
+
+from math import isnan
+
+import pytest
+
+from libecalc.domain.process.value_objects.chart.chart import ChartData
+
+from .cases import ExpectedControlAction, PressureExpectation, SpeedBoundaryClass, TrialCase
+
+PRESSURE_TOLERANCE = 1e-3
+POWER_TOLERANCE = 0.1
+RECIRCULATION_TOLERANCE = 1e-6
+
+
+def assert_pressure_expectation(outlet_pressure_bara: float, case: TrialCase) -> None:
+    expected_pressure = case.region.discharge_pressure_bara
+    expectation = case.expectation.pressure_expectation
+    if expectation is PressureExpectation.TARGET:
+        assert outlet_pressure_bara == pytest.approx(expected_pressure, abs=PRESSURE_TOLERANCE)
+    elif expectation is PressureExpectation.ABOVE_TARGET:
+        assert outlet_pressure_bara > expected_pressure
+    elif expectation is PressureExpectation.BELOW_TARGET:
+        assert outlet_pressure_bara < expected_pressure
+    elif expectation is PressureExpectation.NAN:
+        assert isnan(outlet_pressure_bara)
+    elif expectation is PressureExpectation.NOT_ASSERTED:
+        return
+    else:
+        raise AssertionError(f"Unexpected pressure expectation: {expectation}")
+
+
+def assert_speed_boundary(speed: float, chart_data: ChartData, case: TrialCase) -> None:
+    boundary_class = case.region.speed_boundary_class
+    if boundary_class is SpeedBoundaryClass.NOT_ASSERTED:
+        return
+
+    speeds = [curve.speed for curve in chart_data.get_adjusted_curves()]
+    minimum_speed = min(speeds)
+    maximum_speed = max(speeds)
+    if boundary_class is SpeedBoundaryClass.MINIMUM:
+        assert speed == pytest.approx(minimum_speed, rel=1e-4)
+    elif boundary_class is SpeedBoundaryClass.MAXIMUM:
+        assert speed == pytest.approx(maximum_speed, rel=1e-4)
+    elif boundary_class is SpeedBoundaryClass.INTERNAL:
+        assert minimum_speed < speed < maximum_speed
+    else:
+        raise AssertionError(f"Unexpected speed boundary class: {boundary_class}")
+
+
+def assert_control_behavior(
+    case: TrialCase,
+    *,
+    recirculation_rates: tuple[float, ...],
+    anti_surge_recirculation_rates: tuple[float, ...],
+    choke_delta_pressure: float | None = None,
+    suction_pressure_after_upstream_choke_bara: float | None = None,
+) -> None:
+    has_recirculation = any(rate > RECIRCULATION_TOLERANCE for rate in recirculation_rates)
+    has_anti_surge_recirculation = any(rate > RECIRCULATION_TOLERANCE for rate in anti_surge_recirculation_rates)
+
+    if case.region.expect_auto_anti_surge:
+        assert has_anti_surge_recirculation
+    elif case.expectation.success and case.mode in {"DOWNSTREAM_CHOKE", "UPSTREAM_CHOKE"}:
+        assert not has_anti_surge_recirculation
+
+    action = case.expectation.control_action
+    if action is ExpectedControlAction.RECIRCULATION:
+        assert has_recirculation
+
+    if action is ExpectedControlAction.DOWNSTREAM_CHOKE:
+        assert choke_delta_pressure is None or choke_delta_pressure > 0.0
+    elif action is ExpectedControlAction.UPSTREAM_CHOKE:
+        assert choke_delta_pressure is None or choke_delta_pressure > 0.0
+    elif choke_delta_pressure is not None:
+        assert choke_delta_pressure == pytest.approx(0.0, abs=PRESSURE_TOLERANCE)
+
+    if action is ExpectedControlAction.UPSTREAM_CHOKE and suction_pressure_after_upstream_choke_bara is not None:
+        assert suction_pressure_after_upstream_choke_bara < case.region.suction_pressure_bara

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/cases.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/cases.py
@@ -1,0 +1,249 @@
+"""Shared data model and trial cases for the solver-path matrix.
+
+Defines 9 operating regions × 5 pressure-control modes = 45 trial cases
+that exercise every legacy and new-process solver path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import get_args
+
+from libecalc.ecalc_model.process_simulation import PressureControlType
+
+
+class PressureExpectation(StrEnum):
+    TARGET = "target"
+    ABOVE_TARGET = "above_target"
+    BELOW_TARGET = "below_target"
+    NOT_ASSERTED = "not_asserted"
+    NAN = "nan"
+
+
+class SpeedBoundaryClass(StrEnum):
+    MINIMUM = "minimum"
+    MAXIMUM = "maximum"
+    INTERNAL = "internal"
+    NOT_ASSERTED = "not_asserted"
+
+
+@dataclass(frozen=True)
+class SolverRegion:
+    id: str
+    rate_sm3_day: float
+    suction_pressure_bara: float
+    discharge_pressure_bara: float
+    speed_boundary_class: SpeedBoundaryClass
+    expect_auto_anti_surge: bool = False
+
+
+class ExpectedControlAction(StrEnum):
+    NONE = "none"
+    DOWNSTREAM_CHOKE = "downstream_choke"
+    UPSTREAM_CHOKE = "upstream_choke"
+    RECIRCULATION = "recirculation"
+
+
+class ExpectedOutcome(StrEnum):
+    SUCCESS = "success"
+    PRESSURE_TOO_HIGH = "pressure_too_high"
+    PRESSURE_TOO_LOW = "pressure_too_low"
+    ABOVE_MAX_FLOW = "above_max_flow"
+    BELOW_MIN_FLOW = "below_min_flow"
+    NOT_CALCULATED = "not_calculated"
+
+
+@dataclass(frozen=True)
+class ExpectedResult:
+    outcome: ExpectedOutcome
+    power_mw: float
+    pressure_expectation: PressureExpectation
+    control_action: ExpectedControlAction = ExpectedControlAction.NONE
+
+    @property
+    def success(self) -> bool:
+        return self.outcome is ExpectedOutcome.SUCCESS
+
+
+@dataclass(frozen=True)
+class TrialCase:
+    region: SolverRegion
+    mode: PressureControlType
+    expectation: ExpectedResult
+
+    @property
+    def id(self) -> str:
+        return f"{self.region.id}-{self.mode}"
+
+
+MODES = get_args(PressureControlType)
+
+REGIONS = {
+    "R1": SolverRegion(
+        id="R1",
+        rate_sm3_day=5_000_000.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=100.0,
+        speed_boundary_class=SpeedBoundaryClass.INTERNAL,
+    ),
+    "R2": SolverRegion(
+        id="R2",
+        rate_sm3_day=2_000_000.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=90.0,
+        speed_boundary_class=SpeedBoundaryClass.INTERNAL,
+        expect_auto_anti_surge=True,
+    ),
+    "R3": SolverRegion(
+        id="R3",
+        rate_sm3_day=500_000.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=60.0,
+        speed_boundary_class=SpeedBoundaryClass.MINIMUM,
+        expect_auto_anti_surge=True,
+    ),
+    "R4": SolverRegion(
+        id="R4",
+        rate_sm3_day=5_000_000.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=200.0,
+        speed_boundary_class=SpeedBoundaryClass.MAXIMUM,
+    ),
+    "R5": SolverRegion(
+        id="R5",
+        rate_sm3_day=15_000_000.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=50.0,
+        speed_boundary_class=SpeedBoundaryClass.MAXIMUM,
+    ),
+    "R6": SolverRegion(
+        id="R6",
+        rate_sm3_day=5_000_000.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=108.0,
+        speed_boundary_class=SpeedBoundaryClass.INTERNAL,
+    ),
+    "R7": SolverRegion(
+        id="R7",
+        rate_sm3_day=3_500_000.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=62.0,
+        speed_boundary_class=SpeedBoundaryClass.MINIMUM,
+    ),
+    "R8": SolverRegion(
+        id="R8",
+        rate_sm3_day=0.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=100.0,
+        speed_boundary_class=SpeedBoundaryClass.NOT_ASSERTED,
+    ),
+    "R9": SolverRegion(
+        id="R9",
+        rate_sm3_day=4_000_000.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=45.0,
+        speed_boundary_class=SpeedBoundaryClass.MINIMUM,
+    ),
+}
+
+
+def _ok(
+    power_mw: float,
+    control: ExpectedControlAction = ExpectedControlAction.NONE,
+    pressure: PressureExpectation = PressureExpectation.TARGET,
+) -> ExpectedResult:
+    return ExpectedResult(
+        outcome=ExpectedOutcome.SUCCESS, power_mw=power_mw, pressure_expectation=pressure, control_action=control
+    )
+
+
+def _fail(
+    outcome: ExpectedOutcome,
+    power_mw: float,
+    pressure: PressureExpectation = PressureExpectation.NOT_ASSERTED,
+    control: ExpectedControlAction = ExpectedControlAction.NONE,
+) -> ExpectedResult:
+    return ExpectedResult(outcome=outcome, power_mw=power_mw, pressure_expectation=pressure, control_action=control)
+
+
+EXPECTED_RESULTS: dict[tuple[str, PressureControlType], ExpectedResult] = {
+    # R1 — nominal internal point, all modes succeed
+    ("R1", "UPSTREAM_CHOKE"): _ok(8.231),
+    ("R1", "DOWNSTREAM_CHOKE"): _ok(8.231),
+    ("R1", "INDIVIDUAL_ASV_RATE"): _ok(8.231),
+    ("R1", "INDIVIDUAL_ASV_PRESSURE"): _ok(8.231),
+    ("R1", "COMMON_ASV"): _ok(8.231),
+    # R2 — below minimum flow, auto anti-surge brings it back
+    ("R2", "UPSTREAM_CHOKE"): _ok(5.283),
+    ("R2", "DOWNSTREAM_CHOKE"): _ok(5.283),
+    ("R2", "INDIVIDUAL_ASV_RATE"): _ok(5.283),
+    ("R2", "INDIVIDUAL_ASV_PRESSURE"): _ok(5.283),
+    ("R2", "COMMON_ASV"): _ok(5.283),
+    # R3 — minimum speed, pressure control active
+    ("R3", "DOWNSTREAM_CHOKE"): _ok(2.492, ExpectedControlAction.DOWNSTREAM_CHOKE),
+    ("R3", "UPSTREAM_CHOKE"): _ok(2.227, ExpectedControlAction.UPSTREAM_CHOKE),
+    ("R3", "INDIVIDUAL_ASV_RATE"): _ok(2.967, ExpectedControlAction.RECIRCULATION),
+    ("R3", "INDIVIDUAL_ASV_PRESSURE"): _ok(2.967, ExpectedControlAction.RECIRCULATION),
+    ("R3", "COMMON_ASV"): _ok(2.967, ExpectedControlAction.RECIRCULATION),
+    # R4 — target pressure unreachable (too high)
+    ("R4", "UPSTREAM_CHOKE"): _fail(ExpectedOutcome.PRESSURE_TOO_HIGH, 9.288, PressureExpectation.BELOW_TARGET),
+    ("R4", "DOWNSTREAM_CHOKE"): _fail(ExpectedOutcome.PRESSURE_TOO_HIGH, 9.288, PressureExpectation.BELOW_TARGET),
+    ("R4", "INDIVIDUAL_ASV_RATE"): _fail(ExpectedOutcome.PRESSURE_TOO_HIGH, 9.288, PressureExpectation.BELOW_TARGET),
+    ("R4", "INDIVIDUAL_ASV_PRESSURE"): _fail(
+        ExpectedOutcome.PRESSURE_TOO_HIGH, 9.288, PressureExpectation.BELOW_TARGET
+    ),
+    ("R4", "COMMON_ASV"): _fail(ExpectedOutcome.PRESSURE_TOO_HIGH, 9.288, PressureExpectation.BELOW_TARGET),
+    # R5 — above maximum flow rate
+    ("R5", "UPSTREAM_CHOKE"): _fail(ExpectedOutcome.ABOVE_MAX_FLOW, 22.47),
+    ("R5", "DOWNSTREAM_CHOKE"): _fail(ExpectedOutcome.ABOVE_MAX_FLOW, 22.47),
+    ("R5", "INDIVIDUAL_ASV_RATE"): _fail(ExpectedOutcome.ABOVE_MAX_FLOW, 22.47),
+    ("R5", "INDIVIDUAL_ASV_PRESSURE"): _fail(ExpectedOutcome.ABOVE_MAX_FLOW, 22.47),
+    ("R5", "COMMON_ASV"): _fail(ExpectedOutcome.ABOVE_MAX_FLOW, 22.47),
+    # R6 — near max speed, all modes succeed
+    ("R6", "UPSTREAM_CHOKE"): _ok(9.053),
+    ("R6", "DOWNSTREAM_CHOKE"): _ok(9.053),
+    ("R6", "INDIVIDUAL_ASV_RATE"): _ok(9.053),
+    ("R6", "INDIVIDUAL_ASV_PRESSURE"): _ok(9.053),
+    ("R6", "COMMON_ASV"): _ok(9.053),
+    # R7 — minimum speed, pressure control active
+    ("R7", "DOWNSTREAM_CHOKE"): _ok(2.824, ExpectedControlAction.DOWNSTREAM_CHOKE),
+    ("R7", "UPSTREAM_CHOKE"): _ok(2.767, ExpectedControlAction.UPSTREAM_CHOKE),
+    ("R7", "INDIVIDUAL_ASV_RATE"): _ok(2.945, ExpectedControlAction.RECIRCULATION),
+    ("R7", "INDIVIDUAL_ASV_PRESSURE"): _ok(2.945, ExpectedControlAction.RECIRCULATION),
+    ("R7", "COMMON_ASV"): _ok(2.945, ExpectedControlAction.RECIRCULATION),
+    # R8 — zero rate (not calculated)
+    ("R8", "UPSTREAM_CHOKE"): _ok(0.0, pressure=PressureExpectation.NAN),
+    ("R8", "DOWNSTREAM_CHOKE"): _ok(0.0, pressure=PressureExpectation.NAN),
+    ("R8", "INDIVIDUAL_ASV_RATE"): _ok(0.0, pressure=PressureExpectation.NAN),
+    ("R8", "INDIVIDUAL_ASV_PRESSURE"): _ok(0.0, pressure=PressureExpectation.NAN),
+    ("R8", "COMMON_ASV"): _ok(0.0, pressure=PressureExpectation.NAN),
+    # R9 — edge case: high rate + low target pressure
+    ("R9", "DOWNSTREAM_CHOKE"): _ok(2.950, ExpectedControlAction.DOWNSTREAM_CHOKE),
+    ("R9", "UPSTREAM_CHOKE"): _fail(
+        ExpectedOutcome.ABOVE_MAX_FLOW, 2.697, control=ExpectedControlAction.UPSTREAM_CHOKE
+    ),
+    ("R9", "INDIVIDUAL_ASV_RATE"): _fail(
+        ExpectedOutcome.PRESSURE_TOO_LOW, 2.964, control=ExpectedControlAction.RECIRCULATION
+    ),
+    ("R9", "INDIVIDUAL_ASV_PRESSURE"): _fail(
+        ExpectedOutcome.PRESSURE_TOO_LOW, 2.964, control=ExpectedControlAction.RECIRCULATION
+    ),
+    ("R9", "COMMON_ASV"): _fail(ExpectedOutcome.ABOVE_MAX_FLOW, 4.456),
+}
+
+# Fail fast if a new PressureControlType is added without test coverage.
+_tested_modes = {mode for _, mode in EXPECTED_RESULTS}
+_untested_modes = set(MODES) - _tested_modes
+if _untested_modes:
+    raise AssertionError(
+        f"New PressureControlType values {_untested_modes} have no expected results in the solver-path matrix. "
+        f"Add entries to EXPECTED_RESULTS for each new mode."
+    )
+
+
+TEST_CASES = tuple(
+    TrialCase(region=region, mode=mode, expectation=EXPECTED_RESULTS[(region.id, mode)])
+    for region in REGIONS.values()
+    for mode in MODES
+)

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/conftest.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/conftest.py
@@ -1,0 +1,87 @@
+"""Fixtures for solver-path matrix tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
+from libecalc.domain.process.compressor.core.train.compressor_train_common_shaft import CompressorTrainCommonShaft
+from libecalc.domain.process.compressor.core.train.stage import CompressorTrainStage
+from libecalc.domain.process.value_objects.chart.chart import ChartData
+from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.shaft import VariableSpeedShaft
+from tests.libecalc.process.helpers import ProcessSolverSystem
+
+from .cases import TrialCase
+
+INLET_TEMPERATURE_KELVIN = 303.15
+
+
+@pytest.fixture(scope="session")
+def pure_methane_fluid_model(fluid_model_factory) -> FluidModel:
+    return fluid_model_factory(
+        fluid_composition=FluidComposition(
+            water=0.0,
+            nitrogen=0.0,
+            CO2=0.0,
+            methane=1.0,
+            ethane=0.0,
+            propane=0.0,
+            i_butane=0.0,
+            n_butane=0.0,
+            i_pentane=0.0,
+            n_pentane=0.0,
+            n_hexane=0.0,
+        ),
+        eos_model=EoSModel.SRK,
+    )
+
+
+@pytest.fixture
+def legacy_train_factory(compressor_stage_factory, fluid_service, pure_methane_fluid_model):
+    def create_legacy_train(
+        chart_data: ChartData,
+        pressure_control: FixedSpeedPressureControl | None,
+    ) -> CompressorTrainCommonShaft:
+        shaft = VariableSpeedShaft()
+        stage: CompressorTrainStage = compressor_stage_factory(
+            shaft=shaft,
+            compressor_chart_data=chart_data,
+            inlet_temperature_kelvin=INLET_TEMPERATURE_KELVIN,
+            remove_liquid_after_cooling=True,
+            pressure_drop_ahead_of_stage=0.0,
+        )
+        train = CompressorTrainCommonShaft(
+            shaft=shaft,
+            fluid_service=fluid_service,
+            energy_usage_adjustment_constant=0,
+            energy_usage_adjustment_factor=1,
+            stages=[stage],
+            pressure_control=pressure_control,
+            calculate_max_rate=False,
+        )
+        train._fluid_model = [pure_methane_fluid_model]
+        return train
+
+    return create_legacy_train
+
+
+@pytest.fixture
+def process_solver_case_factory(stream_factory, build_solver_system, pure_methane_fluid_model):
+    def create(chart_data: ChartData, case: TrialCase) -> tuple[ProcessSolverSystem, FluidStream]:
+        system = build_solver_system(
+            chart_data=chart_data,
+            pressure_control_type=case.mode,
+            inlet_temperature_kelvin=INLET_TEMPERATURE_KELVIN,
+            remove_liquid_after_cooling=True,
+        )
+        inlet_stream = stream_factory(
+            standard_rate_m3_per_day=case.region.rate_sm3_day,
+            pressure_bara=case.region.suction_pressure_bara,
+            temperature_kelvin=INLET_TEMPERATURE_KELVIN,
+            fluid_model=pure_methane_fluid_model,
+        )
+        return system, inlet_stream
+
+    return create

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_legacy_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_legacy_solver.py
@@ -1,0 +1,140 @@
+"""Legacy solver path matrix tests.
+
+Tests the legacy CompressorTrainCommonShaft.evaluate_given_constraints() across
+all 45 trial cases (9 regions × 5 pressure-control modes).
+"""
+
+from __future__ import annotations
+
+from math import isnan
+
+import pytest
+
+from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
+from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
+from libecalc.domain.process.core.results.compressor import CompressorTrainCommonShaftFailureStatus
+from libecalc.domain.process.value_objects.chart.chart_area_flag import ChartAreaFlag
+
+from .assertions import (
+    POWER_TOLERANCE,
+    assert_control_behavior,
+    assert_pressure_expectation,
+    assert_speed_boundary,
+)
+from .cases import TEST_CASES, ExpectedOutcome, TrialCase
+
+_LEGACY_TO_OUTCOME: dict[CompressorTrainCommonShaftFailureStatus, ExpectedOutcome] = {
+    CompressorTrainCommonShaftFailureStatus.NO_FAILURE: ExpectedOutcome.SUCCESS,
+    CompressorTrainCommonShaftFailureStatus.TARGET_DISCHARGE_PRESSURE_TOO_HIGH: ExpectedOutcome.PRESSURE_TOO_HIGH,
+    CompressorTrainCommonShaftFailureStatus.TARGET_DISCHARGE_PRESSURE_TOO_LOW: ExpectedOutcome.PRESSURE_TOO_LOW,
+    CompressorTrainCommonShaftFailureStatus.ABOVE_MAXIMUM_FLOW_RATE: ExpectedOutcome.ABOVE_MAX_FLOW,
+    CompressorTrainCommonShaftFailureStatus.BELOW_MINIMUM_FLOW_RATE: ExpectedOutcome.BELOW_MIN_FLOW,
+    CompressorTrainCommonShaftFailureStatus.NOT_CALCULATED: ExpectedOutcome.NOT_CALCULATED,
+}
+
+# Per-region chart area flag. R4 is intentionally absent (assertion skipped).
+LEGACY_CHART_AREAS: dict[tuple[str, str], ChartAreaFlag] = {
+    # R1 — internal point for all modes
+    ("R1", "UPSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R1", "DOWNSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R1", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R1", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R1", "COMMON_ASV"): ChartAreaFlag.INTERNAL_POINT,
+    # R2 — below minimum flow (anti-surge kicks in)
+    ("R2", "UPSTREAM_CHOKE"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    ("R2", "DOWNSTREAM_CHOKE"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    ("R2", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    ("R2", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    ("R2", "COMMON_ASV"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    # R3 — below minimum flow at min speed
+    ("R3", "UPSTREAM_CHOKE"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    ("R3", "DOWNSTREAM_CHOKE"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    ("R3", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    ("R3", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    ("R3", "COMMON_ASV"): ChartAreaFlag.BELOW_MINIMUM_FLOW_RATE,
+    # R4 — target pressure unreachable, but operating point is internal at max speed
+    ("R4", "UPSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R4", "DOWNSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R4", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R4", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R4", "COMMON_ASV"): ChartAreaFlag.INTERNAL_POINT,
+    # R5 — above maximum flow
+    ("R5", "UPSTREAM_CHOKE"): ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE,
+    ("R5", "DOWNSTREAM_CHOKE"): ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE,
+    ("R5", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE,
+    ("R5", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE,
+    ("R5", "COMMON_ASV"): ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE,
+    # R6 — internal point near max speed
+    ("R6", "UPSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R6", "DOWNSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R6", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R6", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R6", "COMMON_ASV"): ChartAreaFlag.INTERNAL_POINT,
+    # R7 — internal point at min speed
+    ("R7", "UPSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R7", "DOWNSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R7", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R7", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R7", "COMMON_ASV"): ChartAreaFlag.INTERNAL_POINT,
+    # R8 — zero rate, not calculated
+    ("R8", "UPSTREAM_CHOKE"): ChartAreaFlag.NOT_CALCULATED,
+    ("R8", "DOWNSTREAM_CHOKE"): ChartAreaFlag.NOT_CALCULATED,
+    ("R8", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.NOT_CALCULATED,
+    ("R8", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.NOT_CALCULATED,
+    ("R8", "COMMON_ASV"): ChartAreaFlag.NOT_CALCULATED,
+    # R9 — internal point except UPSTREAM_CHOKE and COMMON_ASV (above max flow)
+    ("R9", "UPSTREAM_CHOKE"): ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE,
+    ("R9", "DOWNSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R9", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R9", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.INTERNAL_POINT,
+    ("R9", "COMMON_ASV"): ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE,
+}
+
+
+def _safe_delta(left: float, right: float) -> float:
+    if isnan(left) or isnan(right):
+        return 0.0
+    return left - right
+
+
+@pytest.mark.parametrize("case", TEST_CASES, ids=lambda case: case.id)
+def test_legacy_solver_path(
+    case: TrialCase,
+    variable_speed_compressor_chart_data,
+    legacy_train_factory,
+):
+    train = legacy_train_factory(
+        chart_data=variable_speed_compressor_chart_data,
+        pressure_control=FixedSpeedPressureControl(case.mode),
+    )
+    result = train.evaluate_given_constraints(
+        CompressorTrainEvaluationInput(
+            rates=[case.region.rate_sm3_day],
+            suction_pressure=case.region.suction_pressure_bara,
+            discharge_pressure=case.region.discharge_pressure_bara,
+        )
+    )
+    stage_result = result.stage_results[0]
+    speed = result.speed if not isnan(result.speed) else train.shaft.get_speed()
+
+    assert result.is_valid is case.expectation.success
+    assert _LEGACY_TO_OUTCOME[result.failure_status] is case.expectation.outcome
+    assert_pressure_expectation(result.discharge_pressure, case)
+    assert_speed_boundary(speed, variable_speed_compressor_chart_data, case)
+    assert result.power_megawatt == pytest.approx(case.expectation.power_mw, abs=POWER_TOLERANCE)
+    expected_chart_area = LEGACY_CHART_AREAS.get((case.region.id, case.mode))
+    if expected_chart_area is not None:
+        assert result.chart_area_status is expected_chart_area
+
+    recirculation_rate = _safe_delta(
+        stage_result.standard_rate_asv_corrected_sm3_per_day,
+        stage_result.standard_rate_sm3_per_day,
+    )
+    assert_control_behavior(
+        case,
+        recirculation_rates=(recirculation_rate,),
+        anti_surge_recirculation_rates=(recirculation_rate,) if case.region.expect_auto_anti_surge else (),
+        suction_pressure_after_upstream_choke_bara=(
+            stage_result.inlet_stream.pressure_bara if stage_result.inlet_stream is not None else None
+        ),
+    )

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
@@ -1,0 +1,183 @@
+"""Process-domain solver path matrix tests.
+
+Tests the new OutletPressureSolver.find_solution() across all 45 trial cases
+(9 regions × 5 pressure-control modes). Cases where the process solver does not
+yet match legacy behavior are marked as strict xfails.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pytest
+
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
+from libecalc.process.process_solver.configuration import (
+    ChokeConfiguration,
+    Configuration,
+    RecirculationConfiguration,
+    SpeedConfiguration,
+)
+from libecalc.process.process_solver.float_constraint import FloatConstraint
+from libecalc.process.process_solver.solver import (
+    RateTooHighFailure,
+    Solution,
+    TargetDirection,
+    TargetPressureUnreachableFailure,
+)
+from libecalc.process.process_solver.solver import (
+    RateTooLowFailure as SolverRateTooLowFailure,
+)
+from libecalc.process.process_units.compressor import Compressor
+
+from .assertions import (
+    POWER_TOLERANCE,
+    PRESSURE_TOLERANCE,
+    assert_control_behavior,
+    assert_pressure_expectation,
+    assert_speed_boundary,
+)
+from .cases import TEST_CASES, ExpectedOutcome, TrialCase
+
+# ---------------------------------------------------------------------------
+# Expected failures — remove entries as the process solver improves
+# ---------------------------------------------------------------------------
+PROCESS_XFAILS: dict[tuple[str, str], str] = {
+    # R1 — SpeedSolver does not converge when min-speed point starts above stonewall
+    ("R1", "UPSTREAM_CHOKE"): "SpeedSolver bracketing failure at min-speed.",
+    ("R1", "DOWNSTREAM_CHOKE"): "SpeedSolver bracketing failure at min-speed.",
+    ("R1", "INDIVIDUAL_ASV_RATE"): "SpeedSolver bracketing failure at min-speed.",
+    ("R1", "INDIVIDUAL_ASV_PRESSURE"): "SpeedSolver bracketing failure at min-speed.",
+    ("R1", "COMMON_ASV"): "SpeedSolver bracketing failure at min-speed.",
+    # R3 — upstream choke power mismatch
+    ("R3", "UPSTREAM_CHOKE"): "Process solver finds different upstream choke ΔP → power mismatch (2.41 vs 2.23 MW).",
+    # R5 — Common-ASV loses flow-capacity failure
+    ("R5", "COMMON_ASV"): "Common-ASV topology loses flow-capacity failure for stonewall case.",
+    # R6 — similar SpeedSolver convergence issue near max-speed boundary
+    ("R6", "UPSTREAM_CHOKE"): "SpeedSolver convergence issue near max-speed boundary.",
+    ("R6", "DOWNSTREAM_CHOKE"): "SpeedSolver convergence issue near max-speed boundary.",
+    ("R6", "INDIVIDUAL_ASV_RATE"): "SpeedSolver convergence issue near max-speed boundary.",
+    ("R6", "INDIVIDUAL_ASV_PRESSURE"): "SpeedSolver convergence issue near max-speed boundary.",
+    ("R6", "COMMON_ASV"): "SpeedSolver convergence issue near max-speed boundary.",
+    # R8 — process solver does not implement legacy zero-rate short-circuit
+    ("R8", "UPSTREAM_CHOKE"): "No zero-rate short-circuit in process solver.",
+    ("R8", "DOWNSTREAM_CHOKE"): "No zero-rate short-circuit in process solver.",
+    ("R8", "INDIVIDUAL_ASV_RATE"): "No zero-rate short-circuit in process solver.",
+    ("R8", "INDIVIDUAL_ASV_PRESSURE"): "No zero-rate short-circuit in process solver.",
+    ("R8", "COMMON_ASV"): "No zero-rate short-circuit in process solver.",
+    # R9 — individual case mismatches
+    ("R9", "UPSTREAM_CHOKE"): "Upstream-choke strategy reports success for stonewall-limited over-compression.",
+    ("R9", "COMMON_ASV"): "Common-ASV reports pressure-limit where legacy reports stonewall for R9.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Test parametrization and helpers
+# ---------------------------------------------------------------------------
+
+
+def _outcome_from_process_solution(
+    solution: Solution[Sequence[Configuration]],
+) -> ExpectedOutcome:
+    if solution.success:
+        return ExpectedOutcome.SUCCESS
+    if solution.failure is None:
+        return ExpectedOutcome.NOT_CALCULATED
+    match solution.failure:
+        case RateTooHighFailure():
+            return ExpectedOutcome.ABOVE_MAX_FLOW
+        case SolverRateTooLowFailure():
+            return ExpectedOutcome.BELOW_MIN_FLOW
+        case TargetPressureUnreachableFailure(direction=TargetDirection.MAX_BELOW_TARGET):
+            return ExpectedOutcome.PRESSURE_TOO_HIGH
+        case TargetPressureUnreachableFailure(direction=TargetDirection.MIN_ABOVE_TARGET):
+            return ExpectedOutcome.PRESSURE_TOO_LOW
+        case _:
+            return ExpectedOutcome.NOT_CALCULATED
+
+
+def _calculate_compressor_power_mw(
+    compressor: Compressor,
+    compressor_inlet_stream: FluidStream,
+) -> float:
+    """Calculate compressor power [MW] from inlet/outlet enthalpy difference.
+
+    Power = Δh × ṁ, where Δh = (h_outlet - h_inlet) [J/kg]
+    and ṁ is the mass rate through the compressor (including recirculation).
+    """
+    compressor_outlet_stream = compressor.propagate_stream(compressor_inlet_stream)
+    delta_h = compressor_outlet_stream.enthalpy_joule_per_kg - compressor_inlet_stream.enthalpy_joule_per_kg
+    mass_rate = compressor_inlet_stream.mass_rate_kg_per_h
+    return delta_h * mass_rate / 3600.0 / 1e6
+
+
+PROCESS_TEST_PARAMS = tuple(
+    pytest.param(
+        case,
+        id=case.id,
+        marks=pytest.mark.xfail(reason=PROCESS_XFAILS[(case.region.id, case.mode)], strict=True),
+    )
+    if (case.region.id, case.mode) in PROCESS_XFAILS
+    else pytest.param(case, id=case.id)
+    for case in TEST_CASES
+)
+
+
+@pytest.mark.parametrize("case", PROCESS_TEST_PARAMS)
+def test_process_solver_path(
+    case: TrialCase,
+    variable_speed_compressor_chart_data,
+    process_solver_case_factory,
+):
+    system, inlet_stream = process_solver_case_factory(chart_data=variable_speed_compressor_chart_data, case=case)
+
+    solution = system.solver.find_solution(
+        pressure_constraint=FloatConstraint(case.region.discharge_pressure_bara, abs_tol=PRESSURE_TOLERANCE),
+        inlet_stream=inlet_stream,
+    )
+    system.runner.apply_configurations(solution.configuration)
+    try:
+        outlet_stream = system.runner.run(inlet_stream=inlet_stream)
+        outlet_pressure = outlet_stream.pressure_bara
+    except RateTooHighError:
+        outlet_pressure = np.nan
+
+    outcome = _outcome_from_process_solution(solution)
+    speed = next(
+        (c.value.speed for c in solution.configuration if isinstance(c.value, SpeedConfiguration)),
+        system.shaft.get_speed(),
+    )
+
+    assert solution.success is case.expectation.success
+    assert outcome is case.expectation.outcome
+    assert_pressure_expectation(outlet_pressure, case)
+    assert_speed_boundary(speed, variable_speed_compressor_chart_data, case)
+
+    # Power assertion: compute from compressor inlet/outlet enthalpy difference.
+    # Skipped when the compressor rejects the operating point (e.g. R5 above-max-flow),
+    # since the process solver doesn't extrapolate beyond the chart like legacy does.
+    compressor = system.compressors[0]
+    try:
+        compressor_inlet = system.runner.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
+        power_mw = _calculate_compressor_power_mw(compressor, compressor_inlet)
+        assert power_mw == pytest.approx(case.expectation.power_mw, abs=POWER_TOLERANCE)
+    except (RateTooHighError, RateTooLowError):
+        pass
+
+    recirculation_rates = tuple(
+        c.value.recirculation_rate for c in solution.configuration if isinstance(c.value, RecirculationConfiguration)
+    )
+    choke_delta_pressure = next(
+        (c.value.delta_pressure for c in solution.configuration if isinstance(c.value, ChokeConfiguration)),
+        None,
+    )
+    anti_surge_solution = system.solver.get_anti_surge_solution()
+    anti_surge_recirculation_rates = tuple(c.value.recirculation_rate for c in anti_surge_solution.configuration)
+    assert_control_behavior(
+        case,
+        recirculation_rates=recirculation_rates,
+        anti_surge_recirculation_rates=anti_surge_recirculation_rates,
+        choke_delta_pressure=choke_delta_pressure,
+    )

--- a/tests/libecalc/process/process_solver/conftest.py
+++ b/tests/libecalc/process/process_solver/conftest.py
@@ -3,6 +3,8 @@ from collections.abc import Sequence
 import pytest
 
 from libecalc.domain.process.value_objects.chart import ChartCurve
+from libecalc.domain.process.value_objects.chart.chart import ChartData
+from libecalc.ecalc_model.process_simulation import PressureControlType
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
@@ -25,6 +27,37 @@ from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
 from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.shaft import Shaft
+from tests.libecalc.process.helpers import ProcessSolverBuilder, ProcessSolverSystem, StageConfig
+
+
+@pytest.fixture
+def build_solver_system(fluid_service):
+    def create(
+        *,
+        chart_data: ChartData | None = None,
+        stages: Sequence[StageConfig] | None = None,
+        pressure_control_type: PressureControlType,
+        inlet_temperature_kelvin: float = 303.15,
+        remove_liquid_after_cooling: bool = True,
+    ) -> ProcessSolverSystem:
+        if stages is None:
+            if chart_data is None:
+                raise ValueError("Either chart_data or stages must be provided")
+            stages = [
+                StageConfig(
+                    chart_data=chart_data,
+                    inlet_temperature_kelvin=inlet_temperature_kelvin,
+                    remove_liquid_after_cooling=remove_liquid_after_cooling,
+                )
+            ]
+
+        return ProcessSolverBuilder(
+            stages=stages,
+            pressure_control_type=pressure_control_type,
+            fluid_service=fluid_service,
+        ).build()
+
+    return create
 
 
 @pytest.fixture

--- a/tests/libecalc/process/process_solver/test_process_solver_builder.py
+++ b/tests/libecalc/process/process_solver/test_process_solver_builder.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import get_args
+
+import pytest
+
+from libecalc.ecalc_model.process_simulation import PressureControlType
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_unit import ProcessUnit
+from libecalc.process.process_solver.anti_surge.common_asv import CommonASVAntiSurgeStrategy
+from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
+from libecalc.process.process_solver.configuration import RecirculationConfiguration
+from libecalc.process.process_solver.float_constraint import FloatConstraint
+from libecalc.process.process_solver.pressure_control.common_asv import CommonASVPressureControlStrategy
+from libecalc.process.process_solver.pressure_control.downstream_choke import DownstreamChokePressureControlStrategy
+from libecalc.process.process_solver.pressure_control.individual_asv import (
+    IndividualASVPressureControlStrategy,
+    IndividualASVRateControlStrategy,
+)
+from libecalc.process.process_solver.pressure_control.upstream_choke import UpstreamChokePressureControlStrategy
+from libecalc.process.process_units.choke import Choke
+from libecalc.process.process_units.compressor import Compressor
+from libecalc.process.process_units.direct_mixer import DirectMixer
+from libecalc.process.process_units.direct_splitter import DirectSplitter
+from libecalc.process.process_units.liquid_remover import LiquidRemover
+from libecalc.process.process_units.temperature_setter import TemperatureSetter
+from tests.libecalc.process.helpers import ProcessSolverBuilder, ProcessSolverSystem, StageConfig
+
+PRESSURE_CONTROL_TYPES = get_args(PressureControlType)
+PRESSURE_CONTROL_STRATEGY_TYPES = {
+    "DOWNSTREAM_CHOKE": DownstreamChokePressureControlStrategy,
+    "UPSTREAM_CHOKE": UpstreamChokePressureControlStrategy,
+    "COMMON_ASV": CommonASVPressureControlStrategy,
+    "INDIVIDUAL_ASV_RATE": IndividualASVRateControlStrategy,
+    "INDIVIDUAL_ASV_PRESSURE": IndividualASVPressureControlStrategy,
+}
+
+
+@dataclass(frozen=True)
+class SolverRunResult:
+    success: bool
+    speed: float
+    outlet_pressure_bara: float
+    recirculation_rates: tuple[float, ...]
+
+
+@pytest.fixture
+def two_stage_configs(chart_data_factory) -> list[StageConfig]:
+    return [
+        StageConfig(
+            chart_data=chart_data_factory.from_design_point(rate=1200, head=70_000, efficiency=0.75),
+            inlet_temperature_kelvin=300.0,
+        ),
+        StageConfig(
+            chart_data=chart_data_factory.from_design_point(rate=900, head=50_000, efficiency=0.72),
+            inlet_temperature_kelvin=300.0,
+        ),
+    ]
+
+
+@pytest.fixture
+def inlet_stream(stream_factory) -> FluidStream:
+    return stream_factory(standard_rate_m3_per_day=500_000.0, pressure_bara=30.0, temperature_kelvin=300.0)
+
+
+def _run_solver(system: ProcessSolverSystem, inlet_stream: FluidStream) -> SolverRunResult:
+    target_pressure = FloatConstraint(75.0, abs_tol=1e-3)
+    solution = system.solver.find_solution(pressure_constraint=target_pressure, inlet_stream=inlet_stream)
+    system.runner.apply_configurations(solution.configuration)
+    outlet_stream = system.runner.run(inlet_stream=inlet_stream)
+    speed = solution.get_configuration(system.shaft.get_id()).speed
+    recirculation_rates = tuple(
+        configuration.value.recirculation_rate
+        for configuration in solution.configuration
+        if isinstance(configuration.value, RecirculationConfiguration)
+    )
+    return SolverRunResult(
+        success=solution.success,
+        speed=speed,
+        outlet_pressure_bara=outlet_stream.pressure_bara,
+        recirculation_rates=recirculation_rates,
+    )
+
+
+@pytest.mark.parametrize("pressure_control_type", PRESSURE_CONTROL_TYPES)
+def test_builder_produces_working_solver_for_each_production_pressure_control_mode(
+    pressure_control_type,
+    fluid_service,
+    two_stage_configs,
+    inlet_stream,
+):
+    system = ProcessSolverBuilder(
+        stages=two_stage_configs,
+        pressure_control_type=pressure_control_type,
+        fluid_service=fluid_service,
+    ).build()
+
+    result = _run_solver(system=system, inlet_stream=inlet_stream)
+
+    assert result.success
+    assert result.outlet_pressure_bara == pytest.approx(75.0, abs=1e-3)
+
+
+@pytest.mark.parametrize("pressure_control_type", PRESSURE_CONTROL_TYPES)
+def test_builder_wires_expected_solver_strategies(
+    pressure_control_type,
+    fluid_service,
+    two_stage_configs,
+):
+    system = ProcessSolverBuilder(
+        stages=two_stage_configs,
+        pressure_control_type=pressure_control_type,
+        fluid_service=fluid_service,
+    ).build()
+    expected_anti_surge_strategy_type = (
+        CommonASVAntiSurgeStrategy if pressure_control_type == "COMMON_ASV" else IndividualASVAntiSurgeStrategy
+    )
+
+    assert isinstance(system.solver.anti_surge_strategy, expected_anti_surge_strategy_type)
+    assert isinstance(system.solver.pressure_control_strategy, PRESSURE_CONTROL_STRATEGY_TYPES[pressure_control_type])
+
+
+def test_builder_uses_single_recirculation_loop_for_common_asv(
+    fluid_service,
+    two_stage_configs,
+):
+    system = ProcessSolverBuilder(
+        stages=two_stage_configs,
+        pressure_control_type="COMMON_ASV",
+        fluid_service=fluid_service,
+    ).build()
+
+    assert len(system.compressors) == 2
+    assert len(system.recirculation_loops) == 1
+    assert system.choke is None
+    assert _unit_types(system.pipeline.get_process_units()) == (
+        DirectMixer,
+        TemperatureSetter,
+        Choke,
+        LiquidRemover,
+        Compressor,
+        TemperatureSetter,
+        Choke,
+        LiquidRemover,
+        Compressor,
+        DirectSplitter,
+    )
+
+
+def test_builder_supports_multi_stage_individual_asv(
+    fluid_service,
+    two_stage_configs,
+    inlet_stream,
+):
+    system = ProcessSolverBuilder(
+        stages=two_stage_configs,
+        pressure_control_type="INDIVIDUAL_ASV_RATE",
+        fluid_service=fluid_service,
+    ).build()
+
+    result = _run_solver(system=system, inlet_stream=inlet_stream)
+
+    assert len(system.compressors) == 2
+    assert len(system.recirculation_loops) == 2
+    assert system.choke is None
+    assert _unit_types(system.pipeline.get_process_units()) == (
+        DirectMixer,
+        TemperatureSetter,
+        Choke,
+        LiquidRemover,
+        Compressor,
+        DirectSplitter,
+        DirectMixer,
+        TemperatureSetter,
+        Choke,
+        LiquidRemover,
+        Compressor,
+        DirectSplitter,
+    )
+    assert result.success
+
+
+@pytest.mark.parametrize(
+    ("pressure_control_type", "expected_choke_index"),
+    [
+        ("UPSTREAM_CHOKE", 0),
+        ("DOWNSTREAM_CHOKE", -1),
+    ],
+)
+def test_builder_places_pressure_control_choke_around_individual_asv_topology(
+    pressure_control_type,
+    expected_choke_index,
+    fluid_service,
+    two_stage_configs,
+):
+    system = ProcessSolverBuilder(
+        stages=two_stage_configs,
+        pressure_control_type=pressure_control_type,
+        fluid_service=fluid_service,
+    ).build()
+
+    process_units = system.pipeline.get_process_units()
+
+    assert len(system.compressors) == 2
+    assert len(system.recirculation_loops) == 2
+    assert system.choke is not None
+    assert process_units[expected_choke_index] is system.choke
+
+
+def _unit_types(process_units: list[ProcessUnit]) -> tuple[type[ProcessUnit], ...]:
+    return tuple(type(unit) for unit in process_units)


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

Adds a **9-region × 5-mode test matrix** (45 trial cases) that exercises every solver path in both the legacy `CompressorTrainCommonShaft` and the new process-domain `OutletPressureSolver`.

Each trial case specifies an operating region on the compressor chart (internal, below surge, above stonewall, below/above speed limits, zero-rate, over-compression) and a pressure-control mode (upstream choke, downstream choke, individual ASV rate/pressure, common ASV). Tests assert:

- Success/failure status and failure reason
- Discharge pressure target achievement
- Speed boundary correctness (min/max/internal)
- Power output (MW)
- Pressure-control behavior (choke ΔP, recirculation rates, anti-surge)
- Chart area flag (legacy only)

Also extracts `ProcessSolverBuilder` into a reusable test helper (`tests/libecalc/process/helpers/`) and adds `PressureControlType` as a `Literal` type alias.

**Results:** All 45 legacy tests pass. 26 of 45 process tests pass; 19 are marked as strict xfails (see below).

## Further Work

### Discrepancies Found (xfails)

19 process solver xfails grouped by root cause hypothesis (to be investigated deeper):

| Regions | Modes | Count | Root Cause Hypothesis |
|---------|-------|-------|------------|
| R1 (all) | All 5 | 5 | SpeedSolver bracketing failure — min-speed evaluation hits stonewall, breaking the root-find bracket |
| R6 (all) | All 5 | 5 | SpeedSolver convergence near max-speed boundary — similar bracketing issue at the upper speed limit |
| R8 (all) | All 5 | 5 | No zero-rate short-circuit — legacy returns `power=0, status=OK` for zero rate; process solver attempts full evaluation |
| R3 | Upstream choke | 1 | Decoupled solving — anti-surge is optimized at nominal suction pressure before the choke reduces it, leading to over-recirculation and 7.5% power mismatch |
| R5 | Common ASV | 1 | Common-ASV topology wraps the entire pipeline in one recirculation loop, masking the above-max-flow failure that legacy reports |
| R9 | Upstream choke | 1 | Upstream choke reports success for a stonewall-limited point where legacy correctly reports above-max-flow |
| R9 | Common ASV | 1 | Common-ASV reports pressure-unreachable where legacy reports above-max-flow for below-min-speed near-stonewall region |

### Two-Stage Tests

The current matrix uses a single-stage compressor train. Future two-stage tests could involve:
- Interstage cooling and pressure-drop-ahead-of-stage
- Per-stage vs common ASV recirculation behavior
- Stage-to-stage stream propagation through the process pipeline
- Multi-stage speed coupling on a shared shaft

These will validate the process solver for production-representative train configurations where interstage interactions create additional solver complexity.

