### PR TITLE
test: add tests for process simulation mapper using yaml builders

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -361,16 +361,6 @@ class ProcessSimulationMapper:
                             f"in a process pipeline. Allowed types are: {', '.join(allowed_types)}."
                         )
 
-            # Trailing units (units after the last compressor) are not supported: each segment
-            # must end with a compressor so it can be wrapped in an ASV recirculation loop.
-            # Units placed after the last compressor would otherwise be silently dropped from
-            # the simulated pipeline.
-            if current_segment_unit_ids:
-                raise EcalcValidationException(
-                    f"Process pipeline '{item.name}' has {len(current_segment_unit_ids)} unit(s) "
-                    f"after the last compressor. Each compressor segment must end with a compressor."
-                )
-
             for compressor_id in compressor_ids:
                 compressor = process_unit_map[compressor_id]
                 assert isinstance(compressor, Compressor)
@@ -393,6 +383,10 @@ class ProcessSimulationMapper:
                     recirculation_loop, stage_process_units = with_asv(units=segment_units)
                     problem_configuration_handlers.append(recirculation_loop)
                     process_units.extend(stage_process_units)
+
+                # Trailing units after last compressor — outside any ASV loop
+                if current_segment_unit_ids:
+                    process_units.extend([process_unit_map[uid] for uid in current_segment_unit_ids])
 
             if pressure_control == "DOWNSTREAM_CHOKE":
                 choke, choke_configuration_handler = choke_factory(fluid_service=self._fluid_service)

