### PR TITLE
feat(libecalc): add closed-form pump for incompressible liquids to process domain

### DIFF
--- a/src/libecalc/process/pump/exceptions.py
+++ b/src/libecalc/process/pump/exceptions.py
@@ -1,0 +1,32 @@
+"""Exceptions for invalid liquid streams and pump configuration."""
+
+from libecalc.common.errors.exceptions import EcalcError
+
+
+class InvalidLiquidStreamException(EcalcError):
+    def __init__(self, title: str | None = None, reason: str | None = None):
+        super().__init__(title=f"Invalid liquid stream: {title or ''}", message=reason or "")
+
+
+class NonPositiveDensityException(InvalidLiquidStreamException):
+    """Raised when a liquid density is not strictly positive."""
+
+    def __init__(self, density_kg_per_m3: float):
+        self.density_kg_per_m3 = density_kg_per_m3
+        super().__init__(reason="Liquid density must be positive.")
+
+
+class NegativeMassRateException(InvalidLiquidStreamException):
+    """Raised when a liquid stream mass rate is negative."""
+
+    def __init__(self, mass_rate_kg_per_h: float):
+        self.mass_rate_kg_per_h = mass_rate_kg_per_h
+        super().__init__(reason="Mass rate cannot be negative.")
+
+
+class NonPositivePressureException(InvalidLiquidStreamException):
+    """Raised when a liquid pressure is not strictly positive."""
+
+    def __init__(self, pressure_bara: float):
+        self.pressure_bara = pressure_bara
+        super().__init__(reason="Pressure must be positive.")

