### PR TITLE
test: use fixture factories instead of functions directly

### DIFF
--- a/tests/libecalc/process/process_solver/conftest.py
+++ b/tests/libecalc/process/process_solver/conftest.py
@@ -2,11 +2,12 @@ from collections.abc import Sequence
 
 import pytest
 
+from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.domain.process.value_objects.chart import ChartCurve
 from libecalc.domain.process.value_objects.chart.chart import ChartData
 from libecalc.ecalc_model.process_simulation import PressureControlType
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
-from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
+from libecalc.process.process_pipeline.process_unit import ProcessUnit
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.anti_surge.common_asv import CommonASVAntiSurgeStrategy
 from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
@@ -26,7 +27,8 @@ from libecalc.process.process_solver.pressure_control.upstream_choke import Upst
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
 from libecalc.process.process_units.compressor import Compressor
-from libecalc.process.shaft import Shaft
+from libecalc.process.shaft import Shaft, VariableSpeedShaft
+from libecalc.testing.chart_data_factory import ChartDataFactory
 from libecalc.testing.no_asv import NoASVAntiSurgeStrategy
 from tests.libecalc.process.helpers import ProcessSolverBuilder, ProcessSolverSystem, StageConfig
 
@@ -210,7 +212,7 @@ def individual_asv_pressure_control_strategy_factory(root_finding_strategy):
 def upstream_choke_pressure_control_strategy_factory(root_finding_strategy):
     def create(
         runner: ProcessRunner,
-        choke_id: ProcessUnitId,
+        choke_id: ConfigurationHandlerId,
         anti_surge_strategy: AntiSurgeStrategy | None = None,
     ) -> UpstreamChokePressureControlStrategy:
         return UpstreamChokePressureControlStrategy(
@@ -227,7 +229,7 @@ def upstream_choke_pressure_control_strategy_factory(root_finding_strategy):
 def downstream_choke_pressure_control_strategy_factory():
     def create(
         runner: ProcessRunner,
-        choke_id: ProcessUnitId,
+        choke_id: ConfigurationHandlerId,
     ) -> DownstreamChokePressureControlStrategy:
         return DownstreamChokePressureControlStrategy(
             simulator=runner,
@@ -269,3 +271,95 @@ def variable_speed_chart_data_factory():
         )
 
     return create_variable_speed_chart_data
+
+
+@pytest.fixture
+def affinity_law_scaled_variable_speed_chart_data_factory():
+    def create_variable_speed_chart(
+        min_rate: float, max_rate: float, head_hi: float, head_lo: float, eff: float = 0.75
+    ):
+        """Five affinity-law-scaled speed curves (60–100 rpm)."""
+        curves = []
+        for n in [60.0, 70.0, 80.0, 90.0, 100.0]:
+            f = n / 100.0
+            curves.append(
+                ChartCurve(
+                    speed_rpm=n,
+                    rate_actual_m3_hour=[min_rate * f, max_rate * f],
+                    polytropic_head_joule_per_kg=[head_hi * f**2, head_lo * f**2],
+                    efficiency_fraction=[eff, eff],
+                )
+            )
+        return ChartDataFactory.from_curves(curves, control_margin=0.0)
+
+    return create_variable_speed_chart
+
+
+@pytest.fixture()
+def single_compressor_process_pipeline_factory(
+    affinity_law_scaled_variable_speed_chart_data_factory,
+    outlet_pressure_solver_factory,
+    compressor_factory,
+    recirculation_loop_factory,
+    process_runner_factory,
+    temperature_setter_factory,
+    direct_mixer_factory,
+    direct_splitter_factory,
+    individual_asv_anti_surge_strategy_factory,
+    individual_asv_pressure_control_strategy_factory,
+):
+    def create_process_pipeline(
+        *,
+        min_rate: float,
+        max_rate: float,
+        head_hi: float,
+        head_lo: float,
+        inlet_temperature_kelvin: float,
+    ) -> OutletPressureSolver:
+        """One independently-shafted process pipeline: TemperatureSetter → Compressor with individual ASV."""
+        chart_data = affinity_law_scaled_variable_speed_chart_data_factory(min_rate, max_rate, head_hi, head_lo)
+
+        compressor = compressor_factory(
+            chart_data=chart_data,
+        )
+
+        shaft = VariableSpeedShaft()
+        shaft.connect(compressor)
+
+        mixer = direct_mixer_factory()
+        splitter = direct_splitter_factory()
+        loop = recirculation_loop_factory(
+            mixer=mixer,
+            splitter=splitter,
+        )
+
+        runner = process_runner_factory(
+            configuration_handlers=[shaft, loop],
+            units=[
+                temperature_setter_factory(required_temperature_kelvin=inlet_temperature_kelvin),
+                mixer,
+                compressor,
+                splitter,
+            ],
+        )
+
+        anti_surge = individual_asv_anti_surge_strategy_factory(
+            recirculation_loop_ids=[loop.get_id()],
+            compressors=[compressor],
+            runner=runner,
+        )
+        pressure_control = individual_asv_pressure_control_strategy_factory(
+            runner=runner,
+            recirculation_loop_ids=[loop.get_id()],
+            compressors=[compressor],
+        )
+
+        return outlet_pressure_solver_factory(
+            process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
+            runner=runner,
+            anti_surge_strategy=anti_surge,
+            pressure_control_strategy=pressure_control,
+            shaft=shaft,
+        )
+
+    return create_process_pipeline

--- a/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
@@ -3,13 +3,39 @@ import pytest
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl, InterstagePressureControl
 from libecalc.domain.process.compressor.core.train.compressor_train_common_shaft import CompressorTrainCommonShaft
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
+from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
+from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_pressure_solver import MultiPressureSolver
 from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
+from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.solver import TargetPressureUnreachableFailure
 from libecalc.process.process_units.mixer import Mixer
 from libecalc.process.process_units.splitter import Splitter
-from libecalc.process.shaft import VariableSpeedShaft
+from libecalc.process.shaft import Shaft, VariableSpeedShaft
+
+
+@pytest.fixture
+def segment_factory(root_finding_strategy):
+    def create_segment(
+        runner: ProcessRunner,
+        anti_surge_strategy: AntiSurgeStrategy,
+        pressure_control_strategy: PressureControlStrategy,
+        process_pipeline_id: ProcessPipelineId,
+        shaft: Shaft,
+    ):
+        return OutletPressureSolver(
+            process_pipeline_id=process_pipeline_id,
+            anti_surge_strategy=anti_surge_strategy,
+            shaft_id=shaft.get_id(),
+            speed_boundary=shaft.get_speed_boundary(),
+            pressure_control_strategy=pressure_control_strategy,
+            runner=runner,
+            root_finding_strategy=root_finding_strategy,
+        )
+
+    return create_segment
 
 
 @pytest.mark.parametrize("pd_target", [92.0, 150.0])
@@ -27,8 +53,8 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
     individual_asv_rate_control_strategy_factory,
     multi_pressure_solver_factory,
     compressor_stage_factory,
-    root_finding_strategy,
     variable_speed_chart_data_factory,
+    segment_factory,
 ):
     temperature = 300.0
     interstage_pressure_target = 60.0  # bara