--- a/src/libecalc/testing/direct_reference_service.py
+++ b/src/libecalc/testing/direct_reference_service.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+from libecalc.dto import FuelType
+from libecalc.presentation.yaml.domain.reference_service import ReferenceService, YamlCompressorModel
+from libecalc.presentation.yaml.mappers.yaml_path import YamlPath
+from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import (
+    YamlGeneratorSetModel,
+    YamlPumpChartSingleSpeed,
+    YamlPumpChartVariableSpeed,
+    YamlTabularModel,
+)
+from libecalc.presentation.yaml.yaml_types.models import YamlCompressorChart, YamlFluidModel, YamlTurbine
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
+from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
+
+
+class DirectReferenceService(ReferenceService):
+    def __init__(self, references: dict[str, Any]):
+        self._references = references
+
+    def _resolve_reference(self, reference: str) -> Any:
+        return self._references[reference]
+
+    def get_yaml_path(self, reference: str) -> YamlPath:
+        raise NotImplementedError()
+
+    def get_fluid(self, reference: str) -> YamlFluidModel:
+        raise NotImplementedError()
+
+    def get_turbine(self, reference: str) -> YamlTurbine:
+        raise NotImplementedError()
+
+    def get_compressor_chart(self, reference: str) -> YamlCompressorChart:
+        return self._resolve_reference(reference)
+
+    def get_fuel_reference(self, reference: str) -> FuelType:
+        raise NotImplementedError()
+
+    def get_generator_set_model(self, reference: str) -> YamlGeneratorSetModel:
+        raise NotImplementedError()
+
+    def get_compressor_model(self, reference: str) -> YamlCompressorModel:
+        raise NotImplementedError()
+
+    def get_pump_model(self, reference: str) -> YamlPumpChartSingleSpeed | YamlPumpChartVariableSpeed:
+        raise NotImplementedError()
+
+    def get_tabulated_model(self, reference: str) -> YamlTabularModel:
+        raise NotImplementedError()
+
+    def get_process_pipeline(self, reference: str) -> YamlProcessPipeline:
+        raise NotImplementedError()
+
+    def get_process_unit(self, reference: str) -> YamlProcessUnit:
+        raise NotImplementedError()
+
+    def get_stream(self, reference: str) -> YamlInletStream:
+        raise NotImplementedError()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -648,7 +648,6 @@ def patch_uuid():
 def process_simulation_mapper(
     fluid_service,
     expression_evaluator_factory,
-    with_neqsim_service,
 ):
     """
     Minimal ProcessSimulationMapper for testing.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -579,7 +579,7 @@ def fluid_model_dry(fluid_model_factory, fluid_composition_factory) -> FluidMode
 
 
 @pytest.fixture(scope="session")
-def fluid_service(with_neqsim_service):
+def fluid_service():
     """Session-scoped fluid service singleton for all tests.
 
     This fixture provides the same NeqSimFluidService.instance() singleton

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -648,6 +648,7 @@ def patch_uuid():
 def process_simulation_mapper(
     fluid_service,
     expression_evaluator_factory,
+    with_neqsim_service,
 ):
     """
     Minimal ProcessSimulationMapper for testing.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ from libecalc.presentation.yaml.domain.expression_time_series_pressure import Ex
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 from libecalc.presentation.yaml.domain.time_series_resource import TimeSeriesResource
 from libecalc.presentation.yaml.mappers.fluid_mapper import DRY_MW_18P3, MEDIUM_MW_19P4, RICH_MW_21P4
+from libecalc.presentation.yaml.mappers.process_simulation_mapper import ProcessSimulationMapper
 from libecalc.presentation.yaml.model import YamlModel
 from libecalc.presentation.yaml.resource_service import ResourceService, TupleWithError
 from libecalc.presentation.yaml.yaml_entities import MemoryResource, ResourceStream
@@ -47,6 +48,7 @@ from libecalc.testing.yaml_builder import (
     YamlInstallationBuilder,
     YamlTimeSeriesBuilder,
 )
+from tests.libecalc.input.mappers.test_model_mapper import DirectReferenceService
 
 # Attribute name for storing cache stats in pytest config
 _CACHE_STATS_ATTR = "ecalc_cache_stats"
@@ -640,3 +642,25 @@ def patch_uuid():
     # Patch the uuid.uuid4 function to return values from the list sequentially
     with patch("uuid.uuid4", side_effect=fixed_uuids):
         yield
+
+
+@pytest.fixture
+def process_simulation_mapper(
+    fluid_service,
+    expression_evaluator_factory,
+):
+    """
+    Minimal ProcessSimulationMapper for testing.
+    """
+    period = Period(start=datetime(2020, 1, 1), end=datetime(2030, 1, 1))
+
+    expression_evaluator = expression_evaluator_factory.from_periods(periods=[period])
+    reference_service = DirectReferenceService(references={})
+
+    return ProcessSimulationMapper(
+        expression_evaluator=expression_evaluator,
+        fluid_service=fluid_service,
+        reference_service=reference_service,
+        process_simulation_period=period,
+        resources={},
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -579,7 +579,7 @@ def fluid_model_dry(fluid_model_factory, fluid_composition_factory) -> FluidMode
 
 
 @pytest.fixture(scope="session")
-def fluid_service():
+def fluid_service(with_neqsim_service):
     """Session-scoped fluid service singleton for all tests.
 
     This fixture provides the same NeqSimFluidService.instance() singleton

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ from libecalc.presentation.yaml.yaml_models.yaml_model import ReaderType, YamlCo
 from libecalc.presentation.yaml.yaml_types.components.yaml_asset import YamlAsset
 from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
 from libecalc.process.fluid_stream.fluid_service import FluidService
