### PR TITLE
fix: bisection rel_diff not updated on rejected probes

### DIFF
--- a/src/libecalc/common/numeric_methods.py
+++ b/src/libecalc/common/numeric_methods.py
@@ -209,11 +209,9 @@ def maximize_x_given_boolean_condition_function(
         x2 = (x0 + x1) / 2  # Bisecting x0 and x1.
         if bool_func(x2):
             x0, x1 = x2, x1  # x2 is valid. We can now search to the right in the binary three.
-            # Avoid division by zero: https://en.wikipedia.org/wiki/Relative_change_and_difference
-            rel_diff = 0 if x0 == x1 else abs(x1 - x0) / max(abs(x0), abs(x1))
         else:
             x0, x1 = x0, x2  # x2 is invalid. We can now search to the left in the binary three
-            # rel_diff does not change since the solution is not valid. Otherwise we could accept a non-True solution.
+        rel_diff = 0 if x0 == x1 else abs(x1 - x0) / max(abs(x0), abs(x1))
         i += 1
 
     if i > maximum_number_of_iterations:
@@ -223,4 +221,4 @@ def maximize_x_given_boolean_condition_function(
             f" bool_func: {bool_func}"
         )
         logger.error(msg)
-    return x2
+    return x0

--- a/src/libecalc/process/process_solver/search_strategies.py
+++ b/src/libecalc/process/process_solver/search_strategies.py
@@ -51,7 +51,6 @@ class BinarySearchStrategy(SearchStrategy):
         Note: This requires that the boolean condition is an indicator function where x > threshold returns False.
         """
         x0, x1 = boundary.min, boundary.max
-        x2 = (x0 + x1) / 2  # Initial value x2.
         last_accepted: float | None = None
         i = 0
         rel_diff = 100.0
@@ -66,9 +65,7 @@ class BinarySearchStrategy(SearchStrategy):
             else:
                 x0, x1 = x0, x2  # x2 is invalid. We can now search to the left in the binary three
 
-            if accepted:
-                # Avoid division by zero: https://en.wikipedia.org/wiki/Relative_change_and_difference
-                rel_diff = 0 if x0 == x1 else abs(x1 - x0) / max(abs(x0), abs(x1))
+            rel_diff = 0 if x0 == x1 else abs(x1 - x0) / max(abs(x0), abs(x1))
             i += 1
 
         if i >= self._max_iterations:
@@ -77,7 +74,7 @@ class BinarySearchStrategy(SearchStrategy):
                 tolerance=self._tolerance,
                 iterations=self._max_iterations,
             )
-        return last_accepted if last_accepted is not None else x2
+        return last_accepted if last_accepted is not None else x1
 
 
 class RootFindingStrategy(abc.ABC):

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_chart_generator.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_chart_generator.py
@@ -217,7 +217,7 @@ def test_compressor_chart_from_head_and_rate_data(chart_data_factory, compressor
     )
 
     assert compressor_chart.design_head == pytest.approx(96909.05)
-    assert compressor_chart.design_rate == pytest.approx(4451.96)
+    assert compressor_chart.design_rate == pytest.approx(4451.965)
 
 
 def test_compressor_chart_from_head_and_rate_data_2():

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_train_common_shaft.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_train_common_shaft.py
@@ -276,7 +276,7 @@ class TestCompressorTrainCommonShaft:
 
         np.testing.assert_almost_equal(
             result.outlet_stream.pressure,
-            [238.2, 270.0, 277.2, 220.4],
+            [238.2, 270.0, 277.0, 220.4],
             decimal=1,
         )
 

--- a/tests/libecalc/core/models/compressor_modelling/test_numeric_methods.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_numeric_methods.py
@@ -81,6 +81,20 @@ def test_maximize_x_given_invalid_boolean_condition_function():
     assert result == pytest.approx(0, rel=0.01)
 
 
+def test_maximize_x_converges_when_threshold_is_near_lower_bound():
+    """Converges within a tight iteration budget even when the first several probes are all False."""
+    threshold = 11.0
+    result = maximize_x_given_boolean_condition_function(
+        x_min=10.0,
+        x_max=20.0,
+        bool_func=lambda x: x <= threshold,
+        convergence_tolerance=0.001,
+        maximum_number_of_iterations=10,
+    )
+    assert result <= threshold
+    assert result == pytest.approx(threshold, rel=0.001)
+
+
 def test_adaptive_pressure_update_beta_reduces_after_two_large_flips():
     """
     After two sign flips with large amplitude β must be < 1 (damped).

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/test_process_solver.py
@@ -22,7 +22,6 @@ from libecalc.process.process_solver.configuration import (
     SpeedConfiguration,
 )
 from libecalc.process.process_solver.float_constraint import FloatConstraint
-from libecalc.process.process_solver.search_strategies import DidNotConvergeError
 from libecalc.process.process_solver.solver import (
     RateTooHighFailure,
     Solution,
@@ -62,23 +61,6 @@ class _Xfail:
 
 
 PROCESS_XFAILS: dict[tuple[str, str], _Xfail] = {
-    # R1 — SpeedSolver does not converge when the min-speed point starts above stonewall;
-    # the search raises DidNotConvergeError instead of returning a structured solution.
-    ("R1", "UPSTREAM_CHOKE"): _Xfail("SpeedSolver bracketing failure at min-speed.", raises=DidNotConvergeError),
-    ("R1", "DOWNSTREAM_CHOKE"): _Xfail("SpeedSolver bracketing failure at min-speed.", raises=DidNotConvergeError),
-    ("R1", "INDIVIDUAL_ASV_RATE"): _Xfail("SpeedSolver bracketing failure at min-speed.", raises=DidNotConvergeError),
-    ("R1", "INDIVIDUAL_ASV_PRESSURE"): _Xfail(
-        "SpeedSolver bracketing failure at min-speed.", raises=DidNotConvergeError
-    ),
-    ("R1", "COMMON_ASV"): _Xfail("SpeedSolver bracketing failure at min-speed.", raises=DidNotConvergeError),
-    # R6 — similar SpeedSolver non-convergence near the max-speed boundary (also raises).
-    ("R6", "UPSTREAM_CHOKE"): _Xfail("SpeedSolver convergence issue near max-speed.", raises=DidNotConvergeError),
-    ("R6", "DOWNSTREAM_CHOKE"): _Xfail("SpeedSolver convergence issue near max-speed.", raises=DidNotConvergeError),
-    ("R6", "INDIVIDUAL_ASV_RATE"): _Xfail("SpeedSolver convergence issue near max-speed.", raises=DidNotConvergeError),
-    ("R6", "INDIVIDUAL_ASV_PRESSURE"): _Xfail(
-        "SpeedSolver convergence issue near max-speed.", raises=DidNotConvergeError
-    ),
-    ("R6", "COMMON_ASV"): _Xfail("SpeedSolver convergence issue near max-speed.", raises=DidNotConvergeError),
     # R8 — process solver does not implement the legacy zero-rate short-circuit: it returns a
     # real (non-NaN) outlet pressure instead, so this is a wrong-but-structured outcome (no crash).
     ("R8", "UPSTREAM_CHOKE"): _Xfail("No zero-rate short-circuit in process solver."),


### PR DESCRIPTION
Fixes equinor/ecalc-internal#1910