### PR TITLE
fix(process): short-circuit RateTooHigh before anti-surge in OutletPressureSolver

### DIFF
--- a/src/libecalc/process/process_solver/outlet_pressure_solver.py
+++ b/src/libecalc/process/process_solver/outlet_pressure_solver.py
@@ -17,6 +17,7 @@ from libecalc.process.process_solver.pressure_control.pressure_control_strategy 
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
+    RateTooHighFailure,
     Solution,
     TargetDirection,
     TargetPressureUnreachableFailure,
@@ -111,8 +112,7 @@ class OutletPressureSolver:
         self._simulator.apply_configurations(configurations)
         return self._simulator.run(inlet_stream=inlet_stream)
 
-    def get_anti_surge_solution(self) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
-        assert self._anti_surge_solution is not None
+    def get_anti_surge_solution(self) -> Solution[Sequence[Configuration[RecirculationConfiguration]]] | None:
         return self._anti_surge_solution
 
     def find_solution(
@@ -130,6 +130,14 @@ class OutletPressureSolver:
             configuration_handler_id=self._shaft_id,
             value=speed_solution.configuration,
         )
+
+        # Short-circuit: if rate exceeds compressor capacity at all speeds, anti-surge cannot help
+        if isinstance(speed_solution.failure, RateTooHighFailure):
+            return Solution(
+                success=False,
+                configuration=list(configurations.values()),
+                failure=speed_solution.failure,
+            )
 
         self._simulator.reset_to(configurations=list(configurations.values()))
         self._anti_surge_solution = self._anti_surge_strategy.apply(inlet_stream=inlet_stream)

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
@@ -51,8 +51,6 @@ PROCESS_XFAILS: dict[tuple[str, str], str] = {
     ("R1", "INDIVIDUAL_ASV_RATE"): "SpeedSolver bracketing failure at min-speed.",
     ("R1", "INDIVIDUAL_ASV_PRESSURE"): "SpeedSolver bracketing failure at min-speed.",
     ("R1", "COMMON_ASV"): "SpeedSolver bracketing failure at min-speed.",
-    # R5 — Common-ASV loses flow-capacity failure
-    ("R5", "COMMON_ASV"): "Common-ASV topology loses flow-capacity failure for stonewall case.",
     # R6 — similar SpeedSolver convergence issue near max-speed boundary
     ("R6", "UPSTREAM_CHOKE"): "SpeedSolver convergence issue near max-speed boundary.",
     ("R6", "DOWNSTREAM_CHOKE"): "SpeedSolver convergence issue near max-speed boundary.",
@@ -172,7 +170,11 @@ def test_process_solver_path(
         None,
     )
     anti_surge_solution = system.solver.get_anti_surge_solution()
-    anti_surge_recirculation_rates = tuple(c.value.recirculation_rate for c in anti_surge_solution.configuration)
+    anti_surge_recirculation_rates = (
+        tuple(c.value.recirculation_rate for c in anti_surge_solution.configuration)
+        if anti_surge_solution is not None
+        else ()
+    )
     assert_control_behavior(
         case,
         recirculation_rates=recirculation_rates,

--- a/tests/libecalc/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
+++ b/tests/libecalc/process/process_solver/test_outlet_pressure_solver_with_common_asv.py
@@ -73,6 +73,7 @@ def test_outlet_pressure_solver_with_common_asv(
     speed_configuration = config_dict[shaft.get_id()]
 
     recirculation_at_capacity_solution = common_asv_solver.get_anti_surge_solution()
+    assert recirculation_at_capacity_solution is not None
 
     assert solution.success
     assert speed_configuration.speed == pytest.approx(94.40, rel=1e-3)


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Github issue nr in the footer!

## What is this PR all about?

When the speed solver reports `RateTooHighFailure` (rate exceeds compressor capacity at all speeds), applying anti-surge recirculation cannot help — it only adds more flow. The solver now short-circuits before anti-surge, propagating the failure directly.

- Add early return in `OutletPressureSolver.find_solution()` when `speed_solution.failure` is `RateTooHighFailure`
- Make `get_anti_surge_solution()` return `Optional` (anti-surge may not be applied)
- Remove R5-COMMON_ASV from process solver xfails (now passes)

Fixes equinor/ecalc-internal#1851

## What else did you consider?

Could also fix this by making the Common-ASV anti-surge strategy return `success=True` when there is no surge condition (stonewall ≠ surge). But the short-circuit is more robust — anti-surge can never help when the rate exceeds capacity at all speeds, regardless of topology.

## Between the lines?

Existing test `test_process_solver_path[R5-COMMON_ASV]` was a strict xfail documenting this bug — it now passes. No new test needed.