### PR TITLE
fix(libecalc): reset recirculation inside AntiSurgeStrategy.apply()

### DIFF
--- a/src/libecalc/process/process_solver/anti_surge/common_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/common_asv.py
@@ -46,7 +46,7 @@ class CommonASVAntiSurgeStrategy(AntiSurgeStrategy):
         )
 
     def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
-        # Increase recirculation to give minimum feasible flow and return outlet.
+        self.reset()
         recirculation_solution = self._increase_recirculation_to_minimum_feasible(inlet_stream)
         return Solution(
             success=recirculation_solution.success,

--- a/src/libecalc/process/process_solver/anti_surge/individual_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/individual_asv.py
@@ -51,6 +51,7 @@ class IndividualASVAntiSurgeStrategy(AntiSurgeStrategy):
 
     @override
     def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
+        self.reset()
         configurations: Sequence[Configuration[RecirculationConfiguration]] = []
         for loop_id, compressor in zip(self._recirculation_loop_ids, self._compressors, strict=True):
             try:

--- a/src/libecalc/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/common_asv.py
@@ -38,27 +38,27 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
         self._first_compressor = first_compressor
         self._root_finding_strategy = root_finding_strategy
 
-    def apply(
-        self,
-        target_pressure: FloatConstraint,
-        inlet_stream: FluidStream,
-    ) -> Solution[Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]]:
-        def recirculation_func(config: RecirculationConfiguration) -> FluidStream:
-            self._simulator.apply_configuration(
-                Configuration(configuration_handler_id=self._recirculation_loop_id, value=config)
-            )
-            return self._simulator.run(inlet_stream=inlet_stream)
-
-        # Check feasibility: can we reach target pressure at maximum recirculation?
-        # Reset recirculation before computing the boundary — the mixer may carry
-        # residual state from anti-surge, which inflates the inlet rate and
-        # shrinks the recirculation range.
+    def reset(self) -> None:
         self._simulator.apply_configuration(
             Configuration(
                 configuration_handler_id=self._recirculation_loop_id,
                 value=RecirculationConfiguration(recirculation_rate=0.0),
             )
         )
+
+    def apply(
+        self,
+        target_pressure: FloatConstraint,
+        inlet_stream: FluidStream,
+    ) -> Solution[Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]]:
+        self.reset()
+
+        def recirculation_func(config: RecirculationConfiguration) -> FluidStream:
+            self._simulator.apply_configuration(
+                Configuration(configuration_handler_id=self._recirculation_loop_id, value=config)
+            )
+            return self._simulator.run(inlet_stream=inlet_stream)
+
         compressor_inlet_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=self._first_compressor.get_id())
         boundary = self._first_compressor.get_recirculation_range(compressor_inlet_stream)
         min_configuration = RecirculationConfiguration(recirculation_rate=boundary.max)

--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -40,25 +40,31 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
         self._compressors = compressors
         self._root_finding_strategy = root_finding_strategy
 
+    def reset(self) -> None:
+        for recirculation_loop_id in self._recirculation_loop_ids:
+            self._simulator.apply_configuration(
+                Configuration(
+                    configuration_handler_id=recirculation_loop_id,
+                    value=RecirculationConfiguration(recirculation_rate=0.0),
+                )
+            )
+
     def apply(
         self,
         target_pressure: FloatConstraint,
         inlet_stream: FluidStream,
     ) -> Solution[Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]]:
