### PR TITLE
feat: introduce yaml splitter

### DIFF
--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -117,7 +117,7 @@ class ProcessSimulation(Entity[ProcessSimulationId]):  # process_model?
                 TimeSeriesTemperatureSetterConfiguration
                 | TimeSeriesPressureDropperConfiguration
                 | TimeSeriesSplitterConfiguration
-                | TimeSeriesMixerConfiguration ,
+                | TimeSeriesMixerConfiguration,
             ],
         ]
         | None = None,

--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -9,6 +9,7 @@ from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.ecalc_model.time_series_configuration import (
     TimeSeriesMixerConfiguration,
     TimeSeriesPressureDropperConfiguration,
+    TimeSeriesSplitterConfiguration,
     TimeSeriesTemperatureSetterConfiguration,
 )
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
@@ -115,7 +116,8 @@ class ProcessSimulation(Entity[ProcessSimulationId]):  # process_model?
                 ProcessUnitId,
                 TimeSeriesTemperatureSetterConfiguration
                 | TimeSeriesPressureDropperConfiguration
-                | TimeSeriesMixerConfiguration,
+                | TimeSeriesSplitterConfiguration
+                | TimeSeriesMixerConfiguration ,
             ],
         ]
         | None = None,

--- a/src/libecalc/ecalc_model/time_series_configuration.py
+++ b/src/libecalc/ecalc_model/time_series_configuration.py
@@ -1,5 +1,6 @@
 from libecalc.common.ddd import value_object
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
+from libecalc.presentation.yaml.domain.expression_time_series_flow_rate import ExpressionTimeSeriesFlowRate
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 
 
@@ -16,3 +17,8 @@ class TimeSeriesTemperatureSetterConfiguration:
 @value_object
 class TimeSeriesMixerConfiguration:
     sidestream: TimeSeriesStream
+
+
+@value_object
+class TimeSeriesSplitterConfiguration:
+    offtake_rate: ExpressionTimeSeriesFlowRate

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -385,14 +385,13 @@ class ProcessSimulationMapper:
                         # Mixer should not be wrapped in ASV-loop
                         pipeline_chunks.append((False, [mixer.get_id()]))
 
-
                     case YamlSplitter():
                         splitter = Splitter(fluid_service=self._fluid_service)
                         problem_time_series_configurations[splitter.get_id()] = TimeSeriesSplitterConfiguration(
                             offtake_rate=self._map_rate(yaml_process_unit.offtake_rate),
                         )
                         process_unit_map[splitter.get_id()] = splitter
-                        current_segment_unit_ids.append(splitter.get_id())
+                        pipeline_chunks.append((False, [splitter.get_id()]))
 
                     case _:
                         # Unreachable for valid YAML (pydantic discriminator rejects unknown types).

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -22,6 +22,7 @@ from libecalc.ecalc_model.process_simulation import (
 from libecalc.ecalc_model.time_series_configuration import (
     TimeSeriesMixerConfiguration,
     TimeSeriesPressureDropperConfiguration,
+    TimeSeriesSplitterConfiguration,
     TimeSeriesTemperatureSetterConfiguration,
 )
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
@@ -49,6 +50,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
     YamlMixer,
     YamlPressureDropper,
     YamlProcessUnit,
+    YamlSplitter,
     YamlTemperatureSetter,
 )
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream, YamlInletStreamRate
@@ -79,6 +81,7 @@ from libecalc.process.process_units.direct_splitter import DirectSplitter
 from libecalc.process.process_units.liquid_remover import LiquidRemover
 from libecalc.process.process_units.mixer import Mixer
 from libecalc.process.process_units.pressure_dropper import PressureDropper
+from libecalc.process.process_units.splitter import Splitter
 from libecalc.process.process_units.temperature_setter import TemperatureSetter
 from libecalc.process.shaft import VariableSpeedShaft
 from libecalc.process.stream_distribution.common_stream_distribution import (
@@ -301,7 +304,8 @@ class ProcessSimulationMapper:
                 ProcessUnitId,
                 TimeSeriesTemperatureSetterConfiguration
                 | TimeSeriesPressureDropperConfiguration
-                | TimeSeriesMixerConfiguration,
+                | TimeSeriesMixerConfiguration
+                | TimeSeriesSplitterConfiguration,
             ],
         ] = {}
 
