### PR TITLE
feat(libecalc): add pump for incompressible liquid to process domain

### DIFF
--- a/src/libecalc/process/process_pipeline/process_pipeline.py
+++ b/src/libecalc/process/process_pipeline/process_pipeline.py
@@ -9,9 +9,12 @@ from libecalc.process.process_pipeline.process_unit import ProcessUnit
 ProcessPipelineId = NewType("ProcessPipelineId", UUID)
 
 
-class ProcessPipeline(Entity[ProcessPipelineId]):
+class ProcessPipeline[TStream](Entity[ProcessPipelineId]):
     def __init__(
-        self, name: str, stream_propagators: Sequence[ProcessUnit], process_pipeline_id: ProcessPipelineId | None = None
+        self,
+        name: str,
+        stream_propagators: Sequence[ProcessUnit[TStream]],
+        process_pipeline_id: ProcessPipelineId | None = None,
     ):
         self._name = name
         self._stream_propagators = stream_propagators
@@ -23,7 +26,7 @@ class ProcessPipeline(Entity[ProcessPipelineId]):
     def get_name(self) -> str:
         return self._name
 
-    def get_process_units(self) -> list[ProcessUnit]:
+    def get_process_units(self) -> list[ProcessUnit[TStream]]:
         return list(self._stream_propagators)
 
     @classmethod

--- a/src/libecalc/process/process_pipeline/process_unit.py
+++ b/src/libecalc/process/process_pipeline/process_unit.py
@@ -9,7 +9,7 @@ from libecalc.process.process_pipeline.stream_propagator import StreamPropagator
 ProcessUnitId = NewType("ProcessUnitId", UUID)
 
 
-class ProcessUnit(Entity[ProcessUnitId], StreamPropagator, abc.ABC):
+class ProcessUnit[TStream](Entity[ProcessUnitId], StreamPropagator[TStream], abc.ABC):
     @abc.abstractmethod
     def get_id(self) -> ProcessUnitId: ...
 

--- a/src/libecalc/process/process_pipeline/stream_propagator.py
+++ b/src/libecalc/process/process_pipeline/stream_propagator.py
@@ -1,8 +1,6 @@
 import abc
 
-from libecalc.process.fluid_stream.fluid_stream import FluidStream
 
-
-class StreamPropagator(abc.ABC):
+class StreamPropagator[TStream](abc.ABC):
     @abc.abstractmethod
-    def propagate_stream(self, inlet_stream: FluidStream) -> FluidStream: ...
+    def propagate_stream(self, inlet_stream: TStream) -> TStream: ...

--- a/src/libecalc/process/process_solver/process_pipeline_runner.py
+++ b/src/libecalc/process/process_solver/process_pipeline_runner.py
@@ -7,7 +7,7 @@ from libecalc.process.process_solver.configuration_handler import ConfigurationH
 from libecalc.process.process_solver.process_runner import ProcessRunner
 
 
-def propagate_stream_many(process_units: Sequence[ProcessUnit], inlet_stream: FluidStream) -> FluidStream:
+def propagate_stream_many[TStream](process_units: Sequence[ProcessUnit[TStream]], inlet_stream: TStream) -> TStream:
     current_stream = inlet_stream
     for process_unit in process_units:
         current_stream = process_unit.propagate_stream(current_stream)
