### PR TITLE
feat: introduce yaml mixer

### DIFF
--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -7,6 +7,7 @@ from libecalc.common.ddd.entity import Entity
 from libecalc.common.time_utils import Period
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.ecalc_model.time_series_configuration import (
+    TimeSeriesMixerConfiguration,
     TimeSeriesPressureDropperConfiguration,
     TimeSeriesTemperatureSetterConfiguration,
 )
@@ -110,7 +111,12 @@ class ProcessSimulation(Entity[ProcessSimulationId]):  # process_model?
         process_simulation_id: ProcessSimulationId | None = None,
         process_configurations: dict[
             ProcessPipelineId,
-            dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration | TimeSeriesPressureDropperConfiguration],
+            dict[
+                ProcessUnitId,
+                TimeSeriesTemperatureSetterConfiguration
+                | TimeSeriesPressureDropperConfiguration
+                | TimeSeriesMixerConfiguration,
+            ],
         ]
         | None = None,
     ):

--- a/src/libecalc/ecalc_model/time_series_configuration.py
+++ b/src/libecalc/ecalc_model/time_series_configuration.py
@@ -15,4 +15,4 @@ class TimeSeriesTemperatureSetterConfiguration:
 
 @value_object
 class TimeSeriesMixerConfiguration:
-    inlet_stream: TimeSeriesStream
+    sidestream: TimeSeriesStream

--- a/src/libecalc/ecalc_model/time_series_configuration.py
+++ b/src/libecalc/ecalc_model/time_series_configuration.py
@@ -1,4 +1,5 @@
 from libecalc.common.ddd import value_object
+from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 
 
@@ -10,3 +11,8 @@ class TimeSeriesPressureDropperConfiguration:
 @value_object
 class TimeSeriesTemperatureSetterConfiguration:
     temperature_in_celsius: TimeSeriesExpression
+
+
+@value_object
+class TimeSeriesMixerConfiguration:
+    inlet_stream: TimeSeriesStream

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -311,7 +311,6 @@ class ProcessSimulationMapper:
             shaft = VariableSpeedShaft()
             item = self._resolve_train_reference(yaml_compressor_train_item.target)
             process_unit_map: dict[ProcessUnitId, ProcessUnit] = {}
-            compressor_segments: list[list[ProcessUnitId]] = []
             compressor_ids: list[ProcessUnitId] = []
             problem_time_series_configurations: dict[
                 ProcessUnitId,
@@ -323,6 +322,7 @@ class ProcessSimulationMapper:
             # Group units into compressor segments: each segment contains the units leading up to
             # (and including) one compressor. Used downstream to wrap each segment in its own ASV
             # recirculation loop when pressure_control is INDIVIDUAL_ASV.
+            pipeline_chunks: list[tuple[bool, list[ProcessUnitId]]] = []  # (wrap_in_asv, ids)
             current_segment_unit_ids: list[ProcessUnitId] = []
             for yaml_pipeline_item in item.items:
                 yaml_process_unit = yaml_pipeline_item.target
@@ -335,8 +335,8 @@ class ProcessSimulationMapper:
                         process_unit_map[compressor.get_id()] = compressor
                         compressor_ids.append(compressor.get_id())
                         current_segment_unit_ids.append(compressor.get_id())
-                        # Compressor closes the current segment
-                        compressor_segments.append(current_segment_unit_ids)
+                        # Compressor should be wrapped in ASV-loop
+                        pipeline_chunks.append((True, current_segment_unit_ids))
                         current_segment_unit_ids = []
 
                     case YamlPressureDropper():
@@ -377,7 +377,8 @@ class ProcessSimulationMapper:
                             )
                         )
                         process_unit_map[mixer.get_id()] = mixer
-                        current_segment_unit_ids.append(mixer.get_id())
+                        # Mixer should not be wrapped in ASV-loop
+                        pipeline_chunks.append((False, [mixer.get_id()]))
 
                     case _:
                         # Unreachable for valid YAML (pydantic discriminator rejects unknown types).