@@ -316,7 +320,8 @@ class ProcessSimulationMapper:
                 ProcessUnitId,
                 TimeSeriesTemperatureSetterConfiguration
                 | TimeSeriesPressureDropperConfiguration
-                | TimeSeriesMixerConfiguration,
+                | TimeSeriesMixerConfiguration
+                | TimeSeriesSplitterConfiguration,
             ] = {}
 
             # Group units into compressor segments: each segment contains the units leading up to
@@ -379,6 +384,15 @@ class ProcessSimulationMapper:
                         process_unit_map[mixer.get_id()] = mixer
                         # Mixer should not be wrapped in ASV-loop
                         pipeline_chunks.append((False, [mixer.get_id()]))
+
+
+                    case YamlSplitter():
+                        splitter = Splitter(fluid_service=self._fluid_service)
+                        problem_time_series_configurations[splitter.get_id()] = TimeSeriesSplitterConfiguration(
+                            offtake_rate=self._map_rate(yaml_process_unit.offtake_rate),
+                        )
+                        process_unit_map[splitter.get_id()] = splitter
+                        current_segment_unit_ids.append(splitter.get_id())
 
                     case _:
                         # Unreachable for valid YAML (pydantic discriminator rejects unknown types).

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
@@ -8,6 +8,7 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_chart import U
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
 from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution import StreamRef
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
+from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStreamRate
 from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import DataOrFile
 
 
@@ -89,7 +90,21 @@ class YamlMixer(YamlBase):
     ]
 
 
+class YamlSplitter(YamlBase):
+    """Removes a fixed rate from the through-stream at an
+    intermediate point in the pipeline (e.g. fuel gas offtake)."""
+
+    type: Literal["SPLITTER"]
+    offtake_rate: Annotated[
+        YamlInletStreamRate,
+        Field(
+            description="Standard rate to split off.",
+            title="OFFTAKE_RATE",
+        ),
+    ]
+
+
 YamlProcessUnit = Annotated[
-    YamlCompressor | YamlPressureDropper | YamlTemperatureSetter | YamlLiquidRemover | YamlMixer,
+    YamlCompressor | YamlPressureDropper | YamlTemperatureSetter | YamlLiquidRemover | YamlMixer | YamlSplitter,
     Field(discriminator="type"),
 ]

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
@@ -7,8 +7,7 @@ from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type impor
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_chart import UnitsField, YamlCurve, YamlUnits
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
 from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution import StreamRef
-from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
-from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStreamRate
+from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream, YamlInletStreamRate
 from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import DataOrFile
 
 

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -51,6 +51,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
     YamlCompressorChart,
     YamlProcessUnit,
     YamlMixer,
+    YamlSplitter,
 )
 
 
@@ -84,9 +85,9 @@ class YamlCurveBuilder(Builder[YamlCurve]):
 
     def with_test_data(self) -> Self:
         self.speed = 10000.0
-        self.rate = [3000.0, 4000.0, 5000.0]
-        self.head = [100000.0, 90000.0, 75000.0]
-        self.efficiency = [0.72, 0.74, 0.70]
+        self.rate = [500.0, 3000.0, 5000.0, 8000.0]
+        self.head = [30000.0, 25000.0, 20000.0, 15000.0]
+        self.efficiency = [0.68, 0.72, 0.74, 0.70]
         return self
 
 
@@ -208,6 +209,20 @@ class YamlMixerBuilder(Builder[YamlMixer]):
             .with_rate(YamlInletStreamRateBuilder().with_test_data().with_value(200000).validate())
             .validate()
         )
+        return self
+
+
+class YamlSplitterBuilder(Builder[YamlSplitter]):
+    def __init__(self):
+        self.type = "SPLITTER"
+        self.offtake_rate = None
+
+    def with_offtake_rate(self, offtake_rate: YamlInletStreamRate) -> Self:
+        self.offtake_rate = offtake_rate
+        return self
+
+    def with_test_data(self) -> Self:
+        self.offtake_rate = YamlInletStreamRateBuilder().with_test_data().with_value(50_000).validate()
         return self
 
 

