### PR TITLE
refactor(libecalc): implement reset_handler() on individual configuration handlers

### DIFF
--- a/src/libecalc/process/process_solver/anti_surge/common_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/common_asv.py
@@ -38,12 +38,7 @@ class CommonASVAntiSurgeStrategy(AntiSurgeStrategy):
         self._simulator = simulator
 
     def reset(self) -> None:
-        self._simulator.apply_configuration(
-            Configuration(
-                configuration_handler_id=self._recirculation_loop_id,
-                value=RecirculationConfiguration(recirculation_rate=0.0),
-            )
-        )
+        self._simulator.reset_configuration_handler(self._recirculation_loop_id)
 
     def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
         self.reset()

--- a/src/libecalc/process/process_solver/anti_surge/individual_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/individual_asv.py
@@ -35,19 +35,9 @@ class IndividualASVAntiSurgeStrategy(AntiSurgeStrategy):
         self._compressors = compressors
         self._simulator = simulator
 
-    def _apply_recirculation_configuration(self, loop_id: ConfigurationHandlerId, recirculation_rate: float):
-        self._simulator.apply_configuration(
-            Configuration(
-                configuration_handler_id=loop_id,
-                value=RecirculationConfiguration(
-                    recirculation_rate=recirculation_rate,
-                ),
-            )
-        )
-
     def reset(self) -> None:
         for loop_id in self._recirculation_loop_ids:
-            self._apply_recirculation_configuration(loop_id=loop_id, recirculation_rate=0.0)
+            self._simulator.reset_configuration_handler(loop_id)
 
     @override
     def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:

--- a/src/libecalc/process/process_solver/multi_pressure_solver.py
+++ b/src/libecalc/process/process_solver/multi_pressure_solver.py
@@ -91,7 +91,8 @@ class MultiPressureSolver:
         current_inlet = inlet_stream
 
         for segment, target in zip(self._segments, pressure_targets):
-            segment.runner.reset_to(configurations=[shaft_config])
+            segment.pressure_control_strategy.reset()  #  to clear a potential upstream/downstream choke
+            segment.runner.apply_configuration(shaft_config)
 
             anti_surge_solution = segment.anti_surge_strategy.apply(inlet_stream=current_inlet)
             segment.runner.apply_configurations(anti_surge_solution.configuration)

--- a/src/libecalc/process/process_solver/outlet_pressure_solver.py
+++ b/src/libecalc/process/process_solver/outlet_pressure_solver.py
@@ -87,6 +87,8 @@ class OutletPressureSolver:
         pressure_constraint: FloatConstraint,
         inlet_stream: FluidStream,
     ) -> Solution[SpeedConfiguration]:
+        # The speed search evaluates the train with pressure control disengaged
+        self._pressure_control_strategy.reset()
         speed_solver = SpeedSolver(
             search_strategy=BinarySearchStrategy(),
             root_finding_strategy=self._root_finding_strategy,
@@ -95,8 +97,9 @@ class OutletPressureSolver:
         )
 
         def speed_func(configuration: SpeedConfiguration) -> FluidStream:
