### PR TITLE
chore: solution failure if asv is triggered when no asv chosen

### DIFF
--- a/src/libecalc/process/process_solver/anti_surge/anti_surge_strategy.py
+++ b/src/libecalc/process/process_solver/anti_surge/anti_surge_strategy.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from dataclasses import dataclass
 from enum import StrEnum
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration import Configuration, RecirculationConfiguration
-from libecalc.process.process_solver.solver import Solution
+from libecalc.process.process_solver.solver import Solution, SolverFailure
 
 
 class AntiSurgeType(StrEnum):
@@ -41,3 +43,32 @@ class AntiSurgeStrategy(ABC):
         from a previous evaluation would corrupt the result (e.g. upstream-choke search).
         """
         ...
+
+
+@dataclass
+class NoAntiSurgeControlFailure(SolverFailure):
+    source_id: ProcessUnitId
+    reason: str = ""
+
+
+class NoAntiSurgeStrategy(AntiSurgeStrategy):
+    """
+    TODO: Should this raise error if attempted to be used, because that would mean that
+    we need Anti-Surge, but we have no way of handling it.
+    """
+
+    def __init__(
+        self,
+        source_id: ProcessUnitId,
+    ):
+        self._source_id = source_id
+
+    def reset(self) -> None: ...
+
+    def apply(self, inlet_stream: FluidStream) -> Solution[Sequence[Configuration[RecirculationConfiguration]]]:
+        return Solution(
+            configuration=[],
+            failure=NoAntiSurgeControlFailure(
+                source_id=self._source_id, reason="No Anti-Surge protection added when apparently needed."
+            ),
+        )


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
