### PR TITLE
chore: store process section info on ProcessProblem

### DIFF
--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -15,7 +15,7 @@ from libecalc.ecalc_model.time_series_configuration import (
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
-from libecalc.process.process_pipeline.process_unit import ProcessUnitId
+from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeType
 from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
@@ -60,6 +60,15 @@ class Constraint:
 ProcessProblemId = NewType("ProcessProblemId", UUID)
 
 
+@value_object
+class ProcessProblemSection:
+    """A process section assembled for solver execution."""
+
+    process_units: list[ProcessUnit]
+    configuration_handlers: Sequence[ConfigurationHandler]
+    constraint: Constraint
+
+
 class ProcessProblem(Entity[ProcessProblemId]):  # TODO: Rename to subproblem?
     # can a problem exist wo. a simulation? yes, e.g. get max rate ...
     # given a physical pipeline (a contained problem, such as a compressor train), the user needs to define strategies to find a solution for the sub problem
@@ -67,14 +76,14 @@ class ProcessProblem(Entity[ProcessProblemId]):  # TODO: Rename to subproblem?
 
     def __init__(
         self,
-        constraints: list[Constraint],
+        sections: Sequence[ProcessProblemSection],
         configuration_handlers: Sequence[ConfigurationHandler],
         process_pipeline_id: ProcessPipelineId,
         process_problem_id: ProcessProblemId | None = None,
     ):
-        self.constraints = constraints
-        self.process_pipeline_id = process_pipeline_id
+        self.sections = sections
         self.configuration_handlers = configuration_handlers
+        self.process_pipeline_id = process_pipeline_id
         self._id: Final[ProcessProblemId] = process_problem_id or ProcessProblem._create_id()
 
     def get_id(self) -> ProcessProblemId:
@@ -85,7 +94,7 @@ class ProcessProblem(Entity[ProcessProblemId]):  # TODO: Rename to subproblem?
         return ProcessProblemId(ecalc_id_generator())
 
     def get_constraints(self) -> list[Constraint]:
-        return self.constraints
+        return [section.constraint for section in self.sections]
 
 
 ProcessSimulationId = NewType("ProcessSimulationId", UUID)

--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -76,12 +76,12 @@ class ProcessProblem(Entity[ProcessProblemId]):  # TODO: Rename to subproblem?
 
     def __init__(
         self,
-        sections: Sequence[ProcessProblemSection],
+        process_problem_sections: Sequence[ProcessProblemSection],
         configuration_handlers: Sequence[ConfigurationHandler],
         process_pipeline_id: ProcessPipelineId,
         process_problem_id: ProcessProblemId | None = None,
     ):
-        self.sections = sections
+        self.process_problem_sections = process_problem_sections
         self.configuration_handlers = configuration_handlers
         self.process_pipeline_id = process_pipeline_id
         self._id: Final[ProcessProblemId] = process_problem_id or ProcessProblem._create_id()
@@ -94,7 +94,7 @@ class ProcessProblem(Entity[ProcessProblemId]):  # TODO: Rename to subproblem?
         return ProcessProblemId(ecalc_id_generator())
 
     def get_constraints(self) -> list[Constraint]:
-        return [section.constraint for section in self.sections]
+        return [section.constraint for section in self.process_problem_sections]
 
 
 ProcessSimulationId = NewType("ProcessSimulationId", UUID)

--- a/src/libecalc/ecalc_model/process_simulation.py
+++ b/src/libecalc/ecalc_model/process_simulation.py
@@ -15,7 +15,7 @@ from libecalc.ecalc_model.time_series_configuration import (
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
-from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeType
 from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
@@ -64,7 +64,7 @@ ProcessProblemId = NewType("ProcessProblemId", UUID)
 class ProcessProblemSection:
     """A process section assembled for solver execution."""
 
-    process_units: list[ProcessUnit]
+    process_unit_ids: list[ProcessUnitId]
     configuration_handlers: Sequence[ConfigurationHandler]
     constraint: Constraint
 

--- a/src/libecalc/presentation/yaml/mappers/process/build_sections.py
+++ b/src/libecalc/presentation/yaml/mappers/process/build_sections.py
@@ -1,4 +1,3 @@
-from libecalc.common.ddd import value_object
 from libecalc.presentation.yaml.mappers.process.mapped_section_validator import MappedSectionValidator
 from libecalc.presentation.yaml.mappers.process.process_partitioner import (
     MappedSection,
@@ -8,73 +7,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_references impor
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessConstraint
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
-from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeType
-from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
-from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
-from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
-from libecalc.process.process_units.choke import Choke
-from libecalc.process.process_units.compressor import Compressor
-from libecalc.process.process_units.direct_mixer import DirectMixer
-from libecalc.process.process_units.direct_splitter import DirectSplitter
-from libecalc.process.process_units.mixer import Mixer
-from libecalc.process.process_units.splitter import Splitter
-
-
-@value_object
-class AssembledSection:
-    """Solver-ready process units + handlers for a given process section."""
-
-    process_units: list[ProcessUnit]
-    configuration_handlers: list[ConfigurationHandler]
-
-
-def _wrap_compressor_in_recirculation_loop(
-    process_units: list[ProcessUnit],
-) -> tuple[RecirculationLoop, list[ProcessUnit]]:
-    mixer, splitter = DirectMixer(), DirectSplitter()
-    loop = RecirculationLoop(mixer=mixer, splitter=splitter)
-    return loop, [mixer, *process_units, splitter]
-
-
-def assemble_section(section: MappedSection, fluid_service: FluidService) -> AssembledSection:
-    """Assemble a validated mapped section into solver-ready process units and configuration handlers."""
-    handlers: list[ConfigurationHandler] = []
-
-    if section.constraint.anti_surge == AntiSurgeType.COMMON_ASV:
-        loop, solver_units = _wrap_compressor_in_recirculation_loop(section.process_units)
-        handlers.append(loop)
-    else:
-        solver_units = []
-        pending_units: list[
-            ProcessUnit
-        ] = []  # held until a boundary (compressor → assembled with ASV; mixer/splitter/end → unchanged)
-        for unit in section.process_units:
-            # Mixer and Splitter are always kept outside recirculation loops.
-            if isinstance(unit, (Mixer, Splitter)):
-                solver_units.extend(pending_units)  # units without a compressor are left unchanged
-                pending_units = []
-                solver_units.append(unit)  # mixer/splitter stays outside the loop
-                continue
-            pending_units.append(unit)  # hold until we reach the compressor
-            if isinstance(unit, Compressor):
-                loop, assembled = _wrap_compressor_in_recirculation_loop(pending_units)
-                handlers.append(loop)
-                solver_units.extend(assembled)  # add the assembled group
-                pending_units = []
-        solver_units.extend(pending_units)  # units after the last compressor
-
-    if section.constraint.pressure_control in ("UPSTREAM_CHOKE", "DOWNSTREAM_CHOKE"):
-        choke = Choke(fluid_service=fluid_service)
-        handlers.append(ChokeConfigurationHandler(choke=choke))
-        if section.constraint.pressure_control == "UPSTREAM_CHOKE":
-            solver_units = [choke, *solver_units]
-        else:
-            solver_units = [*solver_units, choke]
-
-    return AssembledSection(
-        process_units=solver_units,
-        configuration_handlers=handlers,
-    )
+from libecalc.process.process_solver.section_assembly import assemble_process_section, AssembledSection
 
 
 class ProcessSectionBuilder:
@@ -94,7 +27,7 @@ class ProcessSectionBuilder:
         process_unit_map: dict[ProcessUnitId, ProcessUnit],
         unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
         pipeline_constraints: list[YamlProcessConstraint],
-    ):
+    ) -> list[MappedSection]:
         sections = self._partitioner.partition(
             process_unit_map=process_unit_map,
             unit_name_to_id=unit_name_to_id,
@@ -103,7 +36,14 @@ class ProcessSectionBuilder:
         self._validator.validate(sections)
         return sections
 
-    def assemble_sections(
-        self, mapped_sections: list[MappedSection], fluid_service: FluidService
-    ) -> list[AssembledSection]:
-        return [assemble_section(s, fluid_service) for s in mapped_sections]
+    @staticmethod
+    def assemble_sections(mapped_sections: list[MappedSection], fluid_service: FluidService) -> list[AssembledSection]:
+        return [
+            assemble_process_section(
+                process_units=s.process_units,
+                anti_surge=s.constraint.anti_surge,
+                pressure_control=s.constraint.pressure_control,
+                fluid_service=fluid_service,
+            )
+            for s in mapped_sections
+        ]

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -366,7 +366,7 @@ class ProcessSimulationMapper:
                 )
                 process_problem_sections.append(
                     ProcessProblemSection(
-                        process_units=assembled_section.process_units,
+                        process_unit_ids=[u.get_id() for u in assembled_section.process_units],
                         configuration_handlers=assembled_section.configuration_handlers,
                         constraint=constraint,
                     )

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -385,7 +385,7 @@ class ProcessSimulationMapper:
             process_pipelines.append(process_pipeline)
             process_problems.append(
                 ProcessProblem(
-                    sections=process_problem_sections,
+                    process_problem_sections=process_problem_sections,
                     configuration_handlers=problem_configuration_handlers,
                     process_pipeline_id=process_pipeline.get_id(),
                 )

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from typing import assert_never, get_args
 
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
@@ -17,6 +16,7 @@ from libecalc.ecalc_model.process_simulation import (
     IndividualStreamDistributionConfig,
     PressureControlConfig,
     ProcessProblem,
+    ProcessProblemSection,
     ProcessSimulation,
 )
 from libecalc.ecalc_model.time_series_configuration import (
@@ -65,7 +65,6 @@ from libecalc.process.process_pipeline.process_pipeline import (
     ProcessPipelineId,
 )
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
-from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
 from libecalc.process.process_solver.feasibility_solver import FeasibilitySolver
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_units.compressor import Compressor
@@ -238,8 +237,7 @@ class ProcessSimulationMapper:
         self, yaml_process_simulation: YamlProcessSimulation, process_periods: list[Period]
     ) -> tuple[list[ProcessPipeline], ProcessSimulation]:
         process_pipelines: list[ProcessPipeline] = []
-        constraints: dict[ProcessPipelineId, list[Constraint]] = {}
-        configuration_handlers: dict[ProcessPipelineId, Sequence[ConfigurationHandler]] = {}
+        process_problems: list[ProcessProblem] = []
 
         # Some configurations are not found/set by the solver, but set by user upon process_simulation creation
         predefined_configurations: dict[
@@ -341,7 +339,9 @@ class ProcessSimulationMapper:
             problem_configuration_handlers.append(shaft)
 
             process_units: list[ProcessUnit] = []
+            process_problem_sections: list[ProcessProblemSection] = []
             pipeline_constraints = yaml_process_simulation.constraints.get(item.name)
+
             if not pipeline_constraints:
                 raise EcalcValidationException(f"Missing constraint for process system '{item.name}'")
 
@@ -353,36 +353,43 @@ class ProcessSimulationMapper:
             assembled_sections = section_builder.assemble_sections(
                 mapped_sections=mapped_sections, fluid_service=self._fluid_service
             )
-            for section in assembled_sections:
-                process_units.extend(section.process_units)
-                problem_configuration_handlers.extend(section.configuration_handlers)
+
+            for mapped_section, assembled_section in zip(mapped_sections, assembled_sections, strict=True):
+                constraint = Constraint(
+                    outlet_pressure=TimeSeriesExpression(
+                        expression=mapped_section.constraint.outlet_pressure,
+                        expression_evaluator=self._expression_evaluator,
+                    ),
+                    pressure_control=PressureControlConfig(type=mapped_section.constraint.pressure_control),
+                    anti_surge=AntiSurgeConfig(mapped_section.constraint.anti_surge),
+                    target_process_unit_id=mapped_section.target_process_unit_id,
+                )
+                process_problem_sections.append(
+                    ProcessProblemSection(
+                        process_units=assembled_section.process_units,
+                        configuration_handlers=assembled_section.configuration_handlers,
+                        constraint=constraint,
+                    )
+                )
+                process_units.extend(assembled_section.process_units)
 
             # A pipeline must have a start and an end - always add process units for that (ie owner of inlet and outlet streams)
             process_units.append(Outlet())
             process_units.insert(0, Inlet())
 
             process_pipeline = ProcessPipeline(name=item.name, stream_propagators=process_units)
-            constraints[process_pipeline.get_id()] = [
-                Constraint(
-                    outlet_pressure=TimeSeriesExpression(
-                        expression=s.constraint.outlet_pressure, expression_evaluator=self._expression_evaluator
-                    ),
-                    pressure_control=PressureControlConfig(type=s.constraint.pressure_control),
-                    anti_surge=AntiSurgeConfig(s.constraint.anti_surge),
-                    target_process_unit_id=s.target_process_unit_id,
-                )
-                for s in mapped_sections
-            ]
-            if len(constraints[process_pipeline.get_id()]) != 1:
-                raise EcalcValidationException(
-                    "We currently only support one constraint per problem. Please come back later for multi-constraint problem support."
-                )
 
-            configuration_handlers[process_pipeline.get_id()] = problem_configuration_handlers
             predefined_configurations[process_pipeline.get_id()] = problem_time_series_configurations
 
             process_pipeline_reference_to_id_map[item.name] = process_pipeline.get_id()
             process_pipelines.append(process_pipeline)
+            process_problems.append(
+                ProcessProblem(
+                    sections=process_problem_sections,
+                    configuration_handlers=problem_configuration_handlers,
+                    process_pipeline_id=process_pipeline.get_id(),
+                )
+            )
 
         for process_pipeline_reference in yaml_process_simulation.constraints:
             process_pipeline_id = process_pipeline_reference_to_id_map.get(process_pipeline_reference)
@@ -466,15 +473,6 @@ class ProcessSimulationMapper:
                 )
             case _:
                 assert_never(yaml_stream_distribution.method)
-
-        process_problems = [
-            ProcessProblem(
-                process_pipeline_id=process_pipeline.get_id(),
-                constraints=constraints[process_pipeline.get_id()],
-                configuration_handlers=configuration_handlers[process_pipeline.get_id()],
-            )
-            for process_pipeline in process_pipelines
-        ]
 
         return (
             process_pipelines,

--- a/src/libecalc/process/process_solver/section_assembly.py
+++ b/src/libecalc/process/process_solver/section_assembly.py
@@ -40,7 +40,7 @@ def assemble_process_section(
     handlers: list[ConfigurationHandler] = []
 
     if anti_surge == AntiSurgeType.COMMON_ASV:
-        loop, solver_units = _wrap_compressor_in_recirculation_loop(process_units)
+        loop, solver_units = recirculation_loop(process_units)
         handlers.append(loop)
     else:
         solver_units = []
@@ -56,7 +56,7 @@ def assemble_process_section(
                 continue
             pending_units.append(unit)  # hold until we reach the compressor
             if isinstance(unit, Compressor):
-                loop, assembled = _wrap_compressor_in_recirculation_loop(pending_units)
+                loop, assembled = recirculation_loop(pending_units)
                 handlers.append(loop)
                 solver_units.extend(assembled)  # add the assembled group
                 pending_units = []

--- a/src/libecalc/process/process_solver/section_assembly.py
+++ b/src/libecalc/process/process_solver/section_assembly.py
@@ -22,7 +22,7 @@ class AssembledSection:
     configuration_handlers: list[ConfigurationHandler]
 
 
-def _wrap_compressor_in_recirculation_loop(
+def recirculation_loop(
     process_units: list[ProcessUnit],
 ) -> tuple[RecirculationLoop, list[ProcessUnit]]:
     mixer, splitter = DirectMixer(), DirectSplitter()

--- a/src/libecalc/process/process_solver/section_assembly.py
+++ b/src/libecalc/process/process_solver/section_assembly.py
@@ -1,0 +1,76 @@
+from libecalc.common.ddd import value_object
+from libecalc.process.fluid_stream.fluid_service import FluidService
+from libecalc.process.process_pipeline.process_unit import ProcessUnit
+from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeType
+from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
+from libecalc.process.process_solver.configuration_handler import ConfigurationHandler
+from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
+from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
+from libecalc.process.process_units.choke import Choke
+from libecalc.process.process_units.compressor import Compressor
+from libecalc.process.process_units.direct_mixer import DirectMixer
+from libecalc.process.process_units.direct_splitter import DirectSplitter
+from libecalc.process.process_units.mixer import Mixer
+from libecalc.process.process_units.splitter import Splitter
+
+
+@value_object
+class AssembledSection:
+    """Solver-ready process units + handlers for a given process section."""
+
+    process_units: list[ProcessUnit]
+    configuration_handlers: list[ConfigurationHandler]
+
+
+def _wrap_compressor_in_recirculation_loop(
+    process_units: list[ProcessUnit],
+) -> tuple[RecirculationLoop, list[ProcessUnit]]:
+    mixer, splitter = DirectMixer(), DirectSplitter()
+    loop = RecirculationLoop(mixer=mixer, splitter=splitter)
+    return loop, [mixer, *process_units, splitter]
+
+
+def assemble_process_section(
+    process_units: list[ProcessUnit],
+    anti_surge: AntiSurgeType,
+    pressure_control: PressureControlType,
+    fluid_service: FluidService,
+) -> AssembledSection:
+    """Assemble validated section process units into solver-ready process units and configuration handlers."""
+    handlers: list[ConfigurationHandler] = []
+
+    if anti_surge == AntiSurgeType.COMMON_ASV:
+        loop, solver_units = _wrap_compressor_in_recirculation_loop(process_units)
+        handlers.append(loop)
+    else:
+        solver_units = []
+        pending_units: list[
+            ProcessUnit
+        ] = []  # held until a boundary (compressor → assembled with ASV; mixer/splitter/end → unchanged)
+        for unit in process_units:
+            # Mixer and Splitter are always kept outside recirculation loops.
+            if isinstance(unit, (Mixer, Splitter)):
+                solver_units.extend(pending_units)  # units without a compressor are left unchanged
+                pending_units = []
+                solver_units.append(unit)  # mixer/splitter stays outside the loop
+                continue
+            pending_units.append(unit)  # hold until we reach the compressor
+            if isinstance(unit, Compressor):
+                loop, assembled = _wrap_compressor_in_recirculation_loop(pending_units)
+                handlers.append(loop)
+                solver_units.extend(assembled)  # add the assembled group
+                pending_units = []
+        solver_units.extend(pending_units)  # units after the last compressor
+
+    if pressure_control in ("UPSTREAM_CHOKE", "DOWNSTREAM_CHOKE"):
+        choke = Choke(fluid_service=fluid_service)
+        handlers.append(ChokeConfigurationHandler(choke=choke))
+        if pressure_control == "UPSTREAM_CHOKE":
+            solver_units = [choke, *solver_units]
+        else:
+            solver_units = [*solver_units, choke]
+
+    return AssembledSection(
+        process_units=solver_units,
+        configuration_handlers=handlers,
+    )

--- a/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
@@ -4,7 +4,12 @@ import pytest
 
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
 from libecalc.common.time_utils import Period
+from libecalc.ecalc_model.process_simulation import Constraint
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessConstraint
+from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeType
+from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
+from libecalc.process.process_solver.recirculation_loop import RecirculationLoop
 from libecalc.process.process_units.choke import Choke
 from libecalc.process.process_units.compressor import Compressor
 from libecalc.process.process_units.direct_mixer import DirectMixer
@@ -14,6 +19,7 @@ from libecalc.process.process_units.liquid_remover import LiquidRemover
 from libecalc.process.process_units.outlet import Outlet
 from libecalc.process.process_units.pressure_dropper import PressureDropper
 from libecalc.process.process_units.temperature_setter import TemperatureSetter
+from libecalc.process.shaft import VariableSpeedShaft
 from libecalc.testing.process_builders import (
     YamlCommonStreamDistributionBuilder,
     YamlCompressorBuilder,
@@ -337,3 +343,79 @@ def test_duplicate_process_unit_names_not_allowed(process_simulation_mapper):
         process_simulation_mapper.map_process_simulation(yaml_simulation, process_periods=[PERIOD])
 
     assert "Duplicate process unit name 'temp_setter_1'" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Tests: process sections
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_builds_single_process_problem_section(process_simulation_mapper):
+    """A single constraint pipeline produces one ProcessProblemSection."""
+    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline())
+    _, simulation = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+    assert len(simulation.process_problems) == 1
+    problem = simulation.process_problems[0]
+
+    assert len(problem.configuration_handlers) == 1
+    assert isinstance(problem.configuration_handlers[0], VariableSpeedShaft)
+
+    assert len(problem.sections) == 1
+
+    section = problem.sections[0]
+
+    assert isinstance(section.constraint, Constraint)
+
+    # Section-specific solver handlers (ASV-loop, chokes etc.) live on the section.
+    assert any(isinstance(h, RecirculationLoop) for h in section.configuration_handlers)
+
+
+def test_mapper_builds_multiple_process_problem_sections(process_simulation_mapper):
+    """Each mapped process section becomes a ProcessProblemSection"""
+    yaml_pipeline = (
+        YamlProcessPipelineBuilder()
+        .with_name("train_with_intermediate_constraint")
+        .with_item(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_item(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_item(target=YamlMixerBuilder().with_test_data().validate())
+        .with_item(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
+        .validate()
+    )
+
+    yaml_simulation = _build_simulation_with_pipeline(pipeline=yaml_pipeline, pressure_control="DOWNSTREAM_CHOKE")
+
+    constraint = YamlProcessConstraint(
+        process_unit="compressor_1",
+        outlet_pressure=30,
+        pressure_control="INDIVIDUAL_ASV_RATE",
+        anti_surge=AntiSurgeType.INDIVIDUAL_ASV,
+    )
+    yaml_simulation.constraints[yaml_pipeline.name].insert(0, constraint)
+
+    _, simulation = process_simulation_mapper.map_process_simulation(
+        yaml_process_simulation=yaml_simulation,
+        process_periods=[PERIOD],
+    )
+
+    problem = simulation.process_problems[0]
+
+    # Train-wide handlers (currently only Shaft) remain on ProcessProblem.
+    assert len(problem.configuration_handlers) == 1
+    assert isinstance(problem.configuration_handlers[0], VariableSpeedShaft)
+
+    # Each solver section owns its own constraint and section-specific handlers.
+    assert len(problem.sections) == 2
+
+    assert problem.sections[0].constraint.pressure_control.type == "INDIVIDUAL_ASV_RATE"
+    assert problem.sections[1].constraint.pressure_control.type == "DOWNSTREAM_CHOKE"
+
+    assert any(isinstance(h, RecirculationLoop) for h in problem.sections[0].configuration_handlers)
+    assert any(isinstance(h, ChokeConfigurationHandler) for h in problem.sections[1].configuration_handlers)
+
+    assert (
+        problem.sections[0].constraint.target_process_unit_id != problem.sections[1].constraint.target_process_unit_id
+    )

--- a/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
@@ -363,9 +363,9 @@ def test_mapper_builds_single_process_problem_section(process_simulation_mapper)
     assert len(problem.configuration_handlers) == 1
     assert isinstance(problem.configuration_handlers[0], VariableSpeedShaft)
 
-    assert len(problem.sections) == 1
+    assert len(problem.process_problem_sections) == 1
 
-    section = problem.sections[0]
+    section = problem.process_problem_sections[0]
 
     assert isinstance(section.constraint, Constraint)
 
@@ -408,14 +408,17 @@ def test_mapper_builds_multiple_process_problem_sections(process_simulation_mapp
     assert isinstance(problem.configuration_handlers[0], VariableSpeedShaft)
 
     # Each solver section owns its own constraint and section-specific handlers.
-    assert len(problem.sections) == 2
+    assert len(problem.process_problem_sections) == 2
 
-    assert problem.sections[0].constraint.pressure_control.type == "INDIVIDUAL_ASV_RATE"
-    assert problem.sections[1].constraint.pressure_control.type == "DOWNSTREAM_CHOKE"
+    assert problem.process_problem_sections[0].constraint.pressure_control.type == "INDIVIDUAL_ASV_RATE"
+    assert problem.process_problem_sections[1].constraint.pressure_control.type == "DOWNSTREAM_CHOKE"
 
-    assert any(isinstance(h, RecirculationLoop) for h in problem.sections[0].configuration_handlers)
-    assert any(isinstance(h, ChokeConfigurationHandler) for h in problem.sections[1].configuration_handlers)
+    assert any(isinstance(h, RecirculationLoop) for h in problem.process_problem_sections[0].configuration_handlers)
+    assert any(
+        isinstance(h, ChokeConfigurationHandler) for h in problem.process_problem_sections[1].configuration_handlers
+    )
 
     assert (
-        problem.sections[0].constraint.target_process_unit_id != problem.sections[1].constraint.target_process_unit_id
+        problem.process_problem_sections[0].constraint.target_process_unit_id
+        != problem.process_problem_sections[1].constraint.target_process_unit_id
     )


### PR DESCRIPTION
This preserves the process section information produced during mapping, enabling support for multi-constraint support without rebuilding the section structure later.

Refs: equinor/ecalc-internal#2023

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
