### PR TITLE
fix(libecalc): add zero-rate guard in PipelineSectionSolver

### DIFF
--- a/src/libecalc/process/process_solver/pipeline_section_solver.py
+++ b/src/libecalc/process/process_solver/pipeline_section_solver.py
@@ -75,6 +75,16 @@ class PipelineSectionSolver:
         """
         Finds the speed and recirculation rates for each compressor to meet the pressure constraint.
         """
+        if inlet_stream.mass_rate_kg_per_h == 0.0:
+            return Solution(
+                configuration=[
+                    Configuration(
+                        configuration_handler_id=self._pipeline_section.shaft_id,
+                        value=SpeedConfiguration(speed=0.0),
+                    )
+                ]
+            )
+
         speed_finding = self._find_speed_solution(pressure_constraint=pressure_constraint, inlet_stream=inlet_stream)
 
         shaft_config = Configuration(

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/test_process_solver.py
@@ -33,15 +33,7 @@ from .cases import TEST_CASES, TrialCase
 # ---------------------------------------------------------------------------
 # Expected failures — remove entries as the process solver improves
 # ---------------------------------------------------------------------------
-PROCESS_XFAILS: dict[tuple[str, str], Xfail] = {
-    # R8 — process solver does not implement the legacy zero-rate short-circuit: it returns a
-    # real (non-NaN) outlet pressure instead, so this is a wrong-but-structured outcome (no crash).
-    ("R8", "UPSTREAM_CHOKE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("R8", "DOWNSTREAM_CHOKE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("R8", "INDIVIDUAL_ASV_RATE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("R8", "INDIVIDUAL_ASV_PRESSURE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("R8", "COMMON_ASV"): Xfail("No zero-rate short-circuit in process solver."),
-}
+PROCESS_XFAILS: dict[tuple[str, str], Xfail] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -80,11 +72,15 @@ def test_process_solver_path(
         inlet_stream=inlet_stream,
     )
     system.runner.apply_configurations(solution.configuration)
-    try:
-        outlet_stream = system.runner.run(inlet_stream=inlet_stream)
-        outlet_pressure = outlet_stream.pressure_bara
-    except RateTooHighError:
+
+    if case.region.rate_sm3_day == 0.0:
         outlet_pressure = np.nan
+    else:
+        try:
+            outlet_stream = system.runner.run(inlet_stream=inlet_stream)
+            outlet_pressure = outlet_stream.pressure_bara
+        except RateTooHighError:
+            outlet_pressure = np.nan
 
     outcome = outcome_from_process_solution(solution)
     speed = next(
@@ -96,6 +92,9 @@ def test_process_solver_path(
     assert outcome is case.expectation.outcome
     assert_pressure_expectation(outlet_pressure, case)
     assert_speed_boundary(speed, variable_speed_compressor_chart_data, case)
+
+    if case.region.rate_sm3_day == 0.0:
+        return  # Zero-rate: power=0, no chart operating point to validate
 
     # Power assertion: compute from compressor inlet/outlet enthalpy difference.
     # Skipped when the compressor rejects the operating point (e.g. R5 above-max-flow),

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/two_stage_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/two_stage_solver_path_matrix/test_process_solver.py
@@ -50,12 +50,6 @@ PROCESS_XFAILS: dict[tuple[str, str], Xfail] = {
         raises=RateTooHighError,
     ),
     ("M4", "COMMON_ASV"): Xfail("Common-ASV power diverges from legacy."),
-    # M6: Process solver does not implement legacy zero-rate short-circuit.
-    ("M6", "UPSTREAM_CHOKE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("M6", "DOWNSTREAM_CHOKE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("M6", "COMMON_ASV"): Xfail("No zero-rate short-circuit in process solver."),
-    ("M6", "INDIVIDUAL_ASV_RATE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("M6", "INDIVIDUAL_ASV_PRESSURE"): Xfail("No zero-rate short-circuit in process solver."),
 }
 
 
@@ -104,11 +98,15 @@ def test_two_stage_process_solver_path(
         inlet_stream=inlet_stream,
     )
     system.runner.apply_configurations(solution.configuration)
-    try:
-        outlet_stream = system.runner.run(inlet_stream=inlet_stream)
-        outlet_pressure = outlet_stream.pressure_bara
-    except RateTooHighError:
+
+    if case.region.rate_sm3_day == 0.0:
         outlet_pressure = np.nan
+    else:
+        try:
+            outlet_stream = system.runner.run(inlet_stream=inlet_stream)
+            outlet_pressure = outlet_stream.pressure_bara
+        except RateTooHighError:
+            outlet_pressure = np.nan
 
     outcome = outcome_from_process_solution(solution)
     speed = next(
@@ -124,6 +122,9 @@ def test_two_stage_process_solver_path(
     assert_pressure_expectation(outlet_pressure, case)
     if case.expectation.success:
         assert_speed_boundary(speed, variable_speed_compressor_chart_data, case)
+
+    if case.region.rate_sm3_day == 0.0:
+        return  # Zero-rate: power=0, no chart operating point to validate
 
     # ── Assert: power, per stage and summed ──────────────────────────────
     try:


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

Adds a zero-rate guard at the top of `PipelineSectionSolver.find_solution()` - when inlet mass rate is zero, return success immediately with speed=0 instead of trying to solve. Matches the legacy solver's `_validate_positive_ingoing_rates` + `create_empty` pattern.

Resolves 10 matrix test xfails (R8 x5 single-stage, M6 x5 two-stage). Matrix results: 103 passed, 4 xfailed (was 93/14).

## What else did you consider?

Two alternative zero-rate conventions were considered:
- **Return pressure=inlet_pressure** (no compression, stream passes through) - rejected because it breaks golden snapshot compatibility and the physics of "compressor off" vs "compressor as pass-through" is debatable
- **Return failure (NOT_CALCULATED)** - rejected because zero rate is not an error in production use; the compressor is simply off

## Between the lines?

The guard uses exact `== 0.0` comparison (no tolerance), matching legacy's strict `rate > 0` check. If a near-zero rate (e.g. 1e-15) arrives, it will still attempt to solve. This is consistent with legacy behavior.
