### PR TITLE
fix(libecalc): remove manual max-probe from common-ASV pressure control

### DIFF
--- a/src/libecalc/process/process_solver/pressure_control/common_asv.py
+++ b/src/libecalc/process/process_solver/pressure_control/common_asv.py
@@ -12,10 +12,7 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlStrategy
 from libecalc.process.process_solver.process_runner import ProcessRunner
 from libecalc.process.process_solver.search_strategies import Bisect, RootFindingStrategy
-from libecalc.process.process_solver.solver import (
-    Solution,
-    TargetDirection,
-)
+from libecalc.process.process_solver.solver import Solution
 from libecalc.process.process_units.compressor import Compressor
 
 
@@ -57,21 +54,6 @@ class CommonASVPressureControlStrategy(PressureControlStrategy):
 
         compressor_inlet_stream = self._simulator.run(inlet_stream=inlet_stream, to_id=self._first_compressor.get_id())
         boundary = self._first_compressor.get_recirculation_range(compressor_inlet_stream)
-        min_configuration = RecirculationConfiguration(recirculation_rate=boundary.max)
-        min_pressure_stream = recirculation_func(min_configuration)
-
-        if min_pressure_stream.pressure_bara > target_pressure.value:
-            return Solution.target_pressure_unreachable(
-                configuration=[
-                    Configuration(
-                        configuration_handler_id=self._recirculation_loop_id,
-                        value=min_configuration,
-                    )
-                ],
-                achievable_pressure_bara=min_pressure_stream.pressure_bara,
-                target_pressure_bara=target_pressure.value,
-                direction=TargetDirection.MIN_ABOVE_TARGET,
-            )
 
         finder = RecirculationLoopRateFinder(
             search_strategy=Bisect(tolerance=10e-3),

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/single_stage_solver_path_matrix/test_process_solver.py
@@ -34,13 +34,20 @@ from .cases import TEST_CASES, TrialCase
 # Expected failures — remove entries as the process solver improves
 # ---------------------------------------------------------------------------
 PROCESS_XFAILS: dict[tuple[str, str], Xfail] = {
-    # R8 — process solver does not implement the legacy zero-rate short-circuit: it returns a
-    # real (non-NaN) outlet pressure instead, so this is a wrong-but-structured outcome (no crash).
-    ("R8", "UPSTREAM_CHOKE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("R8", "DOWNSTREAM_CHOKE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("R8", "INDIVIDUAL_ASV_RATE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("R8", "INDIVIDUAL_ASV_PRESSURE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("R8", "COMMON_ASV"): Xfail("No zero-rate short-circuit in process solver."),
+    # R8: at zero inlet rate, legacy short-circuits to power=0, pressure=NaN (compressor off).
+    # The process solver has no zero-rate guard - it solves normally, finding a speed and
+    # recirculation rate that hits target pressure with all flow circulating internally
+    # (outlet mass rate = 0). Whether this or legacy's behavior is "correct" is a design
+    # decision that depends on what zero-rate means operationally.
+    ("R8", "UPSTREAM_CHOKE"): Xfail("Zero-rate: process solver solves normally; legacy short-circuits to power=0."),
+    ("R8", "DOWNSTREAM_CHOKE"): Xfail("Zero-rate: process solver solves normally; legacy short-circuits to power=0."),
+    ("R8", "INDIVIDUAL_ASV_RATE"): Xfail(
+        "Zero-rate: process solver solves normally; legacy short-circuits to power=0."
+    ),
+    ("R8", "INDIVIDUAL_ASV_PRESSURE"): Xfail(
+        "Zero-rate: process solver solves normally; legacy short-circuits to power=0."
+    ),
+    ("R8", "COMMON_ASV"): Xfail("Zero-rate: process solver solves normally; legacy short-circuits to power=0."),
 }
 
 

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/two_stage_solver_path_matrix/cases.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/two_stage_solver_path_matrix/cases.py
@@ -118,6 +118,14 @@ REGIONS = {
         discharge_pressure_bara=100.0,
         speed_boundary_class=SpeedBoundaryClass.NOT_ASSERTED,
     ),
+    # M7: Over-compression where common-ASV LP max overloads HP but mid-range solution exists
+    "M7": TwoStageRegion(
+        id="M7",
+        rate_sm3_day=3_500_000.0,
+        suction_pressure_bara=40.0,
+        discharge_pressure_bara=95.0,
+        speed_boundary_class=SpeedBoundaryClass.MINIMUM,
+    ),
 }
 
 
@@ -131,6 +139,8 @@ _CHOKE_CONTROL_ACTIONS: dict[tuple[str, str], ExpectedControlAction] = {
     ("M1", "DOWNSTREAM_CHOKE"): ExpectedControlAction.DOWNSTREAM_CHOKE,
     ("M2", "UPSTREAM_CHOKE"): ExpectedControlAction.UPSTREAM_CHOKE,
     ("M2", "DOWNSTREAM_CHOKE"): ExpectedControlAction.DOWNSTREAM_CHOKE,
+    ("M7", "UPSTREAM_CHOKE"): ExpectedControlAction.UPSTREAM_CHOKE,
+    ("M7", "DOWNSTREAM_CHOKE"): ExpectedControlAction.DOWNSTREAM_CHOKE,
 }
 
 

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/two_stage_solver_path_matrix/golden_snapshot/two_stage_matrix.json
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/two_stage_solver_path_matrix/golden_snapshot/two_stage_matrix.json
@@ -388,5 +388,70 @@
     "outcome": "SUCCESS",
     "power_mw": 0.0,
     "speed": null
+  },
+  "M7-COMMON_ASV": {
+    "discharge_pressure_bara": 95.0,
+    "hp_chart_area": "INTERNAL_POINT",
+    "hp_power_mw": 3.192,
+    "hp_recirculation_rate_sm3_day": 608381.284,
+    "is_valid": true,
+    "lp_chart_area": "INTERNAL_POINT",
+    "lp_power_mw": 2.974,
+    "lp_recirculation_rate_sm3_day": 608381.284,
+    "outcome": "SUCCESS",
+    "power_mw": 6.166,
+    "speed": 7689.0
+  },
+  "M7-DOWNSTREAM_CHOKE": {
+    "discharge_pressure_bara": 95.0,
+    "hp_chart_area": "INTERNAL_POINT",
+    "hp_power_mw": 3.107,
+    "hp_recirculation_rate_sm3_day": 0.0,
+    "is_valid": true,
+    "lp_chart_area": "INTERNAL_POINT",
+    "lp_power_mw": 2.848,
+    "lp_recirculation_rate_sm3_day": 0.0,
+    "outcome": "SUCCESS",
+    "power_mw": 5.955,
+    "speed": 7689.0
+  },
+  "M7-INDIVIDUAL_ASV_PRESSURE": {
+    "discharge_pressure_bara": 96.285,
+    "hp_chart_area": "INTERNAL_POINT",
+    "hp_power_mw": 2.984,
+    "hp_recirculation_rate_sm3_day": 340424.539,
+    "is_valid": false,
+    "lp_chart_area": "INTERNAL_POINT",
+    "lp_power_mw": 2.966,
+    "lp_recirculation_rate_sm3_day": 507536.709,
+    "outcome": "PRESSURE_TOO_LOW",
+    "power_mw": 5.95,
+    "speed": 7689.0
+  },
+  "M7-INDIVIDUAL_ASV_RATE": {
+    "discharge_pressure_bara": 95.0,
+    "hp_chart_area": "INTERNAL_POINT",
+    "hp_power_mw": 2.915,
+    "hp_recirculation_rate_sm3_day": 188063.505,
+    "is_valid": true,
+    "lp_chart_area": "INTERNAL_POINT",
+    "lp_power_mw": 2.977,
+    "lp_recirculation_rate_sm3_day": 685073.773,
+    "outcome": "SUCCESS",
+    "power_mw": 5.892,
+    "speed": 7689.0
+  },
+  "M7-UPSTREAM_CHOKE": {
+    "discharge_pressure_bara": 95.0,
+    "hp_chart_area": "INTERNAL_POINT",
+    "hp_power_mw": 2.857,
+    "hp_recirculation_rate_sm3_day": 0.0,
+    "is_valid": true,
+    "lp_chart_area": "INTERNAL_POINT",
+    "lp_power_mw": 2.72,
+    "lp_recirculation_rate_sm3_day": 0.0,
+    "outcome": "SUCCESS",
+    "power_mw": 5.577,
+    "speed": 7689.0
   }
 }