+from libecalc.testing.direct_reference_service import DirectReferenceService
 from libecalc.testing.yaml_builder import (
     YamlAssetBuilder,
     YamlElectricityConsumerBuilder,
@@ -48,7 +49,6 @@ from libecalc.testing.yaml_builder import (
     YamlInstallationBuilder,
     YamlTimeSeriesBuilder,
 )
-from tests.libecalc.input.mappers.test_model_mapper import DirectReferenceService
 
 # Attribute name for storing cache stats in pytest config
 _CACHE_STATS_ATTR = "ecalc_cache_stats"

--- a/tests/ecalc_neqsim_wrapper/conftest.py
+++ b/tests/ecalc_neqsim_wrapper/conftest.py
@@ -66,3 +66,15 @@ def heavy_fluid_with_water() -> NeqsimFluid:
     composition = HEAVY_FLUID_COMPOSITION.model_copy()
     composition["water"] = 0.15
     return NeqsimFluid.create_thermo_system(composition=composition)
+
+
+@pytest.fixture(scope="session")
+def fluid_service():
+    """Override of root fluid_service for ecalc_neqsim_wrapper tests.
+
+    Cannot depend on with_neqsim_service because the local function-scoped
+    version overrides the session-scoped one for tests in this directory.
+    """
+    from ecalc_neqsim_wrapper.fluid_service import NeqSimFluidService
+
+    return NeqSimFluidService.instance()

--- a/tests/ecalc_neqsim_wrapper/conftest.py
+++ b/tests/ecalc_neqsim_wrapper/conftest.py
@@ -66,15 +66,3 @@ def heavy_fluid_with_water() -> NeqsimFluid:
     composition = HEAVY_FLUID_COMPOSITION.model_copy()
     composition["water"] = 0.15
     return NeqsimFluid.create_thermo_system(composition=composition)
-
-
-@pytest.fixture(scope="session")
-def fluid_service():
-    """Override of root fluid_service for ecalc_neqsim_wrapper tests.
-
-    Cannot depend on with_neqsim_service because the local function-scoped
-    version overrides the session-scoped one for tests in this directory.
-    """
-    from ecalc_neqsim_wrapper.fluid_service import NeqSimFluidService
-
-    return NeqSimFluidService.instance()

--- a/tests/ecalc_neqsim_wrapper/unit_tests/test_java_service.py
+++ b/tests/ecalc_neqsim_wrapper/unit_tests/test_java_service.py
@@ -138,7 +138,9 @@ class TestPy4JShutdownOnExit:
         ):
             service.shutdown()
         NeqsimService.reset_py4j_config()
-        # Debug/check: re-initialize for subsequent tests in the same process
+        # Re-initialize NeqSim for subsequent tests in the same shard.
+        # These tests shut down the global service intentionally; without this
+        # re-init, later tests fail with "not initialized".
         NeqsimService.factory(use_jpype=False).initialize()
 
     def test_shutdown_on_exit_false_config(self):

--- a/tests/ecalc_neqsim_wrapper/unit_tests/test_java_service.py
+++ b/tests/ecalc_neqsim_wrapper/unit_tests/test_java_service.py
@@ -138,9 +138,7 @@ class TestPy4JShutdownOnExit:
         ):
             service.shutdown()
         NeqsimService.reset_py4j_config()
-        # Re-initialize NeqSim for subsequent tests in the same shard.
-        # These tests shut down the global service intentionally; without this
-        # re-init, later tests fail with "not initialized".
+        # Re-initialize NeqSim for subsequent tests.
         NeqsimService.factory(use_jpype=False).initialize()
 
     def test_shutdown_on_exit_false_config(self):

--- a/tests/ecalc_neqsim_wrapper/unit_tests/test_java_service.py
+++ b/tests/ecalc_neqsim_wrapper/unit_tests/test_java_service.py
@@ -138,6 +138,8 @@ class TestPy4JShutdownOnExit:
         ):
             service.shutdown()
         NeqsimService.reset_py4j_config()
+        # Debug/check: re-initialize for subsequent tests in the same process
+        NeqsimService.factory(use_jpype=False).initialize()
 
     def test_shutdown_on_exit_false_config(self):
         """With shutdown_on_exit=False, service stays alive after shutdown is skipped."""

--- a/tests/libecalc/input/mappers/test_model_mapper.py
+++ b/tests/libecalc/input/mappers/test_model_mapper.py
@@ -1,67 +1,10 @@
-from typing import Any
-
 from pydantic import TypeAdapter
 
 from libecalc.domain.resource import Resources
-from libecalc.dto import FuelType
-from libecalc.presentation.yaml.domain.reference_service import ReferenceService, YamlCompressorModel
 from libecalc.presentation.yaml.mappers.consumer_function_mapper import CompressorModelMapper
