### PR TITLE
fix: recompute anti-surge recirculation at each upstream-choke probe

### DIFF
--- a/src/libecalc/process/process_solver/anti_surge/anti_surge_strategy.py
+++ b/src/libecalc/process/process_solver/anti_surge/anti_surge_strategy.py
@@ -26,3 +26,12 @@ class AntiSurgeStrategy(ABC):
             Outlet stream after applying anti-surge adjustments (e.g. setting ASV recirculation).
         """
         ...
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Zero all recirculation managed by this strategy.
+
+        Called before re-evaluating anti-surge in contexts where stale recirculation
+        from a previous evaluation would corrupt the result (e.g. upstream-choke search).
+        """
+        ...

--- a/src/libecalc/process/process_solver/anti_surge/common_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/common_asv.py
@@ -37,6 +37,14 @@ class CommonASVAntiSurgeStrategy(AntiSurgeStrategy):
         self._root_finding_strategy = root_finding_strategy
         self._simulator = simulator
 
+    def reset(self) -> None:
+        self._simulator.apply_configuration(
+            Configuration(
+                configuration_handler_id=self._recirculation_loop_id,
+                value=RecirculationConfiguration(recirculation_rate=0.0),
+            )
+        )
+
     def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
         # Increase recirculation to give minimum feasible flow and return outlet.
         recirculation_solution = self._increase_recirculation_to_minimum_feasible(inlet_stream)

--- a/src/libecalc/process/process_solver/anti_surge/individual_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/individual_asv.py
@@ -45,6 +45,10 @@ class IndividualASVAntiSurgeStrategy(AntiSurgeStrategy):
             )
         )
 
+    def reset(self) -> None:
+        for loop_id in self._recirculation_loop_ids:
+            self._apply_recirculation_configuration(loop_id=loop_id, recirculation_rate=0.0)
+
     @override
     def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
         configurations: Sequence[Configuration[RecirculationConfiguration]] = []

--- a/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
+++ b/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.float_constraint import FloatConstraint
@@ -22,6 +23,11 @@ class UpstreamChokePressureControlStrategy(PressureControlStrategy):
     The strategy models pressure control by reducing suction pressure (upstream choking).
     It computes a safe ΔP search interval from the inlet stream pressure at solve time,
     then uses a root-finding solver to find the ΔP that makes outlet pressure match the target.
