### PR TITLE
chore: pinpoint outlet pressure target failures to connection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
         name: Check for typos in code
         additional_dependencies: [ tomli ]
         exclude: docs/docs/changelog/changelog.md|.*\.ipynb
+        args: ["--write-changes"]  # Instead of just complaining about typos, automatically fix them in the files.
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: 1d7031e6d0bbfce76e5a625b0cec24fb22e517a0  # frozen: v9.25.0
 

--- a/src/libecalc/process/process_pipeline/process_pipeline.py
+++ b/src/libecalc/process/process_pipeline/process_pipeline.py
@@ -77,7 +77,7 @@ class ProcessPipeline(Entity[ProcessPipelineId]):
     ):
         self._name = name
         self._process_pipeline_sections = process_pipeline_sections
-        self._process_unit_connections = ProcessPipeline._create_process_unit_connections(
+        self._process_unit_connections = ProcessPipeline._create_process_unit_connections(  # NOTE: this can currently only be used in mapper, to create connections first time!
             process_pipeline_sections=process_pipeline_sections
         )
         self._process_pipeline_id = process_pipeline_id

--- a/src/libecalc/process/process_solver/multi_pressure_solver.py
+++ b/src/libecalc/process/process_solver/multi_pressure_solver.py
@@ -139,7 +139,7 @@ class MultiPressureSolver(PipelineSolver):
                     configuration=solution.configuration,
                     achievable_pressure_bara=outlet.pressure_bara,
                     target_pressure_bara=target.value,
-                    source_id=self._pipeline.get_id(),  # TODO: Might want to change to section or unit id, or include both/thrith (yes, I just invented that word)
+                    source_id=pipeline_section.get_id(),
                     direction=TargetDirection.MAX_BELOW_TARGET,
                 )
 

--- a/src/libecalc/process/process_solver/pipeline_section_solver.py
+++ b/src/libecalc/process/process_solver/pipeline_section_solver.py
@@ -130,7 +130,7 @@ class PipelineSectionSolver(PipelineSolver):
         if isinstance(speed_finding.failure, TargetPressureUnreachableFailure) and (
             speed_finding.failure.direction == TargetDirection.MAX_BELOW_TARGET
         ):
-            failure = speed_finding.failure.with_source_id(self._pipeline_section.get_process_pipeline_id())
+            failure = speed_finding.failure.with_source_id(self._pipeline_section.get_id())
             return Solution(configuration=speed_and_anti_surge_configurations, failure=failure)
 
         outlet_at_chosen_speed = self._get_outlet_stream(
@@ -147,7 +147,7 @@ class PipelineSectionSolver(PipelineSolver):
         )
         failure = pressure_control_solution.failure
         if isinstance(failure, TargetPressureUnreachableFailure) and failure.source_id is None:
-            failure = failure.with_source_id(self._pipeline_section.get_process_pipeline_id())
+            failure = failure.with_source_id(self._pipeline_section.get_id())
         return Solution(
             configuration=merge_configurations(
                 speed_and_anti_surge_configurations, pressure_control_solution.configuration

--- a/src/libecalc/process/process_solver/solver.py
+++ b/src/libecalc/process/process_solver/solver.py
@@ -17,7 +17,7 @@ from libecalc.process.process_pipeline.process_error import (
     OfftakeExceedsInletError,
     ProcessError,
 )
-from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId
+from libecalc.process.process_pipeline.process_pipeline import ProcessPipelineId, ProcessPipelineSectionId
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.process_solver.configuration import (
     Configuration,
@@ -157,9 +157,16 @@ class TargetPressureUnreachableFailure(SolverFailure):
     achievable_pressure_bara: float
     target_pressure_bara: float
     direction: TargetDirection
-    source_id: ProcessPipelineId | None = None  # TODO: Replace with failing process unit!
+    source_id: ProcessPipelineSectionId | None = (
+        None  # NOTE: This currently uniquely identifies the unit and connection as well, the last one in the section
+    )
 
-    def with_source_id(self, source_id: ProcessPipelineId) -> Self:  # TODO: Change to processunitid? ...
+    def with_source_id(self, source_id: ProcessPipelineSectionId) -> Self:
+        """
+        This is a smart way of potentially adding more metadata to the failure as it is sent up the hierarchy. We
+        do not necessarily need to send all kinds of metadata and irrelevant data to a given function just to
+        add metadata to the failure. Instead, we can add more metadata as it is being sent up the hierarchy.
+        """
         return dataclasses.replace(self, source_id=source_id)
 
 
@@ -189,7 +196,7 @@ class Solution[TConfiguration]:
         achievable_pressure_bara: float,
         target_pressure_bara: float,
         direction: TargetDirection,
-        source_id: ProcessPipelineId | None = None,
+        source_id: ProcessPipelineSectionId | None = None,
     ) -> Solution[T]:
         """Build an unsuccessful Solution carrying a TargetPressureUnreachableFailure."""
         return Solution(

--- a/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
+++ b/tests/libecalc/process/process_solver/test_multi_pressure_solver.py
@@ -3,6 +3,7 @@ import pytest
 from libecalc.common.fixed_speed_pressure_control import FixedSpeedPressureControl, InterstagePressureControl
 from libecalc.domain.process.compressor.core.train.compressor_train_common_shaft import CompressorTrainCommonShaft
 from libecalc.domain.process.compressor.core.train.train_evaluation_input import CompressorTrainEvaluationInput
+from libecalc.process.process_pipeline.process_pipeline import ProcessPipeline
 from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.multi_pressure_solver import MultiPressureSolver
 from libecalc.process.process_solver.pipeline_section import Pipeline
@@ -380,7 +381,6 @@ def test_target_not_achievable_event_identifies_failing_segment(
     lp_units, lp_loops = with_individual_asv(lp_units_raw)
     lp_loop_ids = [loop.get_id() for loop in lp_loops]
     lp_runner = process_runner_factory(units=lp_units, configuration_handlers=[shaft, *lp_loops])
-    lp_process_pipeline = process_pipeline_factory(units=lp_units)
 
     hp_compressor = compressor_factory(chart_data=chart_data)
     hp_units_raw = stage_units_factory(compressor=hp_compressor, shaft=shaft, temperature_kelvin=temperature)
@@ -388,7 +388,8 @@ def test_target_not_achievable_event_identifies_failing_segment(
     hp_units, hp_loops = with_individual_asv(hp_units_raw)
     hp_loop_ids = [loop.get_id() for loop in hp_loops]
     hp_runner = process_runner_factory(units=hp_units, configuration_handlers=[shaft, *hp_loops])
-    hp_process_pipeline = process_pipeline_factory(units=hp_units)
+
+    process_pipeline_id = ProcessPipeline._create_id()
 
     lp_segment = pipeline_section_factory(
         runner=lp_runner,
@@ -399,7 +400,7 @@ def test_target_not_achievable_event_identifies_failing_segment(
             runner=lp_runner, recirculation_loop_ids=lp_loop_ids, compressors=lp_compressors
         ),
         shaft=shaft,
-        process_pipeline_id=lp_process_pipeline.get_id(),
+        process_pipeline_id=process_pipeline_id,
     )
     hp_segment = pipeline_section_factory(
         runner=hp_runner,
@@ -410,10 +411,13 @@ def test_target_not_achievable_event_identifies_failing_segment(
             runner=hp_runner, recirculation_loop_ids=hp_loop_ids, compressors=hp_compressors
         ),
         shaft=shaft,
-        process_pipeline_id=hp_process_pipeline.get_id(),
+        process_pipeline_id=process_pipeline_id,
     )
 
-    solver = MultiPressureSolver(Pipeline(process_pipeline_sections=[lp_segment, hp_segment]))
+    process_pipeline = Pipeline(
+        process_pipeline_sections=[lp_segment, hp_segment], process_pipeline_id=process_pipeline_id
+    )
+    solver = MultiPressureSolver(pipeline=process_pipeline)
 
     inlet_stream = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
 
@@ -425,7 +429,9 @@ def test_target_not_achievable_event_identifies_failing_segment(
 
     assert not solution.success
     assert isinstance(solution.failure, TargetPressureUnreachableFailure)
-    assert solution.failure.source_id == hp_process_pipeline.get_id()
+    assert (
+        solution.failure.source_id == process_pipeline.get_process_pipeline_sections()[1].get_id()
+    )  # HP section fails
 
 
 def test_target_not_achievable_event_when_first_segment_fails(
@@ -465,7 +471,6 @@ def test_target_not_achievable_event_when_first_segment_fails(
     lp_units, lp_loops = with_individual_asv(lp_units_raw)
     lp_loop_ids = [loop.get_id() for loop in lp_loops]
     lp_runner = process_runner_factory(units=lp_units, configuration_handlers=[shaft, *lp_loops])
-    lp_process_pipeline = process_pipeline_factory(units=lp_units)
 
     hp_compressor = compressor_factory(chart_data=chart_data)
     hp_units_raw = stage_units_factory(compressor=hp_compressor, shaft=shaft, temperature_kelvin=temperature)
@@ -473,7 +478,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
     hp_units, hp_loops = with_individual_asv(hp_units_raw)
     hp_loop_ids = [loop.get_id() for loop in hp_loops]
     hp_runner = process_runner_factory(units=hp_units, configuration_handlers=[shaft, *hp_loops])
-    hp_process_pipeline = process_pipeline_factory(units=hp_units)
+    process_pipeline_id = ProcessPipeline._create_id()
 
     lp_segment = pipeline_section_factory(
         runner=lp_runner,
@@ -484,7 +489,7 @@ def test_target_not_achievable_event_when_first_segment_fails(
             runner=lp_runner, recirculation_loop_ids=lp_loop_ids, compressors=lp_compressors
         ),
         shaft=shaft,
-        process_pipeline_id=lp_process_pipeline.get_id(),
+        process_pipeline_id=process_pipeline_id,
     )
     hp_segment = pipeline_section_factory(
         runner=hp_runner,
@@ -495,10 +500,14 @@ def test_target_not_achievable_event_when_first_segment_fails(
             runner=hp_runner, recirculation_loop_ids=hp_loop_ids, compressors=hp_compressors
         ),
         shaft=shaft,
-        process_pipeline_id=hp_process_pipeline.get_id(),
+        process_pipeline_id=process_pipeline_id,
     )
 
-    solver = MultiPressureSolver(pipeline=Pipeline(process_pipeline_sections=[lp_segment, hp_segment]))
+    process_pipeline = Pipeline(
+        process_pipeline_sections=[lp_segment, hp_segment], process_pipeline_id=process_pipeline_id
+    )
+
+    solver = MultiPressureSolver(pipeline=process_pipeline)
 
     inlet_stream = stream_factory(standard_rate_m3_per_day=10_000, pressure_bara=30.0, temperature_kelvin=temperature)
 
@@ -510,4 +519,6 @@ def test_target_not_achievable_event_when_first_segment_fails(
 
     assert not solution.success
     assert isinstance(solution.failure, TargetPressureUnreachableFailure)
-    assert solution.failure.source_id == lp_process_pipeline.get_id()
+    assert (
+        solution.failure.source_id == process_pipeline.get_process_pipeline_sections()[0].get_id()
+    )  # LP section fails


### PR DESCRIPTION
Previously, an outlet pressure target failures was pinpointed to a pipeline. We have now implemented support for intermediate pressure targets, which means that there are more places than one place (outlet pressure + intermediate pressures) where we are not able to reach a target pressure. We therefore need to pinpoint that more specifically. It will now specify the section id of where it failed, which can unambigiously also pinpoint the last process unit and its outlet as where it actually failed.

Refs: equinor/ecalc-internal#1992

## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