--- a/src/libecalc/process/pump/liquid_stream.py
+++ b/src/libecalc/process/pump/liquid_stream.py
@@ -1,0 +1,72 @@
+"""A constant-density liquid stream defined by pressure, density and mass flow rate.
+
+It carries no equation of state, composition, temperature or viscosity.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from libecalc.common.ddd import value_object
+from libecalc.common.units import UnitConstants
+from libecalc.process.pump.exceptions import (
+    NegativeMassRateException,
+    NonPositiveDensityException,
+    NonPositivePressureException,
+)
+
+
+@value_object
+class LiquidStream:
+    """A liquid stream modelled with constant density.
+
+    Attributes:
+        pressure_bara: Stream pressure [bara].
+        density_kg_per_m3: Liquid density [kg/m3].
+        mass_rate_kg_per_h: Mass flow rate [kg/h].
+    """
+
+    pressure_bara: float
+    density_kg_per_m3: float
+    mass_rate_kg_per_h: float
+
+    def __post_init__(self):
+        if self.density_kg_per_m3 <= 0:
+            raise NonPositiveDensityException(self.density_kg_per_m3)
+        if self.mass_rate_kg_per_h < 0:
+            raise NegativeMassRateException(self.mass_rate_kg_per_h)
+        if self.pressure_bara <= 0:
+            raise NonPositivePressureException(self.pressure_bara)
+
+    @property
+    def volumetric_rate_m3_per_hour(self) -> float:
+        """Volumetric flow rate [m3/h]"""
+        return self.mass_rate_kg_per_h / self.density_kg_per_m3
+
+    @property
+    def volumetric_rate_m3_per_day(self) -> float:
+        """Volumetric flow rate [m3/day]"""
+        return self.volumetric_rate_m3_per_hour * UnitConstants.HOURS_PER_DAY
+
+    def with_mass_rate(self, mass_rate_kg_per_h: float) -> LiquidStream:
+        """Return a new stream with the same state but a different mass rate."""
+        return dataclasses.replace(self, mass_rate_kg_per_h=mass_rate_kg_per_h)
+
+    def with_pressure(self, pressure_bara: float) -> LiquidStream:
+        """Return a new stream at a different pressure while keeping density unchanged."""
+        return dataclasses.replace(self, pressure_bara=pressure_bara)
+
+    @classmethod
+    def from_volumetric_rate(
+        cls,
+        volumetric_rate_m3_per_day: float,
+        pressure_bara: float,
+        density_kg_per_m3: float,
+    ) -> LiquidStream:
+        """Create a stream from an actual volumetric flow rate [m3/day]."""
+        mass_rate_kg_per_h = volumetric_rate_m3_per_day * density_kg_per_m3 / UnitConstants.HOURS_PER_DAY
+        return cls(
+            pressure_bara=pressure_bara,
+            density_kg_per_m3=density_kg_per_m3,
+            mass_rate_kg_per_h=mass_rate_kg_per_h,
+        )

--- a/src/libecalc/process/pump/liquid_stream_propagator.py
+++ b/src/libecalc/process/pump/liquid_stream_propagator.py
@@ -1,0 +1,8 @@
+import abc
+
+from libecalc.process.pump.liquid_stream import LiquidStream
+
+
+class LiquidStreamPropagator(abc.ABC):
+    @abc.abstractmethod
+    def propagate_stream(self, inlet_stream: LiquidStream) -> LiquidStream: ...

--- a/src/libecalc/process/pump/pump.py
+++ b/src/libecalc/process/pump/pump.py
@@ -1,0 +1,327 @@
+"""A single-speed / variable-speed pump for an incompressible liquid.
+
+The pump raises an inlet liquid stream toward a required (target) discharge pressure. The head
+follows directly from the pressure rise and the density (``head = (p_d - p_s) / rho``), and the
+pump chart supplies the efficiency and the feasible operating window. Everything is closed-form:
+the operating point is read off the chart envelope, so there is no solver and no iteration.
+
+When the pump cannot sit exactly on the target - a single-speed pump is pinned to its curve, and a
+variable-speed pump cannot deliver less head than its minimum-speed curve - it delivers a higher
+(operating) head than required. The result exposes both the required and the operating discharge
+pressure; the excess would be dropped by a downstream choke.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Final
+
+import numpy as np
+
+from libecalc.common.ddd import value_object
+from libecalc.common.ddd.entity import Entity
+from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
+from libecalc.common.units import Unit, UnitConstants
+from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
+from libecalc.domain.process.value_objects.chart import Chart
+from libecalc.domain.process.value_objects.chart.chart import ChartData
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
+from libecalc.process.pump.exceptions import NonPositivePressureException
+from libecalc.process.pump.liquid_stream import LiquidStream
+from libecalc.process.pump.liquid_stream_propagator import LiquidStreamPropagator
+
+
+class PumpFailureStatus(StrEnum):
+    """Feasibility outcome of a pump evaluation."""
+
+    NO_FAILURE = "NO_FAILURE"
+    ABOVE_MAXIMUM_PUMP_RATE = "ABOVE_MAXIMUM_PUMP_RATE"
+    ABOVE_MAXIMUM_HEAD_AT_RATE = "ABOVE_MAXIMUM_HEAD_AT_RATE"
+    ABOVE_MAXIMUM_PUMP_RATE_AND_MAXIMUM_HEAD_AT_RATE = "ABOVE_MAXIMUM_PUMP_RATE_AND_MAXIMUM_HEAD_AT_RATE"
+
+
+@value_object
+class PumpResult:
+    """Result of a single pump evaluation.
+
+    Attributes:
+        inlet_stream: The liquid stream at suction conditions the pump was evaluated for
+            (carries suction pressure, density and requested rate).
+        power_mw: Shaft power demand [MW].
+        required_head_joule_per_kg: Head implied by the suction and required discharge pressures,
+            ``(p_d - p_s) / rho`` [J/kg].
+        operational_head_joule_per_kg: Actual head the pump operates at [J/kg], after min-head
+            choking. It exceeds the required head when the pump cannot deliver less head than its
+            (minimum-speed) curve at the operating rate; otherwise it equals the required head.
+        operational_volumetric_rate_m3_per_hour: Actual volumetric rate the pump operates at
+            [m3/h], i.e. the requested rate raised to the minimum flow when recirculating.
+        recirculation_rate_m3_per_hour: Internal recirculation [m3/h] to maintain the minimum flow
+            = operational rate minus requested rate; zero when not recirculating.
+        required_discharge_pressure_bara: Discharge pressure the pump was asked to deliver [bara].
+        operational_discharge_pressure_bara: Discharge pressure the pump actually delivers [bara],
+            from the operational head. Exceeds the required discharge pressure when the pump
+            over-delivers head; the difference is what a downstream choke would drop.
+        speed_rpm: Operating speed [rpm] of the pump (the speed curve through the operating point);
+            the single curve's speed for a single-speed pump, ``None`` when not running.
+        failure_status: Feasibility outcome; ``NO_FAILURE`` when within the chart envelope.
+        process_unit_id: Identity of the pump that produced this result; lets a stored result be
+            traced back to its pump (e.g. for persistence or a downstream energy calculation).
+    """
+
+    inlet_stream: LiquidStream
+    power_mw: float
+    required_head_joule_per_kg: float
+    operational_head_joule_per_kg: float
+    operational_volumetric_rate_m3_per_hour: float
+    recirculation_rate_m3_per_hour: float
+    required_discharge_pressure_bara: float
+    operational_discharge_pressure_bara: float
+    speed_rpm: float | None
+    failure_status: PumpFailureStatus
+    process_unit_id: ProcessUnitId
+
+    @property
+    def is_valid(self) -> bool:
+        return self.failure_status == PumpFailureStatus.NO_FAILURE
+
+    @property
+    def choke_pressure_drop_bara(self) -> float:
+        """Pressure a downstream choke would drop to reach the required discharge pressure [bara].
+
+        The excess the pump over-delivers = operational minus required discharge pressure (>= 0).
+        """
+        return max(0.0, self.operational_discharge_pressure_bara - self.required_discharge_pressure_bara)
+
+
+class Pump(Entity[ProcessUnitId], LiquidStreamPropagator):
+    """A single-speed / variable-speed pump.
+
+    Args:
+        pump_chart: Chart data (rate/head/efficiency curves). A single curve gives a
+            single-speed pump; multiple curves give a variable-speed pump.
+        minimum_flow_rate_m3_per_hour: Required minimum continuous flow [actual m3/h]. A fixed
+            vertical line in the rate-head plane; the operating rate is recirculated up to it.
+            Must be at least the chart's minimum rate.
+        process_unit_id: Identity used to reference the pump; generated when not provided.
+    """
+
+    def __init__(
+        self,
+        pump_chart: ChartData,
+        minimum_flow_rate_m3_per_hour: float,
+        process_unit_id: ProcessUnitId | None = None,
+    ):
+        self._id: Final[ProcessUnitId] = process_unit_id or Pump._create_id()
+        self._pump_chart = Chart(pump_chart)
+        self._validate_pump_chart_efficiency()
+        if minimum_flow_rate_m3_per_hour < self._pump_chart.minimum_rate:
+            raise EcalcValidationException(
+                f"Minimum flow rate ({minimum_flow_rate_m3_per_hour} m3/h) cannot be below the "
+                f"chart's minimum rate ({self._pump_chart.minimum_rate} m3/h); the operating "
+                f"point would fall outside the pump chart."
+            )
+        self._minimum_flow_rate_m3_per_hour = minimum_flow_rate_m3_per_hour
+        self._discharge_pressure_bara: float | None = None
+
+    def get_id(self) -> ProcessUnitId:
+        return self._id
+
+    @classmethod
+    def _create_id(cls) -> ProcessUnitId:
+        return ProcessUnitId(ecalc_id_generator())
+
+    @property
+    def pump_chart(self) -> Chart:
+        return self._pump_chart
+
+    @property
+    def minimum_flow_rate_m3_per_hour(self) -> float:
+        """The pump's minimum continuous flow [actual m3/h] - the fixed vertical line in the
+        rate-head plane, for plotting the min-flow line on the chart."""
+        return self._minimum_flow_rate_m3_per_hour
+
+    def set_discharge_pressure(self, discharge_pressure_bara: float) -> None:
+        """Set the required (target) discharge pressure used by ``propagate_stream``."""
+        self._validate_discharge_pressure(discharge_pressure_bara)
+        self._discharge_pressure_bara = discharge_pressure_bara
+
+    def propagate_stream(self, inlet_stream: LiquidStream) -> LiquidStream:
+        """Propagate the inlet stream to the pump's delivered outlet stream.
+
+        The delivered stream is at the requested (demand) rate - recirculation is internal - at the
+        operational discharge pressure. For the full evaluation (power, heads, speed, feasibility),
+        call ``evaluate``; it is closed-form and deterministic, so it reproduces this outlet exactly.
+        """
+        if self._discharge_pressure_bara is None:
+            raise ValueError("Discharge pressure not set. Call set_discharge_pressure first.")
+        result = self.evaluate(inlet_stream, self._discharge_pressure_bara)
+        return inlet_stream.with_pressure(result.operational_discharge_pressure_bara)
+
+    def evaluate(self, inlet_stream: LiquidStream, discharge_pressure_bara: float) -> PumpResult:
+        """Evaluate the pump for a given inlet liquid stream and required discharge pressure.
+
+        Points that fall outside the chart envelope still produce a power value but are flagged via
+        ``failure_status``. A non-positive rate means the pump is not running: power and heads are
+        zero and the result is valid.
+        """
+        self._validate_discharge_pressure(discharge_pressure_bara)
+
+        density = inlet_stream.density_kg_per_m3
+        rate_m3_per_hour = inlet_stream.volumetric_rate_m3_per_hour
+
+        required_head = self._calculate_head(
+            suction_pressure=inlet_stream.pressure_bara,
+            discharge_pressure=discharge_pressure_bara,
+            density=density,
+        )
+
+        if rate_m3_per_hour <= 0:
+            # Pump not running: no head produced, so the operational discharge equals the suction
+            # pressure. The required side still reflects the requested duty.
+            return PumpResult(
+                inlet_stream=inlet_stream,
+                power_mw=0.0,
+                required_head_joule_per_kg=required_head,
+                operational_head_joule_per_kg=0.0,
+                operational_volumetric_rate_m3_per_hour=0.0,
+                recirculation_rate_m3_per_hour=0.0,
+                required_discharge_pressure_bara=discharge_pressure_bara,
+                operational_discharge_pressure_bara=inlet_stream.pressure_bara,
+                speed_rpm=None,
+                failure_status=PumpFailureStatus.NO_FAILURE,
+                process_unit_id=self._id,
+            )
+
+        # Recirculation (internal): clamp the operating rate up to the largest binding minimum
+        # flow - the user-defined vertical line and the chart's minimum-flow line at the required
+        # head (which collapses to the chart minimum rate for a single-speed chart).
+        chart_minimum_flow_at_head = float(self._pump_chart.minimum_rate_as_function_of_head(required_head))
+        operating_rate_m3_per_hour = max(
+            rate_m3_per_hour,
+            self._minimum_flow_rate_m3_per_hour,
+            chart_minimum_flow_at_head,
+        )
+
+        minimum_head_at_rate = float(self._pump_chart.minimum_head_as_function_of_rate(operating_rate_m3_per_hour))
+        operational_head = max(required_head, minimum_head_at_rate)
+
+        maximum_head_at_rate = float(self._pump_chart.maximum_head_as_function_of_rate(operating_rate_m3_per_hour))
+
+        failure_status = self._determine_failure_status(
+            head=operational_head,
+            maximum_head_at_rate=maximum_head_at_rate,
+            rate_m3_per_hour=operating_rate_m3_per_hour,
+        )
+
+        efficiency = self._efficiency(rate_m3_per_hour=operating_rate_m3_per_hour, head=operational_head)
+        power = self._calculate_power(
+            density=density,
+            head_joule_per_kg=operational_head,
+            rate=operating_rate_m3_per_hour,
+            efficiency=efficiency,
+        )
+
+        return PumpResult(
+            inlet_stream=inlet_stream,
+            power_mw=power,
+            required_head_joule_per_kg=required_head,
+            operational_head_joule_per_kg=operational_head,
+            operational_volumetric_rate_m3_per_hour=operating_rate_m3_per_hour,
+            recirculation_rate_m3_per_hour=operating_rate_m3_per_hour - rate_m3_per_hour,
+            required_discharge_pressure_bara=discharge_pressure_bara,
+            operational_discharge_pressure_bara=self._discharge_pressure(
+                suction_pressure=inlet_stream.pressure_bara,
+                head_joule_per_kg=operational_head,
+                density=density,
+            ),
+            speed_rpm=self._speed_at_operating_point(operating_rate_m3_per_hour, operational_head),
+            failure_status=failure_status,
+            process_unit_id=self._id,
+        )
+
+    def get_max_volumetric_rate_m3_per_day(
+        self, suction_pressure: float, discharge_pressure: float, density: float
+    ) -> float:
+        """Maximum volumetric rate [m3/day] the pump can deliver at the given pressures and density."""
+        head = self._calculate_head(
+            suction_pressure=suction_pressure, discharge_pressure=discharge_pressure, density=density
+        )
+        return float(self._pump_chart.maximum_rate_as_function_of_head(head) * UnitConstants.HOURS_PER_DAY)
+
+    def _speed_at_operating_point(self, rate_m3_per_hour: float, head_joule_per_kg: float) -> float:
+        """Speed [rpm] of the speed curve through the operating point (rate, head).
+
+        Single-speed chart: the single curve's speed. Variable-speed: linear interpolation between
+        the adjacent speed curves whose head at the operating rate brackets the operating head.
+        """
+        curves = sorted(self._pump_chart.curves, key=lambda c: c.speed_rpm)
+        if len(curves) == 1:
+            return float(curves[0].speed_rpm)
+
+        speeds = [float(c.speed_rpm) for c in curves]
+        heads = [float(c.head_as_function_of_rate(rate_m3_per_hour)) for c in curves]
+        if head_joule_per_kg <= heads[0]:
+            return speeds[0]
+        if head_joule_per_kg >= heads[-1]:
+            return speeds[-1]
+        for i in range(len(curves) - 1):
+            head_low, head_high = heads[i], heads[i + 1]
+            if head_low <= head_joule_per_kg <= head_high:
+                fraction = (head_joule_per_kg - head_low) / (head_high - head_low) if head_high != head_low else 0.0
+                return speeds[i] + fraction * (speeds[i + 1] - speeds[i])
+        return speeds[-1]
+
+    def _efficiency(self, rate_m3_per_hour: float, head: float) -> float:
+        if self._pump_chart.is_100_percent_efficient:
+            return 1.0
+        return float(
+            self._pump_chart.efficiency_as_function_of_rate_and_head(
+                rates=np.asarray([rate_m3_per_hour]),
+                heads=np.asarray([head]),
+            )[0]
+        )
+
+    def _determine_failure_status(
+        self, head: float, maximum_head_at_rate: float, rate_m3_per_hour: float
+    ) -> PumpFailureStatus:
+        above_max_head = head > maximum_head_at_rate
+        above_max_rate = rate_m3_per_hour > float(self._pump_chart.maximum_rate)
+
+        if above_max_head and above_max_rate:
+            return PumpFailureStatus.ABOVE_MAXIMUM_PUMP_RATE_AND_MAXIMUM_HEAD_AT_RATE
+        if above_max_head:
+            return PumpFailureStatus.ABOVE_MAXIMUM_HEAD_AT_RATE
+        if above_max_rate:
+            return PumpFailureStatus.ABOVE_MAXIMUM_PUMP_RATE
+        return PumpFailureStatus.NO_FAILURE
+
+    @staticmethod
+    def _validate_discharge_pressure(discharge_pressure_bara: float) -> None:
+        if discharge_pressure_bara <= 0:
+            raise NonPositivePressureException(discharge_pressure_bara)
+
+    def _validate_pump_chart_efficiency(self) -> None:
+        if any(efficiency <= 0 for curve in self._pump_chart.curves for efficiency in curve.efficiency):
+            raise EcalcValidationException("Pump efficiency must be greater than zero.")
+
+    @staticmethod
+    def _calculate_head(suction_pressure: float, discharge_pressure: float, density: float) -> float:
+        """Head in joule per kg [J/kg]."""
+        return Unit.BARA.to(Unit.PASCAL)(discharge_pressure - suction_pressure) / density
+
+    @staticmethod
+    def _discharge_pressure(suction_pressure: float, head_joule_per_kg: float, density: float) -> float:
+        """Discharge pressure [bara] corresponding to a head at the given suction and density."""
+        return suction_pressure + Unit.PASCAL.to(Unit.BARA)(head_joule_per_kg * density)
+
+    @staticmethod
+    def _calculate_power(density: float, head_joule_per_kg: float, efficiency: float, rate: float) -> float:
+        """Pump power [MW] from density, head [J/kg], actual rate [m3/h] and efficiency."""
+        return float(
+            density
+            * head_joule_per_kg
+            * rate
+            / UnitConstants.SECONDS_PER_HOUR
+            / UnitConstants.WATT_PER_MEGAWATT
+            / efficiency
+        )