-        minimum_achievable_pressure_configurations = _minimum_achievable_pressure(
+        self.reset()
+        min_configurations, min_pressure_bara = compute_minimum_achievable_pressure(
             simulator=self._simulator,
             recirculation_loop_ids=self._recirculation_loop_ids,
             compressors=self._compressors,
             inlet_stream=inlet_stream,
         )
-        self._simulator.apply_configurations(minimum_achievable_pressure_configurations)
-        minimum_achievable_pressure_stream = self._simulator.run(inlet_stream=inlet_stream)
-        if minimum_achievable_pressure_stream.pressure_bara > target_pressure.value:
-            # Even at maximum recirculation, the outlet pressure is still above the target.
-            # The compressor train cannot deliver a pressure this low at the current speed.
+        if min_pressure_bara > target_pressure.value:
             return Solution.target_pressure_unreachable(
-                configuration=minimum_achievable_pressure_configurations,
-                achievable_pressure_bara=minimum_achievable_pressure_stream.pressure_bara,
+                configuration=min_configurations,
+                achievable_pressure_bara=min_pressure_bara,
                 target_pressure_bara=target_pressure.value,
                 direction=TargetDirection.MIN_ABOVE_TARGET,
             )
@@ -69,15 +75,8 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
         configurations: list[Configuration[RecirculationConfiguration | ChokeConfiguration]] = []
 
         for i, (recirculation_loop_id, compressor) in enumerate(zip(self._recirculation_loop_ids, self._compressors)):
-            # Target pressure for this stage: cumulative from original inlet
             stage_target_pressure = inlet_stream.pressure_bara * (pressure_ratio_per_stage ** (i + 1))
 
-            self._simulator.apply_configuration(
-                Configuration(
-                    configuration_handler_id=recirculation_loop_id,
-                    value=RecirculationConfiguration(recirculation_rate=0.0),
-                )
-            )
             current_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
             boundary = compressor.get_recirculation_range(inlet_stream=current_stream)
 
@@ -132,20 +131,24 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
         self._recirculation_loop_ids = recirculation_loop_ids
         self._compressors = compressors
 
-    def _get_configurations_from_fraction(
-        self,
-        inlet_stream: FluidStream,
-        asv_rate_fraction: float,
-    ) -> Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]:
-        """Propagate stream through all stages, interpolating recirculation between min and max per stage."""
-        configurations: list[Configuration[RecirculationConfiguration | ChokeConfiguration]] = []
-        for recirculation_loop_id, compressor in zip(self._recirculation_loop_ids, self._compressors):
+    def reset(self) -> None:
+        for recirculation_loop_id in self._recirculation_loop_ids:
             self._simulator.apply_configuration(
                 Configuration(
                     configuration_handler_id=recirculation_loop_id,
                     value=RecirculationConfiguration(recirculation_rate=0.0),
                 )
             )
+
+    def _get_configurations_from_fraction(
+        self,
+        inlet_stream: FluidStream,
+        asv_rate_fraction: float,
+    ) -> Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]:
+        """Propagate stream through all stages, interpolating recirculation between min and max per stage."""
+        self.reset()
+        configurations: list[Configuration[RecirculationConfiguration | ChokeConfiguration]] = []
+        for recirculation_loop_id, compressor in zip(self._recirculation_loop_ids, self._compressors):
             current_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
             boundary = compressor.get_recirculation_range(inlet_stream=current_stream)
             recirculation_rate = boundary.min + asv_rate_fraction * (boundary.max - boundary.min)
@@ -164,20 +167,17 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
         target_pressure: FloatConstraint,
         inlet_stream: FluidStream,
     ) -> Solution[Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]]:
-        minimum_achievable_pressure_configurations = _minimum_achievable_pressure(
+        self.reset()
+        min_configurations, min_pressure_bara = compute_minimum_achievable_pressure(
             simulator=self._simulator,
             recirculation_loop_ids=self._recirculation_loop_ids,
             compressors=self._compressors,
             inlet_stream=inlet_stream,
         )
-        self._simulator.apply_configurations(minimum_achievable_pressure_configurations)
-        minimum_achievable_pressure_stream = self._simulator.run(inlet_stream=inlet_stream)
-        if minimum_achievable_pressure_stream.pressure_bara > target_pressure.value:
-            # Even at maximum recirculation, the outlet pressure is still above the target.
-            # The compressor train cannot deliver a pressure this low at the current speed.
+        if min_pressure_bara > target_pressure.value:
             return Solution.target_pressure_unreachable(
-                configuration=minimum_achievable_pressure_configurations,
-                achievable_pressure_bara=minimum_achievable_pressure_stream.pressure_bara,
+                configuration=min_configurations,
+                achievable_pressure_bara=min_pressure_bara,
                 target_pressure_bara=target_pressure.value,
                 direction=TargetDirection.MIN_ABOVE_TARGET,
             )
@@ -209,21 +209,18 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
         )
 
 
