### PR TITLE
refactor(libecalc): introduce BisectStrategy base with BisectLowest and BisectHighest

### DIFF
--- a/src/libecalc/process/process_solver/anti_surge/common_asv.py
+++ b/src/libecalc/process/process_solver/anti_surge/common_asv.py
@@ -4,7 +4,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
 from libecalc.process.process_solver.configuration import Configuration, ConfigurationHandlerId
 from libecalc.process.process_solver.process_runner import ProcessRunner
-from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
+from libecalc.process.process_solver.search_strategies import Bisect, RootFindingStrategy
 from libecalc.process.process_solver.solver import Solution
 from libecalc.process.process_solver.solvers.recirculation_solver import (
     RecirculationConfiguration,
@@ -72,7 +72,7 @@ class CommonASVAntiSurgeStrategy(AntiSurgeStrategy):
         # target_pressure=None means: "solve only for within-capacity feasibility",
         # not for meeting any pressure constraint.
         solver = RecirculationSolver(
-            search_strategy=BinarySearchStrategy(tolerance=10e-3),
+            search_strategy=Bisect(tolerance=10e-3),
             root_finding_strategy=self._root_finding_strategy,
             recirculation_rate_boundary=boundary,
             target_pressure=None,  # capacity only

--- a/src/libecalc/process/process_solver/feasibility_solver.py
+++ b/src/libecalc/process/process_solver/feasibility_solver.py
@@ -4,9 +4,9 @@ from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pipeline_section_solver import PipelineSectionSolver
 from libecalc.process.process_solver.search_strategies import (
-    BinarySearchStrategy,
+    Bisect,
+    BisectResult,
     DidNotConvergeError,
-    SearchStrategy,
 )
 
 _RATE_SEARCH_TOLERANCE = 1e-4
@@ -24,10 +24,10 @@ class FeasibilitySolver:
     def __init__(
         self,
         pipeline_section_solver: PipelineSectionSolver,
-        search_strategy: SearchStrategy | None = None,
+        search_strategy: Bisect | None = None,
     ):
         self._solver = pipeline_section_solver
-        self._search_strategy = search_strategy or BinarySearchStrategy(
+        self._search_strategy = search_strategy or Bisect(
             tolerance=_RATE_SEARCH_TOLERANCE,
             max_iterations=_RATE_SEARCH_MAX_ITERATIONS,
         )
@@ -62,9 +62,9 @@ class FeasibilitySolver:
         try:
             return self._search_strategy.search(
                 boundary=boundary,
-                func=lambda rate: (
-                    self._is_feasible(inlet_stream.with_standard_rate(rate), target_pressure),
-                    True,
+                func=lambda rate: BisectResult(
+                    higher=self._is_feasible(inlet_stream.with_standard_rate(rate), target_pressure),
+                    accepted=True,
                 ),
             )
         except DidNotConvergeError:

--- a/src/libecalc/process/process_solver/pipeline_section_solver.py
+++ b/src/libecalc/process/process_solver/pipeline_section_solver.py
@@ -11,7 +11,7 @@ from libecalc.process.process_solver.configuration import (
 )
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pipeline_section import PipelineSection
-from libecalc.process.process_solver.search_strategies import BinarySearchStrategy
+from libecalc.process.process_solver.search_strategies import Bisect
 from libecalc.process.process_solver.solver import (
     RateTooHighFailure,
     Solution,
@@ -42,7 +42,7 @@ class PipelineSectionSolver:
         # The speed search evaluates the train with pressure control disengaged
         self._pipeline_section.pressure_control_strategy.reset()
         speed_solver = SpeedSolver(
-            search_strategy=BinarySearchStrategy(),
+            search_strategy=Bisect(),
             root_finding_strategy=self._pipeline_section.root_finding_strategy,
             boundary=self._get_initial_speed_boundary(),
             target_pressure=pressure_constraint.value,

--- a/src/libecalc/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/common_asv.py
@@ -5,7 +5,7 @@ from libecalc.process.process_solver.configuration import ChokeConfiguration, Co
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
-from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
+from libecalc.process.process_solver.search_strategies import Bisect, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     Solution,
     TargetDirection,
@@ -72,7 +72,7 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
             )
 
         solver = RecirculationSolver(
-            search_strategy=BinarySearchStrategy(tolerance=10e-3),
+            search_strategy=Bisect(tolerance=10e-3),
             root_finding_strategy=self._root_finding_strategy,
             recirculation_rate_boundary=boundary,
             target_pressure=target_pressure,

--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -6,7 +6,7 @@ from libecalc.process.process_solver.configuration import ChokeConfiguration, Co
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
-from libecalc.process.process_solver.search_strategies import BinarySearchStrategy, RootFindingStrategy
+from libecalc.process.process_solver.search_strategies import Bisect, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     Solution,
     TargetDirection,
@@ -82,7 +82,7 @@ class IndividualASVPressureControlStrategy(PressureControlStrategy):
                 return compressor.propagate_stream(inlet_stream=compressor_inlet_stream)
 
             solver = RecirculationSolver(
-                search_strategy=BinarySearchStrategy(tolerance=10e-3),
+                search_strategy=Bisect(tolerance=10e-3),
                 root_finding_strategy=self._root_finding_strategy,
                 recirculation_rate_boundary=boundary,
                 target_pressure=FloatConstraint(stage_target_pressure),

--- a/src/libecalc/process/process_solver/search_strategies.py
+++ b/src/libecalc/process/process_solver/search_strategies.py
@@ -1,5 +1,6 @@
 import abc
 from collections.abc import Callable
+from typing import NamedTuple
 
 from scipy.optimize import root_scalar
 
@@ -7,6 +8,11 @@ from libecalc.common.errors.exceptions import EcalcError
 from libecalc.process.process_solver.boundary import Boundary
 
 CONVERGENCE_TOLERANCE = 1e-5
+
+
+class BisectResult(NamedTuple):
+    higher: bool
+    accepted: bool
 
 
 class DidNotConvergeError(EcalcError):
@@ -23,58 +29,97 @@ class DidNotConvergeError(EcalcError):
         )
 
 
-class SearchStrategy(abc.ABC):
-    @abc.abstractmethod
-    def search(self, boundary: Boundary, func: Callable[[float], tuple[bool, bool]]) -> float: ...
+class Bisect:
+    """Bisection over a numeric range to locate a boolean threshold.
 
+    The condition is assumed monotonic (a single True/False crossing). Probes are evaluated
+    at the midpoint of a shrinking bracket until it is narrower than ``tolerance``.
+    """
 
-class BinarySearchStrategy(SearchStrategy):
     def __init__(self, tolerance: float = CONVERGENCE_TOLERANCE, max_iterations: int = 20):
         """
 
         Args:
-            tolerance: The tolerance of convergence that will be used to exist the iteration
-            max_iterations: The maximum number of iterations that will be used to find the root.
+            tolerance: The relative bracket width at which the search stops.
+            max_iterations: The maximum number of bisection steps.
         """
         self._tolerance = tolerance
         self._max_iterations = max_iterations
 
-    def search(self, boundary: Boundary, func: Callable[[float], tuple[bool, bool]]) -> float:
-        """Binary search until we reach the maximum x value constrained by x_min and x_max
-        where we have a boolean constraint condition given as a function.
+    def _bisect(
+        self,
+        boundary: Boundary,
+        probe: Callable[[float], BisectResult],
+    ) -> float | None:
+        """Bisect [boundary.min, boundary.max]. Returns the last accepted x, or ``None``."""
+        x0, x1 = boundary.min, boundary.max
+        last_accepted: float | None = None
+        for _ in range(self._max_iterations):
+            x2 = (x0 + x1) / 2
+            higher, accepted = probe(x2)
+            if accepted:
+                last_accepted = x2
+            if higher:
+                x0 = x2
+            else:
+                x1 = x2
+            rel_diff = (x1 - x0) / max(abs(x0), abs(x1), 1.0)
+            if rel_diff < self._tolerance:
+                break
+        return last_accepted
 
-        max(x) given f(x) == True
+    def search(self, boundary: Boundary, func: Callable[[float], BisectResult]) -> float:
+        """Highest x in ``boundary`` where the indicator holds (``max(x) given f(x) == True``).
+
+        ``func`` returns a ``BisectResult`` so steering (``higher``) and validity (``accepted``)
+        are decoupled: a probe can steer the search without being accepted as a solution.
 
         We assume f(x) to be a binary (Heaviside step) function where f(x) is 1 for x <= n and 0 for x > n.
         n is the target value in this optimization. x == n is the highest possible value of x before f(x) turns to 0.
 
-        Note: This requires that the boolean condition is an indicator function where x > threshold returns False.
+        Raises ``DidNotConvergeError`` if no probe was ever accepted.
         """
-        x0, x1 = boundary.min, boundary.max
-        last_accepted: float | None = None
-        i = 0
-        rel_diff = 100.0
-
-        while (abs(rel_diff) > self._tolerance) and (i < self._max_iterations):
-            x2 = (x0 + x1) / 2  # Bisecting x0 and x1.
-            higher, accepted = func(x2)
-            if higher:
-                x0, x1 = x2, x1  # x2 is valid. We can now search to the right in the binary three.
-                if accepted:
-                    last_accepted = x2
-            else:
-                x0, x1 = x0, x2  # x2 is invalid. We can now search to the left in the binary three
-
-            rel_diff = 0 if x0 == x1 else abs(x1 - x0) / max(abs(x0), abs(x1))
-            i += 1
-
-        if i >= self._max_iterations:
+        result = self._bisect(boundary=boundary, probe=func)
+        if result is None:
             raise DidNotConvergeError(
                 boundary=boundary,
                 tolerance=self._tolerance,
                 iterations=self._max_iterations,
             )
-        return last_accepted if last_accepted is not None else x1
+        return result
+
+    def lowest_true(self, boundary: Boundary, predicate: Callable[[float], bool]) -> float | None:
+        """Return the lowest x in ``boundary`` where ``predicate(x)`` is True, or ``None``."""
+        return self._first_true(boundary, predicate, lowest=True)
+
+    def highest_true(self, boundary: Boundary, predicate: Callable[[float], bool]) -> float | None:
+        """Return the highest x in ``boundary`` where ``predicate(x)`` is True, or ``None``."""
+        return self._first_true(boundary, predicate, lowest=False)
+
+    def _first_true(
+        self,
+        boundary: Boundary,
+        predicate: Callable[[float], bool],
+        *,
+        lowest: bool,
+    ) -> float | None:
+        """Locate the boundary x where ``predicate`` flips, searching from the near end.
+
+        ``lowest=True`` searches up from ``boundary.min`` for the lowest passing x;
+        ``lowest=False`` searches down from ``boundary.max`` for the highest passing x.
+        """
+        near, far = (boundary.min, boundary.max) if lowest else (boundary.max, boundary.min)
+        if predicate(near):
+            return near
+        if not predicate(far):
+            return None
+
+        def probe(x: float) -> BisectResult:
+            ok = predicate(x)
+            return BisectResult(higher=ok != lowest, accepted=ok)
+
+        result = self._bisect(boundary=boundary, probe=probe)
+        return result if result is not None else far
 
 
 class RootFindingStrategy(abc.ABC):

--- a/src/libecalc/process/process_solver/solvers/recirculation_solver.py
+++ b/src/libecalc/process/process_solver/solvers/recirculation_solver.py
@@ -6,7 +6,7 @@ from libecalc.process.process_pipeline.process_error import RateTooHighError, Ra
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import RecirculationConfiguration
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
+from libecalc.process.process_solver.search_strategies import Bisect, BisectResult, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     Solution,
     Solver,
@@ -18,7 +18,7 @@ from libecalc.process.process_solver.solver import (
 class RecirculationSolver(Solver):
     def __init__(
         self,
-        search_strategy: SearchStrategy,
+        search_strategy: Bisect,
         root_finding_strategy: RootFindingStrategy,
         recirculation_rate_boundary: Boundary,
         target_pressure: FloatConstraint | None = None,
@@ -118,16 +118,16 @@ class RecirculationSolver(Solver):
         func: Callable[[RecirculationConfiguration], FluidStream],
         x: float,
         mode: Literal["minimize", "maximize"],
-    ) -> tuple[bool, bool]:
+    ) -> BisectResult:
         """Probe a candidate rate for the search strategy.
 
-        Returns ``(is_higher, is_accepted)``. The two booleans are decoupled so an
+        Returns a ``BisectResult`` where the two booleans are decoupled so an
         out-of-capacity candidate can never be accepted as a solution.
         """
         try:
             func(RecirculationConfiguration(recirculation_rate=x))
-            return False if mode == "minimize" else True, True
+            return BisectResult(higher=mode != "minimize", accepted=True)
         except RateTooLowError:
-            return True, False
+            return BisectResult(higher=True, accepted=False)
         except RateTooHighError:
-            return False, False
+            return BisectResult(higher=False, accepted=False)

--- a/src/libecalc/process/process_solver/solvers/speed_solver.py
+++ b/src/libecalc/process/process_solver/solvers/speed_solver.py
@@ -5,7 +5,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_error import RateTooHighError, RateTooLowError
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import SpeedConfiguration
-from libecalc.process.process_solver.search_strategies import RootFindingStrategy, SearchStrategy
+from libecalc.process.process_solver.search_strategies import Bisect, BisectResult, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     Solution,
     Solver,
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class SpeedSolver(Solver[SpeedConfiguration]):
     def __init__(
         self,
-        search_strategy: SearchStrategy,
+        search_strategy: Bisect,
         root_finding_strategy: RootFindingStrategy,
         boundary: Boundary,
         target_pressure: float,
@@ -91,14 +91,14 @@ class SpeedSolver(Solver[SpeedConfiguration]):
         except RateTooHighError as e:
             logger.debug(f"No solution found for minimum speed: {self._boundary.min}", exc_info=e)
 
-            def bool_speed_func(x: float) -> tuple[bool, bool]:
+            def bool_speed_func(x: float) -> BisectResult:
                 try:
                     func(SpeedConfiguration(speed=x))
-                    return False, True
+                    return BisectResult(higher=False, accepted=True)
                 except RateTooHighError:
-                    return True, False
+                    return BisectResult(higher=True, accepted=False)
                 except RateTooLowError:
-                    return False, False
+                    return BisectResult(higher=False, accepted=False)
 
             minimum_speed_within_capacity = self._search_strategy.search(
                 boundary=self._boundary,

--- a/tests/libecalc/process/conftest.py
+++ b/tests/libecalc/process/conftest.py
@@ -11,7 +11,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 from libecalc.process.process_solver.search_strategies import (
     CONVERGENCE_TOLERANCE,
-    BinarySearchStrategy,
+    Bisect,
     ScipyRootFindingStrategy,
 )
 from libecalc.process.process_units.choke import Choke
@@ -228,6 +228,6 @@ def root_finding_strategy():
 @pytest.fixture
 def search_strategy_factory():
     def create_search_strategy(tolerance: float = CONVERGENCE_TOLERANCE):
-        return BinarySearchStrategy(tolerance=tolerance)
+        return Bisect(tolerance=tolerance)
 
     return create_search_strategy

--- a/tests/libecalc/process/process_solver/test_search_strategies.py
+++ b/tests/libecalc/process/process_solver/test_search_strategies.py
@@ -1,11 +1,11 @@
-"""Tests for BinarySearchStrategy."""
+"""Tests for Bisect."""
 
 from libecalc.process.process_solver.boundary import Boundary
-from libecalc.process.process_solver.search_strategies import BinarySearchStrategy
+from libecalc.process.process_solver.search_strategies import Bisect
 
 
 def test_search_returns_accepted_value():
-    """BinarySearchStrategy.search should return a value that was accepted.
+    """Bisect.search should return a value that was accepted.
 
     The search converges to the boundary between accepted/rejected regions.
     The returned value must be from the accepted side, not an arbitrary midpoint
@@ -19,7 +19,7 @@ def test_search_returns_accepted_value():
         else:
             return False, True  # at/above threshold: go lower
 
-    strategy = BinarySearchStrategy(tolerance=1e-5, max_iterations=50)
+    strategy = Bisect(tolerance=1e-5, max_iterations=50)
     result = strategy.search(boundary=Boundary(min=0.0, max=10.0), func=step_func)
 
     # The result must be below the threshold (on the accepted/valid side)


### PR DESCRIPTION

## What

Extracts/re-writes the bisection loop from `BinarySearchStrategy` into a `BisectStrategy` base class with a single `_bisect()` method. Two new subclasses are added:

- **`BisectLowest`** — finds the lowest `x` in a boundary where a boolean predicate is `True`
- **`BisectHighest`** — finds the highest `x` in a boundary where a boolean predicate is `True`

`BinarySearchStrategy`, which returns a tuple of booleans, becomes a subclass, delegating its loop to `_bisect()`.

The function return type is made explicit with a `BisectResult` named tuple (`higher`, `accepted`), replacing anonymous `tuple[bool, bool]` throughout.

## Bug fixed

Edit: this bug fix has been extracted into a separate PR: https://github.com/equinor/ecalc/pull/1632

~~The original `BinarySearchStrategy` only updated its convergence criterion (`rel_diff`) when a probe was `accepted`. In cases where several consecutive probes are rejected (e.g. the compressor hits stonewall for many consecutive candidate speeds), the convergence check never occured — the interval kept halving but the loop didn't notice, burned through all 20 iterations, and raised `DidNotConvergeError`.~~

~~The new shared `_bisect` loop checks interval width on every step regardless of acceptance. Bisection halves the interval geometrically every step — we just needed to check it every time, not only when lucky enough to get an accepted point.~~

~~This fixes the R1 and R6 path-matrix xfails, which both failed with `DidNotConvergeError` for this reason.~~

## What's next

The `BisectLowest`/`BisectHighest` primitives enable a follow-up fix where `SpeedSolver` narrows its own speed boundary before solving, 
by searching upward from minimum speed when `RateTooHighError` (stonewall) or `CompressorThermodynamicCalculationError` (EOS failure) is encountered, 
and searching downward from maximum speed when `CompressorThermodynamicCalculationError` is encountered.