### PR TITLE
fix(process): binary search returns last accepted value instead of arbitrary midpoint

### DIFF
--- a/src/libecalc/process/process_solver/search_strategies.py
+++ b/src/libecalc/process/process_solver/search_strategies.py
@@ -52,6 +52,7 @@ class BinarySearchStrategy(SearchStrategy):
         """
         x0, x1 = boundary.min, boundary.max
         x2 = (x0 + x1) / 2  # Initial value x2.
+        last_accepted: float | None = None
         i = 0
         rel_diff = 100.0
 
@@ -60,6 +61,8 @@ class BinarySearchStrategy(SearchStrategy):
             higher, accepted = func(x2)
             if higher:
                 x0, x1 = x2, x1  # x2 is valid. We can now search to the right in the binary three.
+                if accepted:
+                    last_accepted = x2
             else:
                 x0, x1 = x0, x2  # x2 is invalid. We can now search to the left in the binary three
 
@@ -74,7 +77,7 @@ class BinarySearchStrategy(SearchStrategy):
                 tolerance=self._tolerance,
                 iterations=self._max_iterations,
             )
-        return x2
+        return last_accepted if last_accepted is not None else x2
 
 
 class RootFindingStrategy(abc.ABC):

--- a/tests/libecalc/process/process_solver/test_search_strategies.py
+++ b/tests/libecalc/process/process_solver/test_search_strategies.py
@@ -1,0 +1,29 @@
+"""Tests for BinarySearchStrategy."""
+
+from libecalc.process.process_solver.boundary import Boundary
+from libecalc.process.process_solver.search_strategies import BinarySearchStrategy
+
+
+def test_search_returns_accepted_value():
+    """BinarySearchStrategy.search should return a value that was accepted.
+
+    The search converges to the boundary between accepted/rejected regions.
+    The returned value must be from the accepted side, not an arbitrary midpoint
+    that might be on the rejected side.
+    """
+    threshold = 0.1  # Chosen so the final midpoint lands on the invalid side
+
+    def step_func(x: float) -> tuple[bool, bool]:
+        if x < threshold:
+            return True, True  # below threshold: go higher, accepted
+        else:
+            return False, True  # at/above threshold: go lower
+
+    strategy = BinarySearchStrategy(tolerance=1e-5, max_iterations=50)
+    result = strategy.search(boundary=Boundary(min=0.0, max=10.0), func=step_func)
+
+    # The result must be below the threshold (on the accepted/valid side)
+    assert result < threshold, (
+        f"search() returned {result} which is >= threshold {threshold}. "
+        f"It should return the last value from the accepted (higher=True) side."
+    )


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

`BinarySearchStrategy.search()` returns the last bisection midpoint (`x2`) when convergence is reached. This midpoint can land on the **rejected** side of the convergence boundary.

**Example:** Searching for the boundary at `x = 0.1` with `boundary=[0, 10]`:
- `x < 0.1` → `(higher=True, accepted=True)` (valid side)
- `x >= 0.1` → `(higher=False, accepted=True)` (invalid side)

Returns `0.10000050…` — just above the threshold, on the wrong side.

**Fix:** Track the last `x2` where `higher=True` AND `accepted=True`, return that instead.

## What else did you consider?

Callers that use `accepted=False` on the invalid side (speed solver, recirculation solver) are already safe — the loop can only exit on an accepted iteration. The bug only manifests for callers that return `accepted=True` on both sides (e.g. `FeasibilitySolver._largest_feasible_rate`).

## Between the lines?