-def _minimum_achievable_pressure(
+def compute_minimum_achievable_pressure(
     simulator: ProcessRunner,
     recirculation_loop_ids: Sequence[ConfigurationHandlerId],
     compressors: Sequence[Compressor],
     inlet_stream: FluidStream,
-) -> Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]]:
-    """Propagate with maximum recirculation on every stage to find the lowest achievable pressure."""
+) -> tuple[Sequence[Configuration[RecirculationConfiguration | ChokeConfiguration]], float]:
+    """Apply maximum recirculation on every stage and return (configurations, outlet pressure bara).
+
+    Assumes all recirculation loops start at zero. Resets all loops to zero on exit.
+    """
     configurations: list[Configuration[RecirculationConfiguration | ChokeConfiguration]] = []
     for loop, compressor in zip(recirculation_loop_ids, compressors):
-        simulator.apply_configuration(
-            Configuration(
-                configuration_handler_id=loop,
-                value=RecirculationConfiguration(recirculation_rate=0.0),
-            )
-        )
         current_stream = simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
         boundary = compressor.get_recirculation_range(current_stream)
         configuration: Configuration[RecirculationConfiguration | ChokeConfiguration] = Configuration(
@@ -232,4 +229,9 @@ def _minimum_achievable_pressure(
         simulator.apply_configuration(configuration)
         configurations.append(configuration)
 
-    return configurations
+    pressure_bara = simulator.run(inlet_stream=inlet_stream).pressure_bara
+    for loop in recirculation_loop_ids:
+        simulator.apply_configuration(
+            Configuration(configuration_handler_id=loop, value=RecirculationConfiguration(recirculation_rate=0.0))
+        )
+    return configurations, pressure_bara

--- a/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
+++ b/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
@@ -65,9 +65,6 @@ class UpstreamChokePressureControlStrategy(PressureControlStrategy):
             self._simulator.apply_configuration(
                 Configuration(configuration_handler_id=self._choke_configuration_handler_id, value=config)
             )
-            # Reset and re-evaluate anti-surge at the current choke setting so that
-            # recirculation reflects the actual (post-choke) compressor inlet conditions.
-            self._anti_surge_strategy.reset()
             anti_surge_solution = self._anti_surge_strategy.apply(inlet_stream=inlet_stream)
             for anti_surge_configuration in anti_surge_solution.configuration:
                 self._simulator.apply_configuration(anti_surge_configuration)

--- a/tests/libecalc/process/process_solver/anti_surge/test_common_asv_anti_surge_strategy.py
+++ b/tests/libecalc/process/process_solver/anti_surge/test_common_asv_anti_surge_strategy.py
@@ -98,3 +98,59 @@ def test_common_asv_anti_surge_uses_compressor_inlet_for_boundary(
         f"expected compressor-inlet stream at T={stage_inlet_temperature_kelvin:.1f} K "
         f"(train-inlet was T={train_inlet_temperature_kelvin:.1f} K)."
     )
+
+
+def test_common_asv_apply_result_independent_of_prior_simulator_state(
+    stream_factory,
+    chart_data_factory,
+    fluid_service,
+    compressor_factory,
+    stage_units_factory,
+    with_common_asv,
+    process_runner_factory,
+    common_asv_anti_surge_strategy_factory,
+):
+    inlet_stream = stream_factory(
+        standard_rate_m3_per_day=500_000.0,
+        pressure_bara=30.0,
+        temperature_kelvin=303.15,
+    )
+    q0 = float(inlet_stream.volumetric_rate_m3_per_hour)
+
+    chart_data = chart_data_factory.from_curves(
+        curves=[
+            ChartCurve(
+                speed_rpm=75.0,
+                rate_actual_m3_hour=[q0 * 2, q0 * 8],
+                polytropic_head_joule_per_kg=[150_000.0, 40_000.0],
+                efficiency_fraction=[0.75, 0.75],
+            ),
+        ],
+        control_margin=0.0,
+    )
+
+    shaft = VariableSpeedShaft()
+    compressor = compressor_factory(chart_data=chart_data)
+    units = stage_units_factory(compressor=compressor, shaft=shaft)
+    shaft.set_speed(75.0)
+
+    recirculation_loop, wrapped_units = with_common_asv(units)
+    runner = process_runner_factory(units=wrapped_units, configuration_handlers=[shaft, recirculation_loop])
+
+    strategy = common_asv_anti_surge_strategy_factory(
+        runner=runner,
+        recirculation_loop_id=recirculation_loop.get_id(),
+        first_compressor=compressor,
+    )
+
+    first = strategy.apply(inlet_stream=inlet_stream)
+    second = strategy.apply(inlet_stream=inlet_stream)
+
+    first_rate = first.configuration[0].value.recirculation_rate
+    second_rate = second.configuration[0].value.recirculation_rate
+
+    assert first_rate > 0.0, "Test setup error: anti-surge did not recirculate on the first call"
+    assert second_rate == pytest.approx(first_rate, rel=1e-6), (
+        f"apply() result depends on prior simulator state: first call set recirculation "
+        f"rate {first_rate:.3f}, second call set {second_rate:.3f} with the same arguments."
+    )


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Github issue nr in the footer!

No changelog entry: the only existing caller affected (`UpstreamChokePressureControlStrategy`) was already resetting externally, so user-visible behaviour is unchanged.

## What is this PR all about?

Closes equinor/ecalc-internal#1860.

`AntiSurgeStrategy.apply()` walks the train using the simulator's current configuration state. Without an internal reset, a second call to `apply()` sees the recirculation rate set by the first call still active on the loop, so the boundary check is computed against the wrong compressor inlet stream and the strategy returns a state-dependent result.

`CommonASVAntiSurgeStrategy.apply()` and `IndividualASVAntiSurgeStrategy.apply()` now call `self.reset()` as their first step, zeroing the recirculation handlers they own before recomputing. Callers no longer need to perform an external reset.

The explicit `self._anti_surge_strategy.reset()` workaround in `UpstreamChokePressureControlStrategy` is removed. `OutletPressureSolver` continues to work unchanged since its outer `reset_to()` already cleared state.

Regression test `test_common_asv_apply_result_independent_of_prior_simulator_state` calls `apply()` twice with the same inlet on a single-stage train and asserts the recirculation rates match. The test fails on `main` with:

```
AssertionError: apply() result depends on prior simulator state:
  first call set recirculation rate 500000.000,
  second call set 500976.562.
```

and passes with the fix applied.

## What else did you consider?

- Leaving the explicit `reset()` in `UpstreamChokePressureControlStrategy` and only documenting the precondition on `apply()`. Rejected: any future caller would have to know the dance, and OPS only works today by coincidence of outer ordering.
- Resetting inside `_increase_recirculation_to_minimum_feasible` instead of at the top of `apply()`. Rejected: `apply()` is the public seam, the helper is an implementation detail.

## Between the lines?

`CommonASVPressureControlStrategy.apply()` has a similar shape with a comparable inline workaround. It is a refactor rather than a fix (the workaround is correct and the result is independent of prior state today), so it is tracked separately and not included here.