@@ -124,9 +150,7 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
     )
     high_pressure_process_pipeline = process_pipeline_factory(units=[splitter, *high_pressure_units_wrapped])
 
-    speed_boundary = shaft_new.get_speed_boundary()
-    low_pressure_segment = OutletPressureSolver(
-        shaft_id=shaft_new.get_id(),
+    low_pressure_segment = segment_factory(
         runner=low_pressure_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=low_pressure_runner,
@@ -138,12 +162,10 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
             recirculation_loop_ids=low_pressure_loop_ids,
             compressors=low_pressure_compressors,
         ),
-        root_finding_strategy=root_finding_strategy,
-        speed_boundary=speed_boundary,
+        shaft=shaft_new,
         process_pipeline_id=low_pressure_process_pipeline.get_id(),
     )
-    high_pressure_segment = OutletPressureSolver(
-        shaft_id=shaft_new.get_id(),
+    high_pressure_segment = segment_factory(
         runner=high_pressure_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=high_pressure_runner,
@@ -155,8 +177,7 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
             recirculation_loop_ids=high_pressure_loop_ids,
             compressors=high_pressure_compressors,
         ),
-        root_finding_strategy=root_finding_strategy,
-        speed_boundary=speed_boundary,
+        shaft=shaft_new,
         process_pipeline_id=high_pressure_process_pipeline.get_id(),
     )
 