@@ -405,11 +406,14 @@ class ProcessSimulationMapper:
                 recirculation_loop, process_units = with_asv(units=list(process_unit_map.values()))
                 problem_configuration_handlers.append(recirculation_loop)
             else:  # INDIVIDUAL ASV (ASV per stage) assumed if not COMMON ASV explicitly set
-                for compressor_segment_ids in compressor_segments:
-                    segment_units = [process_unit_map[segment_unit_id] for segment_unit_id in compressor_segment_ids]
-                    recirculation_loop, stage_process_units = with_asv(units=segment_units)
-                    problem_configuration_handlers.append(recirculation_loop)
-                    process_units.extend(stage_process_units)
+                for wrap_in_asv, unit_ids in pipeline_chunks:
+                    segment_units = [process_unit_map[uid] for uid in unit_ids]
+                    if wrap_in_asv:
+                        recirculation_loop, stage_process_units = with_asv(units=segment_units)
+                        problem_configuration_handlers.append(recirculation_loop)
+                        process_units.extend(stage_process_units)
+                    else:
+                        process_units.extend(segment_units)
 
                 # Trailing units after last compressor — outside any ASV loop
                 if current_segment_unit_ids:

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -20,6 +20,7 @@ from libecalc.ecalc_model.process_simulation import (
     ProcessSimulation,
 )
 from libecalc.ecalc_model.time_series_configuration import (
+    TimeSeriesMixerConfiguration,
     TimeSeriesPressureDropperConfiguration,
     TimeSeriesTemperatureSetterConfiguration,
 )
@@ -45,6 +46,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
     YamlCompressor,
     YamlCompressorModelChart,
     YamlLiquidRemover,
+    YamlMixer,
     YamlPressureDropper,
     YamlProcessUnit,
     YamlTemperatureSetter,
@@ -75,6 +77,7 @@ from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.process_units.direct_mixer import DirectMixer
 from libecalc.process.process_units.direct_splitter import DirectSplitter
 from libecalc.process.process_units.liquid_remover import LiquidRemover
+from libecalc.process.process_units.mixer import Mixer
 from libecalc.process.process_units.pressure_dropper import PressureDropper
 from libecalc.process.process_units.temperature_setter import TemperatureSetter
 from libecalc.process.shaft import VariableSpeedShaft
@@ -294,7 +297,12 @@ class ProcessSimulationMapper:
         # Some configurations are not found/set by the solver, but set by user upon process_simulation creation
         predefined_configurations: dict[
             ProcessPipelineId,
-            dict[ProcessUnitId, TimeSeriesTemperatureSetterConfiguration | TimeSeriesPressureDropperConfiguration],
+            dict[
+                ProcessUnitId,
+                TimeSeriesTemperatureSetterConfiguration
+                | TimeSeriesPressureDropperConfiguration
+                | TimeSeriesMixerConfiguration,
+            ],
         ] = {}
 
         process_pipeline_reference_to_id_map: dict[str, ProcessPipelineId] = {}
@@ -306,7 +314,10 @@ class ProcessSimulationMapper:
             compressor_segments: list[list[ProcessUnitId]] = []
             compressor_ids: list[ProcessUnitId] = []
             problem_time_series_configurations: dict[
-                ProcessUnitId, TimeSeriesTemperatureSetterConfiguration | TimeSeriesPressureDropperConfiguration
+                ProcessUnitId,
+                TimeSeriesTemperatureSetterConfiguration
+                | TimeSeriesPressureDropperConfiguration
+                | TimeSeriesMixerConfiguration,
             ] = {}
 
             # Group units into compressor segments: each segment contains the units leading up to
@@ -352,6 +363,22 @@ class ProcessSimulationMapper:
                         liquid_remover = LiquidRemover(fluid_service=self._fluid_service)
                         process_unit_map[liquid_remover.get_id()] = liquid_remover
                         current_segment_unit_ids.append(liquid_remover.get_id())