-from libecalc.presentation.yaml.mappers.yaml_path import YamlPath
 from libecalc.presentation.yaml.yaml_entities import MemoryResource
-from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import (
-    YamlGeneratorSetModel,
-    YamlPumpChartSingleSpeed,
-    YamlPumpChartVariableSpeed,
-    YamlTabularModel,
-)
-from libecalc.presentation.yaml.yaml_types.models import YamlCompressorChart, YamlFluidModel, YamlTurbine
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
-from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
-
-
-class DirectReferenceService(ReferenceService):
-    def __init__(self, references: dict[str, Any]):
-        self._references = references
-
-    def _resolve_reference(self, reference: str) -> Any:
-        return self._references[reference]
-
-    def get_yaml_path(self, reference: str) -> YamlPath:
-        raise NotImplementedError()
-
-    def get_fluid(self, reference: str) -> YamlFluidModel:
-        raise NotImplementedError()
-
-    def get_turbine(self, reference: str) -> YamlTurbine:
-        raise NotImplementedError()
-
-    def get_compressor_chart(self, reference: str) -> YamlCompressorChart:
-        return self._resolve_reference(reference)
-
-    def get_fuel_reference(self, reference: str) -> FuelType:
-        raise NotImplementedError()
-
-    def get_generator_set_model(self, reference: str) -> YamlGeneratorSetModel:
-        raise NotImplementedError()
-
-    def get_compressor_model(self, reference: str) -> YamlCompressorModel:
-        raise NotImplementedError()
-
-    def get_pump_model(self, reference: str) -> YamlPumpChartSingleSpeed | YamlPumpChartVariableSpeed:
-        raise NotImplementedError()
-
-    def get_tabulated_model(self, reference: str) -> YamlTabularModel:
-        raise NotImplementedError()
-
-    def get_process_pipeline(self, reference: str) -> YamlProcessPipeline:
-        raise NotImplementedError()
-
-    def get_process_unit(self, reference: str) -> YamlProcessUnit:
-        raise NotImplementedError()
-
-    def get_stream(self, reference: str) -> YamlInletStream:
-        raise NotImplementedError()
+from libecalc.presentation.yaml.yaml_types.models import YamlCompressorChart
+from libecalc.testing.direct_reference_service import DirectReferenceService
 
 
 class TestCompressorChartMapping:

--- a/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
@@ -1,8 +1,5 @@
 from datetime import datetime
 
-import pytest
-
-from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
 from libecalc.common.time_utils import Period
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
 from libecalc.process.process_units.choke import Choke
