### PR TITLE
fix(libecalc): compute INDIVIDUAL_ASV_RATE per-stage boundary against realistic upstream inlet

### DIFF
--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -152,14 +152,12 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
             current_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=compressor.get_id())
             boundary = compressor.get_recirculation_range(inlet_stream=current_stream)
             recirculation_rate = boundary.min + asv_rate_fraction * (boundary.max - boundary.min)
-            configurations.append(
-                Configuration(
-                    configuration_handler_id=recirculation_loop_id,
-                    value=RecirculationConfiguration(
-                        recirculation_rate=recirculation_rate,
-                    ),
-                )
+            configuration: Configuration[RecirculationConfiguration | ChokeConfiguration] = Configuration(
+                configuration_handler_id=recirculation_loop_id,
+                value=RecirculationConfiguration(recirculation_rate=recirculation_rate),
             )
+            self._simulator.apply_configuration(configuration)
+            configurations.append(configuration)
         return configurations
 
     def apply(

--- a/tests/libecalc/process/process_solver/pressure_control/test_individual_asv_rate_via_outlet_pressure_solver.py
+++ b/tests/libecalc/process/process_solver/pressure_control/test_individual_asv_rate_via_outlet_pressure_solver.py
@@ -1,0 +1,95 @@
+import pytest
+
+from libecalc.domain.process.value_objects.chart import ChartCurve
+from libecalc.process.process_solver.float_constraint import FloatConstraint
+from libecalc.process.shaft import VariableSpeedShaft
+
+
+def _chart(chart_data_factory, *, q0, min_rate_factor, max_rate_factor, head_hi, head_lo):
+    return chart_data_factory.from_curves(
+        curves=[
+            ChartCurve(
+                speed_rpm=75.0,
+                rate_actual_m3_hour=[q0 * min_rate_factor, q0 * max_rate_factor],
+                polytropic_head_joule_per_kg=[head_hi, head_lo],
+                efficiency_fraction=[0.75, 0.75],
+            ),
+            ChartCurve(
+                speed_rpm=105.0,
+                rate_actual_m3_hour=[q0 * min_rate_factor, q0 * max_rate_factor],
+                polytropic_head_joule_per_kg=[head_hi * 1.05, head_lo * 1.05],
+                efficiency_fraction=[0.75, 0.75],
+            ),
+        ],
+        control_margin=0.0,
+    )
+
+
+def test_individual_asv_rate_via_outlet_pressure_solver_two_stages(
+    stream_factory,
+    chart_data_factory,
+    compressor_factory,
+    stage_units_factory,
+    with_individual_asv,
+    process_pipeline_factory,
+    process_runner_factory,
+    individual_asv_anti_surge_strategy_factory,
+    individual_asv_rate_control_strategy_factory,
+    outlet_pressure_solver_factory,
+):
+    temperature = 300.0
+    inlet_stream = stream_factory(
+        standard_rate_m3_per_day=500_000.0,
+        pressure_bara=30.0,
+        temperature_kelvin=temperature,
+    )
+    q0 = float(inlet_stream.volumetric_rate_m3_per_hour)
+
+    stage1_chart = _chart(
+        chart_data_factory, q0=q0, min_rate_factor=1.5, max_rate_factor=10.0, head_hi=80_000.0, head_lo=40_000.0
+    )
+    stage2_chart = _chart(
+        chart_data_factory, q0=q0, min_rate_factor=1.2, max_rate_factor=6.0, head_hi=60_000.0, head_lo=30_000.0
+    )
+
+    shaft = VariableSpeedShaft()
+    compressor1 = compressor_factory(chart_data=stage1_chart)
+    compressor2 = compressor_factory(chart_data=stage2_chart)
+    units1 = stage_units_factory(compressor=compressor1, shaft=shaft, temperature_kelvin=temperature)
+    units2 = stage_units_factory(compressor=compressor2, shaft=shaft, temperature_kelvin=temperature)
+
+    compressors = [compressor1, compressor2]
+    wrapped_units, loops = with_individual_asv([*units1, *units2])
+    loop_ids = [loop.get_id() for loop in loops]
+
+    pipeline = process_pipeline_factory(units=wrapped_units)
+    runner = process_runner_factory(units=wrapped_units, configuration_handlers=[shaft, *loops])
+    anti_surge_strategy = individual_asv_anti_surge_strategy_factory(
+        runner=runner,
+        recirculation_loop_ids=loop_ids,
+        compressors=compressors,
+    )
+    pressure_control_strategy = individual_asv_rate_control_strategy_factory(
+        runner=runner,
+        recirculation_loop_ids=loop_ids,
+        compressors=compressors,
+    )
+    solver = outlet_pressure_solver_factory(
+        shaft=shaft,
+        runner=runner,
+        anti_surge_strategy=anti_surge_strategy,
+        pressure_control_strategy=pressure_control_strategy,
+        process_pipeline_id=pipeline.get_id(),
+    )
+
+    target_pressure_bara = 70.0
+    solution = solver.find_solution(
+        pressure_constraint=FloatConstraint(target_pressure_bara),
+        inlet_stream=inlet_stream,
+    )
+
+    assert solution.success is True
+
+    runner.apply_configurations(solution.configuration)
+    outlet = runner.run(inlet_stream=inlet_stream)
+    assert outlet.pressure_bara == pytest.approx(target_pressure_bara, rel=1e-3)


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Github issue nr in the footer!

Changelog not updated: the affected code path (`ProcessRunner`-based `IndividualASVRateControlStrategy`) is not yet used by any production code path, so users cannot observe this change.

## What is this PR all about?

Fixes equinor/ecalc-internal#1862. See the issue for the full analysis.

`IndividualASVRateControlStrategy._get_configurations_from_fraction` computed each stage's `[min, max]` recirculation range against an inlet propagated through upstream stages with `recirculation = 0`, even when upstream stages were supposed to be running with non-zero ASV opening. In any multi-stage train where an upstream stage needs anti-surge recycle, the downstream stage's boundary calculation propagated through the upstream stage below its surge minimum and raised `RateTooLowError`.

Fix: apply each stage's chosen configuration to the simulator inside the loop, before computing the next stage's range. Each downstream stage's `[min, max]` is then taken at its realistic suction conditions.

Regression test: `test_individual_asv_rate_via_outlet_pressure_solver.py` — two-stage train where stage 1 needs anti-surge recycle. On main this hits `RateTooLowError` inside `find_root`; with the fix the solver converges and the outlet pressure matches the target.

## What else did you consider?

Legacy `compressor_train_common_shaft._evaluate_train_with_individual_asv_rate` (and the `RateModifier.add_rate` it drives) does not have this bug: each stage's "available capacity" is computed during forward propagation, so the stage sees its realistic inlet stream — with upstream recirculation already applied — before its own ASV rate is decided.

## Between the lines?
