### PR TITLE
fix(libecalc): tighten Solution.combine semantics and clean up OutletPressureSolver

### DIFF
--- a/src/libecalc/process/process_solver/outlet_pressure_solver.py
+++ b/src/libecalc/process/process_solver/outlet_pressure_solver.py
@@ -11,6 +11,7 @@ from libecalc.process.process_solver.configuration import (
     ConfigurationHandlerId,
     RecirculationConfiguration,
     SpeedConfiguration,
+    merge_configurations,
 )
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
@@ -124,9 +125,8 @@ class OutletPressureSolver:
         Finds the speed and recirculation rates for each compressor to meet the pressure constraint.
         """
         self._simulator.reset_to()
-        configurations: dict[ConfigurationHandlerId, Configuration] = {}
         speed_solution = self._find_speed_solution(pressure_constraint=pressure_constraint, inlet_stream=inlet_stream)
-        configurations[self._shaft_id] = Configuration(
+        shaft_config = Configuration(
             configuration_handler_id=self._shaft_id,
             value=speed_solution.configuration,
         )
@@ -135,36 +135,33 @@ class OutletPressureSolver:
         if isinstance(speed_solution.failure, RateTooHighFailure):
             return Solution(
                 success=False,
-                configuration=list(configurations.values()),
+                configuration=[shaft_config],
                 failure=speed_solution.failure,
             )
 
-        self._simulator.reset_to(configurations=list(configurations.values()))
+        self._simulator.reset_to(configurations=[shaft_config])
         self._anti_surge_solution = self._anti_surge_strategy.apply(inlet_stream=inlet_stream)
-        for anti_surge_configuration in self._anti_surge_solution.configuration:
-            configurations[anti_surge_configuration.configuration_handler_id] = anti_surge_configuration
+
+        speed_and_anti_surge_configurations = [shaft_config, *self._anti_surge_solution.configuration]
 
         if speed_solution.success:
-            return Solution(
-                success=True,
-                configuration=list(configurations.values()),
-            )
+            return Solution(success=True, configuration=speed_and_anti_surge_configurations)
 
         if not self._anti_surge_solution.success:
             return Solution(
                 success=False,
-                configuration=list(configurations.values()),
+                configuration=speed_and_anti_surge_configurations,
                 failure=self._anti_surge_solution.failure,
             )
 
         outlet_at_chosen_speed = self._get_outlet_stream(
             inlet_stream=inlet_stream,
-            configurations=list(configurations.values()),
+            configurations=speed_and_anti_surge_configurations,
         )
 
         if outlet_at_chosen_speed.pressure_bara < pressure_constraint:
             return Solution.target_pressure_unreachable(
-                configuration=list(configurations.values()),
+                configuration=speed_and_anti_surge_configurations,
                 achievable_pressure_bara=outlet_at_chosen_speed.pressure_bara,
                 target_pressure_bara=pressure_constraint.value,
                 source_id=self._process_pipeline_id,
@@ -175,9 +172,9 @@ class OutletPressureSolver:
             target_pressure=pressure_constraint,
             inlet_stream=inlet_stream,
         )
-
-        for pressure_control_configuration in pressure_control_solution.configuration:
-            configurations[pressure_control_configuration.configuration_handler_id] = pressure_control_configuration
+        final_configs = merge_configurations(
+            speed_and_anti_surge_configurations, pressure_control_solution.configuration
+        )
 
         failure = pressure_control_solution.failure
         if isinstance(failure, TargetPressureUnreachableFailure) and failure.source_id is None:
@@ -185,6 +182,6 @@ class OutletPressureSolver:
 
         return Solution(
             success=pressure_control_solution.success,
-            configuration=list(configurations.values()),
+            configuration=final_configs,
             failure=failure,
         )

--- a/src/libecalc/process/process_solver/solver.py
+++ b/src/libecalc/process/process_solver/solver.py
@@ -135,10 +135,22 @@ class Solution[TConfiguration]:
         self: Solution[Sequence[Configuration[OperatingConfiguration]]],
         other: Solution[Sequence[Configuration[OperatingConfiguration]]],
     ) -> Solution[Sequence[Configuration[OperatingConfiguration]]]:
-        """Combine two solutions: merge configurations and success flags."""
+        """Combine two solutions as a strict sequential aggregation.
+
+        If self has already failed, returns self unchanged: once a segment in the
+        pipeline fails, subsequent segments cannot meaningfully extend it, and the
+        failure must keep referring to the configurations it was generated from.
+
+        Otherwise both stages must succeed for the combined solution to succeed;
+        any failure carried by other becomes the combined failure. Configurations
+        are merged with later entries winning per handler.
+        """
+        if not self.success:
+            return self
         return Solution(
-            success=self.success and other.success,
+            success=other.success,
             configuration=merge_configurations(self.configuration, other.configuration),
+            failure=other.failure,
         )
 
 

--- a/tests/libecalc/process/process_solver/test_solution.py
+++ b/tests/libecalc/process/process_solver/test_solution.py
@@ -1,0 +1,53 @@
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
+from libecalc.process.process_solver.configuration import (
+    Configuration,
+    ConfigurationHandlerId,
+    SpeedConfiguration,
+)
+from libecalc.process.process_solver.solver import (
+    RateTooHighFailure,
+    RateTooLowFailure,
+    Solution,
+)
+
+
+def _shaft_config(speed: float) -> Configuration[SpeedConfiguration]:
+    return Configuration(
+        configuration_handler_id=ConfigurationHandlerId("shaft"),
+        value=SpeedConfiguration(speed=speed),
+    )
+
+
+def test_combine_propagates_others_failure_when_self_succeeded():
+    failure = RateTooHighFailure(source_id=ProcessUnitId("u1"))
+    success_solution: Solution = Solution(success=True, configuration=[])
+    failing_solution: Solution = Solution(success=False, configuration=[], failure=failure)
+
+    combined = success_solution.combine(failing_solution)
+
+    assert combined.success is False
+    assert combined.failure is failure
+
+
+def test_combine_short_circuits_when_self_already_failed():
+    """Once a stage fails, the failure must keep referring to the configurations it was generated from."""
+    self_failure = RateTooLowFailure(source_id=ProcessUnitId("u1"))
+    failed = Solution(success=False, configuration=[_shaft_config(100.0)], failure=self_failure)
+    later = Solution(success=True, configuration=[_shaft_config(200.0)])
+
+    combined = failed.combine(later)
+
+    assert combined is failed
+    assert combined.failure is self_failure
+    assert combined.configuration == [_shaft_config(100.0)]
+
+
+def test_combine_short_circuits_even_when_other_also_failed():
+    self_failure = RateTooLowFailure(source_id=ProcessUnitId("u1"))
+    other_failure = RateTooHighFailure(source_id=ProcessUnitId("u2"))
+    a: Solution = Solution(success=False, configuration=[], failure=self_failure)
+    b: Solution = Solution(success=False, configuration=[], failure=other_failure)
+
+    combined = a.combine(b)
+
+    assert combined.failure is self_failure


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why) — new `test_solution.py` covers the failure-propagation semantics
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [x] I have included the Github issue nr in the footer!

## What is this PR all about?

Closes equinor/ecalc-internal#1873.

`Solution.combine` was used in two incompatible ways: strict sequential aggregation (`MultiPressureSolver`) and pure configuration merging (`OutletPressureSolver`). It silently dropped `failure`, hiding the cause of combined failures.

This PR tightens `combine` to mean **strict sequential aggregation**:

- If the running solution has already failed, return it unchanged. Subsequent stages cannot meaningfully extend a failed pipeline, and the failure must keep referring to the configurations it was generated from.
- Otherwise: `success` follows other, `failure` is whatever other carries, configurations are merged with later entries winning per handler.

`OutletPressureSolver.find_solution` is rewritten to use an explicit configuration list + module-level `merge_configurations(...)` at the single point where deduplication actually matters (pressure control may re-emit anti-surge configurations). No more accumulating into a dict only to flatten it at every return.

## What else did you consider?

## Between the lines?

`MultiPressureSolver` gets correct failure propagation for free — it previously silently lost `pressure_control_solution.failure`. No call-site changes needed there.