@@ -187,27 +184,39 @@ def test_mapper_attaches_anti_surge_config_to_process_problem(process_simulation
 
 
 # ---------------------------------------------------------------------------
-# Tests: validation
+# Tests: trailing units
 # ---------------------------------------------------------------------------
 
 
-def test_mapper_raises_when_pipeline_has_units_after_last_compressor(process_simulation_mapper):
-    """Trailing units (after the last compressor) are not allowed."""
-    pipeline = (
+def test_mapper_places_trailing_units_after_last_asv_loop(process_simulation_mapper):
+    """Units after the last compressor are placed outside any ASV recirculation loop."""
+    yaml_pipeline = (
         YamlProcessPipelineBuilder()
-        .with_name("invalid_train")
+        .with_name("train_with_aftercooler")
         .with_items(
             [
+                YamlTemperatureSetterBuilder().with_test_data().validate(),
                 YamlCompressorBuilder().with_test_data().validate(),
-                YamlPressureDropperBuilder().with_test_data().validate(),  # trailing
+                YamlTemperatureSetterBuilder().with_test_data().validate(),
+                YamlCompressorBuilder().with_test_data().validate(),
+                YamlTemperatureSetterBuilder().with_test_data().validate(),  # trailing
             ]
         )
         .validate()
     )
-    yaml_simulation = _build_simulation_with_pipeline(pipeline)
+    yaml_simulation = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
 
-    with pytest.raises(EcalcValidationException, match="after the last compressor"):
-        process_simulation_mapper.map_process_simulation(
-            yaml_process_simulation=yaml_simulation,
-            process_periods=[PERIOD],
-        )
+    pipelines, _ = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    units = pipelines[0].get_process_units()
+
+    # Two ASV loops = two DirectSplitters. Trailing TemperatureSetter should be after both.
+    splitter_indices = [i for i, u in enumerate(units) if isinstance(u, DirectSplitter)]
+    assert len(splitter_indices) == 2
+
+    trailing_temp_index = len(units) - 1
+    assert isinstance(units[trailing_temp_index], TemperatureSetter)
+    assert trailing_temp_index > max(splitter_indices)

--- a/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
@@ -1,0 +1,213 @@
+from datetime import datetime
+
+import pytest
+
+from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
+from libecalc.common.time_utils import Period
+from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
+from libecalc.process.process_units.choke import Choke
+from libecalc.process.process_units.compressor import Compressor
+from libecalc.process.process_units.direct_mixer import DirectMixer
+from libecalc.process.process_units.direct_splitter import DirectSplitter
+from libecalc.process.process_units.liquid_remover import LiquidRemover
+from libecalc.process.process_units.pressure_dropper import PressureDropper
+from libecalc.process.process_units.temperature_setter import TemperatureSetter
+from libecalc.testing.process_builders import (
+    YamlCommonStreamDistributionBuilder,
+    YamlCompressorBuilder,
+    YamlLiquidRemoverBuilder,
+    YamlPressureDropperBuilder,
+    YamlProcessPipelineBuilder,
+    YamlProcessSimulationBuilder,
+    YamlTemperatureSetterBuilder,
+)
+
+PERIOD = Period(start=datetime(2020, 1, 1), end=datetime(2030, 1, 1))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _simple_pipeline(name: str = "train_1"):
+    return (
+        YamlProcessPipelineBuilder()
+        .with_name(name)
+        .with_items(
+            [
+                YamlPressureDropperBuilder().with_test_data().validate(),
+                YamlTemperatureSetterBuilder().with_test_data().validate(),
+                YamlLiquidRemoverBuilder().validate(),
+                YamlCompressorBuilder().with_test_data().validate(),
+            ]
+        )
+        .validate()
+    )
+
+
+def _build_simulation_with_pipeline(
+    pipeline,
+    name: str = "test_sim",
+    pressure_control: PressureControlType = "DOWNSTREAM_CHOKE",
+    outlet_pressure: float = 100.0,
+):
+    """Build a YamlProcessSimulation with one pipeline and default stream distribution."""
+    return (
+        YamlProcessSimulationBuilder()
+        .with_name(name)
+        .with_pipeline(
+            pipeline,
+            pressure_control=pressure_control,
+            outlet_pressure=outlet_pressure,
+        )
+        .with_stream_distribution(YamlCommonStreamDistributionBuilder().with_test_data().validate())
+        .validate()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: basic structure
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_returns_one_pipeline_per_target(process_simulation_mapper):
+    """One ProcessPipeline is produced per YAML target."""
+    yaml_simulation = (
+        YamlProcessSimulationBuilder()
+        .with_name("multi")
+        .with_pipeline(_simple_pipeline("train_a"))
+        .with_pipeline(_simple_pipeline("train_b"))
+        .with_stream_distribution(
+            YamlCommonStreamDistributionBuilder().with_test_data().with_rate_fractions([0.5, 0.5]).validate()
+        )
+        .validate()
+    )
+
+    pipelines, _ = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    assert len(pipelines) == 2
+    assert {p.get_name() for p in pipelines} == {"train_a", "train_b"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: pipeline composition (mapper adds infrastructure units)
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_wraps_compressor_segment_with_mixer_and_splitter(process_simulation_mapper):
+    """Each compressor segment is wrapped with DirectMixer + DirectSplitter to enable
+    ASV recirculation. This is not visible in YAML but added by the mapper."""
+    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline())
+
+    pipelines, _ = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    units = pipelines[0].get_process_units()
+    assert isinstance(units[0], DirectMixer)
+    splitter_index = next(i for i, u in enumerate(units) if isinstance(u, DirectSplitter))
+    compressor_index = next(i for i, u in enumerate(units) if isinstance(u, Compressor))
+    assert splitter_index > compressor_index
+
+
+def test_mapper_preserves_yaml_unit_order_inside_segment(process_simulation_mapper):
+    """User-defined units appear in the order specified in YAML."""
+    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline())
+
+    pipelines, _ = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    units = pipelines[0].get_process_units()
+
+    def position_of(unit_type):
+        return next(i for i, u in enumerate(units) if isinstance(u, unit_type))
+
+    # YAML order: PressureDropper → TemperatureSetter → LiquidRemover → Compressor
+    assert position_of(PressureDropper) < position_of(TemperatureSetter)
+    assert position_of(TemperatureSetter) < position_of(LiquidRemover)
+    assert position_of(LiquidRemover) < position_of(Compressor)
+
+
+def test_mapper_adds_choke_for_downstream_choke_pressure_control(process_simulation_mapper):
+    """DOWNSTREAM_CHOKE pressure control adds a Choke at the end of the pipeline."""
+    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline(), pressure_control="DOWNSTREAM_CHOKE")
+
+    pipelines, _ = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    units = pipelines[0].get_process_units()
+    assert isinstance(units[-1], Choke)
+
+
+def test_mapper_adds_choke_for_upstream_choke_pressure_control(process_simulation_mapper):
+    """UPSTREAM_CHOKE pressure control adds a Choke at the very start of the pipeline."""
+    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline(), pressure_control="UPSTREAM_CHOKE")
+
+    pipelines, _ = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    units = pipelines[0].get_process_units()
+    assert isinstance(units[0], Choke)
+
+
+# ---------------------------------------------------------------------------
+# Tests: process problem / strategy mapping
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_attaches_anti_surge_config_to_process_problem(process_simulation_mapper):
+    """Anti-surge strategy follows from pressure control choice."""
+    yaml_common = _build_simulation_with_pipeline(_simple_pipeline("train_common"), pressure_control="COMMON_ASV")
+    yaml_individual = _build_simulation_with_pipeline(
+        _simple_pipeline("train_individual"), pressure_control="INDIVIDUAL_ASV_RATE"
+    )
+
+    _, sim_common = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_common,
+        process_periods=[PERIOD],
+    )
+    _, sim_individual = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_individual,
+        process_periods=[PERIOD],
+    )
+
+    assert sim_common.process_problems[0].get_anti_surge_strategy().type == "COMMON_ASV"
+    assert sim_individual.process_problems[0].get_anti_surge_strategy().type == "INDIVIDUAL_ASV"
+
+
+# ---------------------------------------------------------------------------
+# Tests: validation
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_raises_when_pipeline_has_units_after_last_compressor(process_simulation_mapper):
+    """Trailing units (after the last compressor) are not allowed."""
+    pipeline = (
+        YamlProcessPipelineBuilder()
+        .with_name("invalid_train")
+        .with_items(
+            [
+                YamlCompressorBuilder().with_test_data().validate(),
+                YamlPressureDropperBuilder().with_test_data().validate(),  # trailing
+            ]
+        )
+        .validate()
+    )
+    yaml_simulation = _build_simulation_with_pipeline(pipeline)
+
+    with pytest.raises(EcalcValidationException, match="after the last compressor"):
+        process_simulation_mapper.map_process_simulation(
+            yaml_process_simulation=yaml_simulation,
+            process_periods=[PERIOD],
+        )


### PR DESCRIPTION
Adds tests for `ProcessSimulationMapper`.

Copilot was used as a sparring partner to evaluate test scope, test code and challenge weak/low-value tests.

---

## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
