### PR TITLE
fix(libecalc): surface stonewall failure from upstream-choke pressure control

### DIFF
--- a/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
+++ b/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
@@ -81,4 +81,5 @@ class UpstreamChokePressureControlStrategy(PressureControlStrategy):
                     configuration_handler_id=self._choke_configuration_handler_id, value=solution.configuration
                 ),
             ],
+            failure=solution.failure,
         )

--- a/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
+++ b/src/libecalc/process/process_solver/solvers/upstream_choke_solver.py
@@ -35,41 +35,43 @@ class UpstreamChokeSolver(Solver):
 
         assert outlet_pressure(0) > self._target_pressure
 
-        search_boundary = self._feasible_boundary(func)
-        max_pressure = outlet_pressure(search_boundary.max)
+        # Upstream choking increase the rate (lower pressure, higher volume)
+        # If we choke too much, to rate will exceed the capacity / stonewall
+        # If so, bisect to the highest ΔP that doesn't exceed stonewall
+        stonewall_error: RateTooHighError | None = None
+        try:
+            outlet_pressure(self._boundary.max)
+            search_max = self._boundary.max
+        except RateTooHighError as e:
+            stonewall_error = e
+            lo, hi = self._boundary.min, self._boundary.max
+            while hi - lo > PRESSURE_CALCULATION_TOLERANCE:
+                mid = (lo + hi) / 2
+                try:
+                    outlet_pressure(mid)
+                    lo = mid
+                except RateTooHighError as bisect_error:
+                    stonewall_error = bisect_error
+                    hi = mid
+            search_max = lo
+
+        max_pressure = outlet_pressure(search_max)
 
         if max_pressure > self._target_pressure:
+            if stonewall_error is not None:
+                return Solution.from_rate_too_high(
+                    stonewall_error,
+                    configuration=ChokeConfiguration(delta_pressure=search_max),
+                )
             return Solution.target_pressure_unreachable(
-                configuration=ChokeConfiguration(delta_pressure=search_boundary.max),
+                configuration=ChokeConfiguration(delta_pressure=search_max),
                 achievable_pressure_bara=max_pressure,
                 target_pressure_bara=self._target_pressure,
                 direction=TargetDirection.MIN_ABOVE_TARGET,
             )
 
         delta_pressure = self._root_finding_strategy.find_root(
-            boundary=search_boundary,
+            boundary=Boundary(min=self._boundary.min, max=search_max),
             func=lambda x: outlet_pressure(x) - self._target_pressure,
         )
         return Solution(success=True, configuration=ChokeConfiguration(delta_pressure=delta_pressure))
-
-    def _feasible_boundary(self, func: Callable[[ChokeConfiguration], FluidStream]) -> Boundary:
-        """Return the search boundary narrowed to the feasible region (no RateTooHighError).
-
-        Probes the upper bound first; if feasible, returns the original boundary immediately.
-        Otherwise bisects for the largest ΔP before rate capacity is exceeded.
-        """
-        try:
-            func(ChokeConfiguration(delta_pressure=self._boundary.max))
-            return self._boundary
-        except RateTooHighError:
-            pass
-
-        lo, hi = self._boundary.min, self._boundary.max
-        while hi - lo > PRESSURE_CALCULATION_TOLERANCE:
-            mid = (lo + hi) / 2
-            try:
-                func(ChokeConfiguration(delta_pressure=mid))
-                lo = mid
-            except RateTooHighError:
-                hi = mid
-        return Boundary(min=self._boundary.min, max=lo)

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
@@ -64,7 +64,6 @@ PROCESS_XFAILS: dict[tuple[str, str], str] = {
     ("R8", "INDIVIDUAL_ASV_PRESSURE"): "No zero-rate short-circuit in process solver.",
     ("R8", "COMMON_ASV"): "No zero-rate short-circuit in process solver.",
     # R9 — individual case mismatches
-    ("R9", "UPSTREAM_CHOKE"): "Upstream-choke strategy reports success for stonewall-limited over-compression.",
     ("R9", "COMMON_ASV"): "Common-ASV reports pressure-limit where legacy reports stonewall for R9.",
 }
 

--- a/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
+++ b/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
@@ -5,6 +5,7 @@ from libecalc.process.process_pipeline.process_error import RateTooHighError
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.process_pipeline_runner import propagate_stream_many
+from libecalc.process.process_solver.solver import RateTooHighFailure
 from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.upstream_choke_solver import UpstreamChokeSolver
 
@@ -77,16 +78,18 @@ def test_upstream_choke_solver_handles_rate_too_high_at_max_choke(
     assert abs(solution.configuration.delta_pressure - 70.0) < 1e-3
 
 
-def test_upstream_choke_solver_reports_failure_when_rate_capacity_prevents_reaching_target(
+def test_upstream_choke_solver_reports_rate_too_high_when_stonewall_prevents_reaching_target(
     root_finding_strategy,
     stream_factory,
 ):
-    """When RateTooHighError creates a discontinuity that prevents the outlet from reaching
-    the target, the solver must report failure rather than false success at the discontinuity boundary.
+    """When choking further would exceed rate capacity (RateTooHighError) AND the maximum
+    feasible choke still leaves outlet pressure above target, the solver must classify the
+    failure as ``RateTooHighFailure``: stonewall is the actual blocker, not an unreachable
+    pressure.
 
     Scenario: outlet = inlet - dp + 50. RateTooHighError at dp > 40 (suction < 60).
     Target = 80 requires dp = 70, which is in the infeasible region.
-    Root-finding converges at dp ≈ 40 (discontinuity boundary) where actual outlet = 110, not 80.
+    At dp = 40 (stonewall edge), outlet = 110 > target = 80 — stonewall is the blocker.
     """
     inlet_pressure = 100.0
     feasible_suction_minimum = 60.0  # RateTooHighError below this
@@ -111,9 +114,7 @@ def test_upstream_choke_solver_reports_failure_when_rate_capacity_prevents_reach
     solution = upstream_choke_solver.solve(choke_func)
 
     assert not solution.success
-    assert solution.failure is not None
-    assert solution.failure.target_pressure_bara == target_pressure
-    assert solution.failure.achievable_pressure_bara > target_pressure
+    assert isinstance(solution.failure, RateTooHighFailure)
 
 
 def test_upstream_choke_solver_reports_failure_when_max_choke_still_above_target(


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Github issue nr in the footer!

Changelog not updated: the affected code path (`UpstreamChokePressureControlStrategy`) is not yet used by any production code path, so users cannot observe this change.

## What is this PR all about?

Fixes equinor/ecalc-internal#1867.

`UpstreamChokeSolver` now returns `RateTooHighFailure` (instead of `TargetPressureUnreachable`) when the search interval was clamped by stonewall and the achievable max pressure still exceeds the target. `UpstreamChokePressureControlStrategy.apply` now forwards `solution.failure` on the outer `Solution` instead of stripping it.

The `R9 / UPSTREAM_CHOKE` xfail is removed; matrix goes 227 → 228 passed, 17 → 16 xfailed.

## What else did you consider?


## Between the lines?