--- a/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
@@ -7,7 +7,6 @@ from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.process_units.direct_mixer import DirectMixer
 from libecalc.process.process_units.direct_splitter import DirectSplitter
 from libecalc.process.process_units.liquid_remover import LiquidRemover
-from libecalc.process.process_units.mixer import Mixer
 from libecalc.process.process_units.pressure_dropper import PressureDropper
 from libecalc.process.process_units.temperature_setter import TemperatureSetter
 from libecalc.testing.process_builders import (
@@ -18,6 +17,7 @@ from libecalc.testing.process_builders import (
     YamlPressureDropperBuilder,
     YamlProcessPipelineBuilder,
     YamlProcessSimulationBuilder,
+    YamlSplitterBuilder,
     YamlTemperatureSetterBuilder,
 )
 
@@ -160,15 +160,16 @@ def test_mapper_adds_choke_for_upstream_choke_pressure_control(process_simulatio
     assert isinstance(units[0], Choke)
 
 
-def test_mixer_is_placed_between_asv_loops(process_simulation_mapper):
-    """Mixer must sit between ASV recirculation loops, not inside one."""
+def test_mixer_and_splitter_are_placed_between_asv_loops(process_simulation_mapper):
+    """Mixer and Splitter must sit between ASV recirculation loops, not inside one."""
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
-        .with_name("train_with_mixer")
+        .with_name("train_with_mixer_and_splitter")
         .with_items(
             [
                 YamlTemperatureSetterBuilder().with_test_data().validate(),
                 YamlCompressorBuilder().with_test_data().validate(),
+                YamlSplitterBuilder().with_test_data().validate(),
                 YamlMixerBuilder().with_test_data().validate(),
                 YamlTemperatureSetterBuilder().with_test_data().validate(),
                 YamlCompressorBuilder().with_test_data().validate(),
@@ -184,12 +185,20 @@ def test_mixer_is_placed_between_asv_loops(process_simulation_mapper):
     )
 
     units = pipelines[0].get_process_units()
-    mixer_index = next(i for i, u in enumerate(units) if isinstance(u, Mixer))
+    unit_types = [type(u).__name__ for u in units]
 
-    # ASV loop 1 ends (DirectSplitter) before Mixer
-    assert isinstance(units[mixer_index - 1], DirectSplitter)
-    # ASV loop 2 starts (DirectMixer) after Mixer
-    assert isinstance(units[mixer_index + 1], DirectMixer)
+    assert unit_types == [
+        "DirectMixer",
+        "TemperatureSetter",
+        "Compressor",
+        "DirectSplitter",  # ASV loop 1
+        "Splitter",  # between loops
+        "Mixer",  # between loops
+        "DirectMixer",
+        "TemperatureSetter",
+        "Compressor",
+        "DirectSplitter",  # ASV loop 2
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/libecalc/process/test_splitter_integration.py
+++ b/tests/libecalc/process/test_splitter_integration.py
@@ -31,6 +31,7 @@ def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper, flui
     """
 
     # -- Build YAML --
+    yaml_splitter = YamlSplitterBuilder().with_test_data().validate()
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
         .with_name("train_with_splitter")
@@ -38,7 +39,7 @@ def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper, flui
             [
                 YamlTemperatureSetterBuilder().with_test_data().validate(),
                 YamlCompressorBuilder().with_test_data().validate(),
-                YamlSplitterBuilder().with_test_data().validate(),
+                yaml_splitter,
                 YamlTemperatureSetterBuilder().with_test_data().validate(),
                 YamlCompressorBuilder().with_test_data().validate(),
             ]
@@ -86,7 +87,7 @@ def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper, flui
     outlet = propagate_stream_many(units, inlet_stream)
 
     # -- Assert: mass is conserved — outlet = inlet - offtake --
-    offtake_rate_sm3_per_day = 50_000  # fra YamlSplitterBuilder.with_test_data()
+    offtake_rate_sm3_per_day = yaml_splitter.offtake_rate.value
     expected_offtake_mass_rate = fluid_service.standard_rate_to_mass_rate(
         fluid_model=simulation.get_inlet_streams()[0].fluid_model,
         standard_rate_m3_per_day=offtake_rate_sm3_per_day,

--- a/tests/libecalc/process/test_splitter_integration.py
+++ b/tests/libecalc/process/test_splitter_integration.py
@@ -1,0 +1,98 @@
+from datetime import datetime
+
+import pytest
+
+from libecalc.common.time_utils import Period
+from libecalc.common.units import Unit
+from libecalc.ecalc_model.time_series_configuration import (
+    TimeSeriesSplitterConfiguration,
+    TimeSeriesTemperatureSetterConfiguration,
+)
+from libecalc.process.process_solver.process_pipeline_runner import propagate_stream_many
+from libecalc.process.shaft import Shaft
+from libecalc.testing.process_builders import (
+    YamlCommonStreamDistributionBuilder,
+    YamlCompressorBuilder,
+    YamlProcessPipelineBuilder,
+    YamlProcessSimulationBuilder,
+    YamlSplitterBuilder,
+    YamlTemperatureSetterBuilder,
+)
+
+PERIOD = Period(start=datetime(2020, 1, 1), end=datetime(2030, 1, 1))
+
+
+def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper, fluid_service):
+    """Verify that a Splitter defined in YAML survives the full chain:
+    YAML → mapper → runtime configuration → pipeline execution.
+
+    Complements test_mixer_splitter.py (which tests Splitter in isolation)
+    by proving the mapper wires it correctly into a runnable pipeline.
+    """
+
+    # -- Build YAML --
+    yaml_pipeline = (
+        YamlProcessPipelineBuilder()
+        .with_name("train_with_splitter")
+        .with_items(
+            [
+                YamlTemperatureSetterBuilder().with_test_data().validate(),
+                YamlCompressorBuilder().with_test_data().validate(),
+                YamlSplitterBuilder().with_test_data().validate(),
+                YamlTemperatureSetterBuilder().with_test_data().validate(),
+                YamlCompressorBuilder().with_test_data().validate(),
+            ]
+        )
+        .validate()
+    )
+    yaml_simulation = (
+        YamlProcessSimulationBuilder()
+        .with_name("splitter_test")
+        .with_pipeline(yaml_pipeline)
+        .with_stream_distribution(YamlCommonStreamDistributionBuilder().with_test_data().validate())
+        .validate()
+    )
+
+    # -- Map to domain objects --
+    pipelines, simulation = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    units = pipelines[0].get_process_units()
+    problem = simulation.process_problems[0]
+    configs = simulation.process_configurations[problem.process_pipeline_id]
+
+    # -- Configure units --
+    shaft = next(h for h in problem.configuration_handlers if isinstance(h, Shaft))
+    shaft.set_speed(10000)
+
+    for unit_id, config in configs.items():
+        unit = next(u for u in units if u.get_id() == unit_id)
+        match config:
+            case TimeSeriesTemperatureSetterConfiguration():
+                unit.set_temperature(Unit.CELSIUS.to(Unit.KELVIN)(config.temperature_in_celsius.get_masked_values()[0]))
+            case TimeSeriesSplitterConfiguration():
+                unit.set_rate(config.offtake_rate.get_stream_day_values()[0])
+
+    # -- Run pipeline --
+    inlet_stream = fluid_service.create_stream_from_standard_rate(
+        fluid_model=simulation.get_inlet_streams()[0].fluid_model,
+        pressure_bara=20.0,
+        temperature_kelvin=303.15,
+        standard_rate_m3_per_day=2_000_000,
+    )
+
+    outlet = propagate_stream_many(units, inlet_stream)
+
+    # -- Assert: mass is conserved — outlet = inlet - offtake --
+    offtake_rate_sm3_per_day = 50_000  # fra YamlSplitterBuilder.with_test_data()
+    expected_offtake_mass_rate = fluid_service.standard_rate_to_mass_rate(
+        fluid_model=simulation.get_inlet_streams()[0].fluid_model,
+        standard_rate_m3_per_day=offtake_rate_sm3_per_day,
+    )
+
+    assert outlet.mass_rate_kg_per_h == pytest.approx(
+        inlet_stream.mass_rate_kg_per_h - expected_offtake_mass_rate,
+        rel=1e-10,
+    )


### PR DESCRIPTION
Explicit splitter in YAML so stream offtake (fuel gas or flare interstage etc.) is modelled as a process unit.

Refs: equinor/ecalc-internal#1896

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