@@ -196,8 +217,8 @@ def test_three_stage_train_with_mixers_and_splitters_at_interstage(
     individual_asv_anti_surge_strategy_factory,
     individual_asv_rate_control_strategy_factory,
     multi_pressure_solver_factory,
-    root_finding_strategy,
     variable_speed_chart_data_factory,
+    segment_factory,
 ):
     """LP → [Mixer1, Mixer2] → MP → [Splitter1, Splitter2] → HP, with interstage pressures at both junctions."""
     temperature = 300.0
@@ -290,11 +311,9 @@ def test_three_stage_train_with_mixers_and_splitters_at_interstage(
     mixer1.set_stream(injection_stream)
     mixer2.set_stream(injection_stream)
 
-    speed_boundary = shaft.get_speed_boundary()
-
     def make_segment(runner, loop_ids, compressors, process_pipeline):
-        return OutletPressureSolver(
-            shaft_id=shaft.get_id(),
+        return segment_factory(
+            shaft=shaft,
             runner=runner,
             anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
                 runner=runner,
@@ -306,8 +325,6 @@ def test_three_stage_train_with_mixers_and_splitters_at_interstage(
                 recirculation_loop_ids=loop_ids,
                 compressors=compressors,
             ),
-            root_finding_strategy=root_finding_strategy,
-            speed_boundary=speed_boundary,
             process_pipeline_id=process_pipeline.get_id(),
         )
 
@@ -359,6 +376,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
     individual_asv_rate_control_strategy_factory,
     root_finding_strategy,
     variable_speed_chart_data_factory,
+    segment_factory,
 ):
     """TargetPressureUnreachableFailure.source_id should identify the second segment when it fails."""
 
@@ -393,10 +411,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
     hp_runner = process_runner_factory(units=hp_units, configuration_handlers=[shaft, *hp_loops])
     hp_process_pipeline = process_pipeline_factory(units=hp_units)
 
-    speed_boundary = shaft.get_speed_boundary()
-
-    lp_segment = OutletPressureSolver(
-        shaft_id=shaft.get_id(),
+    lp_segment = segment_factory(
         runner=lp_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=lp_runner, recirculation_loop_ids=lp_loop_ids, compressors=lp_compressors
@@ -404,12 +419,10 @@ def test_target_not_achievable_event_identifies_failing_segment(
         pressure_control_strategy=individual_asv_rate_control_strategy_factory(
             runner=lp_runner, recirculation_loop_ids=lp_loop_ids, compressors=lp_compressors
         ),
-        root_finding_strategy=root_finding_strategy,
-        speed_boundary=speed_boundary,
+        shaft=shaft,
         process_pipeline_id=lp_process_pipeline.get_id(),
     )
-    hp_segment = OutletPressureSolver(
-        shaft_id=shaft.get_id(),
+    hp_segment = segment_factory(
         runner=hp_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=hp_runner, recirculation_loop_ids=hp_loop_ids, compressors=hp_compressors
@@ -417,8 +430,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
         pressure_control_strategy=individual_asv_rate_control_strategy_factory(
             runner=hp_runner, recirculation_loop_ids=hp_loop_ids, compressors=hp_compressors
         ),
-        root_finding_strategy=root_finding_strategy,
-        speed_boundary=speed_boundary,
+        shaft=shaft,
         process_pipeline_id=hp_process_pipeline.get_id(),
     )
 
@@ -450,6 +462,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
     individual_asv_rate_control_strategy_factory,
     root_finding_strategy,
     variable_speed_chart_data_factory,
+    segment_factory,
 ):
     """TargetPressureUnreachableFailure.source_id should identify the first segment when it fails."""
     temperature = 300.0
@@ -483,10 +496,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
     hp_runner = process_runner_factory(units=hp_units, configuration_handlers=[shaft, *hp_loops])
     hp_process_pipeline = process_pipeline_factory(units=hp_units)
 
-    speed_boundary = shaft.get_speed_boundary()
-
-    lp_segment = OutletPressureSolver(
-        shaft_id=shaft.get_id(),
+    lp_segment = segment_factory(
         runner=lp_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=lp_runner, recirculation_loop_ids=lp_loop_ids, compressors=lp_compressors
@@ -494,12 +504,10 @@ def test_target_not_achievable_event_when_first_segment_fails(
         pressure_control_strategy=individual_asv_rate_control_strategy_factory(
             runner=lp_runner, recirculation_loop_ids=lp_loop_ids, compressors=lp_compressors
         ),
-        root_finding_strategy=root_finding_strategy,
-        speed_boundary=speed_boundary,
+        shaft=shaft,
         process_pipeline_id=lp_process_pipeline.get_id(),
     )
-    hp_segment = OutletPressureSolver(
-        shaft_id=shaft.get_id(),
+    hp_segment = segment_factory(
         runner=hp_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=hp_runner, recirculation_loop_ids=hp_loop_ids, compressors=hp_compressors
@@ -507,8 +515,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
         pressure_control_strategy=individual_asv_rate_control_strategy_factory(
             runner=hp_runner, recirculation_loop_ids=hp_loop_ids, compressors=hp_compressors
         ),
-        root_finding_strategy=root_finding_strategy,
-        speed_boundary=speed_boundary,
+        shaft=shaft,
         process_pipeline_id=hp_process_pipeline.get_id(),
     )
 

--- a/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
@@ -2,121 +2,27 @@
 
 import pytest
 
-from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
-from libecalc.domain.process.value_objects.chart import ChartCurve
-from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
-from libecalc.process.process_pipeline.process_unit import ProcessUnitId
-from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
-from libecalc.process.process_solver.configuration import ConfigurationHandlerId, SpeedConfiguration
+from libecalc.process.process_solver.configuration import SpeedConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_shaft_equal_ratio_solver import MultiShaftEqualRatioSolver
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
-from libecalc.process.process_solver.pressure_control.individual_asv import IndividualASVPressureControlStrategy
-from libecalc.process.process_solver.process_pipeline_runner import ProcessPipelineRunner
-from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
-from libecalc.process.process_units.compressor import Compressor
-from libecalc.process.process_units.direct_mixer import DirectMixer
-from libecalc.process.process_units.direct_splitter import DirectSplitter
-from libecalc.process.process_units.temperature_setter import TemperatureSetter
-from libecalc.process.shaft import VariableSpeedShaft
-from libecalc.testing.chart_data_factory import ChartDataFactory
-
-
-def make_variable_speed_chart(min_rate: float, max_rate: float, head_hi: float, head_lo: float, eff: float = 0.75):
-    """Five affinity-law-scaled speed curves (60–100 rpm)."""
-    curves = []
-    for n in [60.0, 70.0, 80.0, 90.0, 100.0]:
-        f = n / 100.0
-        curves.append(
-            ChartCurve(
-                speed_rpm=n,
-                rate_actual_m3_hour=[min_rate * f, max_rate * f],
-                polytropic_head_joule_per_kg=[head_hi * f**2, head_lo * f**2],
-                efficiency_fraction=[eff, eff],
-            )
-        )
-    return ChartDataFactory.from_curves(curves, control_margin=0.0)
-
-
-def make_process_pipeline(
-    *,
-    min_rate: float,
-    max_rate: float,
-    head_hi: float,
-    head_lo: float,
-    inlet_temperature_kelvin: float,
-    fluid_service,
-    root_finding_strategy,
-) -> OutletPressureSolver:
-    """One independently-shafted process pipeline: TemperatureSetter → Compressor with individual ASV."""
-    chart_data = make_variable_speed_chart(min_rate, max_rate, head_hi, head_lo)
-
-    compressor = Compressor(
-        compressor_chart=chart_data,
-        fluid_service=fluid_service,
-        process_unit_id=ProcessUnitId(ecalc_id_generator()),
-    )
-
-    shaft = VariableSpeedShaft(configuration_handler_id=ConfigurationHandlerId(ecalc_id_generator()))
-    shaft.connect(compressor)
-
-    mixer = DirectMixer()
-    splitter = DirectSplitter()
-    loop = RecirculationLoop(
-        mixer=mixer,
-        splitter=splitter,
-        configuration_handler_id=ConfigurationHandlerId(ecalc_id_generator()),
-    )
-
-    runner = ProcessPipelineRunner(
-        configuration_handlers=[shaft, loop],
-        units=[
-            TemperatureSetter(required_temperature_kelvin=inlet_temperature_kelvin, fluid_service=fluid_service),
-            mixer,
-            compressor,
-            splitter,
-        ],
-    )
-
-    anti_surge = IndividualASVAntiSurgeStrategy(
-        recirculation_loop_ids=[loop.get_id()],
-        compressors=[compressor],
-        simulator=runner,
-    )
-    pressure_control = IndividualASVPressureControlStrategy(
-        simulator=runner,
-        recirculation_loop_ids=[loop.get_id()],
-        compressors=[compressor],
-        root_finding_strategy=root_finding_strategy,
-    )
-
-    return OutletPressureSolver(
-        shaft_id=shaft.get_id(),
-        process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
-        runner=runner,
-        anti_surge_strategy=anti_surge,
-        pressure_control_strategy=pressure_control,
-        root_finding_strategy=root_finding_strategy,
-        speed_boundary=shaft.get_speed_boundary(),
-    )
 
 
 @pytest.fixture
-def pipeline_kwargs(fluid_service, root_finding_strategy):
+def pipeline_kwargs():
     return {
         "head_hi": 200_000,
         "head_lo": 140_000,
         "inlet_temperature_kelvin": 303.15,
-        "fluid_service": fluid_service,
-        "root_finding_strategy": root_finding_strategy,
     }
 
 
-def test_three_shaft_train_hits_target_pressure(stream_factory, pipeline_kwargs):
+def test_three_shaft_train_hits_target_pressure(
+    stream_factory, pipeline_kwargs, single_compressor_process_pipeline_factory
+):
     pipelines = [
-        make_process_pipeline(min_rate=200, max_rate=5000, **pipeline_kwargs),
-        make_process_pipeline(min_rate=150, max_rate=3500, **pipeline_kwargs),
-        make_process_pipeline(min_rate=100, max_rate=2500, **pipeline_kwargs),
+        single_compressor_process_pipeline_factory(min_rate=200, max_rate=5000, **pipeline_kwargs),
+        single_compressor_process_pipeline_factory(min_rate=150, max_rate=3500, **pipeline_kwargs),
+        single_compressor_process_pipeline_factory(min_rate=100, max_rate=2500, **pipeline_kwargs),
     ]
     solver = MultiShaftEqualRatioSolver(process_pipelines=pipelines)
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
@@ -126,12 +32,14 @@ def test_three_shaft_train_hits_target_pressure(stream_factory, pipeline_kwargs)
     assert solution.success, f"Expected success; failure: {solution.failure}"
 
 
-def test_each_shaft_runs_at_different_speed(stream_factory, pipeline_kwargs):
+def test_each_shaft_runs_at_different_speed(
+    stream_factory, pipeline_kwargs, single_compressor_process_pipeline_factory
+):
     """Real-gas effects cause each pipeline to need a different shaft speed."""
     pipelines = [
-        make_process_pipeline(min_rate=200, max_rate=5000, **pipeline_kwargs),
-        make_process_pipeline(min_rate=150, max_rate=3500, **pipeline_kwargs),
-        make_process_pipeline(min_rate=100, max_rate=2500, **pipeline_kwargs),
+        single_compressor_process_pipeline_factory(min_rate=200, max_rate=5000, **pipeline_kwargs),
+        single_compressor_process_pipeline_factory(min_rate=150, max_rate=3500, **pipeline_kwargs),
+        single_compressor_process_pipeline_factory(min_rate=100, max_rate=2500, **pipeline_kwargs),
     ]
     solver = MultiShaftEqualRatioSolver(process_pipelines=pipelines)
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
@@ -143,19 +51,19 @@ def test_each_shaft_runs_at_different_speed(stream_factory, pipeline_kwargs):
     assert len(set(speeds)) == 3, f"expected three distinct speeds, got {speeds}"
 
 
-def test_intercooler_changes_stage_speed(stream_factory, fluid_service, root_finding_strategy):
+def test_intercooler_changes_stage_speed(
+    stream_factory, fluid_service, root_finding_strategy, single_compressor_process_pipeline_factory
+):
     """Warmer inlet temperature changes the required shaft speed."""
     common = {
         "min_rate": 200,
         "max_rate": 5000,
         "head_hi": 200_000,
         "head_lo": 140_000,
-        "fluid_service": fluid_service,
-        "root_finding_strategy": root_finding_strategy,
     }
 
-    cool = [make_process_pipeline(**common, inlet_temperature_kelvin=303.15) for _ in range(3)]
-    warm = [make_process_pipeline(**common, inlet_temperature_kelvin=360.0) for _ in range(3)]
+    cool = [single_compressor_process_pipeline_factory(**common, inlet_temperature_kelvin=303.15) for _ in range(3)]
+    warm = [single_compressor_process_pipeline_factory(**common, inlet_temperature_kelvin=360.0) for _ in range(3)]
 
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
     constraint = FloatConstraint(270.0, abs_tol=5.0)
@@ -183,9 +91,9 @@ def test_empty_pipelines(stream_factory):
     assert solution.failure is None
 
 
-def test_single_pipeline_hits_exact_target(stream_factory, pipeline_kwargs):
+def test_single_pipeline_hits_exact_target(stream_factory, pipeline_kwargs, single_compressor_process_pipeline_factory):
     """With one pipeline the target is the exact constraint (no intermediate splitting)."""
-    pipeline = make_process_pipeline(min_rate=200, max_rate=5000, **pipeline_kwargs)
+    pipeline = single_compressor_process_pipeline_factory(min_rate=200, max_rate=5000, **pipeline_kwargs)
     solver = MultiShaftEqualRatioSolver(process_pipelines=[pipeline])
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
@@ -197,11 +105,13 @@ def test_single_pipeline_hits_exact_target(stream_factory, pipeline_kwargs):
     assert outlet.pressure_bara == pytest.approx(60.0, abs=0.5)
 
 
-def test_two_pipeline_intermediate_target_is_geometric_mean(stream_factory, pipeline_kwargs):
+def test_two_pipeline_intermediate_target_is_geometric_mean(
+    stream_factory, pipeline_kwargs, single_compressor_process_pipeline_factory
+):
     """With two pipelines the intermediate target should be sqrt(P_in * P_out)."""
     pipelines = [
-        make_process_pipeline(min_rate=200, max_rate=5000, **pipeline_kwargs),
-        make_process_pipeline(min_rate=150, max_rate=3500, **pipeline_kwargs),
+        single_compressor_process_pipeline_factory(min_rate=200, max_rate=5000, **pipeline_kwargs),
+        single_compressor_process_pipeline_factory(min_rate=150, max_rate=3500, **pipeline_kwargs),
     ]
     solver = MultiShaftEqualRatioSolver(process_pipelines=pipelines)
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)

--- a/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
@@ -4,19 +4,16 @@ import pytest
 
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_shaft_solver import MultiShaftSolver
-from tests.libecalc.process.process_solver.test_multi_shaft_equal_ratio_solver import make_process_pipeline
 
 
-def test_mismatched_targets_raises(stream_factory, fluid_service, root_finding_strategy):
+def test_mismatched_targets_raises(single_compressor_process_pipeline_factory, stream_factory):
     pipelines = [
-        make_process_pipeline(
+        single_compressor_process_pipeline_factory(
             min_rate=200,
             max_rate=5000,
             head_hi=200_000,
             head_lo=140_000,
             inlet_temperature_kelvin=303.15,
-            fluid_service=fluid_service,
-            root_finding_strategy=root_finding_strategy,
         )
     ]
     solver = MultiShaftSolver(process_pipelines=pipelines)
@@ -37,17 +34,15 @@ def test_empty_pipelines(stream_factory):
     assert solution.failure is None
 
 
-def test_unreachable_target_reports_failure(stream_factory, fluid_service, root_finding_strategy):
+def test_unreachable_target_reports_failure(single_compressor_process_pipeline_factory, stream_factory):
     """A target far beyond the chart capability should return success=False."""
     pipelines = [
-        make_process_pipeline(
+        single_compressor_process_pipeline_factory(
             min_rate=200,
             max_rate=5000,
             head_hi=200_000,
             head_lo=140_000,
             inlet_temperature_kelvin=303.15,
-            fluid_service=fluid_service,
-            root_finding_strategy=root_finding_strategy,
         )
     ]
     solver = MultiShaftSolver(process_pipelines=pipelines)
@@ -60,26 +55,22 @@ def test_unreachable_target_reports_failure(stream_factory, fluid_service, root_
     assert solution.failure is not None
 
 
-def test_second_pipeline_failure_preserves_first_failure(stream_factory, fluid_service, root_finding_strategy):
+def test_second_pipeline_failure_preserves_first_failure(single_compressor_process_pipeline_factory, stream_factory):
     """When multiple pipelines fail, the first failure is preserved."""
     pipelines = [
-        make_process_pipeline(
+        single_compressor_process_pipeline_factory(
             min_rate=200,
             max_rate=5000,
             head_hi=200_000,
             head_lo=140_000,
             inlet_temperature_kelvin=303.15,
-            fluid_service=fluid_service,
-            root_finding_strategy=root_finding_strategy,
         ),
-        make_process_pipeline(
+        single_compressor_process_pipeline_factory(
             min_rate=200,
             max_rate=5000,
             head_hi=200_000,
             head_lo=140_000,
             inlet_temperature_kelvin=303.15,
-            fluid_service=fluid_service,
-            root_finding_strategy=root_finding_strategy,
         ),
     ]
     solver = MultiShaftSolver(process_pipelines=pipelines)

--- a/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
@@ -9,10 +9,6 @@ from libecalc.domain.process.compressor.core.train.simplified_train.simplified_t
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_shaft_equal_ratio_solver import MultiShaftEqualRatioSolver
-from tests.libecalc.process.process_solver.test_multi_shaft_equal_ratio_solver import (
-    make_process_pipeline,
-    make_variable_speed_chart,
-)
 
 _RATE_SM3_DAY = 1_500_000.0
 _P_IN_BARA = 30.0
@@ -27,13 +23,14 @@ _MAX_RATE = 5_000.0
 
 def test_multi_shaft_outlet_pressure_matches_simplified_train(
     stream_factory,
-    fluid_service,
-    root_finding_strategy,
     compressor_stage_factory,
+    fluid_service,
+    affinity_law_scaled_variable_speed_chart_data_factory,
+    single_compressor_process_pipeline_factory,
 ):
     """Outlet pressure should match within 1% relative tolerance."""
     # Legacy: CompressorTrainSimplified
-    chart_data = make_variable_speed_chart(_MIN_RATE, _MAX_RATE, _HEAD_HI, _HEAD_LO)
+    chart_data = affinity_law_scaled_variable_speed_chart_data_factory(_MIN_RATE, _MAX_RATE, _HEAD_HI, _HEAD_LO)
     legacy_stages = [
         compressor_stage_factory(compressor_chart_data=chart_data, inlet_temperature_kelvin=_T_IN_KELVIN)
         for _ in range(_N_STAGES)
@@ -56,14 +53,12 @@ def test_multi_shaft_outlet_pressure_matches_simplified_train(
 
     # New: MultiShaftEqualRatioSolver
     solver_pipelines = [
-        make_process_pipeline(
+        single_compressor_process_pipeline_factory(
             min_rate=_MIN_RATE,
             max_rate=_MAX_RATE,
             head_hi=_HEAD_HI,
             head_lo=_HEAD_LO,
             inlet_temperature_kelvin=_T_IN_KELVIN,
-            fluid_service=fluid_service,
-            root_finding_strategy=root_finding_strategy,
         )
         for _ in range(_N_STAGES)
     ]

--- a/tests/libecalc/process/process_solver/test_process_solver_builder.py
+++ b/tests/libecalc/process/process_solver/test_process_solver_builder.py
@@ -113,11 +113,6 @@ def test_builder_wires_expected_solver_strategies(
         pressure_control_type=pressure_control_type,
         fluid_service=fluid_service,
     ).build()
-    expected_anti_surge_strategy_type = (
-        CommonASVAntiSurgeStrategy if pressure_control_type == "COMMON_ASV" else IndividualASVAntiSurgeStrategy
-    )
-
-    assert isinstance(system.solver.anti_surge_strategy, expected_anti_surge_strategy_type)
     assert isinstance(system.solver.pressure_control_strategy, PRESSURE_CONTROL_STRATEGY_TYPES[pressure_control_type])
 
 


### PR DESCRIPTION
This gives us access to the fixture context without passing it in to the
functions