@@ -15,7 +15,9 @@ def propagate_stream_many(process_units: Sequence[ProcessUnit], inlet_stream: Fl
 
 
 class ProcessPipelineRunner(ProcessRunner):
-    def __init__(self, configuration_handlers: Sequence[ConfigurationHandler], units: Sequence[ProcessUnit]):
+    def __init__(
+        self, configuration_handlers: Sequence[ConfigurationHandler], units: Sequence[ProcessUnit[FluidStream]]
+    ):
         self._configuration_handlers = {handler.get_id(): handler for handler in configuration_handlers}
         self._units = {unit.get_id(): unit for unit in units}
 
@@ -36,7 +38,7 @@ class ProcessPipelineRunner(ProcessRunner):
     def _propagate_stream_to_id(
         self,
         inlet_stream: FluidStream,
-        units: Iterable[ProcessUnit],
+        units: Iterable[ProcessUnit[FluidStream]],
         to_id: ProcessUnitId,
     ) -> tuple[FluidStream, bool]:
         current_stream = inlet_stream

--- a/src/libecalc/process/process_solver/section_assembly.py
+++ b/src/libecalc/process/process_solver/section_assembly.py
@@ -1,5 +1,6 @@
 from libecalc.common.ddd import value_object
 from libecalc.process.fluid_stream.fluid_service import FluidService
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeType
 from libecalc.process.process_solver.choke_configuration_handler import ChokeConfigurationHandler
@@ -18,20 +19,20 @@ from libecalc.process.process_units.splitter import Splitter
 class AssembledSection:
     """Solver-ready process units + handlers for a given process section."""
 
-    process_units: list[ProcessUnit]
+    process_units: list[ProcessUnit[FluidStream]]
     configuration_handlers: list[ConfigurationHandler]
 
 
 def recirculation_loop(
-    process_units: list[ProcessUnit],
-) -> tuple[RecirculationLoop, list[ProcessUnit]]:
+    process_units: list[ProcessUnit[FluidStream]],
+) -> tuple[RecirculationLoop, list[ProcessUnit[FluidStream]]]:
     mixer, splitter = DirectMixer(), DirectSplitter()
     loop = RecirculationLoop(mixer=mixer, splitter=splitter)
     return loop, [mixer, *process_units, splitter]
 
 
 def assemble_process_section(
-    process_units: list[ProcessUnit],
+    process_units: list[ProcessUnit[FluidStream]],
     anti_surge: AntiSurgeType,
     pressure_control: PressureControlType,
     fluid_service: FluidService,
@@ -45,7 +46,7 @@ def assemble_process_section(
     else:
         solver_units = []
         pending_units: list[
-            ProcessUnit
+            ProcessUnit[FluidStream]
         ] = []  # held until a boundary (compressor → assembled with ASV; mixer/splitter/end → unchanged)
         for unit in process_units:
             # Mixer and Splitter are always kept outside recirculation loops.

--- a/src/libecalc/process/process_solver/solver_assembly.py
+++ b/src/libecalc/process/process_solver/solver_assembly.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from typing import assert_never
 
 from libecalc.common.ddd import value_object
+from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_pipeline import ProcessPipeline
 from libecalc.process.process_pipeline.process_unit import ProcessUnit
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeStrategy
@@ -62,7 +63,7 @@ class ProcessSolverSystem:
 
 def assemble_solver(
     *,
-    process_units: Sequence[ProcessUnit],
+    process_units: Sequence[ProcessUnit[FluidStream]],
     configuration_handlers: Sequence[ConfigurationHandler],
     compressors: Sequence[Compressor],
     recirculation_loops: Sequence[RecirculationLoop],

--- a/src/libecalc/process/process_units/choke.py
+++ b/src/libecalc/process/process_units/choke.py
@@ -6,7 +6,7 @@ from libecalc.process.process_pipeline.process_error import OutsideCapacityError
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class Choke(ProcessUnit):
+class Choke(ProcessUnit[FluidStream]):
     def __init__(
         self,
         fluid_service: FluidService,

--- a/src/libecalc/process/process_units/compressor.py
+++ b/src/libecalc/process/process_units/compressor.py
@@ -13,7 +13,7 @@ from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessU
 from libecalc.process.process_solver.boundary import Boundary
 
 
-class Compressor(ProcessUnit):
+class Compressor(ProcessUnit[FluidStream]):
     def __init__(
         self,
         compressor_chart: ChartData,

--- a/src/libecalc/process/process_units/direct_mixer.py
+++ b/src/libecalc/process/process_units/direct_mixer.py
@@ -5,7 +5,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class DirectMixer(ProcessUnit):
+class DirectMixer(ProcessUnit[FluidStream]):
     def __init__(self, mix_rate: float = 0, process_unit_id: ProcessUnitId | None = None):
         self._id: Final[ProcessUnitId] = process_unit_id or ProcessUnit._create_id()
         self._mix_rate = mix_rate

--- a/src/libecalc/process/process_units/direct_splitter.py
+++ b/src/libecalc/process/process_units/direct_splitter.py
@@ -5,7 +5,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class DirectSplitter(ProcessUnit):
+class DirectSplitter(ProcessUnit[FluidStream]):
     def __init__(self, process_unit_id: ProcessUnitId | None = None, split_rate: float = 0):
         self._id: Final[ProcessUnitId] = process_unit_id or ProcessUnit._create_id()
         self._split_rate = split_rate

--- a/src/libecalc/process/process_units/inlet.py
+++ b/src/libecalc/process/process_units/inlet.py
@@ -4,7 +4,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class Inlet(ProcessUnit):
+class Inlet(ProcessUnit[FluidStream]):
     """
     Inlet, or Feed, is where a process stream is considered born/created in eCalc. We just know
     that the inlet stream conditions are given at this point.

--- a/src/libecalc/process/process_units/liquid_remover.py
+++ b/src/libecalc/process/process_units/liquid_remover.py
@@ -7,7 +7,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class LiquidRemover(ProcessUnit):
+class LiquidRemover(ProcessUnit[FluidStream]):
     def __init__(self, fluid_service: FluidService, process_unit_id: ProcessUnitId | None = None):
         self._id: Final[ProcessUnitId] = process_unit_id or ProcessUnit._create_id()
         self._fluid_service = fluid_service

--- a/src/libecalc/process/process_units/mixer.py
+++ b/src/libecalc/process/process_units/mixer.py
@@ -6,7 +6,7 @@ from libecalc.process.fluid_stream.stream_mixer import StreamMixer
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class Mixer(ProcessUnit):
+class Mixer(ProcessUnit[FluidStream]):
     """Mixes one external stream into the through-stream.
 
     The external stream is set via `set_stream` before propagation. This models

--- a/src/libecalc/process/process_units/outlet.py
+++ b/src/libecalc/process/process_units/outlet.py
@@ -4,7 +4,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class Outlet(ProcessUnit):
+class Outlet(ProcessUnit[FluidStream]):
     """
     A process unit that is the destination for the outlet streams, and where we test the
     outlet criteria on. Does not alter the process stream, and the stream does not go through it,

--- a/src/libecalc/process/process_units/pressure_dropper.py
+++ b/src/libecalc/process/process_units/pressure_dropper.py
@@ -6,7 +6,7 @@ from libecalc.process.process_pipeline.process_error import OutsideCapacityError
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class PressureDropper(ProcessUnit):
+class PressureDropper(ProcessUnit[FluidStream]):
     def __init__(
         self,
         fluid_service: FluidService,

--- a/src/libecalc/process/process_units/splitter.py
+++ b/src/libecalc/process/process_units/splitter.py
@@ -5,7 +5,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class Splitter(ProcessUnit):
+class Splitter(ProcessUnit[FluidStream]):
     """Removes a fixed standard rate from the through-stream.
 
     The split rate is set via `set_rate` before propagation. This models a gas

--- a/src/libecalc/process/process_units/temperature_setter.py
+++ b/src/libecalc/process/process_units/temperature_setter.py
@@ -5,7 +5,7 @@ from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
 
-class TemperatureSetter(ProcessUnit):
+class TemperatureSetter(ProcessUnit[FluidStream]):
     def __init__(
         self,
         fluid_service: FluidService,

--- a/src/libecalc/process/pump/exceptions.py
+++ b/src/libecalc/process/pump/exceptions.py
@@ -1,0 +1,32 @@
+"""Exceptions for invalid liquid streams and pump configuration."""
+
+from libecalc.common.errors.exceptions import EcalcError
+
+
+class InvalidLiquidStreamException(EcalcError):
+    def __init__(self, title: str | None = None, reason: str | None = None):
+        super().__init__(title=f"Invalid liquid stream: {title or ''}", message=reason or "")
+
+
+class NonPositiveDensityException(InvalidLiquidStreamException):
+    """Raised when a liquid density is not strictly positive."""
+
+    def __init__(self, density_kg_per_m3: float):
+        self.density_kg_per_m3 = density_kg_per_m3
+        super().__init__(reason="Liquid density must be positive.")
+
+
+class NegativeMassRateException(InvalidLiquidStreamException):
+    """Raised when a liquid stream mass rate is negative."""
+
+    def __init__(self, mass_rate_kg_per_h: float):
+        self.mass_rate_kg_per_h = mass_rate_kg_per_h
+        super().__init__(reason="Mass rate cannot be negative.")
+
+
+class NonPositivePressureException(InvalidLiquidStreamException):
+    """Raised when a liquid pressure is not strictly positive."""
+
+    def __init__(self, pressure_bara: float):
+        self.pressure_bara = pressure_bara
+        super().__init__(reason="Pressure must be positive.")

--- a/src/libecalc/process/pump/liquid_stream.py
+++ b/src/libecalc/process/pump/liquid_stream.py
@@ -1,0 +1,73 @@
+"""An incompressible-liquid stream defined by pressure, density and mass flow rate.
+
+It carries no equation of state, composition or temperature. Because the liquid is
+incompressible, standard and actual volumetric rates coincide.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from libecalc.common.ddd import value_object
+from libecalc.common.units import UnitConstants
+from libecalc.process.pump.exceptions import (
+    NegativeMassRateException,
+    NonPositiveDensityException,
+    NonPositivePressureException,
+)
+
+
+@value_object
+class SimplifiedLiquidStream:
+    """An incompressible liquid stream.
+
+    Attributes:
+        pressure_bara: Stream pressure [bara].
+        density_kg_per_m3: Liquid density [kg/m3].
+        mass_rate_kg_per_h: Mass flow rate [kg/h].
+    """
+
+    pressure_bara: float
+    density_kg_per_m3: float
+    mass_rate_kg_per_h: float
+
+    def __post_init__(self):
+        if self.density_kg_per_m3 <= 0:
+            raise NonPositiveDensityException(self.density_kg_per_m3)
+        if self.mass_rate_kg_per_h < 0:
+            raise NegativeMassRateException(self.mass_rate_kg_per_h)
+        if self.pressure_bara <= 0:
+            raise NonPositivePressureException(self.pressure_bara)
+
+    @property
+    def volumetric_rate_m3_per_hour(self) -> float:
+        """Volumetric flow rate [m3/h]"""
+        return self.mass_rate_kg_per_h / self.density_kg_per_m3
+
+    @property
+    def volumetric_rate_m3_per_day(self) -> float:
+        """Volumetric flow rate [m3/day]"""
+        return self.volumetric_rate_m3_per_hour * UnitConstants.HOURS_PER_DAY
+
+    def with_mass_rate(self, mass_rate_kg_per_h: float) -> SimplifiedLiquidStream:
+        """Return a new stream with the same state but a different mass rate."""
+        return dataclasses.replace(self, mass_rate_kg_per_h=mass_rate_kg_per_h)
+
+    def with_pressure(self, pressure_bara: float) -> SimplifiedLiquidStream:
+        """Return a new stream at a different pressure (density unchanged, incompressible)."""
+        return dataclasses.replace(self, pressure_bara=pressure_bara)
+
+    @classmethod
+    def from_volumetric_rate(
+        cls,
+        volumetric_rate_m3_per_day: float,
+        pressure_bara: float,
+        density_kg_per_m3: float,
+    ) -> SimplifiedLiquidStream:
+        """Create a stream from an actual volumetric flow rate [m3/day]."""
+        mass_rate_kg_per_h = volumetric_rate_m3_per_day * density_kg_per_m3 / UnitConstants.HOURS_PER_DAY
+        return cls(
+            pressure_bara=pressure_bara,
+            density_kg_per_m3=density_kg_per_m3,
+            mass_rate_kg_per_h=mass_rate_kg_per_h,
+        )

--- a/src/libecalc/process/pump/pump.py
+++ b/src/libecalc/process/pump/pump.py
@@ -1,0 +1,39 @@
+"""A single-point pump for an incompressible liquid.
+
+The pump raises an inlet liquid stream to a set discharge pressure. As the liquid is
+incompressible, the outlet stream is the inlet at the discharge pressure (density and rate
+unchanged).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
+from libecalc.process.pump.exceptions import NonPositivePressureException
+from libecalc.process.pump.liquid_stream import SimplifiedLiquidStream
+
+
+class Pump(ProcessUnit[SimplifiedLiquidStream]):
+    """A single-point pump that raises a liquid stream to a set discharge pressure.
+
+    Args:
+        process_unit_id: Identity used to reference the pump; generated when not provided.
+    """
+
+    def __init__(self, process_unit_id: ProcessUnitId | None = None):
+        self._id: Final[ProcessUnitId] = process_unit_id or ProcessUnit._create_id()
+        self._discharge_pressure_bara: float | None = None
+
+    def get_id(self) -> ProcessUnitId:
+        return self._id
+
+    def set_discharge_pressure(self, discharge_pressure_bara: float) -> None:
+        if discharge_pressure_bara <= 0:
+            raise NonPositivePressureException(discharge_pressure_bara)
+        self._discharge_pressure_bara = discharge_pressure_bara
+
+    def propagate_stream(self, inlet_stream: SimplifiedLiquidStream) -> SimplifiedLiquidStream:
+        if self._discharge_pressure_bara is None:
+            raise ValueError("Discharge pressure not set. Call set_discharge_pressure first.")
+        return inlet_stream.with_pressure(self._discharge_pressure_bara)

--- a/tests/libecalc/process/pump/test_pump.py
+++ b/tests/libecalc/process/pump/test_pump.py
@@ -1,0 +1,32 @@
+from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
+from libecalc.process.pump.liquid_stream import SimplifiedLiquidStream
+from libecalc.process.pump.pump import Pump
+
+DENSITY = 1021.0
+
+
+def _inlet(pressure_bara=10.0, rate_m3_per_day=15000.0, density=DENSITY):
+    return SimplifiedLiquidStream.from_volumetric_rate(
+        volumetric_rate_m3_per_day=rate_m3_per_day,
+        pressure_bara=pressure_bara,
+        density_kg_per_m3=density,
+    )
+
+
+def test_propagate_raises_inlet_to_discharge_pressure():
+    inlet = _inlet(pressure_bara=10.0)
+    pump = Pump()
+    pump.set_discharge_pressure(90.0)
+
+    outlet = pump.propagate_stream(inlet)
+
+    assert outlet.pressure_bara == 90.0
+    assert outlet.density_kg_per_m3 == inlet.density_kg_per_m3
+    assert outlet.mass_rate_kg_per_h == inlet.mass_rate_kg_per_h
+
+
+def test_pump_identity():
+    provided_id = ProcessUnitId(ecalc_id_generator())
+    assert Pump(process_unit_id=provided_id).get_id() == provided_id
+    assert Pump().get_id() != Pump().get_id()


### PR DESCRIPTION
**Note:** this approach (pump as a `ProcessUnit`) is parked as a draft. The proposed implementation is now the isolated liquid subdomain in #1670.

## What is this PR all about?

Adds a pump for a simplified liquid stream to the new process domain.

- `SimplifiedLiquidStream`: a minimal value object with pressure, density and mass rate (no equation of state, composition or temperature).
- `Pump`: a `ProcessUnit` that takes an inlet liquid stream and a set discharge pressure and returns the outlet stream at that pressure (density and rate unchanged). Discharge pressure is a setpoint on the unit (`set_discharge_pressure`).

To let the pump be a `ProcessUnit` without coupling the liquid to the gas `FluidStream`, `StreamPropagator` and `ProcessUnit` are generalized over the stream type: gas units are `ProcessUnit[FluidStream]` and the pump is `ProcessUnit[SimplifiedLiquidStream]`. `ProcessPipeline` and the sequential `propagate_stream_many` are likewise generic, so a future liquid pipeline can reuse them. The generic type parameter keeps a pipeline homogeneous (all gas or all liquid). Gas behaviour is unchanged.

**Scope note:** only the `ProcessPipeline` container and the sequential `propagate_stream_many` helper are generalized. The stateful `ProcessPipelineRunner` / `ProcessRunner` are left gas-typed and are *not* reused for the pump - they carry configuration-handler and pressure-control coupling that a single pump does not need. A liquid pipeline would propagate via `propagate_stream_many`, not the solver runner.

The unit is additive and not yet wired into YAML or any consumer path. The existing (legacy) pump model is untouched.

Chart lookup, efficiency and power, minimum-flow recirculation, and feasibility handling are intentionally left out of this step; power and the result are expected to be owned by the coming energy domain.

## What else did you consider?

- Initially made a functional pump with min-flow recirculation and minimum flow input. Similar to legacy pump but simpler, and some additional result properties related to recirculation. After feedback, reverted this and made a pass-through liquid stream propagator setting the specified outlet pressure. Pump specific logic presumably deferred to energy domain later.
- Keeping the pump as a separate liquid subdomain with its own propagator interface, leaving the gas code untouched. That is the approach we went with - now the proposal in #1670.


