### PR TITLE
chore(libecalc): stop importing configuration types via solver files

### DIFF
--- a/src/libecalc/process/process_solver/anti_surge/anti_surge_strategy.py
+++ b/src/libecalc/process/process_solver/anti_surge/anti_surge_strategy.py
@@ -2,9 +2,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_solver.configuration import Configuration
+from libecalc.process.process_solver.configuration import Configuration, RecirculationConfiguration
 from libecalc.process.process_solver.solver import Solution
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 
 
 class AntiSurgeStrategy(ABC):

--- a/src/libecalc/process/process_solver/anti_surge/individual_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/individual_asv.py
@@ -4,12 +4,15 @@ from typing import override
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooHighError
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
-from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
+from libecalc.process.process_solver.configuration import (
+    Configuration,
+    ConfigurationHandlerId,
+    RecirculationConfiguration,
+)
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.solver import (
     Solution,
 )
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.process.process_units.compressor import Compressor
 
 

--- a/src/libecalc/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/common_asv.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
+from libecalc.process.process_solver.configuration import ChokeConfiguration, Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
@@ -10,7 +10,6 @@ from libecalc.process.process_solver.solver import (
     Solution,
     TargetDirection,
 )
-from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.recirculation_solver import (
     RecirculationConfiguration,
     RecirculationSolver,

--- a/src/libecalc/process/process_solver/pressure_control/downstream_choke.py
+++ b/src/libecalc/process/process_solver/pressure_control/downstream_choke.py
@@ -1,7 +1,11 @@
 from collections.abc import Sequence
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
+from libecalc.process.process_solver.configuration import (
+    Configuration,
+    ConfigurationHandlerId,
+    RecirculationConfiguration,
+)
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
@@ -10,7 +14,6 @@ from libecalc.process.process_solver.solvers.downstream_choke_solver import (
     ChokeConfiguration,
     DownstreamChokeSolver,
 )
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 
 
 class DownstreamChokePressureControlStrategy(PressureControlStrategy):

--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 
 from libecalc.common.numeric_methods import find_root
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
+from libecalc.process.process_solver.configuration import ChokeConfiguration, Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
@@ -11,7 +11,6 @@ from libecalc.process.process_solver.solver import (
     Solution,
     TargetDirection,
 )
-from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.recirculation_solver import (
     RecirculationConfiguration,
     RecirculationSolver,

--- a/src/libecalc/process/process_solver/pressure_control/pressure_control_strategy.py
+++ b/src/libecalc/process/process_solver/pressure_control/pressure_control_strategy.py
@@ -3,11 +3,9 @@ from collections.abc import Sequence
 from typing import Literal
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_solver.configuration import Configuration
+from libecalc.process.process_solver.configuration import ChokeConfiguration, Configuration, RecirculationConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.solver import Solution
-from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 
 PressureControlType = Literal[
     "UPSTREAM_CHOKE",

--- a/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
+++ b/src/libecalc/process/process_solver/pressure_control/upstream_choke.py
@@ -3,14 +3,17 @@ from collections.abc import Sequence
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.boundary import Boundary
-from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
+from libecalc.process.process_solver.configuration import (
+    ChokeConfiguration,
+    Configuration,
+    ConfigurationHandlerId,
+    RecirculationConfiguration,
+)
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy
 from libecalc.process.process_solver.solver import Solution
-from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.process.process_solver.solvers.upstream_choke_solver import UpstreamChokeSolver
 
 PRESSURE_CALCULATION_TOLERANCE = 1e-3

--- a/src/libecalc/testing/no_asv.py
+++ b/src/libecalc/testing/no_asv.py
@@ -3,9 +3,8 @@ from typing import override
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
-from libecalc.process.process_solver.configuration import Configuration
+from libecalc.process.process_solver.configuration import Configuration, RecirculationConfiguration
 from libecalc.process.process_solver.solver import Solution
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 
 
 class NoASVAntiSurgeStrategy(AntiSurgeStrategy):

--- a/tests/libecalc/process/process_solver/solvers/test_downstream_choke_solver.py
+++ b/tests/libecalc/process/process_solver/solvers/test_downstream_choke_solver.py
@@ -1,11 +1,9 @@
 import pytest
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_solver.configuration import ChokeConfiguration
 from libecalc.process.process_solver.process_pipeline_runner import propagate_stream_many
-from libecalc.process.process_solver.solvers.downstream_choke_solver import (
-    ChokeConfiguration,
-    DownstreamChokeSolver,
-)
+from libecalc.process.process_solver.solvers.downstream_choke_solver import DownstreamChokeSolver
 
 
 @pytest.mark.parametrize(

--- a/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
+++ b/tests/libecalc/process/process_solver/solvers/test_upstream_choke_solver.py
@@ -4,9 +4,9 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooHighError
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.boundary import Boundary
+from libecalc.process.process_solver.configuration import ChokeConfiguration
 from libecalc.process.process_solver.process_pipeline_runner import propagate_stream_many
 from libecalc.process.process_solver.solver import RateTooHighFailure
-from libecalc.process.process_solver.solvers.downstream_choke_solver import ChokeConfiguration
 from libecalc.process.process_solver.solvers.upstream_choke_solver import UpstreamChokeSolver
 
 

--- a/tests/libecalc/process/process_solver/test_common_asv_solver_vs_legacy_train.py
+++ b/tests/libecalc/process/process_solver/test_common_asv_solver_vs_legacy_train.py
@@ -6,8 +6,8 @@ from libecalc.domain.process.compressor.core.train.train_evaluation_input import
 from libecalc.domain.process.value_objects.chart import ChartCurve
 from libecalc.process.fluid_stream.fluid_model import FluidModel
 from libecalc.process.fluid_stream.fluid_service import FluidService
+from libecalc.process.process_solver.configuration import RecirculationConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.process.shaft import VariableSpeedShaft
 
 

--- a/tests/libecalc/process/process_solver/test_individual_asv_solver_vs_legacy_train.py
+++ b/tests/libecalc/process/process_solver/test_individual_asv_solver_vs_legacy_train.py
@@ -3,10 +3,8 @@ import pytest
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
 from libecalc.domain.process.value_objects.chart import ChartCurve
-from libecalc.process.process_solver.configuration import Configuration
+from libecalc.process.process_solver.configuration import Configuration, RecirculationConfiguration, SpeedConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
-from libecalc.process.process_solver.solvers.speed_solver import SpeedConfiguration
 from libecalc.process.shaft import VariableSpeedShaft
 
 

--- a/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_common_asv.py
+++ b/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_common_asv.py
@@ -1,8 +1,8 @@
 import pytest
 
 from libecalc.domain.process.value_objects.chart import ChartCurve
+from libecalc.process.process_solver.configuration import RecirculationConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.shaft import VariableSpeedShaft
 from libecalc.testing.chart_data_factory import ChartDataFactory

--- a/tests/libecalc/process/process_solver/test_two_stage_train_with_interstage_splitter_vs_legacy.py
+++ b/tests/libecalc/process/process_solver/test_two_stage_train_with_interstage_splitter_vs_legacy.py
@@ -2,8 +2,8 @@ import pytest
 
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
+from libecalc.process.process_solver.configuration import RecirculationConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.solvers.recirculation_solver import RecirculationConfiguration
 from libecalc.process.process_units.splitter import Splitter
 from libecalc.process.shaft import VariableSpeedShaft
 


### PR DESCRIPTION
Import configurations from where they are defined, not from/through the solvers. 

As preparation to moving (and renaming) single-variables `solvers` (currently located in process_solvers/solvers/) into a new `finders` directory


## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
