### PR TITLE
chore: fix

### DIFF
--- a/src/libecalc/presentation/yaml/yaml_reference_service.py
+++ b/src/libecalc/presentation/yaml/yaml_reference_service.py
@@ -104,12 +104,11 @@ class YamlReferenceService(ReferenceService):
 
         process_units_path = YamlPath(keys=("PROCESS_UNITS",))
         for process_unit_key, process_unit in configuration.process_units.items():
-            name = getattr(process_unit, "name", None)
-            if name is None:
-                continue
+            # TODO: We have both a name attribute (on compressor only) and they key in the dict
+            # It is unnecessary to have both atm, so just using key for now
             process_unit_path = process_units_path.append(process_unit_key)
-            references[name] = process_unit
-            reference_yaml_context[name] = process_unit_path
+            references[process_unit_key] = process_unit
+            reference_yaml_context[process_unit_key] = process_unit_path
 
         process_pipelines_path = YamlPath(keys=("PROCESS_PIPELINES",))
         for process_pipeline_key, process_pipeline in configuration.process_pipelines.items():

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
@@ -36,13 +36,6 @@ class YamlCompressor(YamlBase):
     """
 
     type: Literal["COMPRESSOR"]
-    name: Annotated[
-        ProcessUnitReference,
-        Field(
-            description="Name of the model. See documentation for more information.",
-            title="NAME",
-        ),
-    ]
     compressor_model: YamlCompressorModelChart
 
 


### PR DESCRIPTION
YAML mapper assumed PROCESS_UNITs had NAME, but only COMPRESSOR have that atm. Also, we do not need both dict key and name - if we always use the same and we or the user has no idea which one to use as reference. Skipping name attribute for now.

## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
