### PR TITLE
refactor: remove anti-surge config from PipelineSectionSolver

### DIFF
--- a/src/libecalc/process/process_solver/pipeline_section_solver.py
+++ b/src/libecalc/process/process_solver/pipeline_section_solver.py
@@ -5,7 +5,6 @@ from libecalc.process.process_pipeline.process_error import RateTooLowError
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import (
     Configuration,
-    RecirculationConfiguration,
     SpeedConfiguration,
     merge_configurations,
 )
@@ -32,7 +31,6 @@ class PipelineSectionSolver:
 
     def __init__(self, pipeline_section: PipelineSection) -> None:
         self._pipeline_section = pipeline_section
-        self._anti_surge_solution: Solution[Sequence[Configuration[RecirculationConfiguration]]] | None = None
 
     def _get_initial_speed_boundary(self) -> Boundary:
         return self._pipeline_section.speed_boundary
@@ -69,9 +67,6 @@ class PipelineSectionSolver:
         self._pipeline_section.runner.apply_configurations(configurations)
         return self._pipeline_section.runner.run(inlet_stream=inlet_stream)
 
-    def get_anti_surge_solution(self) -> Solution[Sequence[Configuration[RecirculationConfiguration]]] | None:
-        return self._anti_surge_solution
-
     def find_solution(
         self,
         pressure_constraint: FloatConstraint,
@@ -91,14 +86,14 @@ class PipelineSectionSolver:
             return Solution(configuration=[shaft_config], failure=speed_finding.failure)
 
         self._pipeline_section.runner.apply_configuration(shaft_config)
-        self._anti_surge_solution = self._pipeline_section.anti_surge_strategy.apply(inlet_stream=inlet_stream)
+        anti_surge_solution = self._pipeline_section.anti_surge_strategy.apply(inlet_stream=inlet_stream)
 
-        speed_and_anti_surge_configurations = [shaft_config, *self._anti_surge_solution.configuration]
+        speed_and_anti_surge_configurations = [shaft_config, *anti_surge_solution.configuration]
 
-        if not self._anti_surge_solution.success:
+        if not anti_surge_solution.success:
             return Solution(
                 configuration=speed_and_anti_surge_configurations,
-                failure=self._anti_surge_solution.failure,
+                failure=anti_surge_solution.failure,
             )
 
         if isinstance(speed_finding.failure, TargetPressureUnreachableFailure) and (

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/assertions.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/assertions.py
@@ -73,6 +73,7 @@ def assert_control_behavior(
     action = case.expectation.control_action
     if action is ExpectedControlAction.RECIRCULATION:
         assert has_recirculation
+        assert all(r >= asv for r, asv in zip(recirculation_rates, anti_surge_recirculation_rates))
 
     if action is ExpectedControlAction.DOWNSTREAM_CHOKE:
         assert choke_delta_pressure is None or choke_delta_pressure > 0.0

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/test_process_solver.py
@@ -174,12 +174,14 @@ def test_process_solver_path(
         (c.value.delta_pressure for c in solution.configuration if isinstance(c.value, ChokeConfiguration)),
         None,
     )
-    anti_surge_solution = system.solver.get_anti_surge_solution()
-    anti_surge_recirculation_rates = (
-        tuple(c.value.recirculation_rate for c in anti_surge_solution.configuration)
-        if anti_surge_solution is not None
-        else ()
+
+    # Compute the anti-surge floor at the solution speed, without pressure control.
+    system.runner.apply_configurations(
+        [c for c in solution.configuration if not isinstance(c.value, RecirculationConfiguration)]
     )
+    anti_surge_solution = system.pipeline_section.anti_surge_strategy.apply(inlet_stream=inlet_stream)
+    anti_surge_recirculation_rates = tuple(c.value.recirculation_rate for c in anti_surge_solution.configuration)
+
     assert_control_behavior(
         case,
         recirculation_rates=recirculation_rates,

--- a/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_common_asv.py
+++ b/tests/libecalc/process/process_solver/test_pipeline_section_solver_with_common_asv.py
@@ -72,18 +72,20 @@ def test_pipeline_section_solver_with_common_asv(
 
     speed_configuration = config_dict[shaft.get_id()]
 
-    recirculation_at_capacity_solution = common_asv_solver.get_anti_surge_solution()
-    assert recirculation_at_capacity_solution is not None
-
     assert solution.success
     assert speed_configuration.speed == pytest.approx(94.40, rel=1e-3)
-
-    recirculation_rate_at_capacity = recirculation_at_capacity_solution.configuration[0].value.recirculation_rate
 
     recirculation_configuration = [
         config for config in solution.configuration if isinstance(config.value, RecirculationConfiguration)
     ][0]
     recirculation_rate_after_pressure_control = recirculation_configuration.value.recirculation_rate
+
+    # Get the anti-surge floor at the solution speed, without pressure control.
+    runner.apply_configurations(
+        [config for config in solution.configuration if not isinstance(config.value, RecirculationConfiguration)]
+    )
+    anti_surge_solution = anti_surge_strategy.apply(inlet_stream=inlet_stream)
+    recirculation_rate_at_capacity = anti_surge_solution.configuration[0].value.recirculation_rate
 
     assert recirculation_rate_at_capacity == pytest.approx(336264.9, rel=1e-4)
     assert recirculation_rate_after_pressure_control >= recirculation_rate_at_capacity


### PR DESCRIPTION
The anti-surge configurations are already merged into Solution.configuration, so rates are readable directly from the returned solution.

After potential pressure control, the recirculation rates will change (also the contribution from flow/protection/anti-surge), so it does not make any sense to store them to use as a "floor" for the lowest recirculation either. 

If the goal is to track the contribution from anti-surge and from pressure control on the total recirculation it needs to be done another way.