### PR TITLE
refactor: add solver assembly module for process solver wiring

### DIFF
--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -15,6 +15,7 @@ from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesE
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
+from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
 from libecalc.process.stream_distribution.common_stream_distribution import Overflow
 
 
@@ -38,15 +39,6 @@ class IndividualStreamDistributionConfig:
 @value_object
 class Constraint:  # should this instead be more flexible wrt. matching one or more stream conditions?
     outlet_pressure: TimeSeriesExpression
-
-
-PressureControlType = Literal[
-    "UPSTREAM_CHOKE",
-    "DOWNSTREAM_CHOKE",
-    "COMMON_ASV",
-    "INDIVIDUAL_ASV_RATE",
-    "INDIVIDUAL_ASV_PRESSURE",
-]
 
 
 @value_object

--- a/src/libecalc/process/process_solver/pressure_control/pressure_control_strategy.py
+++ b/src/libecalc/process/process_solver/pressure_control/pressure_control_strategy.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from typing import Literal
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_solver.configuration import Configuration
@@ -7,6 +8,14 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.solver import Solution
 from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
+
+PressureControlType = Literal[
+    "UPSTREAM_CHOKE",
+    "DOWNSTREAM_CHOKE",
+    "COMMON_ASV",
+    "INDIVIDUAL_ASV_RATE",
+    "INDIVIDUAL_ASV_PRESSURE",
+]
 
 
 class PressureControlStrategy(ABC):