-            self._simulator.reset_to(
-                configurations=[Configuration(configuration_handler_id=self._shaft_id, value=configuration)],
+            self._anti_surge_strategy.reset()
+            self._simulator.apply_configuration(
+                Configuration(configuration_handler_id=self._shaft_id, value=configuration),
             )
             try:
                 return self._simulator.run(inlet_stream=inlet_stream)
@@ -124,7 +127,6 @@ class OutletPressureSolver:
         """
         Finds the speed and recirculation rates for each compressor to meet the pressure constraint.
         """
-        self._simulator.reset_to()
         speed_solution = self._find_speed_solution(pressure_constraint=pressure_constraint, inlet_stream=inlet_stream)
         shaft_config = Configuration(
             configuration_handler_id=self._shaft_id,
@@ -139,7 +141,7 @@ class OutletPressureSolver:
                 failure=speed_solution.failure,
             )
 
-        self._simulator.reset_to(configurations=[shaft_config])
+        self._simulator.apply_configuration(shaft_config)
         self._anti_surge_solution = self._anti_surge_strategy.apply(inlet_stream=inlet_stream)
 
         speed_and_anti_surge_configurations = [shaft_config, *self._anti_surge_solution.configuration]

--- a/src/libecalc/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/common_asv.py
@@ -39,12 +39,7 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
         self._root_finding_strategy = root_finding_strategy
 
     def reset(self) -> None:
-        self._simulator.apply_configuration(
-            Configuration(
-                configuration_handler_id=self._recirculation_loop_id,
-                value=RecirculationConfiguration(recirculation_rate=0.0),
-            )
-        )
+        self._simulator.reset_configuration_handler(self._recirculation_loop_id)
 
     def apply(
         self,

--- a/src/libecalc/process/process_solver/pressure_control/downstream_choke.py
+++ b/src/libecalc/process/process_solver/pressure_control/downstream_choke.py
@@ -27,6 +27,9 @@ class DownstreamChokePressureControlStrategy(PressureControlStrategy):
         self._choke_configuration_handler_id = choke_configuration_handler_id
         self._simulator = simulator
 
+    def reset(self) -> None:
+        self._simulator.reset_configuration_handler(self._choke_configuration_handler_id)
+
     def apply(
         self,
         target_pressure: FloatConstraint,

--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -42,12 +42,7 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
 
     def reset(self) -> None:
         for recirculation_loop_id in self._recirculation_loop_ids:
-            self._simulator.apply_configuration(
-                Configuration(
-                    configuration_handler_id=recirculation_loop_id,
-                    value=RecirculationConfiguration(recirculation_rate=0.0),
-                )
-            )
+            self._simulator.reset_configuration_handler(recirculation_loop_id)
 
     def apply(
         self,
@@ -133,12 +128,7 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
 
     def reset(self) -> None:
         for recirculation_loop_id in self._recirculation_loop_ids:
-            self._simulator.apply_configuration(
-                Configuration(
-                    configuration_handler_id=recirculation_loop_id,
-                    value=RecirculationConfiguration(recirculation_rate=0.0),
-                )
-            )
+            self._simulator.reset_configuration_handler(recirculation_loop_id)
 
     def _get_configurations_from_fraction(
         self,
@@ -229,7 +219,5 @@ def compute_minimum_achievable_pressure(
 
     pressure_bara = simulator.run(inlet_stream=inlet_stream).pressure_bara
     for loop in recirculation_loop_ids:
-        simulator.apply_configuration(
-            Configuration(configuration_handler_id=loop, value=RecirculationConfiguration(recirculation_rate=0.0))
-        )
+        simulator.reset_configuration_handler(loop)
     return configurations, pressure_bara

--- a/src/libecalc/process/process_solver/pressure_control/pressure_control_strategy.py
+++ b/src/libecalc/process/process_solver/pressure_control/pressure_control_strategy.py
@@ -40,3 +40,13 @@ class PressureControlStrategy(ABC):
             Solution containing the manipulations (e.g. recirculation rate, choke ΔP) needed to meet the target pressure.
         """
         ...
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Restore any state owned by the strategy to its default/unconfigured value.
+
+        Called before re-evaluating in contexts where stale state from a previous
+        evaluation (e.g. a choke ΔP set during a prior solve) would corrupt the
+        result.
+        """
+        ...

--- a/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
+++ b/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
@@ -43,6 +43,9 @@ class UpstreamChokePressureControlStrategy(PressureControlStrategy):
         self._anti_surge_strategy = anti_surge_strategy
         self._last_anti_surge_configurations: Sequence[Configuration[RecirculationConfiguration]] = []
 
+    def reset(self) -> None:
+        self._simulator.reset_configuration_handler(self._choke_configuration_handler_id)
+
     def apply(
         self,
         target_pressure: FloatConstraint,

--- a/src/libecalc/process/process_solver/process_pipeline_runner.py
+++ b/src/libecalc/process/process_solver/process_pipeline_runner.py
@@ -18,7 +18,6 @@ class ProcessPipelineRunner(ProcessRunner):
     def __init__(self, configuration_handlers: Sequence[ConfigurationHandler], units: Sequence[ProcessUnit]):
         self._configuration_handlers = {handler.get_id(): handler for handler in configuration_handlers}
         self._units = {unit.get_id(): unit for unit in units}
-        self._configurations: dict[ConfigurationHandlerId, Configuration] = {}
 
     @staticmethod
     def _apply_config_for_unit(configuration_handler: ConfigurationHandler, configuration: Configuration):
@@ -26,18 +25,10 @@ class ProcessPipelineRunner(ProcessRunner):
 
     def apply_configuration(self, configuration: Configuration):
         unit = self._get_configuration_handler(configuration.configuration_handler_id)
-        self._configurations[configuration.configuration_handler_id] = configuration
         self._apply_config_for_unit(configuration_handler=unit, configuration=configuration)
 
-    def reset_to(
-        self,
-        configurations: Sequence[Configuration] = (),
-    ) -> None:
-        self._configurations.clear()
-        for handler in self._configuration_handlers.values():
-            handler.reset()
-        if configurations:
-            self.apply_configurations(configurations)
+    def reset_configuration_handler(self, handler_id: ConfigurationHandlerId) -> None:
+        self._get_configuration_handler(handler_id).reset()
 
     def _get_configuration_handler(self, configuration_handler_id: ConfigurationHandlerId) -> ConfigurationHandler:
         return self._configuration_handlers[configuration_handler_id]

--- a/src/libecalc/process/process_solver/process_runner.py
+++ b/src/libecalc/process/process_solver/process_runner.py
@@ -3,7 +3,11 @@ from collections.abc import Sequence
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
-from libecalc.process.process_solver.configuration import Configuration, OperatingConfiguration
+from libecalc.process.process_solver.configuration import (
+    Configuration,
+    ConfigurationHandlerId,
+    OperatingConfiguration,
+)
 
 
 class ProcessRunner(abc.ABC):
@@ -18,18 +22,12 @@ class ProcessRunner(abc.ABC):
             self.apply_configuration(configuration)
 
     @abc.abstractmethod
-    def reset_to(
-        self,
-        configurations: Sequence[Configuration] = (),
-    ) -> None:
-        """Establish a clean starting state for the next evaluation.
+    def reset_configuration_handler(self, handler_id: ConfigurationHandlerId) -> None:
+        """Reset a single configuration handler to its default state.
 
-        Clears all configuration-handler state on the runner (e.g. shaft speed,
-        recirculation rates, choke pressure changes) and then applies the given
-        configurations as the new starting point.
-
-        Call this whenever a solver begins a new attempt so that no state from a
-        previous run leaks into the next one.
+        The default state is owned by the handler itself; this only dispatches to it.
+        The caller (a strategy) decides which handler to reset and when, so no state
+        from a previous evaluation leaks into the next one.
         """
         ...
 

--- a/tests/libecalc/process/process_solver/test_reset_handler.py
+++ b/tests/libecalc/process/process_solver/test_reset_handler.py
@@ -1,0 +1,41 @@
+from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
+from libecalc.process.process_solver.process_pipeline_runner import ProcessPipelineRunner
+from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
+from libecalc.process.process_units.choke import Choke
+from libecalc.process.process_units.direct_mixer import DirectMixer
+from libecalc.process.process_units.direct_splitter import DirectSplitter
+from libecalc.process.shaft import VariableSpeedShaft
+
+
+def test_reset_configuration_handler_zeroes_recirculation_loop():
+    mixer = DirectMixer()
+    splitter = DirectSplitter()
+    loop = RecirculationLoop(mixer=mixer, splitter=splitter)
+    loop.set_recirculation_rate(5.0)
+    runner = ProcessPipelineRunner(configuration_handlers=[loop], units=[mixer, splitter])
+
+    runner.reset_configuration_handler(loop.get_id())
+
+    assert loop.get_recirculation_rate() == 0.0
+
+
+def test_reset_configuration_handler_zeroes_choke(fluid_service):
+    choke = Choke(fluid_service=fluid_service)
+    handler = ChokeConfigurationHandler(choke=choke)
+    choke.set_pressure_change(3.0)
+    runner = ProcessPipelineRunner(configuration_handlers=[handler], units=[choke])
+
+    runner.reset_configuration_handler(handler.get_id())
+
+    assert choke.pressure_change == 0.0
+
+
+def test_reset_configuration_handler_unsets_shaft_speed():
+    shaft = VariableSpeedShaft()
+    shaft.set_speed(5000.0)
+    assert shaft.speed_is_defined
+    runner = ProcessPipelineRunner(configuration_handlers=[shaft], units=[])
+
+    runner.reset_configuration_handler(shaft.get_id())
+
+    assert not shaft.speed_is_defined


### PR DESCRIPTION
The reset_to() method felt a bit off. This is an attempt to let the configuration handlers own it's own neutral/default state, and let the strategies reset then using reset_handler() and config_handler_id.

The shaft is intentionally never reset in the solver flow, the shaft speed is always explicitiy set. Shaft.reset() still exists because it is an abstract method - and maybe at some point we would like to reset it.
