### PR TITLE
fix(libecalc): use speed-aware stonewall bounds in common-ASV evaluation

### DIFF
--- a/docs/drafts/next.draft.md
+++ b/docs/drafts/next.draft.md
@@ -16,6 +16,7 @@ STP: "flare" column has been added to STP Export - for `FIXED` installations onl
 - Hardened compressor PH flash handling so invalid thermodynamic states are no longer used in compressor outlet calculations.
 - `LiquidRemover` now scales the outlet mass rate by the gas mass fraction when liquid is dropped, so the removed liquid mass is no longer carried by the gas stream downstream.
 - Compressor stage rate fields (`inlet_actual_rate`, `mass_rate`, `standard_rate`, etc.) now report `0.0` instead of `NaN` for zero-rate timesteps, so yearly resampling no longer forward-fills stale positive values into idle periods.
+- Common-shaft compressor train under COMMON_ASV control now uses speed-aware stonewall bounds (at the locked shaft speed) instead of the chart-wide maximum rate. Previously this could mis-classify a target-pressure-unreachable case as above-max-flow and report a nonsensical power figure.
 
 ## Breaking changes
 

--- a/src/libecalc/domain/process/compressor/core/train/compressor_train_common_shaft.py
+++ b/src/libecalc/domain/process/compressor/core/train/compressor_train_common_shaft.py
@@ -954,14 +954,19 @@ class CompressorTrainCommonShaft(CompressorTrainModel):
             )
 
         # outer bounds for minimum and maximum mass rate without individual recirculation on stages will be the
-        # minimum and maximum mass rate for the first stage, adjusted for the volume entering the first stage
+        # minimum and maximum mass rate for the first stage at the current (fixed) shaft speed, adjusted for the
+        # volume entering the first stage
+        current_speed = self.shaft.get_speed()
         minimum_mass_rate = max(
             minimum_mass_rate_kg_per_hour,
-            self.stages[0].compressor.compressor_chart.minimum_rate * density_train_inlet_fluid,
+            float(self.stages[0].compressor.compressor_chart.minimum_rate_as_function_of_speed(current_speed))
+            * density_train_inlet_fluid,
         )
         # note: we subtract EPSILON to avoid floating point issues causing the maximum mass rate to exceed chart area maximum rate after round-trip conversion (mass rate -> standard rat -> mass rate)
         maximum_mass_rate = (
-            self.stages[0].compressor.compressor_chart.maximum_rate * density_train_inlet_fluid * (1 - EPSILON)
+            float(self.stages[0].compressor.compressor_chart.maximum_rate_as_function_of_speed(current_speed))
+            * density_train_inlet_fluid
+            * (1 - EPSILON)
         )
 
         # if the minimum_mass_rate_kg_per_hour(i.e. before increasing rate with recirculation to lower pressure)

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/cases.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/cases.py
@@ -229,7 +229,7 @@ EXPECTED_RESULTS: dict[tuple[str, PressureControlType], ExpectedResult] = {
     ("R9", "INDIVIDUAL_ASV_PRESSURE"): _fail(
         ExpectedOutcome.PRESSURE_TOO_LOW, 2.964, control=ExpectedControlAction.RECIRCULATION
     ),
-    ("R9", "COMMON_ASV"): _fail(ExpectedOutcome.ABOVE_MAX_FLOW, 4.456),
+    ("R9", "COMMON_ASV"): _fail(ExpectedOutcome.PRESSURE_TOO_LOW, 2.970),
 }
 
 # Fail fast if a new PressureControlType is added without test coverage.

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_legacy_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_legacy_solver.py
@@ -82,12 +82,12 @@ LEGACY_CHART_AREAS: dict[tuple[str, str], ChartAreaFlag] = {
     ("R8", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.NOT_CALCULATED,
     ("R8", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.NOT_CALCULATED,
     ("R8", "COMMON_ASV"): ChartAreaFlag.NOT_CALCULATED,
-    # R9 — internal point except UPSTREAM_CHOKE and COMMON_ASV (above max flow)
+    # R9 — internal point except UPSTREAM_CHOKE (above max flow)
     ("R9", "UPSTREAM_CHOKE"): ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE,
     ("R9", "DOWNSTREAM_CHOKE"): ChartAreaFlag.INTERNAL_POINT,
     ("R9", "INDIVIDUAL_ASV_RATE"): ChartAreaFlag.INTERNAL_POINT,
     ("R9", "INDIVIDUAL_ASV_PRESSURE"): ChartAreaFlag.INTERNAL_POINT,
-    ("R9", "COMMON_ASV"): ChartAreaFlag.ABOVE_MAXIMUM_FLOW_RATE,
+    ("R9", "COMMON_ASV"): ChartAreaFlag.INTERNAL_POINT,
 }
 
 

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
@@ -63,8 +63,6 @@ PROCESS_XFAILS: dict[tuple[str, str], str] = {
     ("R8", "INDIVIDUAL_ASV_RATE"): "No zero-rate short-circuit in process solver.",
     ("R8", "INDIVIDUAL_ASV_PRESSURE"): "No zero-rate short-circuit in process solver.",
     ("R8", "COMMON_ASV"): "No zero-rate short-circuit in process solver.",
-    # R9 — individual case mismatches
-    ("R9", "COMMON_ASV"): "Common-ASV reports pressure-limit where legacy reports stonewall for R9.",
 }
 
 


### PR DESCRIPTION
Fixes equinor/ecalc-internal#1869.

The shaft is locked at a fixed speed before `_evaluate_train_with_common_asv` runs, so stonewall bounds should come from the chart at that speed, not the chart-wide min/max.

R9/COMMON_ASV in the solver-path matrix now reports `PRESSURE_TOO_LOW @ 2.97 MW` (matching INDIVIDUAL_ASV), removing one process-solver xfail.