### PR TITLE
refactor(libecalc): extract PipelineSection and rename solver

### DIFF
--- a/src/libecalc/process/process_solver/feasibility_solver.py
+++ b/src/libecalc/process/process_solver/feasibility_solver.py
@@ -2,7 +2,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import OutsideCapacityError
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pipeline_section_solver import PipelineSectionSolver
 from libecalc.process.process_solver.search_strategies import (
     BinarySearchStrategy,
     DidNotConvergeError,
@@ -17,16 +17,16 @@ class FeasibilitySolver:
     """Calculates how much of a given inlet rate exceeds what a compressor train
     can handle for a target pressure.
 
-    Orchestrates OutletPressureSolver and queries compressor charts to find
+    Orchestrates PipelineSectionSolver and queries compressor charts to find
     the feasible rate — the excess is redirected via stream distribution.
     """
 
     def __init__(
         self,
-        outlet_pressure_solver: OutletPressureSolver,
+        pipeline_section_solver: PipelineSectionSolver,
         search_strategy: SearchStrategy | None = None,
     ):
-        self._solver = outlet_pressure_solver
+        self._solver = pipeline_section_solver
         self._search_strategy = search_strategy or BinarySearchStrategy(
             tolerance=_RATE_SEARCH_TOLERANCE,
             max_iterations=_RATE_SEARCH_MAX_ITERATIONS,

--- a/src/libecalc/process/process_solver/multi_pressure_solver.py
+++ b/src/libecalc/process/process_solver/multi_pressure_solver.py
@@ -5,56 +5,57 @@ from libecalc.common.errors.ecalc_validation_error import EcalcValidationExcepti
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_solver.configuration import Configuration, OperatingConfiguration, SpeedConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pipeline_section import PipelineSection
+from libecalc.process.process_solver.pipeline_section_solver import PipelineSectionSolver
 from libecalc.process.process_solver.pressure_control.downstream_choke import DownstreamChokePressureControlStrategy
 from libecalc.process.process_solver.pressure_control.upstream_choke import UpstreamChokePressureControlStrategy
 from libecalc.process.process_solver.solver import Solution, TargetDirection
 
 
 class MultiPressureSolver:
-    """Tries to find the shaft speed satisfying N ordered pressure targets, one per segment. Segments share a
-    single physical shaft. Each segment's runner covers a disjoint sub-sequence of the stream propagation chain.
+    """Tries to find the shaft speed satisfying N ordered pressure targets, one per pipeline section. Pipeline sections share a
+    single physical shaft. Each pipeline section's runner covers a disjoint sub-sequence of the stream propagation chain.
 
-    Independent OutletPressureSolver per segment (sequential) against its own pressure target. This gives the
-    speed each segment would require if unconstrained. The segment requiring the highest speed is the binding
-    constraint. At binding speed, non-binding segments produce more pressure than needed and must have it reduced
+    Independent PipelineSectionSolver per pipeline section (sequential) against its own pressure target. This gives the
+    speed each pipeline section would require if unconstrained. The pipeline section requiring the highest speed is the binding
+    constraint. At binding speed, non-binding pipeline sections produce more pressure than needed and must have it reduced
     by their pressure-control strategy.
 
-    All segments are re-run in sequence at binding_speed. Anti-surge is applied first. If a segment's outlet
-    still exceeds its target, the pressure-control strategy reduces it. The outlet of each segment feeds the inlet
-    of the next. For all but one segment, speed changed from the individual evaluations. Therefore, recirculation
+    All pipeline sections are re-run in sequence at binding_speed. Anti-surge is applied first. If a pipeline section's outlet
+    still exceeds its target, the pressure-control strategy reduces it. The outlet of each pipeline section feeds the inlet
+    of the next. For all but one pipeline section, speed changed from the individual evaluations. Therefore, recirculation
     is re-evaluated from scratch.
     """
 
     def __init__(
         self,
-        segments: list[OutletPressureSolver],
+        pipeline_sections: list[PipelineSection],
     ) -> None:
-        if len(segments) < 2:
-            raise EcalcValidationException("MultiPressureSolver requires at least 2 segments.")
-        shaft_ids = {segment.shaft_id for segment in segments}
+        if len(pipeline_sections) < 2:
+            raise EcalcValidationException("MultiPressureSolver requires at least 2 pipeline sections.")
+        shaft_ids = {pipeline_section.shaft_id for pipeline_section in pipeline_sections}
         if len(shaft_ids) != 1:
-            raise EcalcValidationException("All segments must share the same shaft_id.")
+            raise EcalcValidationException("All pipeline sections must share the same shaft_id.")
         self._shaft_id: Final = next(iter(shaft_ids))
-        self._validate_pressure_control_placement(segments)
-        self._segments: Final = segments
+        self._validate_pressure_control_placement(pipeline_sections)
+        self._pipeline_sections: Final = pipeline_sections
 
     @staticmethod
-    def _validate_pressure_control_placement(segments: list[OutletPressureSolver]) -> None:
-        """Upstream choke is only valid on the first segment; downstream choke only on the last."""
-        for i, segment in enumerate(segments):
-            strategy = segment.pressure_control_strategy
+    def _validate_pressure_control_placement(pipeline_sections: list[PipelineSection]) -> None:
+        """Upstream choke is only valid on the first pipeline_section; downstream choke only on the last."""
+        for i, pipeline_section in enumerate(pipeline_sections):
+            strategy = pipeline_section.pressure_control_strategy
             is_first = i == 0
-            is_last = i == len(segments) - 1
+            is_last = i == len(pipeline_sections) - 1
             if isinstance(strategy, UpstreamChokePressureControlStrategy) and not is_first:
                 raise EcalcValidationException(
-                    f"UpstreamChokePressureControlStrategy is only valid for the first segment "
-                    f"(segment {i} of {len(segments)})."
+                    f"UpstreamChokePressureControlStrategy is only valid for the first pipeline section "
+                    f"(pipeline section {i} of {len(pipeline_sections)})."
                 )
             if isinstance(strategy, DownstreamChokePressureControlStrategy) and not is_last:
                 raise EcalcValidationException(
-                    f"DownstreamChokePressureControlStrategy is only valid for the last segment "
-                    f"(segment {i} of {len(segments)})."
+                    f"DownstreamChokePressureControlStrategy is only valid for the last pipeline section "
+                    f"(pipeline section {i} of {len(pipeline_sections)})."
                 )
 
     def find_solution(
@@ -62,23 +63,25 @@ class MultiPressureSolver:
         pressure_targets: list[FloatConstraint],
         inlet_stream: FluidStream,
     ) -> Solution[Sequence[Configuration]]:
-        if len(pressure_targets) != len(self._segments):
+        if len(pressure_targets) != len(self._pipeline_sections):
             raise EcalcValidationException(
                 f"Number of pressure targets ({len(pressure_targets)}) must match "
-                f"number of segments ({len(self._segments)})."
+                f"number of pipeline sections ({len(self._pipeline_sections)})."
             )
 
         speed_configurations: list[SpeedConfiguration] = []
         current_inlet = inlet_stream
-        for segment, target in zip(self._segments, pressure_targets):
-            solution_for_segment = segment.find_solution(pressure_constraint=target, inlet_stream=current_inlet)
-            if not solution_for_segment.success:
-                return solution_for_segment
-            speed_configuration = solution_for_segment.get_configuration(self._shaft_id)
+        for pipeline_section, target in zip(self._pipeline_sections, pressure_targets):
+            solution_for_pipeline_section = PipelineSectionSolver(pipeline_section).find_solution(
+                pressure_constraint=target, inlet_stream=current_inlet
+            )
+            if not solution_for_pipeline_section.success:
+                return solution_for_pipeline_section
+            speed_configuration = solution_for_pipeline_section.get_configuration(self._shaft_id)
             assert isinstance(speed_configuration, SpeedConfiguration)
             speed_configurations.append(speed_configuration)
-            segment.runner.apply_configurations(solution_for_segment.configuration)
-            current_inlet = segment.runner.run(inlet_stream=current_inlet)
+            pipeline_section.runner.apply_configurations(solution_for_pipeline_section.configuration)
+            current_inlet = pipeline_section.runner.run(inlet_stream=current_inlet)
 
         shaft_config = Configuration(
             configuration_handler_id=self._shaft_id,
@@ -90,30 +93,30 @@ class MultiPressureSolver:
 
         current_inlet = inlet_stream
 
-        for segment, target in zip(self._segments, pressure_targets):
-            segment.pressure_control_strategy.reset()  #  to clear a potential upstream/downstream choke
-            segment.runner.apply_configuration(shaft_config)
+        for pipeline_section, target in zip(self._pipeline_sections, pressure_targets):
+            pipeline_section.pressure_control_strategy.reset()  #  to clear a potential upstream/downstream choke
+            pipeline_section.runner.apply_configuration(shaft_config)
 
-            anti_surge_solution = segment.anti_surge_strategy.apply(inlet_stream=current_inlet)
-            segment.runner.apply_configurations(anti_surge_solution.configuration)
+            anti_surge_solution = pipeline_section.anti_surge_strategy.apply(inlet_stream=current_inlet)
+            pipeline_section.runner.apply_configurations(anti_surge_solution.configuration)
             solution = solution.combine(anti_surge_solution)
 
-            outlet = segment.runner.run(inlet_stream=current_inlet)
+            outlet = pipeline_section.runner.run(inlet_stream=current_inlet)
 
             if outlet.pressure_bara > target:
-                pressure_control_solution = segment.pressure_control_strategy.apply(
+                pressure_control_solution = pipeline_section.pressure_control_strategy.apply(
                     target_pressure=target,
                     inlet_stream=current_inlet,
                 )
                 solution = solution.combine(pressure_control_solution)
-                segment.runner.apply_configurations(pressure_control_solution.configuration)
-                outlet = segment.runner.run(inlet_stream=current_inlet)
+                pipeline_section.runner.apply_configurations(pressure_control_solution.configuration)
+                outlet = pipeline_section.runner.run(inlet_stream=current_inlet)
             elif outlet.pressure_bara < target:
                 solution = Solution.target_pressure_unreachable(
                     configuration=solution.configuration,
                     achievable_pressure_bara=outlet.pressure_bara,
                     target_pressure_bara=target.value,
-                    source_id=segment.process_pipeline_id,
+                    source_id=pipeline_section.process_pipeline_id,
                     direction=TargetDirection.MAX_BELOW_TARGET,
                 )
 

--- a/src/libecalc/process/process_solver/multi_shaft_equal_ratio_solver.py
+++ b/src/libecalc/process/process_solver/multi_shaft_equal_ratio_solver.py
@@ -8,32 +8,32 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_solver.configuration import Configuration, OperatingConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_shaft_solver import MultiShaftSolver
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pipeline_section import PipelineSection
 from libecalc.process.process_solver.solver import Solution
 
 
 class MultiShaftEqualRatioSolver:
-    """Wrapper around MultiShaftSolver that computes per-pipeline pressure targets
+    """Wrapper around MultiShaftSolver that computes per-pipeline section pressure targets
     using equal pressure ratio: target_i = P_in × ratio^(i+1).
     """
 
-    def __init__(self, process_pipelines: Sequence[OutletPressureSolver]) -> None:
-        self._process_pipelines = list(process_pipelines)
-        self._solver = MultiShaftSolver(list(process_pipelines))
+    def __init__(self, pipeline_sections: Sequence[PipelineSection]) -> None:
+        self._pipeline_sections = list(pipeline_sections)
+        self._solver = MultiShaftSolver(list(pipeline_sections))
 
     def find_solution(
         self,
         pressure_constraint: FloatConstraint,
         inlet_stream: FluidStream,
     ) -> Solution[Sequence[Configuration[OperatingConfiguration]]]:
-        """Split overall pressure target into equal per-pipeline ratios and delegate."""
-        n = len(self._process_pipelines)
+        """Split overall pressure target into equal per-pipeline section ratios and delegate."""
+        n = len(self._pipeline_sections)
         if n == 0:
             return Solution(success=True, configuration=[], failure=None)
 
         pressure_ratio = (pressure_constraint.value / inlet_stream.pressure_bara) ** (1.0 / n)
 
-        # Rolling targets: each pipeline targets its actual inlet × ratio.
+        # Rolling targets: each pipeline section targets its actual inlet × ratio.
         # The final target is always the exact requested constraint.
         current_p = inlet_stream.pressure_bara
         targets: list[FloatConstraint] = []

--- a/src/libecalc/process/process_solver/multi_shaft_solver.py
+++ b/src/libecalc/process/process_solver/multi_shaft_solver.py
@@ -1,4 +1,4 @@
-"""Sequential solver with caller-supplied pressure targets per process pipeline."""
+"""Sequential solver with caller-supplied pressure targets per pipeline section."""
 
 from __future__ import annotations
 
@@ -8,33 +8,33 @@ from collections.abc import Sequence
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_solver.configuration import Configuration, OperatingConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pipeline_section import PipelineSection
+from libecalc.process.process_solver.pipeline_section_solver import PipelineSectionSolver
 from libecalc.process.process_solver.solver import Solution
 
 logger = logging.getLogger(__name__)
 
 
 class MultiShaftSolver:
-    """Sequences independently-shafted process pipelines, each driven toward a
-    caller-supplied pressure target.  The outlet of one pipeline feeds the
-    inlet of the next.
+    """Sequences independently-shafted process pipeline sections, each driven toward a
+    caller-supplied pressure target. The outlet of one pipeline section feeds the inlet of the next.
     """
 
-    def __init__(self, process_pipelines: Sequence[OutletPressureSolver]) -> None:
-        self._process_pipelines = list(process_pipelines)
+    def __init__(self, pipeline_sections: Sequence[PipelineSection]) -> None:
+        self._pipeline_sections = list(pipeline_sections)
 
     def find_solution(
         self,
         pressure_targets: Sequence[FloatConstraint],
         inlet_stream: FluidStream,
     ) -> Solution[Sequence[Configuration[OperatingConfiguration]]]:
-        """Run each process pipeline in flow order against its supplied pressure target."""
-        assert len(pressure_targets) == len(self._process_pipelines), (
+        """Run each pipeline section in flow order against its supplied pressure target."""
+        assert len(pressure_targets) == len(self._pipeline_sections), (
             f"Number of pressure targets ({len(pressure_targets)}) must match "
-            f"number of process pipelines ({len(self._process_pipelines)})."
+            f"number of pipeline sections ({len(self._pipeline_sections)})."
         )
 
-        if not self._process_pipelines:
+        if not self._pipeline_sections:
             return Solution(success=True, configuration=[], failure=None)
 
         current_inlet = inlet_stream
@@ -42,18 +42,18 @@ class MultiShaftSolver:
         failure = None
         overall_success = True
 
-        for i, (pipeline, target) in enumerate(zip(self._process_pipelines, pressure_targets)):
-            solution = pipeline.find_solution(target, current_inlet)
+        for i, (pipeline_section, target) in enumerate(zip(self._pipeline_sections, pressure_targets)):
+            solution = PipelineSectionSolver(pipeline_section).find_solution(target, current_inlet)
             all_configurations.extend(solution.configuration)
 
             if not solution.success:
                 overall_success = False
                 if failure is None:
                     failure = solution.failure
-                logger.debug("Process pipeline %d failed to reach target %.1f bara.", i, target.value)
+                logger.debug("PipelineSection %d failed to reach target %.1f bara.", i, target.value)
 
-            pipeline.runner.apply_configurations(solution.configuration)
-            current_inlet = pipeline.runner.run(current_inlet)
+            pipeline_section.runner.apply_configurations(solution.configuration)
+            current_inlet = pipeline_section.runner.run(current_inlet)
 
         return Solution(
             success=overall_success,

--- a/src/libecalc/process/process_solver/pipeline_section.py
+++ b/src/libecalc/process/process_solver/pipeline_section.py
@@ -1,0 +1,21 @@
+from libecalc.common.ddd import value_object
+from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
+from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
+from libecalc.process.process_solver.boundary import Boundary
+from libecalc.process.process_solver.configuration import ConfigurationHandlerId
+from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
+from libecalc.process.process_solver.process_runner import ProcessRunner
+from libecalc.process.process_solver.search_strategies import RootFindingStrategy
+
+
+@value_object
+class PipelineSection:
+    """A self-contained, solvable single-shaft process pipeline section"""
+
+    shaft_id: ConfigurationHandlerId
+    process_pipeline_id: ProcessPipelineId
+    runner: ProcessRunner
+    anti_surge_strategy: AntiSurgeStrategy
+    pressure_control_strategy: PressureControlStrategy
+    speed_boundary: Boundary
+    root_finding_strategy: RootFindingStrategy

--- a/src/libecalc/process/process_solver/pipeline_section_solver.py
+++ b/src/libecalc/process/process_solver/pipeline_section_solver.py
@@ -1,22 +1,17 @@
 from collections.abc import Sequence
-from typing import Final
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooLowError
-from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
-from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import (
     Configuration,
-    ConfigurationHandlerId,
     RecirculationConfiguration,
     SpeedConfiguration,
     merge_configurations,
 )
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
-from libecalc.process.process_solver.process_runner import ProcessRunner
-from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
+from libecalc.process.process_solver.pipeline_section import PipelineSection
+from libecalc.process.process_solver.search_strategies import BinarySearchStrategy
 from libecalc.process.process_solver.solver import (
     RateTooHighFailure,
     Solution,
@@ -26,61 +21,18 @@ from libecalc.process.process_solver.solver import (
 from libecalc.process.process_solver.solvers.speed_solver import SpeedSolver
 
 
-class OutletPressureSolver:
-    """Solver that finds the compressor speed, anti-surge recirculation, and
-    pressure-control settings required to meet a target outlet pressure.
-
-    The solver first searches for a shaft speed that produces the desired
-    outlet pressure.  If the speed search cannot satisfy the constraint
-    (e.g. because the target lies below the minimum-speed outlet pressure),
-    it delegates to a PressureControlStrategy (upstream choke,
-    downstream choke, ASV, etc.) to close the remaining gap.  Anti-surge
-    protection is applied at every evaluation to keep compressor stages
-    within their safe operating envelopes.
+class PipelineSectionSolver:
+    """Solves a single PipelineSection for a target outlet pressure by finding
+    the compressor speed, anti-surge recirculation, and pressure-control
+    settings required to meet it.
     """
 
-    def __init__(
-        self,
-        shaft_id: ConfigurationHandlerId,
-        process_pipeline_id: ProcessPipelineId,
-        runner: ProcessRunner,
-        anti_surge_strategy: AntiSurgeStrategy,
-        pressure_control_strategy: PressureControlStrategy,
-        root_finding_strategy: RootFindingStrategy,
-        speed_boundary: Boundary,
-    ) -> None:
-        self._shaft_id: Final = shaft_id
-        self._process_pipeline_id: Final = process_pipeline_id
-        self._root_finding_strategy: Final = root_finding_strategy
-        self._anti_surge_strategy: Final = anti_surge_strategy
-        self._simulator: Final = runner
-        self._pressure_control_strategy: Final = pressure_control_strategy
-        self._speed_boundary: Final = speed_boundary
-
+    def __init__(self, pipeline_section: PipelineSection) -> None:
+        self._pipeline_section = pipeline_section
         self._anti_surge_solution: Solution[Sequence[Configuration[RecirculationConfiguration]]] | None = None
 
-    @property
-    def runner(self) -> ProcessRunner:
-        return self._simulator
-
-    @property
-    def anti_surge_strategy(self) -> AntiSurgeStrategy:
-        return self._anti_surge_strategy
-
-    @property
-    def pressure_control_strategy(self) -> PressureControlStrategy:
-        return self._pressure_control_strategy
-
-    @property
-    def shaft_id(self) -> ConfigurationHandlerId:
-        return self._shaft_id
-
-    @property
-    def process_pipeline_id(self) -> ProcessPipelineId:
-        return self._process_pipeline_id
-
     def _get_initial_speed_boundary(self) -> Boundary:
-        return self._speed_boundary
+        return self._pipeline_section.speed_boundary
 
     def _find_speed_solution(
         self,
@@ -88,33 +40,33 @@ class OutletPressureSolver:
         inlet_stream: FluidStream,
     ) -> Solution[SpeedConfiguration]:
         # The speed search evaluates the train with pressure control disengaged
-        self._pressure_control_strategy.reset()
+        self._pipeline_section.pressure_control_strategy.reset()
         speed_solver = SpeedSolver(
             search_strategy=BinarySearchStrategy(),
-            root_finding_strategy=self._root_finding_strategy,
+            root_finding_strategy=self._pipeline_section.root_finding_strategy,
             boundary=self._get_initial_speed_boundary(),
             target_pressure=pressure_constraint.value,
         )
 
         def speed_func(configuration: SpeedConfiguration) -> FluidStream:
-            self._anti_surge_strategy.reset()
-            self._simulator.apply_configuration(
-                Configuration(configuration_handler_id=self._shaft_id, value=configuration),
+            self._pipeline_section.anti_surge_strategy.reset()
+            self._pipeline_section.runner.apply_configuration(
+                Configuration(configuration_handler_id=self._pipeline_section.shaft_id, value=configuration),
             )
             try:
-                return self._simulator.run(inlet_stream=inlet_stream)
+                return self._pipeline_section.runner.run(inlet_stream=inlet_stream)
             except RateTooLowError:
-                solution = self._anti_surge_strategy.apply(inlet_stream=inlet_stream)
-                self._simulator.apply_configurations(solution.configuration)
-                return self._simulator.run(inlet_stream=inlet_stream)
+                solution = self._pipeline_section.anti_surge_strategy.apply(inlet_stream=inlet_stream)
+                self._pipeline_section.runner.apply_configurations(solution.configuration)
+                return self._pipeline_section.runner.run(inlet_stream=inlet_stream)
 
         speed_solution = speed_solver.solve(speed_func)
 
         return speed_solution
 
     def _get_outlet_stream(self, inlet_stream: FluidStream, configurations: Sequence[Configuration]):
-        self._simulator.apply_configurations(configurations)
-        return self._simulator.run(inlet_stream=inlet_stream)
+        self._pipeline_section.runner.apply_configurations(configurations)
+        return self._pipeline_section.runner.run(inlet_stream=inlet_stream)
 
     def get_anti_surge_solution(self) -> Solution[Sequence[Configuration[RecirculationConfiguration]]] | None:
         return self._anti_surge_solution
@@ -129,7 +81,7 @@ class OutletPressureSolver:
         """
         speed_solution = self._find_speed_solution(pressure_constraint=pressure_constraint, inlet_stream=inlet_stream)
         shaft_config = Configuration(
-            configuration_handler_id=self._shaft_id,
+            configuration_handler_id=self._pipeline_section.shaft_id,
             value=speed_solution.configuration,
         )
 
@@ -141,8 +93,8 @@ class OutletPressureSolver:
                 failure=speed_solution.failure,
             )
 
-        self._simulator.apply_configuration(shaft_config)
-        self._anti_surge_solution = self._anti_surge_strategy.apply(inlet_stream=inlet_stream)
+        self._pipeline_section.runner.apply_configuration(shaft_config)
+        self._anti_surge_solution = self._pipeline_section.anti_surge_strategy.apply(inlet_stream=inlet_stream)
 
         speed_and_anti_surge_configurations = [shaft_config, *self._anti_surge_solution.configuration]
 
@@ -166,11 +118,11 @@ class OutletPressureSolver:
                 configuration=speed_and_anti_surge_configurations,
                 achievable_pressure_bara=outlet_at_chosen_speed.pressure_bara,
                 target_pressure_bara=pressure_constraint.value,
-                source_id=self._process_pipeline_id,
+                source_id=self._pipeline_section.process_pipeline_id,
                 direction=TargetDirection.MAX_BELOW_TARGET,
             )
 
-        pressure_control_solution = self._pressure_control_strategy.apply(
+        pressure_control_solution = self._pipeline_section.pressure_control_strategy.apply(
             target_pressure=pressure_constraint,
             inlet_stream=inlet_stream,
         )
@@ -180,7 +132,7 @@ class OutletPressureSolver:
 
         failure = pressure_control_solution.failure
         if isinstance(failure, TargetPressureUnreachableFailure) and failure.source_id is None:
-            failure = failure.with_source_id(self._process_pipeline_id)
+            failure = failure.with_source_id(self._pipeline_section.process_pipeline_id)
 
         return Solution(
             success=pressure_control_solution.success,

--- a/src/libecalc/process/process_solver/solver_assembly.py
+++ b/src/libecalc/process/process_solver/solver_assembly.py
@@ -1,7 +1,7 @@
 """Production solver assembly: wire physical components into a working solver.
 
-This module contains the single source of truth for assembling an
-OutletPressureSolver from its collaborating objects (runner, anti-surge
+This module contains the single source of truth for assembling a
+PipelineSectionSolver from its collaborating objects (runner, anti-surge
 strategy, pressure control strategy).  Both the YAML mapper and test
 infrastructure should use ``assemble_solver`` to ensure tests exercise
 the same wiring logic as production.
@@ -20,7 +20,8 @@ from libecalc.process.process_solver.anti_surge.common_asv import CommonASVAntiS
 from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
 from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
 from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pipeline_section import PipelineSection
+from libecalc.process.process_solver.pipeline_section_solver import PipelineSectionSolver
 from libecalc.process.process_solver.pressure_control.common_asv import CommonASVPressureControlStrategy
 from libecalc.process.process_solver.pressure_control.downstream_choke import DownstreamChokePressureControlStrategy
 from libecalc.process.process_solver.pressure_control.individual_asv import (
@@ -45,11 +46,12 @@ from libecalc.process.shaft import VariableSpeedShaft
 class ProcessSolverSystem:
     """A fully-wired solver with all its collaborating objects.
 
-    Bundles the OutletPressureSolver together with the physical components
+    Bundles the PipelineSectionSolver together with the physical components
     it operates on, so callers can inspect topology and run the solver.
     """
 
-    solver: OutletPressureSolver
+    solver: PipelineSectionSolver
+    pipeline_section: PipelineSection
     runner: ProcessRunner
     pipeline: ProcessPipeline
     shaft: VariableSpeedShaft
@@ -71,12 +73,12 @@ def assemble_solver(
     choke_configuration_handler: ChokeConfigurationHandler | None = None,
     root_finding_strategy: RootFindingStrategy | None = None,
 ) -> ProcessSolverSystem:
-    """Assemble a fully-wired OutletPressureSolver from physical components.
+    """Assemble a fully-wired PipelineSectionSolver from physical components.
 
     This is the production solver assembly path.  It creates the
     ProcessPipelineRunner, resolves the anti-surge and pressure control
     strategies from the ``pressure_control_type``, and wires everything
-    into an OutletPressureSolver.
+    into a PipelineSectionSolver.
 
     Args:
         process_units: Ordered list of process units forming the pipeline
@@ -120,7 +122,7 @@ def assemble_solver(
         root_finding_strategy=root_finding_strategy,
     )
 
-    solver = OutletPressureSolver(
+    pipeline_section = PipelineSection(
         shaft_id=shaft.get_id(),
         process_pipeline_id=pipeline.get_id(),
         runner=runner,
@@ -130,8 +132,11 @@ def assemble_solver(
         speed_boundary=shaft.get_speed_boundary(),
     )
 
+    solver = PipelineSectionSolver(pipeline_section)
+
     return ProcessSolverSystem(
         solver=solver,
+        pipeline_section=pipeline_section,
         runner=runner,
         pipeline=pipeline,
         shaft=shaft,

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/test_process_solver.py
@@ -1,6 +1,6 @@
 """Process-domain solver path matrix tests.
 
-Tests the new OutletPressureSolver.find_solution() across all 45 trial cases
+Tests the new PipelineSectionSolver.find_solution() across all 45 trial cases
 (9 regions × 5 pressure-control modes). Cases where the process solver does not
 yet match legacy behavior are marked as strict xfails.
 """

--- a/tests/libecalc/process/process_solver/conftest.py
+++ b/tests/libecalc/process/process_solver/conftest.py
@@ -13,7 +13,8 @@ from libecalc.process.process_solver.anti_surge.common_asv import CommonASVAntiS
 from libecalc.process.process_solver.anti_surge.individual_asv import IndividualASVAntiSurgeStrategy
 from libecalc.process.process_solver.configuration import ConfigurationHandlerId
 from libecalc.process.process_solver.multi_pressure_solver import MultiPressureSolver
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
+from libecalc.process.process_solver.pipeline_section import PipelineSection
+from libecalc.process.process_solver.pipeline_section_solver import PipelineSectionSolver
 from libecalc.process.process_solver.pressure_control.common_asv import CommonASVPressureControlStrategy
 from libecalc.process.process_solver.pressure_control.downstream_choke import (
     DownstreamChokePressureControlStrategy,
@@ -104,25 +105,47 @@ def with_individual_asv(with_common_asv):
 
 
 @pytest.fixture
-def outlet_pressure_solver_factory(root_finding_strategy):
-    def create_outlet_pressure_solver(
-        shaft: Shaft,
+def pipeline_section_factory(root_finding_strategy):
+    def create_segment(
         runner: ProcessRunner,
         anti_surge_strategy: AntiSurgeStrategy,
         pressure_control_strategy: PressureControlStrategy,
         process_pipeline_id: ProcessPipelineId,
-    ):
-        return OutletPressureSolver(
+        shaft: Shaft,
+    ) -> PipelineSection:
+        return PipelineSection(
             shaft_id=shaft.get_id(),
             process_pipeline_id=process_pipeline_id,
             runner=runner,
             anti_surge_strategy=anti_surge_strategy,
             pressure_control_strategy=pressure_control_strategy,
-            root_finding_strategy=root_finding_strategy,
             speed_boundary=shaft.get_speed_boundary(),
+            root_finding_strategy=root_finding_strategy,
         )
 
-    return create_outlet_pressure_solver
+    return create_segment
+
+
+@pytest.fixture
+def pipeline_section_solver_factory(pipeline_section_factory):
+    def create_segment_solver(
+        shaft: Shaft,
+        runner: ProcessRunner,
+        anti_surge_strategy: AntiSurgeStrategy,
+        pressure_control_strategy: PressureControlStrategy,
+        process_pipeline_id: ProcessPipelineId,
+    ) -> PipelineSectionSolver:
+        return PipelineSectionSolver(
+            pipeline_section_factory(
+                shaft=shaft,
+                runner=runner,
+                anti_surge_strategy=anti_surge_strategy,
+                pressure_control_strategy=pressure_control_strategy,
+                process_pipeline_id=process_pipeline_id,
+            )
+        )
+
+    return create_segment_solver
 
 
 @pytest.fixture
@@ -242,9 +265,9 @@ def downstream_choke_pressure_control_strategy_factory():
 @pytest.fixture
 def multi_pressure_solver_factory():
     def create_multi_pressure_solver(
-        segments: list[OutletPressureSolver],
+        pipeline_sections: list[PipelineSection],
     ) -> MultiPressureSolver:
-        return MultiPressureSolver(segments=segments)
+        return MultiPressureSolver(pipeline_sections=pipeline_sections)
 
     return create_multi_pressure_solver
 
@@ -296,9 +319,9 @@ def affinity_law_scaled_variable_speed_chart_data_factory():
 
 
 @pytest.fixture()
-def single_compressor_process_pipeline_factory(
+def single_compressor_pipeline_section_factory(
     affinity_law_scaled_variable_speed_chart_data_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_factory,
     compressor_factory,
     recirculation_loop_factory,
     process_runner_factory,
@@ -308,15 +331,15 @@ def single_compressor_process_pipeline_factory(
     individual_asv_anti_surge_strategy_factory,
     individual_asv_pressure_control_strategy_factory,
 ):
-    def create_process_pipeline(
+    def create_segment(
         *,
         min_rate: float,
         max_rate: float,
         head_hi: float,
         head_lo: float,
         inlet_temperature_kelvin: float,
-    ) -> OutletPressureSolver:
-        """One independently-shafted process pipeline: TemperatureSetter → Compressor with individual ASV."""
+    ) -> PipelineSection:
+        """One independently-shafted process section: TemperatureSetter → Compressor with individual ASV."""
         chart_data = affinity_law_scaled_variable_speed_chart_data_factory(min_rate, max_rate, head_hi, head_lo)
 
         compressor = compressor_factory(
@@ -354,7 +377,7 @@ def single_compressor_process_pipeline_factory(
             compressors=[compressor],
         )
 
-        return outlet_pressure_solver_factory(
+        return pipeline_section_factory(
             process_pipeline_id=ProcessPipelineId(ecalc_id_generator()),
             runner=runner,
             anti_surge_strategy=anti_surge,
@@ -362,4 +385,4 @@ def single_compressor_process_pipeline_factory(
             shaft=shaft,
         )
 
-    return create_process_pipeline
+    return create_segment

--- a/tests/libecalc/process/process_solver/pressure_control/test_individual_asv_rate_via_pipeline_section_solver.py
+++ b/tests/libecalc/process/process_solver/pressure_control/test_individual_asv_rate_via_pipeline_section_solver.py
@@ -25,7 +25,7 @@ def _chart(chart_data_factory, *, q0, min_rate_factor, max_rate_factor, head_hi,
     )
 
 
-def test_individual_asv_rate_via_outlet_pressure_solver_two_stages(
+def test_individual_asv_rate_via_pipeline_section_solver_two_stages(
     stream_factory,
     chart_data_factory,
     compressor_factory,
@@ -35,7 +35,7 @@ def test_individual_asv_rate_via_outlet_pressure_solver_two_stages(
     process_runner_factory,
     individual_asv_anti_surge_strategy_factory,
     individual_asv_rate_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
 ):
     temperature = 300.0
     inlet_stream = stream_factory(
@@ -74,7 +74,7 @@ def test_individual_asv_rate_via_outlet_pressure_solver_two_stages(
         recirculation_loop_ids=loop_ids,
         compressors=compressors,
     )
-    solver = outlet_pressure_solver_factory(
+    solver = pipeline_section_solver_factory(
         shaft=shaft,
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,

--- a/tests/libecalc/process/process_solver/test_common_asv_solver_vs_legacy_train.py
+++ b/tests/libecalc/process/process_solver/test_common_asv_solver_vs_legacy_train.py
@@ -62,7 +62,7 @@ def test_common_asv_solver_vs_legacy_train(
     process_runner_factory,
     common_asv_anti_surge_strategy_factory,
     common_asv_pressure_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
 ):
     temperature = 300.0
     target_pressure = 92.0
@@ -147,7 +147,7 @@ def test_common_asv_solver_vs_legacy_train(
         first_compressor=first_compressor,
     )
     process_pipeline = process_pipeline_factory(units=process_units)
-    train_solver = outlet_pressure_solver_factory(
+    train_solver = pipeline_section_solver_factory(
         shaft=shaft_new,
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,

--- a/tests/libecalc/process/process_solver/test_feasibility_solver.py
+++ b/tests/libecalc/process/process_solver/test_feasibility_solver.py
@@ -161,7 +161,7 @@ def feasibility_solver_setup(
     with_individual_asv,
     individual_asv_anti_surge_strategy_factory,
     individual_asv_rate_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
 ):
     """Factory fixture: build a fully-wired FeasibilitySolver for a given compressor.
 
@@ -192,7 +192,7 @@ def feasibility_solver_setup(
             recirculation_loop_ids=loop_ids,
             compressors=[compressor],
         )
-        outlet_pressure_solver = outlet_pressure_solver_factory(
+        segment_solver = pipeline_section_solver_factory(
             shaft=shaft,
             runner=runner,
             anti_surge_strategy=anti_surge,
@@ -200,7 +200,7 @@ def feasibility_solver_setup(
             process_pipeline_id=process_pipeline.get_id(),
         )
 
-        return FeasibilitySolver(outlet_pressure_solver=outlet_pressure_solver)
+        return FeasibilitySolver(pipeline_section_solver=segment_solver)
 
     return _create
 
@@ -358,7 +358,7 @@ def two_stage_feasibility_solver(
     with_individual_asv,
     individual_asv_anti_surge_strategy_factory,
     individual_asv_rate_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
     fluid_service,
 ):
     """Two identical Unisim stages in series on a shared shaft, with inter-stage cooling."""
@@ -395,14 +395,14 @@ def two_stage_feasibility_solver(
     pressure_control = individual_asv_rate_control_strategy_factory(
         runner=runner, recirculation_loop_ids=loop_ids, compressors=[c1, c2]
     )
-    outlet_pressure_solver = outlet_pressure_solver_factory(
+    segment_solver = pipeline_section_solver_factory(
         shaft=shaft,
         runner=runner,
         anti_surge_strategy=anti_surge,
         pressure_control_strategy=pressure_control,
         process_pipeline_id=process_pipeline.get_id(),
     )
-    return FeasibilitySolver(outlet_pressure_solver=outlet_pressure_solver)
+    return FeasibilitySolver(pipeline_section_solver=segment_solver)
 
 
 class TestTwoStageTrain:

--- a/tests/libecalc/process/process_solver/test_individual_asv_solver_vs_legacy_train.py
+++ b/tests/libecalc/process/process_solver/test_individual_asv_solver_vs_legacy_train.py
@@ -48,7 +48,7 @@ def test_individual_asv_rate_solver_vs_legacy_train(
     process_runner_factory,
     individual_asv_anti_surge_strategy_factory,
     individual_asv_rate_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
 ):
     temperature = 300.0
     target_pressure = pd_target
@@ -136,7 +136,7 @@ def test_individual_asv_rate_solver_vs_legacy_train(
         recirculation_loop_ids=recirculation_loop_ids,
         compressors=compressors,
     )
-    train_solver = outlet_pressure_solver_factory(
+    train_solver = pipeline_section_solver_factory(
         shaft=shaft_new,
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
@@ -192,7 +192,7 @@ def test_individual_asv_pressure_solver_vs_legacy_train(
     process_runner_factory,
     individual_asv_anti_surge_strategy_factory,
     individual_asv_pressure_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
 ):
     temperature = 300.0
     target_pressure = pd_target
@@ -278,7 +278,7 @@ def test_individual_asv_pressure_solver_vs_legacy_train(
         recirculation_loop_ids=recirculation_loop_ids,
         compressors=compressors,
     )
-    train_solver = outlet_pressure_solver_factory(
+    train_solver = pipeline_section_solver_factory(
         shaft=shaft_new,
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
@@ -326,7 +326,7 @@ def test_individual_asv_anti_surge_returns_failure_when_rate_above_stonewall(
     process_runner_factory,
     individual_asv_anti_surge_strategy_factory,
     individual_asv_rate_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
     chart_data_factory,
 ):
     shaft = VariableSpeedShaft()
@@ -363,7 +363,7 @@ def test_individual_asv_anti_surge_returns_failure_when_rate_above_stonewall(
     pressure_control = individual_asv_rate_control_strategy_factory(
         runner=runner, recirculation_loop_ids=loop_ids, compressors=compressors
     )
-    solver = outlet_pressure_solver_factory(
+    solver = pipeline_section_solver_factory(
         shaft=shaft,
         runner=runner,
         anti_surge_strategy=anti_surge,

--- a/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
@@ -3,39 +3,12 @@ import pytest
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl, InterstagePressureControl
 from libecalc.domain.process.compressor.core.train.compressor_train_common_shaft import CompressorTrainCommonShaft
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
-from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
-from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_pressure_solver import MultiPressureSolver
-from libecalc.process.process_solver.outlet_pressure_solver import OutletPressureSolver
-from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
-from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.solver import TargetPressureUnreachableFailure
 from libecalc.process.process_units.mixer import Mixer
 from libecalc.process.process_units.splitter import Splitter
-from libecalc.process.shaft import Shaft, VariableSpeedShaft
-
-
-@pytest.fixture
-def segment_factory(root_finding_strategy):
-    def create_segment(
-        runner: ProcessRunner,
-        anti_surge_strategy: AntiSurgeStrategy,
-        pressure_control_strategy: PressureControlStrategy,
-        process_pipeline_id: ProcessPipelineId,
-        shaft: Shaft,
-    ):
-        return OutletPressureSolver(
-            process_pipeline_id=process_pipeline_id,
-            anti_surge_strategy=anti_surge_strategy,
-            shaft_id=shaft.get_id(),
-            speed_boundary=shaft.get_speed_boundary(),
-            pressure_control_strategy=pressure_control_strategy,
-            runner=runner,
-            root_finding_strategy=root_finding_strategy,
-        )
-
-    return create_segment
+from libecalc.process.shaft import VariableSpeedShaft
 
 
 @pytest.mark.parametrize("pd_target", [92.0, 150.0])
@@ -54,7 +27,7 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
     multi_pressure_solver_factory,
     compressor_stage_factory,
     variable_speed_chart_data_factory,
-    segment_factory,
+    pipeline_section_factory,
 ):
     temperature = 300.0
     interstage_pressure_target = 60.0  # bara
@@ -150,7 +123,7 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
     )
     high_pressure_process_pipeline = process_pipeline_factory(units=[splitter, *high_pressure_units_wrapped])
 
-    low_pressure_segment = segment_factory(
+    low_pressure_segment = pipeline_section_factory(
         runner=low_pressure_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=low_pressure_runner,
@@ -165,7 +138,7 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
         shaft=shaft_new,
         process_pipeline_id=low_pressure_process_pipeline.get_id(),
     )
-    high_pressure_segment = segment_factory(
+    high_pressure_segment = pipeline_section_factory(
         runner=high_pressure_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=high_pressure_runner,
@@ -182,7 +155,7 @@ def test_two_stage_train_with_interstage_pressure_vs_legacy(
     )
 
     solver = multi_pressure_solver_factory(
-        segments=[low_pressure_segment, high_pressure_segment],
+        pipeline_sections=[low_pressure_segment, high_pressure_segment],
     )
     solution = solver.find_solution(
         pressure_targets=[
@@ -218,7 +191,7 @@ def test_three_stage_train_with_mixers_and_splitters_at_interstage(
     individual_asv_rate_control_strategy_factory,
     multi_pressure_solver_factory,
     variable_speed_chart_data_factory,
-    segment_factory,
+    pipeline_section_factory,
 ):
     """LP → [Mixer1, Mixer2] → MP → [Splitter1, Splitter2] → HP, with interstage pressures at both junctions."""
     temperature = 300.0
@@ -312,7 +285,7 @@ def test_three_stage_train_with_mixers_and_splitters_at_interstage(
     mixer2.set_stream(injection_stream)
 
     def make_segment(runner, loop_ids, compressors, process_pipeline):
-        return segment_factory(
+        return pipeline_section_factory(
             shaft=shaft,
             runner=runner,
             anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
@@ -329,7 +302,7 @@ def test_three_stage_train_with_mixers_and_splitters_at_interstage(
         )
 
     solver = multi_pressure_solver_factory(
-        segments=[
+        pipeline_sections=[
             make_segment(
                 low_pressure_runner, low_pressure_loop_ids, low_pressure_compressors, low_pressure_process_pipeline
             ),
@@ -376,7 +349,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
     individual_asv_rate_control_strategy_factory,
     root_finding_strategy,
     variable_speed_chart_data_factory,
-    segment_factory,
+    pipeline_section_factory,
 ):
     """TargetPressureUnreachableFailure.source_id should identify the second segment when it fails."""
 
@@ -411,7 +384,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
     hp_runner = process_runner_factory(units=hp_units, configuration_handlers=[shaft, *hp_loops])
     hp_process_pipeline = process_pipeline_factory(units=hp_units)
 
-    lp_segment = segment_factory(
+    lp_segment = pipeline_section_factory(
         runner=lp_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=lp_runner, recirculation_loop_ids=lp_loop_ids, compressors=lp_compressors
@@ -422,7 +395,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
         shaft=shaft,
         process_pipeline_id=lp_process_pipeline.get_id(),
     )
-    hp_segment = segment_factory(
+    hp_segment = pipeline_section_factory(
         runner=hp_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=hp_runner, recirculation_loop_ids=hp_loop_ids, compressors=hp_compressors
@@ -434,7 +407,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
         process_pipeline_id=hp_process_pipeline.get_id(),
     )
 
-    solver = MultiPressureSolver(segments=[lp_segment, hp_segment])
+    solver = MultiPressureSolver(pipeline_sections=[lp_segment, hp_segment])
 
     inlet_stream = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
 
@@ -462,7 +435,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
     individual_asv_rate_control_strategy_factory,
     root_finding_strategy,
     variable_speed_chart_data_factory,
-    segment_factory,
+    pipeline_section_factory,
 ):
     """TargetPressureUnreachableFailure.source_id should identify the first segment when it fails."""
     temperature = 300.0
@@ -496,7 +469,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
     hp_runner = process_runner_factory(units=hp_units, configuration_handlers=[shaft, *hp_loops])
     hp_process_pipeline = process_pipeline_factory(units=hp_units)
 
-    lp_segment = segment_factory(
+    lp_segment = pipeline_section_factory(
         runner=lp_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=lp_runner, recirculation_loop_ids=lp_loop_ids, compressors=lp_compressors
@@ -507,7 +480,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
         shaft=shaft,
         process_pipeline_id=lp_process_pipeline.get_id(),
     )
-    hp_segment = segment_factory(
+    hp_segment = pipeline_section_factory(
         runner=hp_runner,
         anti_surge_strategy=individual_asv_anti_surge_strategy_factory(
             runner=hp_runner, recirculation_loop_ids=hp_loop_ids, compressors=hp_compressors
@@ -519,7 +492,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
         process_pipeline_id=hp_process_pipeline.get_id(),
     )
 
-    solver = MultiPressureSolver(segments=[lp_segment, hp_segment])
+    solver = MultiPressureSolver(pipeline_sections=[lp_segment, hp_segment])
 
     inlet_stream = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
 

--- a/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_equal_ratio_solver.py
@@ -17,14 +17,14 @@ def pipeline_kwargs():
 
 
 def test_three_shaft_train_hits_target_pressure(
-    stream_factory, pipeline_kwargs, single_compressor_process_pipeline_factory
+    stream_factory, pipeline_kwargs, single_compressor_pipeline_section_factory
 ):
     pipelines = [
-        single_compressor_process_pipeline_factory(min_rate=200, max_rate=5000, **pipeline_kwargs),
-        single_compressor_process_pipeline_factory(min_rate=150, max_rate=3500, **pipeline_kwargs),
-        single_compressor_process_pipeline_factory(min_rate=100, max_rate=2500, **pipeline_kwargs),
+        single_compressor_pipeline_section_factory(min_rate=200, max_rate=5000, **pipeline_kwargs),
+        single_compressor_pipeline_section_factory(min_rate=150, max_rate=3500, **pipeline_kwargs),
+        single_compressor_pipeline_section_factory(min_rate=100, max_rate=2500, **pipeline_kwargs),
     ]
-    solver = MultiShaftEqualRatioSolver(process_pipelines=pipelines)
+    solver = MultiShaftEqualRatioSolver(pipeline_sections=pipelines)
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
     solution = solver.find_solution(FloatConstraint(270.0, abs_tol=5.0), inlet)
@@ -33,15 +33,15 @@ def test_three_shaft_train_hits_target_pressure(
 
 
 def test_each_shaft_runs_at_different_speed(
-    stream_factory, pipeline_kwargs, single_compressor_process_pipeline_factory
+    stream_factory, pipeline_kwargs, single_compressor_pipeline_section_factory
 ):
     """Real-gas effects cause each pipeline to need a different shaft speed."""
     pipelines = [
-        single_compressor_process_pipeline_factory(min_rate=200, max_rate=5000, **pipeline_kwargs),
-        single_compressor_process_pipeline_factory(min_rate=150, max_rate=3500, **pipeline_kwargs),
-        single_compressor_process_pipeline_factory(min_rate=100, max_rate=2500, **pipeline_kwargs),
+        single_compressor_pipeline_section_factory(min_rate=200, max_rate=5000, **pipeline_kwargs),
+        single_compressor_pipeline_section_factory(min_rate=150, max_rate=3500, **pipeline_kwargs),
+        single_compressor_pipeline_section_factory(min_rate=100, max_rate=2500, **pipeline_kwargs),
     ]
-    solver = MultiShaftEqualRatioSolver(process_pipelines=pipelines)
+    solver = MultiShaftEqualRatioSolver(pipeline_sections=pipelines)
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
     solution = solver.find_solution(FloatConstraint(270.0, abs_tol=5.0), inlet)
@@ -52,7 +52,7 @@ def test_each_shaft_runs_at_different_speed(
 
 
 def test_intercooler_changes_stage_speed(
-    stream_factory, fluid_service, root_finding_strategy, single_compressor_process_pipeline_factory
+    stream_factory, fluid_service, root_finding_strategy, single_compressor_pipeline_section_factory
 ):
     """Warmer inlet temperature changes the required shaft speed."""
     common = {
@@ -62,14 +62,14 @@ def test_intercooler_changes_stage_speed(
         "head_lo": 140_000,
     }
 
-    cool = [single_compressor_process_pipeline_factory(**common, inlet_temperature_kelvin=303.15) for _ in range(3)]
-    warm = [single_compressor_process_pipeline_factory(**common, inlet_temperature_kelvin=360.0) for _ in range(3)]
+    cool = [single_compressor_pipeline_section_factory(**common, inlet_temperature_kelvin=303.15) for _ in range(3)]
+    warm = [single_compressor_pipeline_section_factory(**common, inlet_temperature_kelvin=360.0) for _ in range(3)]
 
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
     constraint = FloatConstraint(270.0, abs_tol=5.0)
 
-    sol_cool = MultiShaftEqualRatioSolver(process_pipelines=cool).find_solution(constraint, inlet)
-    sol_warm = MultiShaftEqualRatioSolver(process_pipelines=warm).find_solution(constraint, inlet)
+    sol_cool = MultiShaftEqualRatioSolver(pipeline_sections=cool).find_solution(constraint, inlet)
+    sol_warm = MultiShaftEqualRatioSolver(pipeline_sections=warm).find_solution(constraint, inlet)
 
     assert sol_cool.success and sol_warm.success
 
@@ -81,7 +81,7 @@ def test_intercooler_changes_stage_speed(
 
 
 def test_empty_pipelines(stream_factory):
-    solver = MultiShaftEqualRatioSolver(process_pipelines=[])
+    solver = MultiShaftEqualRatioSolver(pipeline_sections=[])
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
     solution = solver.find_solution(FloatConstraint(270.0, abs_tol=5.0), inlet)
@@ -91,10 +91,10 @@ def test_empty_pipelines(stream_factory):
     assert solution.failure is None
 
 
-def test_single_pipeline_hits_exact_target(stream_factory, pipeline_kwargs, single_compressor_process_pipeline_factory):
+def test_single_pipeline_hits_exact_target(stream_factory, pipeline_kwargs, single_compressor_pipeline_section_factory):
     """With one pipeline the target is the exact constraint (no intermediate splitting)."""
-    pipeline = single_compressor_process_pipeline_factory(min_rate=200, max_rate=5000, **pipeline_kwargs)
-    solver = MultiShaftEqualRatioSolver(process_pipelines=[pipeline])
+    pipeline = single_compressor_pipeline_section_factory(min_rate=200, max_rate=5000, **pipeline_kwargs)
+    solver = MultiShaftEqualRatioSolver(pipeline_sections=[pipeline])
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
     solution = solver.find_solution(FloatConstraint(60.0, abs_tol=0.5), inlet)
@@ -106,14 +106,14 @@ def test_single_pipeline_hits_exact_target(stream_factory, pipeline_kwargs, sing
 
 
 def test_two_pipeline_intermediate_target_is_geometric_mean(
-    stream_factory, pipeline_kwargs, single_compressor_process_pipeline_factory
+    stream_factory, pipeline_kwargs, single_compressor_pipeline_section_factory
 ):
     """With two pipelines the intermediate target should be sqrt(P_in * P_out)."""
     pipelines = [
-        single_compressor_process_pipeline_factory(min_rate=200, max_rate=5000, **pipeline_kwargs),
-        single_compressor_process_pipeline_factory(min_rate=150, max_rate=3500, **pipeline_kwargs),
+        single_compressor_pipeline_section_factory(min_rate=200, max_rate=5000, **pipeline_kwargs),
+        single_compressor_pipeline_section_factory(min_rate=150, max_rate=3500, **pipeline_kwargs),
     ]
-    solver = MultiShaftEqualRatioSolver(process_pipelines=pipelines)
+    solver = MultiShaftEqualRatioSolver(pipeline_sections=pipelines)
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
     solution = solver.find_solution(FloatConstraint(120.0, abs_tol=1.0), inlet)

--- a/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_solver.py
@@ -6,9 +6,9 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_shaft_solver import MultiShaftSolver
 
 
-def test_mismatched_targets_raises(single_compressor_process_pipeline_factory, stream_factory):
+def test_mismatched_targets_raises(single_compressor_pipeline_section_factory, stream_factory):
     pipelines = [
-        single_compressor_process_pipeline_factory(
+        single_compressor_pipeline_section_factory(
             min_rate=200,
             max_rate=5000,
             head_hi=200_000,
@@ -16,7 +16,7 @@ def test_mismatched_targets_raises(single_compressor_process_pipeline_factory, s
             inlet_temperature_kelvin=303.15,
         )
     ]
-    solver = MultiShaftSolver(process_pipelines=pipelines)
+    solver = MultiShaftSolver(pipeline_sections=pipelines)
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
     with pytest.raises(AssertionError, match="must match"):
@@ -24,7 +24,7 @@ def test_mismatched_targets_raises(single_compressor_process_pipeline_factory, s
 
 
 def test_empty_pipelines(stream_factory):
-    solver = MultiShaftSolver(process_pipelines=[])
+    solver = MultiShaftSolver(pipeline_sections=[])
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
     solution = solver.find_solution([], inlet)
@@ -34,10 +34,10 @@ def test_empty_pipelines(stream_factory):
     assert solution.failure is None
 
 
-def test_unreachable_target_reports_failure(single_compressor_process_pipeline_factory, stream_factory):
+def test_unreachable_target_reports_failure(single_compressor_pipeline_section_factory, stream_factory):
     """A target far beyond the chart capability should return success=False."""
     pipelines = [
-        single_compressor_process_pipeline_factory(
+        single_compressor_pipeline_section_factory(
             min_rate=200,
             max_rate=5000,
             head_hi=200_000,
@@ -45,7 +45,7 @@ def test_unreachable_target_reports_failure(single_compressor_process_pipeline_f
             inlet_temperature_kelvin=303.15,
         )
     ]
-    solver = MultiShaftSolver(process_pipelines=pipelines)
+    solver = MultiShaftSolver(pipeline_sections=pipelines)
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
     # 9000 bara from 30 bara inlet is far beyond what a single stage can deliver
@@ -55,17 +55,17 @@ def test_unreachable_target_reports_failure(single_compressor_process_pipeline_f
     assert solution.failure is not None
 
 
-def test_second_pipeline_failure_preserves_first_failure(single_compressor_process_pipeline_factory, stream_factory):
+def test_second_pipeline_failure_preserves_first_failure(single_compressor_pipeline_section_factory, stream_factory):
     """When multiple pipelines fail, the first failure is preserved."""
     pipelines = [
-        single_compressor_process_pipeline_factory(
+        single_compressor_pipeline_section_factory(
             min_rate=200,
             max_rate=5000,
             head_hi=200_000,
             head_lo=140_000,
             inlet_temperature_kelvin=303.15,
         ),
-        single_compressor_process_pipeline_factory(
+        single_compressor_pipeline_section_factory(
             min_rate=200,
             max_rate=5000,
             head_hi=200_000,
@@ -73,7 +73,7 @@ def test_second_pipeline_failure_preserves_first_failure(single_compressor_proce
             inlet_temperature_kelvin=303.15,
         ),
     ]
-    solver = MultiShaftSolver(process_pipelines=pipelines)
+    solver = MultiShaftSolver(pipeline_sections=pipelines)
     inlet = stream_factory(standard_rate_m3_per_day=1_500_000.0, pressure_bara=30.0, temperature_kelvin=303.15)
 
     # Both targets unreachable

--- a/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
+++ b/tests/libecalc/process/process_solver/test_multi_shaft_vs_simplified_train.py
@@ -26,7 +26,7 @@ def test_multi_shaft_outlet_pressure_matches_simplified_train(
     compressor_stage_factory,
     fluid_service,
     affinity_law_scaled_variable_speed_chart_data_factory,
-    single_compressor_process_pipeline_factory,
+    single_compressor_pipeline_section_factory,
 ):
     """Outlet pressure should match within 1% relative tolerance."""
     # Legacy: CompressorTrainSimplified
@@ -53,7 +53,7 @@ def test_multi_shaft_outlet_pressure_matches_simplified_train(
 
     # New: MultiShaftEqualRatioSolver
     solver_pipelines = [
-        single_compressor_process_pipeline_factory(
+        single_compressor_pipeline_section_factory(
             min_rate=_MIN_RATE,
             max_rate=_MAX_RATE,
             head_hi=_HEAD_HI,
@@ -62,7 +62,7 @@ def test_multi_shaft_outlet_pressure_matches_simplified_train(
         )
         for _ in range(_N_STAGES)
     ]
-    solver = MultiShaftEqualRatioSolver(process_pipelines=solver_pipelines)
+    solver = MultiShaftEqualRatioSolver(pipeline_sections=solver_pipelines)
     solution = solver.find_solution(FloatConstraint(_P_OUT_BARA, abs_tol=1.0), inlet_stream)
 
     assert solution.success, f"Solver failed: {solution.failure}"

--- a/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_common_asv.py
+++ b/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_common_asv.py
@@ -15,7 +15,7 @@ def shaft():
 
 @pytest.mark.inlinesnapshot
 @pytest.mark.snapshot
-def test_outlet_pressure_solver_with_common_asv(
+def test_pipeline_section_solver_with_common_asv(
     stream_factory,
     compressor_factory,
     stage_units_factory,
@@ -26,7 +26,7 @@ def test_outlet_pressure_solver_with_common_asv(
     process_runner_factory,
     common_asv_anti_surge_strategy_factory,
     common_asv_pressure_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
 ):
     target_pressure = FloatConstraint(75)
     temperature = 300
@@ -51,7 +51,7 @@ def test_outlet_pressure_solver_with_common_asv(
         recirculation_loop_id=common_asv.get_id(),
         first_compressor=first_compressor,
     )
-    common_asv_solver = outlet_pressure_solver_factory(
+    common_asv_solver = pipeline_section_solver_factory(
         shaft=shaft,
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
@@ -128,7 +128,7 @@ def test_find_solution_returns_failure_when_rate_above_stonewall(
     process_runner_factory,
     common_asv_anti_surge_strategy_factory,
     common_asv_pressure_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
 ):
     common_asv, process_units = with_common_asv([small_chart_compressor])
 
@@ -140,7 +140,7 @@ def test_find_solution_returns_failure_when_rate_above_stonewall(
     pressure_control = common_asv_pressure_control_strategy_factory(
         runner=runner, recirculation_loop_id=common_asv.get_id(), first_compressor=small_chart_compressor
     )
-    solver = outlet_pressure_solver_factory(
+    solver = pipeline_section_solver_factory(
         shaft=shaft,
         runner=runner,
         anti_surge_strategy=anti_surge,
@@ -168,7 +168,7 @@ def test_pressure_control_boundary_not_affected_by_residual_anti_surge_recircula
     process_runner_factory,
     common_asv_anti_surge_strategy_factory,
     common_asv_pressure_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
 ):
     """Regression test: pressure control must reset recirculation before computing
     the recirculation boundary.
@@ -190,7 +190,7 @@ def test_pressure_control_boundary_not_affected_by_residual_anti_surge_recircula
     pressure_control = common_asv_pressure_control_strategy_factory(
         runner=runner, recirculation_loop_id=common_asv.get_id(), first_compressor=small_chart_compressor
     )
-    solver = outlet_pressure_solver_factory(
+    solver = pipeline_section_solver_factory(
         shaft=shaft,
         runner=runner,
         anti_surge_strategy=anti_surge,

--- a/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_downstream_choke.py
+++ b/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_downstream_choke.py
@@ -26,47 +26,45 @@ def single_speed_compressor(fluid_service):
     )
 
 
-def test_outlet_pressure_solver_applies_upstream_choke_when_speed_solution_is_at_min_speed(
+def test_pipeline_section_solver_applies_downstream_choke_when_speed_solution_is_at_min_speed(
     stream_factory,
     choke_factory,
     choke_configuration_handler_factory,
     single_speed_compressor,
-    with_common_asv,
     process_pipeline_factory,
     process_runner_factory,
+    with_common_asv,
     common_asv_anti_surge_strategy_factory,
-    upstream_choke_pressure_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    downstream_choke_pressure_control_strategy_factory,
+    pipeline_section_solver_factory,
 ):
     """
-    If the outlet pressure is higher than the target outlet pressure at minimum speed, SpeedSolver returns
-    success=False and selects the minimum speed. OutletPressureSolver should still attempt pressure control, and with an
-    upstream choke it should be able to meet the target.
+    If the target outlet pressure is lower than the outlet pressure at minimum speed, SpeedSolver returns
+    success=False and selects the minimum speed. PipelineSectionSolver should still attempt pressure control, and with a
+    downstream choke it should be able to meet the target.
     """
     compressor = single_speed_compressor
     shaft = VariableSpeedShaft()
     shaft.connect(compressor)
-    upstream_choke = choke_factory()
-    upstream_choke_configuration_handler = choke_configuration_handler_factory(choke=upstream_choke)
+    downstream_choke = choke_factory()
+    downstream_choke_configuration_handler = choke_configuration_handler_factory(choke=downstream_choke)
 
     recirculation_loop, process_units = with_common_asv([compressor])
-
     runner = process_runner_factory(
-        units=[upstream_choke, *process_units],
-        configuration_handlers=[shaft, recirculation_loop, upstream_choke_configuration_handler],
+        units=[*process_units, downstream_choke],
+        configuration_handlers=[shaft, recirculation_loop, downstream_choke_configuration_handler],
     )
-    process_pipeline = process_pipeline_factory(units=[upstream_choke, *process_units])
+    process_pipeline = process_pipeline_factory(units=[*process_units, downstream_choke])
     anti_surge_strategy = common_asv_anti_surge_strategy_factory(
         runner=runner,
         recirculation_loop_id=recirculation_loop.get_id(),
         first_compressor=compressor,
     )
-    pressure_control_strategy = upstream_choke_pressure_control_strategy_factory(
+    pressure_control_strategy = downstream_choke_pressure_control_strategy_factory(
         runner=runner,
-        choke_id=upstream_choke_configuration_handler.get_id(),
-        anti_surge_strategy=anti_surge_strategy,
+        choke_id=downstream_choke_configuration_handler.get_id(),
     )
-    solver = outlet_pressure_solver_factory(
+    solver = pipeline_section_solver_factory(
         shaft=shaft,
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
@@ -79,24 +77,23 @@ def test_outlet_pressure_solver_applies_upstream_choke_when_speed_solution_is_at
 
     # The compressor (single speed) produces outlet pressure well above 28 bara.
     # SpeedSolver cannot lower it further, so it returns min speed with success=False.
-    # The upstream choke reduces inlet pressure, which lowers outlet pressure to the target.
-    target_pressure = FloatConstraint(28.0, abs_tol=1e-4)
+    # The downstream choke then reduces pressure to the target.
+    target_pressure = FloatConstraint(28.0, abs_tol=1e-12)
 
     solution = solver.find_solution(
         pressure_constraint=target_pressure,
         inlet_stream=inlet_stream,
     )
-
     speed_configuration = solution.get_configuration(shaft.get_id())
 
     # Single-speed compressor: SpeedSolver is forced to return the only available speed.
     assert speed_configuration.speed == shaft.get_speed_boundary().min
 
-    # Overall solver should succeed via upstream choke pressure control.
+    # Overall solver should succeed via downstream choke pressure control.
     assert solution.success
-    assert solution.get_configuration(upstream_choke_configuration_handler.get_id()).delta_pressure > 0
+    assert solution.get_configuration(downstream_choke_configuration_handler.get_id()).delta_pressure > 0
 
-    # Verify that upstream choking actually brings outlet down to target.
+    # Verify that downstream choking actually brings outlet down to target.
     runner.apply_configurations(solution.configuration)
     outlet = runner.run(inlet_stream=inlet_stream)
     assert outlet.pressure_bara == target_pressure

--- a/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_upstream_choke.py
+++ b/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_upstream_choke.py
@@ -26,45 +26,47 @@ def single_speed_compressor(fluid_service):
     )
 
 
-def test_outlet_pressure_solver_applies_downstream_choke_when_speed_solution_is_at_min_speed(
+def test_pipeline_section_solver_applies_upstream_choke_when_speed_solution_is_at_min_speed(
     stream_factory,
     choke_factory,
     choke_configuration_handler_factory,
     single_speed_compressor,
+    with_common_asv,
     process_pipeline_factory,
     process_runner_factory,
-    with_common_asv,
     common_asv_anti_surge_strategy_factory,
-    downstream_choke_pressure_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    upstream_choke_pressure_control_strategy_factory,
+    pipeline_section_solver_factory,
 ):
     """
-    If the target outlet pressure is lower than the outlet pressure at minimum speed, SpeedSolver returns
-    success=False and selects the minimum speed. OutletPressureSolver should still attempt pressure control, and with a
-    downstream choke it should be able to meet the target.
+    If the outlet pressure is higher than the target outlet pressure at minimum speed, SpeedSolver returns
+    success=False and selects the minimum speed. PipelineSectionSolver should still attempt pressure control, and with an
+    upstream choke it should be able to meet the target.
     """
     compressor = single_speed_compressor
     shaft = VariableSpeedShaft()
     shaft.connect(compressor)
-    downstream_choke = choke_factory()
-    downstream_choke_configuration_handler = choke_configuration_handler_factory(choke=downstream_choke)
+    upstream_choke = choke_factory()
+    upstream_choke_configuration_handler = choke_configuration_handler_factory(choke=upstream_choke)
 
     recirculation_loop, process_units = with_common_asv([compressor])
+
     runner = process_runner_factory(
-        units=[*process_units, downstream_choke],
-        configuration_handlers=[shaft, recirculation_loop, downstream_choke_configuration_handler],
+        units=[upstream_choke, *process_units],
+        configuration_handlers=[shaft, recirculation_loop, upstream_choke_configuration_handler],
     )
-    process_pipeline = process_pipeline_factory(units=[*process_units, downstream_choke])
+    process_pipeline = process_pipeline_factory(units=[upstream_choke, *process_units])
     anti_surge_strategy = common_asv_anti_surge_strategy_factory(
         runner=runner,
         recirculation_loop_id=recirculation_loop.get_id(),
         first_compressor=compressor,
     )
-    pressure_control_strategy = downstream_choke_pressure_control_strategy_factory(
+    pressure_control_strategy = upstream_choke_pressure_control_strategy_factory(
         runner=runner,
-        choke_id=downstream_choke_configuration_handler.get_id(),
+        choke_id=upstream_choke_configuration_handler.get_id(),
+        anti_surge_strategy=anti_surge_strategy,
     )
-    solver = outlet_pressure_solver_factory(
+    solver = pipeline_section_solver_factory(
         shaft=shaft,
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,
@@ -77,23 +79,24 @@ def test_outlet_pressure_solver_applies_downstream_choke_when_speed_solution_is_
 
     # The compressor (single speed) produces outlet pressure well above 28 bara.
     # SpeedSolver cannot lower it further, so it returns min speed with success=False.
-    # The downstream choke then reduces pressure to the target.
-    target_pressure = FloatConstraint(28.0, abs_tol=1e-12)
+    # The upstream choke reduces inlet pressure, which lowers outlet pressure to the target.
+    target_pressure = FloatConstraint(28.0, abs_tol=1e-4)
 
     solution = solver.find_solution(
         pressure_constraint=target_pressure,
         inlet_stream=inlet_stream,
     )
+
     speed_configuration = solution.get_configuration(shaft.get_id())
 
     # Single-speed compressor: SpeedSolver is forced to return the only available speed.
     assert speed_configuration.speed == shaft.get_speed_boundary().min
 
-    # Overall solver should succeed via downstream choke pressure control.
+    # Overall solver should succeed via upstream choke pressure control.
     assert solution.success
-    assert solution.get_configuration(downstream_choke_configuration_handler.get_id()).delta_pressure > 0
+    assert solution.get_configuration(upstream_choke_configuration_handler.get_id()).delta_pressure > 0
 
-    # Verify that downstream choking actually brings outlet down to target.
+    # Verify that upstream choking actually brings outlet down to target.
     runner.apply_configurations(solution.configuration)
     outlet = runner.run(inlet_stream=inlet_stream)
     assert outlet.pressure_bara == target_pressure

--- a/tests/libecalc/process/process_solver/test_process_solver_builder.py
+++ b/tests/libecalc/process/process_solver/test_process_solver_builder.py
@@ -113,7 +113,9 @@ def test_builder_wires_expected_solver_strategies(
         pressure_control_type=pressure_control_type,
         fluid_service=fluid_service,
     ).build()
-    assert isinstance(system.solver.pressure_control_strategy, PRESSURE_CONTROL_STRATEGY_TYPES[pressure_control_type])
+    assert isinstance(
+        system.pipeline_section.pressure_control_strategy, PRESSURE_CONTROL_STRATEGY_TYPES[pressure_control_type]
+    )
 
 
 def test_builder_uses_single_recirculation_loop_for_common_asv(

--- a/tests/libecalc/process/process_solver/test_two_stage_train_with_interstage_splitter_vs_legacy.py
+++ b/tests/libecalc/process/process_solver/test_two_stage_train_with_interstage_splitter_vs_legacy.py
@@ -23,7 +23,7 @@ def test_two_stage_train_with_interstage_splitter_vs_legacy(
     process_runner_factory,
     individual_asv_anti_surge_strategy_factory,
     individual_asv_rate_control_strategy_factory,
-    outlet_pressure_solver_factory,
+    pipeline_section_solver_factory,
     variable_speed_chart_data_factory,
 ):
     temperature = 300.0
@@ -116,7 +116,7 @@ def test_two_stage_train_with_interstage_splitter_vs_legacy(
         recirculation_loop_ids=recirculation_loop_ids,
         compressors=compressors,
     )
-    train_solver = outlet_pressure_solver_factory(
+    train_solver = pipeline_section_solver_factory(
         shaft=shaft_new,
         runner=runner,
         anti_surge_strategy=anti_surge_strategy,


### PR DESCRIPTION
An attempt to separate concerns, to separate data from behaviour.

PipelineSection contains data
PipelineSectionSolver contains solver algorithm
Multi-* delegates to PipelineSectionSolvers

Not sure about the name... Segment, SubProblem, Section. We have tried many.

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
