### PR TITLE
chore: skip blowing up exception when it is expected

### DIFF
--- a/src/libecalc/process/process_solver/solvers/speed_solver.py
+++ b/src/libecalc/process/process_solver/solvers/speed_solver.py
@@ -33,10 +33,10 @@ class SpeedSolver(Solver[SpeedConfiguration]):
             max_speed_configuration = SpeedConfiguration(speed=self._boundary.max)
             maximum_speed_outlet_stream = func(max_speed_configuration)
         except RateTooHighError as e:
-            logger.debug(f"No solution found for maximum speed: {max_speed_configuration}", exc_info=e)
+            logger.debug(f"No solution found for maximum speed: {max_speed_configuration}")
             return Solution.from_rate_too_high(e, configuration=max_speed_configuration)
         except RateTooLowError as e:
-            logger.debug(f"No solution found for maximum speed: {max_speed_configuration}", exc_info=e)
+            logger.debug(f"No solution found for maximum speed: {max_speed_configuration}")
             return Solution.from_rate_too_low(e, configuration=max_speed_configuration)
 
         if maximum_speed_outlet_stream.pressure_bara < self._target_pressure:


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
