### PR TITLE
chore: bump NeqSim to 3.13.0

### DIFF
--- a/src/ecalc_neqsim_wrapper/lib/neqsim_version_info.md
+++ b/src/ecalc_neqsim_wrapper/lib/neqsim_version_info.md
@@ -1,4 +1,4 @@
-Current neqsim.jar from latest release of NeqSim (v3.0.38 - https://github.com/equinor/neqsim/releases/tag/v3.0.38)
+Current neqsim.jar from latest release of NeqSim (v3.13.0 - https://github.com/equinor/neqsim/releases/tag/v3.13.0)
 
 NeqSim is currently not considered to be thread-safe. That means that two threads working towards the same gateway, interchangely changing a fluid setting will interfere with each other.
 


### PR DESCRIPTION
Updating NeqSim from version 3.8.0 to 3.13.0
Tested through the NeqSim compatibility suite (https://github.com/equinor/ecalc/pull/1560) - no compatibility issues found

Neqsim-version info was apparently not updated on last bumb.

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