--- a/tests/libecalc/process/process_solver/compressor_solver_path_matrix/two_stage_solver_path_matrix/test_process_solver.py
+++ b/tests/libecalc/process/process_solver/compressor_solver_path_matrix/two_stage_solver_path_matrix/test_process_solver.py
@@ -38,24 +38,41 @@ PROCESS_XFAILS: dict[tuple[str, str], Xfail] = {
     # M1-UPSTREAM_CHOKE: process solver reports NOT_CALCULATED instead of ABOVE_MAX_FLOW
     # when upstream choke pushes HP stage above max at low target discharge.
     ("M1", "UPSTREAM_CHOKE"): Xfail("Upstream choke failure not classified as ABOVE_MAX_FLOW."),
-    # COMMON_ASV multi-stage: the single common recirculation loop is sized from the
-    # LP stage and overloads the narrower HP stage, which raises RateTooHighError
-    # (uncaught) instead of returning a structured ABOVE_MAX_FLOW failure.
+    # M1/M2-COMMON_ASV: process solver returns PRESSURE_TOO_LOW (can't reduce pressure
+    # within feasible common-ASV recirculation range) while legacy returns ABOVE_MAX_FLOW.
+    # Both are valid descriptions of the same physical situation.
     ("M1", "COMMON_ASV"): Xfail(
-        "Common-ASV single loop overloads HP stage; raises instead of ABOVE_MAX_FLOW.",
-        raises=RateTooHighError,
+        "Common-ASV failure classified as PRESSURE_TOO_LOW instead of legacy's ABOVE_MAX_FLOW."
     ),
     ("M2", "COMMON_ASV"): Xfail(
-        "Common-ASV single loop overloads HP stage; raises instead of ABOVE_MAX_FLOW.",
-        raises=RateTooHighError,
+        "Common-ASV failure classified as PRESSURE_TOO_LOW instead of legacy's ABOVE_MAX_FLOW."
     ),
-    ("M4", "COMMON_ASV"): Xfail("Common-ASV power diverges from legacy."),
-    # M6: Process solver does not implement legacy zero-rate short-circuit.
-    ("M6", "UPSTREAM_CHOKE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("M6", "DOWNSTREAM_CHOKE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("M6", "COMMON_ASV"): Xfail("No zero-rate short-circuit in process solver."),
-    ("M6", "INDIVIDUAL_ASV_RATE"): Xfail("No zero-rate short-circuit in process solver."),
-    ("M6", "INDIVIDUAL_ASV_PRESSURE"): Xfail("No zero-rate short-circuit in process solver."),
+    # M4-COMMON_ASV: process solver succeeds but at higher power (11.87 vs 11.19 MW).
+    # Legacy applies per-stage anti-surge (only HP recirculates 648K, LP stays at 0)
+    # even in COMMON_ASV mode. Process solver uses the actual common loop topology
+    # where anti-surge recirculation flows through both stages.
+    ("M4", "COMMON_ASV"): Xfail(
+        "Common-ASV anti-surge topology differs: process uses common loop, legacy uses per-stage."
+    ),
+    # M7-COMMON_ASV: legacy checks chart area flag against the PRE-ASV rate (2336 m3/h)
+    # but computes head/efficiency at the ASV-corrected rate (2742 m3/h). The process
+    # solver checks the full flow (2742) against the speed-based max (2527) and correctly
+    # rejects it. Legacy reports INTERNAL_POINT because 2336 < 2527, even though the
+    # compressor physically processes 2742 m3/h.
+    ("M7", "COMMON_ASV"): Xfail("Legacy checks chart area at pre-ASV rate; process solver checks at full flow."),
+    # M6: at zero inlet rate, legacy short-circuits to power=0, pressure=NaN (compressor off).
+    # The process solver has no zero-rate guard - it solves normally, finding a speed and
+    # recirculation rate that hits target pressure with all flow circulating internally.
+    # Whether this or legacy's behavior is "correct" is a design decision.
+    ("M6", "UPSTREAM_CHOKE"): Xfail("Zero-rate: process solver solves normally; legacy short-circuits to power=0."),
+    ("M6", "DOWNSTREAM_CHOKE"): Xfail("Zero-rate: process solver solves normally; legacy short-circuits to power=0."),
+    ("M6", "COMMON_ASV"): Xfail("Zero-rate: process solver solves normally; legacy short-circuits to power=0."),
+    ("M6", "INDIVIDUAL_ASV_RATE"): Xfail(
+        "Zero-rate: process solver solves normally; legacy short-circuits to power=0."
+    ),
+    ("M6", "INDIVIDUAL_ASV_PRESSURE"): Xfail(
+        "Zero-rate: process solver solves normally; legacy short-circuits to power=0."
+    ),
 }
 
 


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [x] I have added tests (if not, comment why)
- [x] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?

Simplifies `CommonASVPressureControlStrategy.apply()` by removing the manual max-probe and delegating directly to `RecirculationLoopRateFinder`. The finder already handles `RateTooHighError` at the boundary max by bisecting downward to find the highest feasible rate - the same pattern the anti-surge strategy uses.

Previously, the manual max-probe crashed with uncaught `RateTooHighError` when LP's recirculation boundary overloaded the narrower HP stage on multi-stage trains.

M1/M2-COMMON_ASV remain xfailed with a different failure classification. Legacy probes at the first stage's max rate, finds HP above stonewall, and returns ABOVE_MAX_FLOW. The process solver bisects to find the max rate all stages can handle, determines it can't reach target pressure within that range, and returns PRESSURE_TOO_LOW. Same physical conclusion (no common-ASV solution exists), different classification depending on which constraint is encountered first

Also adds M7 region to the two-stage matrix (rate=3.5M, target=95) as a regression test for the scenario where LP max recirc overloads HP but a valid mid-range solution may exist.

Matrix results: 102 passed, 15 xfailed.

## What else did you consider?

The M7-COMMON_ASV xfail documents a legacy chart evaluation quirk: legacy checks the chart area flag against the pre-ASV rate (2336 m3/h < stonewall) but computes head/efficiency at the ASV-corrected rate (2742 m3/h > stonewall). The process solver correctly checks the full flow entering the compressor. This is not a regression - the process solver's boundary check is physically sound. Will address the legacy solver bug in a future PR, and regenerate snasphot.

## Between the lines?

The simplified `common_asv.py` is a net reduction of ~20 lines. The finder's `_find_max_within_capacity_rate` handles the multi-stage boundary gracefully, making the pressure control code have correct behavior.