+
+    When the demanded flow lies below the surge line, the anti-surge strategy is re-evaluated
+    at every choke probe so that the compressor's recirculation rate is consistent with the
+    actual (post-choke) suction pressure — rather than the pre-choke recirculation that
+    would otherwise be frozen by the outer solver.
     """
 
     def __init__(
@@ -29,10 +35,13 @@ class UpstreamChokePressureControlStrategy(PressureControlStrategy):
         simulator: ProcessRunner,
         choke_configuration_handler_id: ConfigurationHandlerId,
         root_finding_strategy: RootFindingStrategy,
+        anti_surge_strategy: AntiSurgeStrategy,
     ):
         self._choke_configuration_handler_id = choke_configuration_handler_id
         self._simulator = simulator
         self._root_finding_strategy = root_finding_strategy
+        self._anti_surge_strategy = anti_surge_strategy
+        self._last_anti_surge_configurations: Sequence[Configuration[RecirculationConfiguration]] = []
 
     def apply(
         self,
@@ -53,22 +62,26 @@ class UpstreamChokePressureControlStrategy(PressureControlStrategy):
         )
 
         def choke_func(config: ChokeConfiguration) -> FluidStream:
-            # The runner is responsible for interpreting upstream ΔP as reduced suction pressure
-            # seen by the downstream process system.
             self._simulator.apply_configuration(
                 Configuration(configuration_handler_id=self._choke_configuration_handler_id, value=config)
             )
-            return self._simulator.run(
-                inlet_stream=inlet_stream,
-            )
+            # Reset and re-evaluate anti-surge at the current choke setting so that
+            # recirculation reflects the actual (post-choke) compressor inlet conditions.
+            self._anti_surge_strategy.reset()
+            anti_surge_solution = self._anti_surge_strategy.apply(inlet_stream=inlet_stream)
+            for anti_surge_configuration in anti_surge_solution.configuration:
+                self._simulator.apply_configuration(anti_surge_configuration)
+            self._last_anti_surge_configurations = anti_surge_solution.configuration
+            return self._simulator.run(inlet_stream=inlet_stream)
 
         solution = solver.solve(choke_func)
 
         return Solution(
             success=solution.success,
             configuration=[
+                *self._last_anti_surge_configurations,
                 Configuration(
                     configuration_handler_id=self._choke_configuration_handler_id, value=solution.configuration
-                )
+                ),
             ],
         )

--- a/src/libecalc/testing/no_asv.py
+++ b/src/libecalc/testing/no_asv.py
@@ -1,0 +1,20 @@
+from collections.abc import Sequence
+from typing import override
+
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
+from libecalc.process.process_solver.configuration import Configuration
+from libecalc.process.process_solver.solver import Solution
+from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
+
+
+class NoASVAntiSurgeStrategy(AntiSurgeStrategy):
+    """No-op anti-surge strategy for tests without a real compressor/ASV setup."""
+
+    @override
+    def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
+        return Solution(success=True, configuration=[])
+
+    @override
+    def reset(self) -> None:
+        pass

--- a/tests/libecalc/process/helpers/process_solver_builder.py
+++ b/tests/libecalc/process/helpers/process_solver_builder.py
@@ -7,6 +7,7 @@ from libecalc.ecalc_model.process_simulation import PressureControlConfig, Press
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipeline
 from libecalc.process.process_pipeline.process_unit import ProcessUnit
+from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.anti_surge.common_asv import CommonASVAntiSurgeStrategy
 from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
 from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
@@ -87,6 +88,7 @@ class ProcessSolverBuilder:
             recirculation_loops=recirculation_loops,
             compressors=compressors,
             choke_configuration_handler=choke_configuration_handler,
+            anti_surge_strategy=anti_surge_strategy,
         )
         solver = OutletPressureSolver(
             shaft_id=shaft.get_id(),
@@ -191,6 +193,7 @@ class ProcessSolverBuilder:
         recirculation_loops: Sequence[RecirculationLoop],
         compressors: Sequence[Compressor],
         choke_configuration_handler: ChokeConfigurationHandler | None,
+        anti_surge_strategy: AntiSurgeStrategy,
     ) -> PressureControlStrategy:
         match self._pressure_control_config.type:
             case "DOWNSTREAM_CHOKE":
@@ -205,6 +208,7 @@ class ProcessSolverBuilder:
                     simulator=runner,
                     choke_configuration_handler_id=choke_configuration_handler.get_id(),
                     root_finding_strategy=self._root_finding_strategy,
+                    anti_surge_strategy=anti_surge_strategy,
                 )
             case "COMMON_ASV":
                 return CommonASVPressureControlStrategy(

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
@@ -51,8 +51,6 @@ PROCESS_XFAILS: dict[tuple[str, str], str] = {
     ("R1", "INDIVIDUAL_ASV_RATE"): "SpeedSolver bracketing failure at min-speed.",
     ("R1", "INDIVIDUAL_ASV_PRESSURE"): "SpeedSolver bracketing failure at min-speed.",
     ("R1", "COMMON_ASV"): "SpeedSolver bracketing failure at min-speed.",
-    # R3 — upstream choke power mismatch
-    ("R3", "UPSTREAM_CHOKE"): "Process solver finds different upstream choke ΔP → power mismatch (2.41 vs 2.23 MW).",
     # R5 — Common-ASV loses flow-capacity failure
     ("R5", "COMMON_ASV"): "Common-ASV topology loses flow-capacity failure for stonewall case.",
     # R6 — similar SpeedSolver convergence issue near max-speed boundary

--- a/tests/libecalc/process/process_solver/conftest.py
+++ b/tests/libecalc/process/process_solver/conftest.py
@@ -27,6 +27,7 @@ from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
 from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.shaft import Shaft
+from libecalc.testing.no_asv import NoASVAntiSurgeStrategy
 from tests.libecalc.process.helpers import ProcessSolverBuilder, ProcessSolverSystem, StageConfig
 
 
@@ -210,11 +211,13 @@ def upstream_choke_pressure_control_strategy_factory(root_finding_strategy):
     def create(
         runner: ProcessRunner,
         choke_id: ProcessUnitId,
+        anti_surge_strategy: AntiSurgeStrategy | None = None,
     ) -> UpstreamChokePressureControlStrategy:
         return UpstreamChokePressureControlStrategy(
             simulator=runner,
             choke_configuration_handler_id=choke_id,
             root_finding_strategy=root_finding_strategy,
+            anti_surge_strategy=anti_surge_strategy or NoASVAntiSurgeStrategy(),
         )
 
     return create

--- a/tests/libecalc/process/process_solver/pressure_control/test_upstream_choke_pressure_control_strategy.py
+++ b/tests/libecalc/process/process_solver/pressure_control/test_upstream_choke_pressure_control_strategy.py
@@ -4,6 +4,7 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.upstream_choke import (
     UpstreamChokePressureControlStrategy,
 )
+from libecalc.testing.no_asv import NoASVAntiSurgeStrategy
 
 
 def test_upstream_choke_strategy_asserts_when_baseline_below_target(
@@ -24,6 +25,7 @@ def test_upstream_choke_strategy_asserts_when_baseline_below_target(
         simulator=runner,
         choke_configuration_handler_id=upstream_choke_configuration_handler.get_id(),
         root_finding_strategy=root_finding_strategy,
+        anti_surge_strategy=NoASVAntiSurgeStrategy(),
     )
 
     inlet_stream = stream_factory(standard_rate_m3_per_day=1000, pressure_bara=50)
@@ -51,6 +53,7 @@ def test_upstream_choke_strategy_baseline_above_target_chokes_to_target(
         simulator=runner,
         choke_configuration_handler_id=upstream_choke_configuration_handler.get_id(),
         root_finding_strategy=root_finding_strategy,
+        anti_surge_strategy=NoASVAntiSurgeStrategy(),
     )
 
     inlet_stream = stream_factory(standard_rate_m3_per_day=1000, pressure_bara=100)

--- a/tests/libecalc/process/process_solver/test_outlet_pressure_solver_with_upstream_choke.py
+++ b/tests/libecalc/process/process_solver/test_outlet_pressure_solver_with_upstream_choke.py
@@ -64,6 +64,7 @@ def test_outlet_pressure_solver_applies_upstream_choke_when_speed_solution_is_at
     pressure_control_strategy = upstream_choke_pressure_control_strategy_factory(
         runner=runner,
         choke_id=upstream_choke_configuration_handler.get_id(),
+        anti_surge_strategy=anti_surge_strategy,
     )
     solver = outlet_pressure_solver_factory(
         shaft=shaft,


### PR DESCRIPTION
## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [x] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

Fixes **systematic over-recirculation** in the process solver when using upstream-choke pressure control on surge-pinned operating points.

### Problem

`OutletPressureSolver.find_solution` applies anti-surge recirculation *once* at unchoked suction pressure, then invokes `UpstreamChokePressureControlStrategy.apply()` which iterates through choke ΔP candidates without ever re-evaluating anti-surge. The recirculation rate remains frozen at its pre-choke value — which is higher than necessary at reduced (post-choke) suction. This causes over-recirculation and elevated power.

**Observed impact** (R3-UPSTREAM_CHOKE scenario, single-speed train, surge-pinned):
- Before fix: 2.41 MW
- After fix: 2.24 MW  
- Legacy reference: 2.23 MW

### Fix

`UpstreamChokePressureControlStrategy` now receives an `anti_surge_strategy` and `recirculation_loop_ids` at construction. Inside the choke search function (called at each ΔP probe):

1. **Zero** all recirculation loops — clearing stale state from the previous probe
2. **Re-evaluate** `anti_surge_strategy.apply(inlet_stream)` so recirculation is computed at the actual post-choke compressor inlet conditions
3. **Return** recirculation configurations alongside the choke configuration so the outer solver overwrites stale auto-ASV entries by handler ID

### Why zeroing is necessary

`IndividualASVAntiSurgeStrategy.apply()` calls `compressor.get_recirculation_range()` which returns `Boundary(min=max(0, min_rate - current_standard_rate))`. If recirculation from a previous probe is still applied, `current_standard_rate` is inflated → `boundary.min` is too low → ASV under-recirculates relative to true conditions. Zeroing ensures the ASV sees the genuine user-rate at the compressor inlet.

## What else did you consider?

1. **ASV self-resets** (adding `_apply_recirculation_configuration(loop_id, 0.0)` inside `IndividualASVAntiSurgeStrategy.apply`): rejected because it mutates ASV behavior for all callers, not just the upstream-choke path.

2. **Passing full `current_configurations` into `PressureControlStrategy.apply()`**: rejected because it requires changing the interface of all 4 strategy implementations + all callers — too invasive for this fix.

3. **Chosen approach**: pass `recirculation_loop_ids` into `UpstreamChokePressureControlStrategy` only. Minimal interface change, scoped to the one strategy that needs it.

## Between the lines?

