### PR TITLE
fix: replace common.find_root with RootFindingStrategy in IndividualASVRateControlStrategy

### DIFF
--- a/src/libecalc/process/process_solver/pressure_control/individual_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/individual_asv.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 
-from libecalc.common.numeric_methods import find_root
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import (
     ChokeConfiguration,
     Configuration,
@@ -119,10 +119,12 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
         simulator: ProcessRunner,
         recirculation_loop_ids: Sequence[ConfigurationHandlerId],
         compressors: Sequence[Compressor],
+        root_finding_strategy: RootFindingStrategy,
     ):
         self._simulator = simulator
         self._recirculation_loop_ids = recirculation_loop_ids
         self._compressors = compressors
+        self._root_finding_strategy = root_finding_strategy
 
     def reset(self) -> None:
         for recirculation_loop_id in self._recirculation_loop_ids:
@@ -178,10 +180,9 @@ class IndividualASVRateControlStrategy(PressureControlStrategy):
 
         # find_root searches for the recirculation fraction [0, 1] where
         # outlet_pressure(fraction) == target_pressure.
-        # find_root raises if no solution exists within [0, 1].
-        result_fraction = find_root(
-            lower_bound=0.0,
-            upper_bound=1.0,
+        # Raises DidNotConvergeError if no solution is found within [0, 1].
+        result_fraction = self._root_finding_strategy.find_root(
+            boundary=Boundary(min=0.0, max=1.0),
             func=lambda x: get_outlet_stream(x).pressure_bara - target_pressure.value,
         )
         # Re-propagate with converged fraction so loops store correct rates

--- a/src/libecalc/process/process_solver/solver_assembly.py
+++ b/src/libecalc/process/process_solver/solver_assembly.py
@@ -211,6 +211,7 @@ def _resolve_pressure_control_strategy(
                 simulator=runner,
                 recirculation_loop_ids=[loop.get_id() for loop in recirculation_loops],
                 compressors=compressors,
+                root_finding_strategy=root_finding_strategy,
             )
         case "INDIVIDUAL_ASV_PRESSURE":
             return IndividualASVPressureControlStrategy(

--- a/tests/libecalc/process/process_solver/conftest.py
+++ b/tests/libecalc/process/process_solver/conftest.py
@@ -199,7 +199,7 @@ def common_asv_pressure_control_strategy_factory(root_finding_strategy):
 
 
 @pytest.fixture
-def individual_asv_rate_control_strategy_factory():
+def individual_asv_rate_control_strategy_factory(root_finding_strategy):
     def create(
         runner: ProcessRunner,
         recirculation_loop_ids: list[ConfigurationHandlerId],
@@ -209,6 +209,7 @@ def individual_asv_rate_control_strategy_factory():
             simulator=runner,
             recirculation_loop_ids=recirculation_loop_ids,
             compressors=compressors,
+            root_finding_strategy=root_finding_strategy,
         )
 
     return create


### PR DESCRIPTION
The legacy find_root helper catches all exceptions silently and never raises on non-convergence, so ProcessError failures and solver divergence were swallowed instead of surfacing as typed Solution failures.