### PR TITLE
chore: add inlet and outlet nodes to easily detect start and end of p…

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -78,8 +78,10 @@ from libecalc.process.process_units.choke import Choke
 from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.process_units.direct_mixer import DirectMixer
 from libecalc.process.process_units.direct_splitter import DirectSplitter
+from libecalc.process.process_units.inlet import Inlet
 from libecalc.process.process_units.liquid_remover import LiquidRemover
 from libecalc.process.process_units.mixer import Mixer
+from libecalc.process.process_units.outlet import Outlet
 from libecalc.process.process_units.pressure_dropper import PressureDropper
 from libecalc.process.process_units.splitter import Splitter
 from libecalc.process.process_units.temperature_setter import TemperatureSetter
@@ -440,6 +442,10 @@ class ProcessSimulationMapper:
                 choke, choke_configuration_handler = choke_factory(fluid_service=self._fluid_service)
                 problem_configuration_handlers.append(choke_configuration_handler)
                 process_units = [choke, *process_units]
+
+            # A pipeline must have a start and an end - always add process units for that (ie owner of inlet and outlet streams)
+            process_units.append(Outlet())
+            process_units.insert(0, Inlet())
 
             process_pipeline = ProcessPipeline(
                 name=item.name,

--- a/src/libecalc/process/process_solver/choke_configuration_handler.py
+++ b/src/libecalc/process/process_solver/choke_configuration_handler.py
@@ -17,7 +17,7 @@ class ChokeConfigurationHandler(ConfigurationHandler):
     def get_choke_id(self) -> ProcessUnitId:
         return self._choke.get_id()
 
-    def get_delta_pressure_change(self) -> float:
+    def get_pressure_change(self) -> float:
         return self._choke.pressure_change
 
     def handle_configuration(self, configuration: Configuration) -> None:

--- a/src/libecalc/process/process_solver/choke_configuration_handler.py
+++ b/src/libecalc/process/process_solver/choke_configuration_handler.py
@@ -17,6 +17,9 @@ class ChokeConfigurationHandler(ConfigurationHandler):
     def get_choke_id(self) -> ProcessUnitId:
         return self._choke.get_id()
 
+    def get_delta_pressure_change(self) -> float:
+        return self._choke.pressure_change
+
     def handle_configuration(self, configuration: Configuration) -> None:
         assert configuration.configuration_handler_id == self._id, (
             f"Configuration id '{configuration.configuration_handler_id}' does not match choke configuration handler id '{self._id}'"

--- a/src/libecalc/process/process_units/inlet.py
+++ b/src/libecalc/process/process_units/inlet.py
@@ -1,0 +1,22 @@
+from typing import Final
+
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
+
+
+class Inlet(ProcessUnit):
+    """
+    Inlet, or Feed, is where a process stream is considered born/created in eCalc. We just know
+    that the inlet stream conditions are given at this point.
+
+    This is like a source in a streaming system - where it all starts.
+    """
+
+    def __init__(self, process_unit_id: ProcessUnitId | None = None):
+        self._id: Final[ProcessUnitId] = process_unit_id or ProcessUnit._create_id()
+
+    def get_id(self) -> ProcessUnitId:
+        return self._id
+
+    def propagate_stream(self, inlet_stream: FluidStream) -> FluidStream:
+        return inlet_stream  # TODO: Copy?

--- a/src/libecalc/process/process_units/outlet.py
+++ b/src/libecalc/process/process_units/outlet.py
@@ -1,0 +1,26 @@
+from typing import Final
+
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
+
+
+class Outlet(ProcessUnit):
+    """
+    A process unit that is the destination for the outlet streams, and where we test the
+    outlet criteria on. Does not alter the process stream, and the stream does not go through it,
+    but "ends" at it.
+
+    We could e.g. say that it has a business criteria/policy, that a given outlet pressure MUST
+    be expected here, otherwise it is considered a failure.
+
+    This is like a sink in a streaming system - where it all ends
+    """
+
+    def __init__(self, process_unit_id: ProcessUnitId | None = None):
+        self._id: Final[ProcessUnitId] = process_unit_id or ProcessUnit._create_id()
+
+    def get_id(self) -> ProcessUnitId:
+        return self._id
+
+    def propagate_stream(self, inlet_stream: FluidStream) -> FluidStream:
+        return inlet_stream  # TODO: Copy?

--- a/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
@@ -6,7 +6,9 @@ from libecalc.process.process_units.choke import Choke
 from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.process_units.direct_mixer import DirectMixer
 from libecalc.process.process_units.direct_splitter import DirectSplitter
+from libecalc.process.process_units.inlet import Inlet
 from libecalc.process.process_units.liquid_remover import LiquidRemover
+from libecalc.process.process_units.outlet import Outlet
 from libecalc.process.process_units.pressure_dropper import PressureDropper
 from libecalc.process.process_units.temperature_setter import TemperatureSetter
 from libecalc.testing.process_builders import (
@@ -108,7 +110,9 @@ def test_mapper_wraps_compressor_segment_with_mixer_and_splitter(process_simulat
     )
 
     units = pipelines[0].get_process_units()
-    assert isinstance(units[0], DirectMixer)
+    assert isinstance(units[0], Inlet)
+    assert isinstance(units[1], DirectMixer)
+    assert isinstance(units[-1], Outlet)
     splitter_index = next(i for i, u in enumerate(units) if isinstance(u, DirectSplitter))
     compressor_index = next(i for i, u in enumerate(units) if isinstance(u, Compressor))
     assert splitter_index > compressor_index
@@ -144,7 +148,9 @@ def test_mapper_adds_choke_for_downstream_choke_pressure_control(process_simulat
     )
 
     units = pipelines[0].get_process_units()
-    assert isinstance(units[-1], Choke)
+    assert isinstance(units[0], Inlet)
+    assert isinstance(units[-2], Choke)
+    assert isinstance(units[-1], Outlet)
 
 
 def test_mapper_adds_choke_for_upstream_choke_pressure_control(process_simulation_mapper):
@@ -157,7 +163,9 @@ def test_mapper_adds_choke_for_upstream_choke_pressure_control(process_simulatio
     )
 
     units = pipelines[0].get_process_units()
-    assert isinstance(units[0], Choke)
+    assert isinstance(units[0], Inlet)
+    assert isinstance(units[1], Choke)
+    assert isinstance(units[-1], Outlet)
 
 
 def test_mixer_and_splitter_are_placed_between_asv_loops(process_simulation_mapper):
@@ -188,6 +196,7 @@ def test_mixer_and_splitter_are_placed_between_asv_loops(process_simulation_mapp
     unit_types = [type(u).__name__ for u in units]
 
     assert unit_types == [
+        "Inlet",
         "DirectMixer",
         "TemperatureSetter",
         "Compressor",
@@ -198,6 +207,7 @@ def test_mixer_and_splitter_are_placed_between_asv_loops(process_simulation_mapp
         "TemperatureSetter",
         "Compressor",
         "DirectSplitter",  # ASV loop 2
+        "Outlet",
     ]
 
 
@@ -260,6 +270,6 @@ def test_mapper_places_trailing_units_after_last_asv_loop(process_simulation_map
     splitter_indices = [i for i, u in enumerate(units) if isinstance(u, DirectSplitter)]
     assert len(splitter_indices) == 2
 
-    trailing_temp_index = len(units) - 1
+    trailing_temp_index = len(units) - 2
     assert isinstance(units[trailing_temp_index], TemperatureSetter)
     assert trailing_temp_index > max(splitter_indices)


### PR DESCRIPTION
…ipeline

Refs: equinor/ecalc-internal#1937

## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