--- a/tests/libecalc/process/pump/test_pump.py
+++ b/tests/libecalc/process/pump/test_pump.py
@@ -1,0 +1,199 @@
+import pytest
+
+from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
+from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
+from libecalc.domain.process.pump.pump import PumpModel
+from libecalc.domain.process.value_objects.chart.chart import ChartCurve
+from libecalc.process.process_pipeline.process_unit import ProcessUnitId
+from libecalc.process.pump.exceptions import NonPositivePressureException
+from libecalc.process.pump.liquid_stream import LiquidStream
+from libecalc.process.pump.pump import Pump, PumpFailureStatus
+
+DENSITY = 1021.0
+CHART_MIN_FLOW = 277.0  # m3/h, minimum rate of both test charts
+
+
+def _single_speed_chart(chart_data_factory):
+    return chart_data_factory.from_curves(
+        curves=[
+            ChartCurve(
+                speed_rpm=1,
+                rate_actual_m3_hour=[277.0, 524.0, 666.0, 832.0, 927.0],
+                polytropic_head_joule_per_kg=[10415.277, 9845.316, 9254.754, 8308.089, 7605.693],
+                efficiency_fraction=[0.4759, 0.6426, 0.6871, 0.7052, 0.6908],
+            )
+        ]
+    )
+
+
+def _variable_speed_chart(chart_data_factory):
+    data = [
+        (
+            2650,
+            [277, 524, 666, 832, 927],
+            [1061.7, 1003.6, 943.4, 846.9, 775.3],
+            [0.4759, 0.6426, 0.6871, 0.7052, 0.6908],
+        ),
+        (
+            3425,
+            [336, 577, 708, 842, 1028],
+            [1778.7, 1718.7, 1665.2, 1587.8, 1460.6],
+            [0.4717, 0.6203, 0.6683, 0.6996, 0.7193],
+        ),
+    ]
+    curves = [
+        ChartCurve(
+            speed_rpm=float(s),
+            rate_actual_m3_hour=[float(x) for x in r],
+            polytropic_head_joule_per_kg=[h * 9.81 for h in hm],
+            efficiency_fraction=e,
+        )
+        for s, r, hm, e in data
+    ]
+    return chart_data_factory.from_curves(curves=curves)
+
+
+@pytest.fixture
+def single_speed_chart(chart_data_factory):
+    return _single_speed_chart(chart_data_factory)
+
+
+@pytest.fixture
+def variable_speed_chart(chart_data_factory):
+    return _variable_speed_chart(chart_data_factory)
+
+
+def _inlet(rate_m3_per_hour, suction_pressure, density=DENSITY):
+    return LiquidStream.from_volumetric_rate(
+        volumetric_rate_m3_per_day=rate_m3_per_hour * 24.0,
+        pressure_bara=suction_pressure,
+        density_kg_per_m3=density,
+    )
+
+
+@pytest.mark.parametrize("chart_name", ["single_speed_chart", "variable_speed_chart"])
+@pytest.mark.parametrize(
+    "rate_m3h, suction, discharge",
+    [
+        (600, 5.0, 100.0),  # normal
+        (150, 5.0, 100.0),  # below min flow -> recirculation
+        (600, 5.0, 50.0),  # required head below curve -> over-delivery / choke
+        (600, 5.0, 250.0),  # required head above curve -> infeasible
+        (1200, 5.0, 100.0),  # rate above max -> infeasible
+    ],
+)
+def test_power_matches_legacy(request, chart_name, rate_m3h, suction, discharge):
+    chart_data = request.getfixturevalue(chart_name)
+    pump = Pump(chart_data, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    legacy_power, _, _ = PumpModel(pump_chart=chart_data).simulate(
+        rate=rate_m3h * 24.0, suction_pressure=suction, discharge_pressure=discharge, fluid_density=DENSITY
+    )
+    result = pump.evaluate(_inlet(rate_m3h, suction), discharge_pressure_bara=discharge)
+    assert result.power_mw == pytest.approx(legacy_power)
+
+
+def test_recirculation_up_to_minimum_flow(single_speed_chart):
+    pump = Pump(single_speed_chart, minimum_flow_rate_m3_per_hour=600.0)
+    result = pump.evaluate(_inlet(400, suction_pressure=5.0), discharge_pressure_bara=90.0)
+    assert result.operational_volumetric_rate_m3_per_hour == pytest.approx(600.0)
+    assert result.recirculation_rate_m3_per_hour == pytest.approx(200.0)
+
+
+def test_over_delivery_exposes_operating_vs_required_and_choke(single_speed_chart):
+    # Single-speed head is pinned to the curve, so a low target over-delivers and needs a choke.
+    pump = Pump(single_speed_chart, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    result = pump.evaluate(_inlet(600, suction_pressure=5.0), discharge_pressure_bara=50.0)
+    assert result.operational_head_joule_per_kg > result.required_head_joule_per_kg
+    assert result.operational_discharge_pressure_bara > result.required_discharge_pressure_bara
+    assert result.choke_pressure_drop_bara == pytest.approx(
+        result.operational_discharge_pressure_bara - result.required_discharge_pressure_bara
+    )
+    assert result.is_valid
+
+
+def test_variable_speed_in_band_sits_on_target_with_interpolated_speed(variable_speed_chart):
+    pump = Pump(variable_speed_chart, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    result = pump.evaluate(_inlet(600, suction_pressure=5.0), discharge_pressure_bara=140.0)
+    assert result.operational_discharge_pressure_bara == pytest.approx(140.0)
+    assert result.choke_pressure_drop_bara == pytest.approx(0.0)
+    assert result.speed_rpm is not None
+    assert 2650.0 < result.speed_rpm < 3425.0
+
+
+@pytest.mark.parametrize(
+    "chart_name, rate_m3h, discharge, expected_status",
+    [
+        ("single_speed_chart", 600, 250.0, PumpFailureStatus.ABOVE_MAXIMUM_HEAD_AT_RATE),
+        ("variable_speed_chart", 1200, 100.0, PumpFailureStatus.ABOVE_MAXIMUM_PUMP_RATE),
+        ("single_speed_chart", 1200, 100.0, PumpFailureStatus.ABOVE_MAXIMUM_PUMP_RATE_AND_MAXIMUM_HEAD_AT_RATE),
+    ],
+)
+def test_feasibility_status(request, chart_name, rate_m3h, discharge, expected_status):
+    chart_data = request.getfixturevalue(chart_name)
+    pump = Pump(chart_data, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    result = pump.evaluate(_inlet(rate_m3h, suction_pressure=5.0), discharge_pressure_bara=discharge)
+    assert result.failure_status == expected_status
+    assert not result.is_valid
+
+
+def test_not_running_when_rate_is_zero(single_speed_chart):
+    pump = Pump(single_speed_chart, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    result = pump.evaluate(_inlet(0.0, suction_pressure=5.0), discharge_pressure_bara=100.0)
+    assert result.power_mw == 0.0
+    assert result.speed_rpm is None
+    assert result.is_valid
+
+
+def test_evaluate_rejects_non_positive_discharge_pressure(single_speed_chart):
+    pump = Pump(single_speed_chart, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+
+    with pytest.raises(NonPositivePressureException):
+        pump.evaluate(_inlet(600, suction_pressure=5.0), discharge_pressure_bara=0.0)
+
+
+def test_set_discharge_pressure_rejects_non_positive_pressure(single_speed_chart):
+    pump = Pump(single_speed_chart, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+
+    with pytest.raises(NonPositivePressureException):
+        pump.set_discharge_pressure(-1.0)
+
+
+def test_rejects_zero_efficiency_pump_chart(chart_data_factory):
+    chart = chart_data_factory.from_curves(
+        curves=[
+            ChartCurve(
+                speed_rpm=1,
+                rate_actual_m3_hour=[100.0, 200.0],
+                polytropic_head_joule_per_kg=[10000.0, 9000.0],
+                efficiency_fraction=[0.0, 0.0],
+            )
+        ]
+    )
+
+    with pytest.raises(EcalcValidationException, match="Pump efficiency must be greater than zero"):
+        Pump(chart, minimum_flow_rate_m3_per_hour=100.0)
+
+
+def test_propagate_stream_delivers_operating_pressure_at_demand_rate(single_speed_chart):
+    inlet = _inlet(600, suction_pressure=5.0)
+    pump = Pump(single_speed_chart, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    pump.set_discharge_pressure(50.0)
+    outlet = pump.propagate_stream(inlet)
+    result = pump.evaluate(inlet, discharge_pressure_bara=50.0)
+    assert outlet.pressure_bara == pytest.approx(result.operational_discharge_pressure_bara)
+    assert outlet.mass_rate_kg_per_h == inlet.mass_rate_kg_per_h  # recirculation is internal
+
+
+def test_pump_identity(single_speed_chart):
+    provided_id = ProcessUnitId(ecalc_id_generator())
+    assert Pump(single_speed_chart, CHART_MIN_FLOW, process_unit_id=provided_id).get_id() == provided_id
+    assert Pump(single_speed_chart, CHART_MIN_FLOW).get_id() != Pump(single_speed_chart, CHART_MIN_FLOW).get_id()
+
+
+def test_result_carries_process_unit_id(single_speed_chart):
+    provided_id = ProcessUnitId(ecalc_id_generator())
+    pump = Pump(single_speed_chart, CHART_MIN_FLOW, process_unit_id=provided_id)
+    running = pump.evaluate(_inlet(600, suction_pressure=5.0), discharge_pressure_bara=100.0)
+    not_running = pump.evaluate(_inlet(0.0, suction_pressure=5.0), discharge_pressure_bara=100.0)
+    assert running.process_unit_id == provided_id
+    assert not_running.process_unit_id == provided_id


### PR DESCRIPTION
## What is this PR all about?

Adds a closed-form pump model for incompressible liquids to the new process domain
(`src/libecalc/process/pump/`).

`Pump.evaluate(inlet, discharge_pressure) -> PumpResult`:

- calculates the required head from the pressure duty and liquid density;
- applies minimum-flow recirculation from the configured and chart-derived limits;
- evaluates the chart operating point, efficiency, speed and feasibility;
- applies legacy minimum-head operation and exposes required and operating discharge pressure; and
- returns power, operating rate, recirculation, required and operating pressure/head, speed and
  feasibility.

The pump also implements `LiquidStreamPropagator`. `propagate_stream()` is a thin adapter
over `evaluate()` that returns the delivered stream at the calculated operating pressure. This keeps
the pump compatible with a possible future sequential liquid process system without making that
orchestration infrastructure part of this PR.

The implementation includes `LiquidStream`, pump-specific validation and exceptions, and tests
covering normal operation, recirculation, minimum-head operation, infeasible points, invalid
pressure/efficiency, identity and legacy power parity.

## Why is the pump evaluated directly?

For the current duty-driven model, rate, suction pressure, required discharge pressure and density
are inputs. Required head follows directly from `dP / rho`, and the corresponding operating point,
speed and minimum-flow correction are obtained from the chart. No iterative control setting or
thermodynamic state must be converged, so the compressor root-finding solver is not required.

This conclusion is intentionally scoped to the current single-pump model. A future coupled liquid
network, system curve or optimization problem could introduce a separate solving requirement.

## Why return a `PumpResult` instead of only a stream?

Correct stream propagation requires the chart-based operating point because the pump may operate at
a higher discharge pressure than requested. `propagate_stream()` must therefore perform the pump
evaluation rather than only copy the requested pressure onto the outlet stream.

That evaluation also determines chart efficiency and pump power. `LiquidStream` contains
pressure, density and mass rate, but no enthalpy or efficiency, so chart-derived shaft work cannot be
reconstructed from the outlet stream alone. The operating-point calculation should happen once in
the pump domain and its result should be available to downstream consumers rather than recalculated
in a solver or energy layer.

A future energy domain may consume pump power or specific shaft work from the process result and add
motor/VSD losses, aggregation or other energy-domain concerns. That does not require moving the
chart evaluation out of the pump.

## Why use a dedicated liquid stream?

A pump user supplies a bulk liquid density without composition or temperature. The gas
`FluidStream` represents an equation-of-state-backed thermodynamic state whose density is calculated
from composition, temperature and pressure. It cannot faithfully represent the pump input without
inventing information the user did not provide.

`LiquidStream` therefore models only pressure, constant density and mass rate. It is deliberately a
separate liquid type rather than a reduced gas stream.

## Design boundary

This PR does not introduce:

- a liquid solver or root-finding strategy;
- a liquid pipeline or runner;
- liquid mixer/splitter units or a structural recirculation loop;
- generalisation of the gas `ProcessUnit` hierarchy to support multiple stream types; or
- YAML, result-presentation or backend/frontend integration.

Those are separate decisions. A liquid pipeline and structural recirculation loop may be useful if
liquid equipment becomes composable, persisted process flowsheets. The propagator interface keeps
that option available, but the current single-pump calculation does not require that infrastructure.

The pump is not polymorphic with gas process units and cannot be inserted into the existing gas
pipeline or solver.