+
+                    case YamlMixer():
+                        yaml_stream = self._resolve_stream_reference(yaml_process_unit.inlet_stream)
+                        yaml_fluid_model = self._resolve_fluid_model_reference(yaml_stream.fluid_model)
+                        mixer = Mixer(fluid_service=self._fluid_service)
+                        problem_time_series_configurations[mixer.get_id()] = TimeSeriesMixerConfiguration(
+                            inlet_stream=TimeSeriesStream(
+                                pressure_bara=self._map_pressure(yaml_stream.pressure),
+                                standard_rate_m3_per_day=self._map_rate(yaml_stream.rate),
+                                temperature_kelvin=self._map_temperature(yaml_stream.temperature),
+                                fluid_model=self._map_fluid_model(yaml_fluid_model),
+                            )
+                        )
+                        process_unit_map[mixer.get_id()] = mixer
+                        current_segment_unit_ids.append(mixer.get_id())
+
                     case _:
                         # Unreachable for valid YAML (pydantic discriminator rejects unknown types).
                         # Guards against bypassed parsing or new union variants missing a case.

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -365,11 +365,11 @@ class ProcessSimulationMapper:
                         current_segment_unit_ids.append(liquid_remover.get_id())
 
                     case YamlMixer():
-                        yaml_stream = self._resolve_stream_reference(yaml_process_unit.inlet_stream)
+                        yaml_stream = self._resolve_stream_reference(yaml_process_unit.sidestream)
                         yaml_fluid_model = self._resolve_fluid_model_reference(yaml_stream.fluid_model)
                         mixer = Mixer(fluid_service=self._fluid_service)
                         problem_time_series_configurations[mixer.get_id()] = TimeSeriesMixerConfiguration(
-                            inlet_stream=TimeSeriesStream(
+                            sidestream=TimeSeriesStream(
                                 pressure_bara=self._map_pressure(yaml_stream.pressure),
                                 standard_rate_m3_per_day=self._map_rate(yaml_stream.rate),
                                 temperature_kelvin=self._map_temperature(yaml_stream.temperature),

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
@@ -1,12 +1,10 @@
 from typing import Literal, TypeVar
 
 from libecalc.presentation.yaml.yaml_types import YamlBase
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessPipelineReference
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
     YamlProcessUnit,
 )
-
-type ProcessPipelineReference = str  # TODO: validate correct reference
-
 
 TTarget = TypeVar("TTarget")
 

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
@@ -1,0 +1,7 @@
+"""
+Shared reference type aliases for YAML process types.
+"""
+
+type StreamRef = str
+type ProcessPipelineReference = str  # TODO: validate correct reference
+type ProcessUnitReference = str

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
@@ -6,6 +6,8 @@ from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_chart import UnitsField, YamlCurve, YamlUnits
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
+from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution import StreamRef
+from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import DataOrFile
 
 ProcessUnitReference = str
@@ -75,7 +77,21 @@ class YamlLiquidRemover(YamlBase):
     type: Literal["LIQUID_REMOVER"]
 
 
+class YamlMixer(YamlBase):
+    """Mixes an external sidestream into the through-stream at an
+    intermediate point in the pipeline."""
+
+    type: Literal["MIXER"]
+    inlet_stream: Annotated[
+        StreamRef | YamlInletStream,
+        Field(
+            description="Sidestream to mix in. Either a reference to a named stream or an inline stream definition.",
+            title="INLET_STREAM",
+        ),
+    ]
+
+
 YamlProcessUnit = Annotated[
-    YamlCompressor | YamlPressureDropper | YamlTemperatureSetter | YamlLiquidRemover,
+    YamlCompressor | YamlPressureDropper | YamlTemperatureSetter | YamlLiquidRemover | YamlMixer,
     Field(discriminator="type"),
 ]

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
@@ -10,8 +10,6 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution impo
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import DataOrFile
 
-ProcessUnitReference = str
-
 
 class YamlControlMargin(YamlBase):
     unit: YamlControlMarginUnits

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
@@ -80,7 +80,7 @@ class YamlMixer(YamlBase):
     intermediate point in the pipeline."""
 
     type: Literal["MIXER"]
-    inlet_stream: Annotated[
+    sidestream: Annotated[
         StreamRef | YamlInletStream,
         Field(
             description="Sidestream to mix in. Either a reference to a named stream or an inline stream definition.",

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_stream_distribution.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_stream_distribution.py
@@ -5,9 +5,7 @@ from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import ProcessPipelineReference
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
-
-
-StreamRef = str
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import StreamRef
 
 
 class YamlOverflow(YamlBase):

--- a/src/libecalc/presentation/yaml/yaml_types/streams/yaml_inlet_stream.py
+++ b/src/libecalc/presentation/yaml/yaml_types/streams/yaml_inlet_stream.py
@@ -8,8 +8,8 @@ from libecalc.common.utils.rates import RateType
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import StreamRef
 
-StreamRef = str
 FluidModelReference = str
 
 

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -108,7 +108,7 @@ class YamlCompressorChartBuilder(Builder[YamlCompressorChart]):
         self.units = YamlUnits(
             rate=YamlRateUnits.AM3_PER_HOUR,
             head=YamlHeadUnits.M,
-            efficiency=YamlEfficiencyUnits.PERCENTAGE,
+            efficiency=YamlEfficiencyUnits.FRACTION,
         )
         return self
 
@@ -194,14 +194,20 @@ class YamlLiquidRemoverBuilder(Builder[YamlLiquidRemover]):
 class YamlMixerBuilder(Builder[YamlMixer]):
     def __init__(self):
         self.type = "MIXER"
-        self.inlet_stream = None
+        self.sidestream = None
 
-    def with_inlet_stream(self, inlet_stream: str | YamlInletStream) -> Self:
-        self.inlet_stream = inlet_stream
+    def with_sidestream(self, sidestream: str | YamlInletStream) -> Self:
+        self.sidestream = sidestream
         return self
 
     def with_test_data(self) -> Self:
-        self.inlet_stream = YamlInletStreamBuilder().with_test_data().with_name("SidestreamDefault").validate()
+        self.sidestream = (
+            YamlInletStreamBuilder()
+            .with_test_data()
+            .with_name("SidestreamDefault")
+            .with_rate(YamlInletStreamRateBuilder().with_test_data().with_value(200000).validate())
+            .validate()
+        )
         return self
 
 

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -50,6 +50,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
     YamlControlMargin,
     YamlCompressorChart,
     YamlProcessUnit,
+    YamlMixer,
 )
 
 
@@ -187,6 +188,20 @@ class YamlLiquidRemoverBuilder(Builder[YamlLiquidRemover]):
         # LIQUID_REMOVER has no configurable fields beyond `type`,
         # so `with_test_data` is a no-op. Kept for API consistency
         # with the other process unit builders.
+        return self
+
+
+class YamlMixerBuilder(Builder[YamlMixer]):
+    def __init__(self):
+        self.type = "MIXER"
+        self.inlet_stream = None
+
+    def with_inlet_stream(self, inlet_stream: str | YamlInletStream) -> Self:
+        self.inlet_stream = inlet_stream
+        return self
+
+    def with_test_data(self) -> Self:
+        self.inlet_stream = YamlInletStreamBuilder().with_test_data().with_name("SidestreamDefault").validate()
         return self
 
 

--- a/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
@@ -7,12 +7,14 @@ from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.process_units.direct_mixer import DirectMixer
 from libecalc.process.process_units.direct_splitter import DirectSplitter
 from libecalc.process.process_units.liquid_remover import LiquidRemover
+from libecalc.process.process_units.mixer import Mixer
 from libecalc.process.process_units.pressure_dropper import PressureDropper
 from libecalc.process.process_units.temperature_setter import TemperatureSetter
 from libecalc.testing.process_builders import (
     YamlCommonStreamDistributionBuilder,
     YamlCompressorBuilder,
     YamlLiquidRemoverBuilder,
+    YamlMixerBuilder,
     YamlPressureDropperBuilder,
     YamlProcessPipelineBuilder,
     YamlProcessSimulationBuilder,
@@ -156,6 +158,38 @@ def test_mapper_adds_choke_for_upstream_choke_pressure_control(process_simulatio
 
     units = pipelines[0].get_process_units()
     assert isinstance(units[0], Choke)
+
+
+def test_mixer_is_placed_between_asv_loops(process_simulation_mapper):
+    """Mixer must sit between ASV recirculation loops, not inside one."""
+    yaml_pipeline = (
+        YamlProcessPipelineBuilder()
+        .with_name("train_with_mixer")
+        .with_items(
+            [
+                YamlTemperatureSetterBuilder().with_test_data().validate(),
+                YamlCompressorBuilder().with_test_data().validate(),
+                YamlMixerBuilder().with_test_data().validate(),
+                YamlTemperatureSetterBuilder().with_test_data().validate(),
+                YamlCompressorBuilder().with_test_data().validate(),
+            ]
+        )
+        .validate()
+    )
+    yaml_simulation = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
+
+    pipelines, _ = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    units = pipelines[0].get_process_units()
+    mixer_index = next(i for i, u in enumerate(units) if isinstance(u, Mixer))
+
+    # ASV loop 1 ends (DirectSplitter) before Mixer
+    assert isinstance(units[mixer_index - 1], DirectSplitter)
+    # ASV loop 2 starts (DirectMixer) after Mixer
+    assert isinstance(units[mixer_index + 1], DirectMixer)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/libecalc/process/test_mixer_integration.py
+++ b/tests/libecalc/process/test_mixer_integration.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+
+from libecalc.common.time_utils import Period
+from libecalc.common.units import Unit
+from libecalc.ecalc_model.time_series_configuration import (
+    TimeSeriesMixerConfiguration,
+    TimeSeriesTemperatureSetterConfiguration,
+)
+from libecalc.process.process_solver.process_pipeline_runner import propagate_stream_many
+from libecalc.process.shaft import Shaft
+from libecalc.testing.process_builders import (
+    YamlCompressorBuilder,
+    YamlIndividualStreamDistributionBuilder,
+    YamlMixerBuilder,
+    YamlProcessPipelineBuilder,
+    YamlProcessSimulationBuilder,
+    YamlTemperatureSetterBuilder,
+)
+
+PERIOD = Period(start=datetime(2020, 1, 1), end=datetime(2030, 1, 1))
+
+
+def test_mixer_defined_in_yaml_produces_pipeline_that_mixes_sidestream(process_simulation_mapper, fluid_service):
+    """
+    Verify that a Mixer defined in YAML survives the full chain:
+    YAML → mapper → runtime configuration → pipeline execution.
+
+    Complements test_mixer_splitter.py (which tests Mixer in isolation)
+    by proving the mapper wires it correctly into a runnable pipeline.
+    """
+
+    # -- Build YAML --
+    yaml_pipeline = (
+        YamlProcessPipelineBuilder()
+        .with_name("train_with_mixer")
+        .with_items(
+            [
+                YamlTemperatureSetterBuilder().with_test_data().validate(),
+                YamlCompressorBuilder().with_test_data().validate(),
+                YamlMixerBuilder().with_test_data().validate(),
+                YamlTemperatureSetterBuilder().with_test_data().validate(),
+                YamlCompressorBuilder().with_test_data().validate(),
+            ]
+        )
+        .validate()
+    )
+
+    yaml_simulation = (
+        YamlProcessSimulationBuilder()
+        .with_name("mixer_test")
+        .with_pipeline(yaml_pipeline)
+        .with_stream_distribution(YamlIndividualStreamDistributionBuilder().with_test_data().validate())
+        .validate()
+    )
+
+    # -- Map to process domain objects --
+    pipelines, simulation = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    units = pipelines[0].get_process_units()
+    problem = simulation.process_problems[0]
+    pipeline_id = problem.process_pipeline_id
+    configs = simulation.process_configurations[pipeline_id]
+
+    # -- Configure units
+    shaft = next(h for h in problem.configuration_handlers if isinstance(h, Shaft))
+    shaft.set_speed(10000)
+
+    for unit_id, config in configs.items():
+        unit = next(u for u in units if u.get_id() == unit_id)
+        match config:
+            case TimeSeriesTemperatureSetterConfiguration():
+                unit.set_temperature(Unit.CELSIUS.to(Unit.KELVIN)(config.temperature_in_celsius.get_masked_values()[0]))
+            case TimeSeriesMixerConfiguration():
+                ts = config.sidestream
+                unit.set_stream(
+                    fluid_service.create_stream_from_standard_rate(
+                        fluid_model=ts.fluid_model,
+                        pressure_bara=ts.pressure_bara.get_masked_values()[0],
+                        temperature_kelvin=ts.temperature_kelvin.get_masked_values()[0],
+                        standard_rate_m3_per_day=ts.standard_rate_m3_per_day.get_stream_day_values()[0],
+                    )
+                )
+
+    # -- Run pipeline --
+    inlet_stream = fluid_service.create_stream_from_standard_rate(
+        fluid_model=simulation.get_inlet_streams()[0].fluid_model,
+        pressure_bara=20.0,
+        temperature_kelvin=303.15,
+        standard_rate_m3_per_day=2_000_000,
+    )
+
+    outlet = propagate_stream_many(units, inlet_stream)
+
+    sidestream_rate_sm3_per_day = 200_000  # from YamlMixerBuilder.with_test_data()
+
+    expected_sidestream_mass_rate = fluid_service.standard_rate_to_mass_rate(
+        fluid_model=simulation.get_inlet_streams()[0].fluid_model,
+        standard_rate_m3_per_day=sidestream_rate_sm3_per_day,
+    )
+
+    assert outlet.mass_rate_kg_per_h == inlet_stream.mass_rate_kg_per_h + expected_sidestream_mass_rate

--- a/tests/libecalc/process/test_mixer_integration.py
+++ b/tests/libecalc/process/test_mixer_integration.py
@@ -30,6 +30,7 @@ def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper, fluid_s
     """
 
     # -- Build YAML --
+    yaml_mixer = YamlMixerBuilder().with_test_data().validate()
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
         .with_name("train_with_mixer")
@@ -37,7 +38,7 @@ def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper, fluid_s
             [
                 YamlTemperatureSetterBuilder().with_test_data().validate(),
                 YamlCompressorBuilder().with_test_data().validate(),
-                YamlMixerBuilder().with_test_data().validate(),
+                yaml_mixer,
                 YamlTemperatureSetterBuilder().with_test_data().validate(),
                 YamlCompressorBuilder().with_test_data().validate(),
             ]
@@ -94,8 +95,7 @@ def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper, fluid_s
 
     outlet = propagate_stream_many(units, inlet_stream)
 
-    sidestream_rate_sm3_per_day = 200_000  # from YamlMixerBuilder.with_test_data()
-
+    sidestream_rate_sm3_per_day = yaml_mixer.sidestream.rate.value
     expected_sidestream_mass_rate = fluid_service.standard_rate_to_mass_rate(
         fluid_model=simulation.get_inlet_streams()[0].fluid_model,
         standard_rate_m3_per_day=sidestream_rate_sm3_per_day,

--- a/tests/libecalc/process/test_mixer_integration.py
+++ b/tests/libecalc/process/test_mixer_integration.py
@@ -20,7 +20,7 @@ from libecalc.testing.process_builders import (
 PERIOD = Period(start=datetime(2020, 1, 1), end=datetime(2030, 1, 1))
 
 
-def test_mixer_defined_in_yaml_produces_pipeline_that_mixes_sidestream(process_simulation_mapper, fluid_service):
+def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper, fluid_service):
     """
     Verify that a Mixer defined in YAML survives the full chain:
     YAML → mapper → runtime configuration → pipeline execution.

--- a/tests/libecalc/process/test_mixer_integration.py
+++ b/tests/libecalc/process/test_mixer_integration.py
@@ -101,4 +101,6 @@ def test_mixer_defined_in_yaml_produces_pipeline_that_mixes_sidestream(process_s
         standard_rate_m3_per_day=sidestream_rate_sm3_per_day,
     )
 
+    # -- Assert: mass is conserved — compressors and temperature setters
+    # change P and T but not mass rate, so outlet = inlet + sidestream --
     assert outlet.mass_rate_kg_per_h == inlet_stream.mass_rate_kg_per_h + expected_sidestream_mass_rate


### PR DESCRIPTION
Explicit mixer in YAML so sidestream injection (flare gas, PW off-gas etc.) is modelled as a process unit.

Refs: equinor/ecalc-internal#1889

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
