### PR TITLE
fix(libecalc): individual_asv_pressure now returns shaft speed instead of nan

### DIFF
--- a/src/libecalc/domain/process/compressor/core/train/compressor_train_common_shaft.py
+++ b/src/libecalc/domain/process/compressor/core/train/compressor_train_common_shaft.py
@@ -893,7 +893,7 @@ class CompressorTrainCommonShaft(CompressorTrainModel):
         return CompressorTrainResultSingleTimeStep(
             inlet_stream=inlet_stream_train,
             outlet_stream=stage_result.outlet_stream,
-            speed=float("nan"),
+            speed=self.shaft.get_speed(),
             stage_results=stage_results,
             target_pressure_status=target_pressure_status,
         )


### PR DESCRIPTION
## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

individual_asv_pressure now returns shaft speed instead of nan