--- a/src/libecalc/process/process_solver/solver_assembly.py
+++ b/src/libecalc/process/process_solver/solver_assembly.py
@@ -1,0 +1,218 @@
+"""Production solver assembly: wire physical components into a working solver.
+
+This module contains the single source of truth for assembling an
+OutletPressureSolver from its collaborating objects (runner, anti-surge
+strategy, pressure control strategy).  Both the YAML mapper and test
+infrastructure should use ``assemble_solver`` to ensure tests exercise
+the same wiring logic as production.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import assert_never
+
+from libecalc.common.ddd import value_object
+from libecalc.process.process_pipeline.process_pipeline import ProcessPipeline
+from libecalc.process.process_pipeline.process_unit import ProcessUnit
+from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
+from libecalc.process.process_solver.anti_surge.common_asv import CommonASVAntiSurgeStrategy
+from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
+from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
+from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
+from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pressure_control.common_asv import CommonASVPressureControlStrategy
+from libecalc.process.process_solver.pressure_control.downstream_choke import DownstreamChokePressureControlStrategy
+from libecalc.process.process_solver.pressure_control.individual_asv import (
+    IndividualASVPressureControlStrategy,
+    IndividualASVRateControlStrategy,
+)
+from libecalc.process.process_solver.pressure_control.pressure_control_strategy import (
+    PressureControlStrategy,
+    PressureControlType,
+)
+from libecalc.process.process_solver.pressure_control.upstream_choke import UpstreamChokePressureControlStrategy
+from libecalc.process.process_solver.process_pipeline_runner import ProcessPipelineRunner
+from libecalc.process.process_solver.process_runner import ProcessRunner
+from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
+from libecalc.process.process_solver.search_strategies import RootFindingStrategy, ScipyRootFindingStrategy
+from libecalc.process.process_units.choke import Choke
+from libecalc.process.process_units.compressor import Compressor
+from libecalc.process.shaft import VariableSpeedShaft
+
+
+@value_object
+class ProcessSolverSystem:
+    """A fully-wired solver with all its collaborating objects.
+
+    Bundles the OutletPressureSolver together with the physical components
+    it operates on, so callers can inspect topology and run the solver.
+    """
+
+    solver: OutletPressureSolver
+    runner: ProcessRunner
+    pipeline: ProcessPipeline
+    shaft: VariableSpeedShaft
+    compressors: tuple[Compressor, ...]
+    recirculation_loops: tuple[RecirculationLoop, ...]
+    choke: Choke | None
+
+
+def assemble_solver(
+    *,
+    process_units: Sequence[ProcessUnit],
+    configuration_handlers: Sequence[ConfigurationHandler],
+    compressors: Sequence[Compressor],
+    recirculation_loops: Sequence[RecirculationLoop],
+    shaft: VariableSpeedShaft,
+    pipeline_name: str,
+    pressure_control_type: PressureControlType,
+    choke: Choke | None = None,
+    choke_configuration_handler: ChokeConfigurationHandler | None = None,
+    root_finding_strategy: RootFindingStrategy | None = None,
+) -> ProcessSolverSystem:
+    """Assemble a fully-wired OutletPressureSolver from physical components.
+
+    This is the production solver assembly path.  It creates the
+    ProcessPipelineRunner, resolves the anti-surge and pressure control
+    strategies from the ``pressure_control_type``, and wires everything
+    into an OutletPressureSolver.
+
+    Args:
+        process_units: Ordered list of process units forming the pipeline
+            (including mixers, splitters, compressors, choke, etc.).
+        configuration_handlers: All configuration handlers for the runner
+            (shaft, recirculation loops, choke handler).
+        compressors: Compressor instances (for strategy wiring).
+        recirculation_loops: Recirculation loops wrapping compressor stages.
+        shaft: The variable-speed shaft connecting the compressors.
+        pipeline_name: Name for the ProcessPipeline.
+        pressure_control_type: Determines which anti-surge and pressure
+            control strategies to instantiate.
+        choke: The pressure-control choke (if any).  Included in the
+            returned ProcessSolverSystem for inspection.
+        choke_configuration_handler: Required for UPSTREAM_CHOKE and
+            DOWNSTREAM_CHOKE modes.
+        root_finding_strategy: Numerical solver strategy.  Defaults to
+            ScipyRootFindingStrategy.
+    """
+    if root_finding_strategy is None:
+        root_finding_strategy = ScipyRootFindingStrategy()
+
+    pipeline = ProcessPipeline(name=pipeline_name, stream_propagators=process_units)
+    runner = ProcessPipelineRunner(units=process_units, configuration_handlers=configuration_handlers)
+
+    anti_surge_strategy = _resolve_anti_surge_strategy(
+        pressure_control_type=pressure_control_type,
+        runner=runner,
+        compressors=compressors,
+        recirculation_loops=recirculation_loops,
+        root_finding_strategy=root_finding_strategy,
+    )
+
+    pressure_control_strategy = _resolve_pressure_control_strategy(
+        pressure_control_type=pressure_control_type,
+        runner=runner,
+        compressors=compressors,
+        recirculation_loops=recirculation_loops,
+        choke_configuration_handler=choke_configuration_handler,
+        anti_surge_strategy=anti_surge_strategy,
+        root_finding_strategy=root_finding_strategy,
+    )
+
+    solver = OutletPressureSolver(
+        shaft_id=shaft.get_id(),
+        process_pipeline_id=pipeline.get_id(),
+        runner=runner,
+        anti_surge_strategy=anti_surge_strategy,
+        pressure_control_strategy=pressure_control_strategy,
+        root_finding_strategy=root_finding_strategy,
+        speed_boundary=shaft.get_speed_boundary(),
+    )
+
+    return ProcessSolverSystem(
+        solver=solver,
+        runner=runner,
+        pipeline=pipeline,
+        shaft=shaft,
+        compressors=tuple(compressors),
+        recirculation_loops=tuple(recirculation_loops),
+        choke=choke,
+    )
+
+
+def _resolve_anti_surge_strategy(
+    *,
+    pressure_control_type: PressureControlType,
+    runner: ProcessPipelineRunner,
+    compressors: Sequence[Compressor],
+    recirculation_loops: Sequence[RecirculationLoop],
+    root_finding_strategy: RootFindingStrategy,
+) -> AntiSurgeStrategy:
+    """Resolve the anti-surge strategy from the pressure control type."""
+    match pressure_control_type:
+        case "COMMON_ASV":
+            return CommonASVAntiSurgeStrategy(
+                simulator=runner,
+                root_finding_strategy=root_finding_strategy,
+                first_compressor=compressors[0],
+                recirculation_loop_id=recirculation_loops[0].get_id(),
+            )
+        case "DOWNSTREAM_CHOKE" | "UPSTREAM_CHOKE" | "INDIVIDUAL_ASV_RATE" | "INDIVIDUAL_ASV_PRESSURE":
+            return IndividualASVAntiSurgeStrategy(
+                simulator=runner,
+                recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
+                compressors=compressors,
+            )
+        case _:
+            assert_never(pressure_control_type)
+
+
+def _resolve_pressure_control_strategy(
+    *,
+    pressure_control_type: PressureControlType,
+    runner: ProcessPipelineRunner,
+    compressors: Sequence[Compressor],
+    recirculation_loops: Sequence[RecirculationLoop],
+    choke_configuration_handler: ChokeConfigurationHandler | None,
+    anti_surge_strategy: AntiSurgeStrategy,
+    root_finding_strategy: RootFindingStrategy,
+) -> PressureControlStrategy:
+    """Resolve the pressure control strategy from the pressure control type."""
+    match pressure_control_type:
+        case "DOWNSTREAM_CHOKE":
+            assert choke_configuration_handler is not None
+            return DownstreamChokePressureControlStrategy(
+                simulator=runner,
+                choke_configuration_handler_id=choke_configuration_handler.get_id(),
+            )
+        case "UPSTREAM_CHOKE":
+            assert choke_configuration_handler is not None
+            return UpstreamChokePressureControlStrategy(
+                simulator=runner,
+                choke_configuration_handler_id=choke_configuration_handler.get_id(),
+                root_finding_strategy=root_finding_strategy,
+                anti_surge_strategy=anti_surge_strategy,
+            )
+        case "COMMON_ASV":
+            return CommonASVPressureControlStrategy(
+                simulator=runner,
+                recirculation_loop_id=recirculation_loops[0].get_id(),
+                first_compressor=compressors[0],
+                root_finding_strategy=root_finding_strategy,
+            )
+        case "INDIVIDUAL_ASV_RATE":
+            return IndividualASVRateControlStrategy(
+                simulator=runner,
+                recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
+                compressors=compressors,
+            )
+        case "INDIVIDUAL_ASV_PRESSURE":
+            return IndividualASVPressureControlStrategy(
+                simulator=runner,
+                recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
+                compressors=compressors,
+                root_finding_strategy=root_finding_strategy,
+            )
+        case _:
+            assert_never(pressure_control_type)

--- a/tests/libecalc/process/helpers/process_solver_builder.py
+++ b/tests/libecalc/process/helpers/process_solver_builder.py
@@ -1,28 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import assert_never
 
 from libecalc.ecalc_model.process_simulation import PressureControlConfig, PressureControlType
 from libecalc.process.fluid_stream.fluid_service import FluidService
-from libecalc.process.process_pipeline.process_pipeline import ProcessPipeline
 from libecalc.process.process_pipeline.process_unit import ProcessUnit
-from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
-from libecalc.process.process_solver.anti_surge.common_asv import CommonASVAntiSurgeStrategy
-from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
 from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
-from libecalc.process.process_solver.pressure_control.common_asv import CommonASVPressureControlStrategy
-from libecalc.process.process_solver.pressure_control.downstream_choke import DownstreamChokePressureControlStrategy
-from libecalc.process.process_solver.pressure_control.individual_asv import (
-    IndividualASVPressureControlStrategy,
-    IndividualASVRateControlStrategy,
-)
-from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
-from libecalc.process.process_solver.pressure_control.upstream_choke import UpstreamChokePressureControlStrategy
-from libecalc.process.process_solver.process_pipeline_runner import ProcessPipelineRunner
 from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy, ScipyRootFindingStrategy
+from libecalc.process.process_solver.solver_assembly import ProcessSolverSystem, assemble_solver
 from libecalc.process.process_units.choke import Choke
 from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.process_units.direct_mixer import DirectMixer
@@ -30,7 +16,7 @@ from libecalc.process.process_units.direct_splitter import DirectSplitter
 from libecalc.process.process_units.liquid_remover import LiquidRemover
 from libecalc.process.process_units.temperature_setter import TemperatureSetter
 from libecalc.process.shaft import VariableSpeedShaft
-from tests.libecalc.process.helpers.process_solver_system import ProcessSolverSystem, StageConfig
+from tests.libecalc.process.helpers.process_solver_system import StageConfig
 
 
 class ProcessSolverBuilder:
@@ -76,38 +62,17 @@ class ProcessSolverBuilder:
             else:
                 process_units = [choke, *process_units]
 
-        pipeline = ProcessPipeline(name="test-pipeline", stream_propagators=process_units)
-        runner = ProcessPipelineRunner(units=process_units, configuration_handlers=configuration_handlers)
-        anti_surge_strategy = self._create_anti_surge_strategy(
-            runner=runner,
-            recirculation_loops=recirculation_loops,
+        return assemble_solver(
+            process_units=process_units,
+            configuration_handlers=configuration_handlers,
             compressors=compressors,
-        )
-        pressure_control_strategy = self._create_pressure_control_strategy(
-            runner=runner,
             recirculation_loops=recirculation_loops,
-            compressors=compressors,
-            choke_configuration_handler=choke_configuration_handler,
-            anti_surge_strategy=anti_surge_strategy,
-        )
-        solver = OutletPressureSolver(
-            shaft_id=shaft.get_id(),
-            process_pipeline_id=pipeline.get_id(),
-            runner=runner,
-            anti_surge_strategy=anti_surge_strategy,
-            pressure_control_strategy=pressure_control_strategy,
-            root_finding_strategy=self._root_finding_strategy,
-            speed_boundary=shaft.get_speed_boundary(),
-        )
-
-        return ProcessSolverSystem(
-            solver=solver,
-            runner=runner,
-            pipeline=pipeline,
             shaft=shaft,
-            compressors=tuple(compressors),
-            recirculation_loops=tuple(recirculation_loops),
+            pipeline_name="test-pipeline",
+            pressure_control_type=self._pressure_control_config.type,
             choke=choke,
+            choke_configuration_handler=choke_configuration_handler,
+            root_finding_strategy=self._root_finding_strategy,
         )
 
     def _create_stage_units(
@@ -161,74 +126,3 @@ class ProcessSolverBuilder:
         splitter = DirectSplitter()
         recirculation_loop = RecirculationLoop(mixer=mixer, splitter=splitter)
         return recirculation_loop, [mixer, *units, splitter]
-
-    def _create_anti_surge_strategy(
-        self,
-        *,
-        runner: ProcessPipelineRunner,
-        recirculation_loops: Sequence[RecirculationLoop],
-        compressors: Sequence[Compressor],
-    ) -> CommonASVAntiSurgeStrategy | IndividualASVAntiSurgeStrategy:
-        match self._pressure_control_config.type:
-            case "COMMON_ASV":
-                return CommonASVAntiSurgeStrategy(
-                    simulator=runner,
-                    root_finding_strategy=self._root_finding_strategy,
-                    first_compressor=compressors[0],
-                    recirculation_loop_id=recirculation_loops[0].get_id(),
-                )
-            case "DOWNSTREAM_CHOKE" | "UPSTREAM_CHOKE" | "INDIVIDUAL_ASV_RATE" | "INDIVIDUAL_ASV_PRESSURE":
-                return IndividualASVAntiSurgeStrategy(
-                    simulator=runner,
-                    recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
-                    compressors=compressors,
-                )
-            case _:
-                assert_never(self._pressure_control_config.type)
-
-    def _create_pressure_control_strategy(
-        self,
-        *,
-        runner: ProcessPipelineRunner,
-        recirculation_loops: Sequence[RecirculationLoop],
-        compressors: Sequence[Compressor],
-        choke_configuration_handler: ChokeConfigurationHandler | None,
-        anti_surge_strategy: AntiSurgeStrategy,
-    ) -> PressureControlStrategy:
-        match self._pressure_control_config.type:
-            case "DOWNSTREAM_CHOKE":
-                assert choke_configuration_handler is not None
-                return DownstreamChokePressureControlStrategy(
-                    simulator=runner,
-                    choke_configuration_handler_id=choke_configuration_handler.get_id(),
-                )
-            case "UPSTREAM_CHOKE":
-                assert choke_configuration_handler is not None
-                return UpstreamChokePressureControlStrategy(
-                    simulator=runner,
-                    choke_configuration_handler_id=choke_configuration_handler.get_id(),
-                    root_finding_strategy=self._root_finding_strategy,
-                    anti_surge_strategy=anti_surge_strategy,
-                )
-            case "COMMON_ASV":
-                return CommonASVPressureControlStrategy(
-                    simulator=runner,
-                    recirculation_loop_id=recirculation_loops[0].get_id(),
-                    first_compressor=compressors[0],
-                    root_finding_strategy=self._root_finding_strategy,
-                )
-            case "INDIVIDUAL_ASV_RATE":
-                return IndividualASVRateControlStrategy(
-                    simulator=runner,
-                    recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
-                    compressors=compressors,
-                )
-            case "INDIVIDUAL_ASV_PRESSURE":
-                return IndividualASVPressureControlStrategy(
-                    simulator=runner,
-                    recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
-                    compressors=compressors,
-                    root_finding_strategy=self._root_finding_strategy,
-                )
-            case _:
-                assert_never(self._pressure_control_config.type)

--- a/tests/libecalc/process/helpers/process_solver_system.py
+++ b/tests/libecalc/process/helpers/process_solver_system.py
@@ -3,13 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from libecalc.domain.process.value_objects.chart.chart import ChartData
-from libecalc.process.process_pipeline.process_pipeline import ProcessPipeline
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
-from libecalc.process.process_solver.process_runner import ProcessRunner
-from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
-from libecalc.process.process_units.choke import Choke
-from libecalc.process.process_units.compressor import Compressor
-from libecalc.process.shaft import VariableSpeedShaft
+from libecalc.process.process_solver.solver_assembly import ProcessSolverSystem
+
+__all__ = ["ProcessSolverSystem", "StageConfig"]
 
 
 @dataclass(frozen=True)
@@ -18,14 +14,3 @@ class StageConfig:
     inlet_temperature_kelvin: float = 303.15
     remove_liquid_after_cooling: bool = True
     pressure_drop_ahead_of_stage: float = 0.0
-
-
-@dataclass(frozen=True)
-class ProcessSolverSystem:
-    solver: OutletPressureSolver
-    runner: ProcessRunner
-    pipeline: ProcessPipeline
-    shaft: VariableSpeedShaft
-    compressors: tuple[Compressor, ...]
-    recirculation_loops: tuple[RecirculationLoop, ...]
-    choke: Choke | None


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

No new tests needed — existing tests (225 passed, 17 xfailed) verify the refactored code exercises the same solver assembly logic.

## What is this PR all about?

Addresses PR #1582 reviewer feedback: `OutletPressureSolver` was only ever instantiated in test code. The test `ProcessSolverBuilder` independently assembled the solver from scratch, risking divergence from how the library would wire it.

This PR adds a solver assembly module in `src/`:

- **New**: `src/libecalc/process/process_solver/solver_assembly.py`
  - `assemble_solver()` — pure function that wires physical components into an `OutletPressureSolver`
  - `ProcessSolverSystem` — `@value_object` that bundles solver + runner + pipeline + physical components
  - Private helpers for resolving anti-surge and pressure control strategies from `PressureControlType`

- **Simplified**: `tests/libecalc/process/helpers/process_solver_builder.py`
  - `build()` now delegates to `assemble_solver()` — removed ~120 lines of duplicated strategy resolution
  - Builder still owns physical unit creation from `StageConfig` (test-only topology DSL)

- **Updated**: `tests/libecalc/process/helpers/process_solver_system.py`
  - Re-exports `ProcessSolverSystem` from `solver_assembly`; keeps `StageConfig` test-only

- **Moved**: `PressureControlType` from `ecalc_model.process_simulation` to `process.process_solver.pressure_control.pressure_control_strategy`
  - Fixes architecture violation (`libecalc.process` must not import from `libecalc.ecalc_model`)
  - `ecalc_model` re-imports it from the new location for backwards compatibility

## What else did you consider?

- **Factory class** vs **assembler function**: Chose a pure function because all inputs are available at once (no progressive construction needed). The test `ProcessSolverBuilder` remains a Builder for incremental topology setup.
- **ProcessRunner abstraction**: `ProcessSolverSystem.runner` uses the abstract `ProcessRunner` type, not the concrete `ProcessPipelineRunner`, preserving the abstraction boundary.

## Between the lines?

This is the first step of connecting the YAML mapper to the new solver. Next steps would perhaps be:
- Wire `ProcessSimulationMapper` to call `assemble_solver()` after creating physical components
- Connect `get_process_simulations()` to actual execution path
- Remove orphaned `map_anti_surge_strategy()` from mapper
