### PR TITLE
1965 shea stadium

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -43,7 +43,9 @@ from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
 from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import YamlCompositionFluidModel, YamlPredefinedFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
+    ProcessUnitReference,
+)
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlEcalcEvent,
     YamlProcessEvent,
@@ -256,50 +258,49 @@ class ProcessSimulationMapper:
     def _validate_and_map_pipeline_events(
         self,
         yaml_pipeline: YamlProcessPipeline,
+        process_unit_map: dict[ProcessUnitId, ProcessUnit],
         unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
     ) -> list[PipelineEvent]:
         """Validate pipeline event references and map to domain objects."""
         events: list[PipelineEvent] = []
-        item_names = {item.name for item in yaml_pipeline.items if item.name is not None}
 
         for yaml_event in yaml_pipeline.events:
-            if yaml_event.change_target not in item_names:
+            if unit_name_to_id.get(yaml_event.change_target, None) is None:
                 raise EcalcValidationException(
                     f"Pipeline event CHANGE_TARGET '{yaml_event.change_target}' does not match any named item "
-                    f"in pipeline '{yaml_pipeline.name}'. Available items: {', '.join(sorted(item_names))}."
+                    f"in pipeline '{yaml_pipeline.name}'. Available items: {', '.join([str(item.name) for item in yaml_pipeline.items])}."
                 )
-
-            # Validate CHANGE_FROM and CHANGE_TO exist as process unit references
-            try:
-                self._reference_service.get_process_unit(yaml_event.change_from)
-            except Exception:
-                raise EcalcValidationException(
-                    f"Pipeline event CHANGE_FROM '{yaml_event.change_from}' does not refer to a known process unit."
-                ) from None
-
-            try:
-                self._reference_service.get_process_unit(yaml_event.change_to)
-            except Exception:
+            #
+            if (change_to_yaml_process_unit := self._reference_service.get_process_unit(yaml_event.change_to)) is None:
                 raise EcalcValidationException(
                     f"Pipeline event CHANGE_TO '{yaml_event.change_to}' does not refer to a known process unit."
                 ) from None
+            match change_to_yaml_process_unit:
+                case YamlCompressor():
+                    change_to_unit = self._get_compressor(change_to_yaml_process_unit)
+                case _:
+                    raise EcalcValidationException(
+                        f"Pipeline event CHANGE_TO '{change_to_yaml_process_unit}' does not match any compressor (chart) unit."
+                    )
 
             # Validate optional REF points to a known process event
-            process_event_ref: str | None = yaml_event.ref if hasattr(yaml_event, "ref") and yaml_event.ref else None
-            if process_event_ref is not None and process_event_ref not in self._process_events_by_name:
+            process_event_ref: str | None = yaml_event.ref
+            if process_event_ref is None or process_event_ref not in self._process_events_by_name:
                 raise EcalcValidationException(
                     f"Pipeline event REF '{process_event_ref}' does not match any PROCESS_EVENT. "
                     f"Available: {', '.join(sorted(self._process_events_by_name.keys()))}."
                 )
+            process_event = self._process_events_by_name[process_event_ref]
+            # NOTE: We have verified that all process events have correct refs already
+            ecalc_event = self._ecalc_events_by_name[process_event.ref]
 
             events.append(
                 PipelineEvent(
                     action=PipelineEventAction(yaml_event.type.value),
-                    change_target=yaml_event.change_target,
-                    change_from=yaml_event.change_from,
-                    change_to=yaml_event.change_to,
+                    change_target=unit_name_to_id[yaml_event.change_target],
+                    change_to=change_to_unit,
                     change_type=PipelineEventChangeType(yaml_event.change_type.value),
-                    process_event_ref=process_event_ref,
+                    change_time=ecalc_event.start,
                 )
             )
 
@@ -443,6 +444,7 @@ class ProcessSimulationMapper:
             pipeline_events = self._validate_and_map_pipeline_events(
                 yaml_pipeline=item,
                 unit_name_to_id=unit_name_to_id,
+                process_unit_map=process_unit_map,
             )
             # TODO: We should move this class to this module/layer
             # in particular because it creates necessary connections, which means that they will get new IDs
@@ -450,6 +452,7 @@ class ProcessSimulationMapper:
                 name=item.name,
                 process_pipeline_sections=process_pipeline_sections,
                 events=pipeline_events,
+                process_periods=process_periods,
             )
 
             # Set up problem and problem sections

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -44,7 +44,11 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import 
 from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import YamlCompositionFluidModel, YamlPredefinedFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitReference
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessSimulation
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
+    YamlEcalcEvent,
+    YamlProcessEvent,
+    YamlProcessSimulation,
+)
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
     YamlCompressor,
     YamlCompressorModelChart,
@@ -61,6 +65,9 @@ from libecalc.process.fluid_stream.fluid_model import FluidModel
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_pipeline import (
+    PipelineEvent,
+    PipelineEventAction,
+    PipelineEventChangeType,
     ProcessPipeline,
     ProcessPipelineId,
     ProcessPipelineSection,
@@ -116,11 +123,23 @@ class ProcessSimulationMapper:
         reference_service: ReferenceService,
         process_simulation_period: Period,
         resources: Resources,
+        ecalc_events: list[YamlEcalcEvent] | None = None,
+        process_events: list[YamlProcessEvent] | None = None,
     ):
         self._expression_evaluator = expression_evaluator.get_subset_for_period(process_simulation_period)
         self._fluid_service = fluid_service
         self._reference_service = reference_service
         self._resources = resources
+        self._ecalc_events_by_name: dict[str, YamlEcalcEvent] = {e.name: e for e in (ecalc_events or [])}
+        self._process_events_by_name: dict[str, YamlProcessEvent] = {e.name: e for e in (process_events or [])}
+
+        # Validate that all PROCESS_EVENT REFs point to known ECALC_EVENTs
+        for pe in process_events or []:
+            if pe.ref not in self._ecalc_events_by_name:
+                raise EcalcValidationException(
+                    f"PROCESS_EVENT '{pe.name}' references ECALC_EVENT '{pe.ref}' which does not exist. "
+                    f"Available: {', '.join(sorted(self._ecalc_events_by_name.keys()))}."
+                )
 
     def _resolve_train_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
         if isinstance(ref, str):
@@ -233,6 +252,58 @@ class ProcessSimulationMapper:
                 return composition_fluid_model_mapper(yaml_fluid_model)
             case _:
                 assert_never(yaml_fluid_model)
+
+    def _validate_and_map_pipeline_events(
+        self,
+        yaml_pipeline: YamlProcessPipeline,
+        unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
+    ) -> list[PipelineEvent]:
+        """Validate pipeline event references and map to domain objects."""
+        events: list[PipelineEvent] = []
+        item_names = {item.name for item in yaml_pipeline.items if item.name is not None}
+
+        for yaml_event in yaml_pipeline.events:
+            if yaml_event.change_target not in item_names:
+                raise EcalcValidationException(
+                    f"Pipeline event CHANGE_TARGET '{yaml_event.change_target}' does not match any named item "
+                    f"in pipeline '{yaml_pipeline.name}'. Available items: {', '.join(sorted(item_names))}."
+                )
+
+            # Validate CHANGE_FROM and CHANGE_TO exist as process unit references
+            try:
+                self._reference_service.get_process_unit(yaml_event.change_from)
+            except Exception:
+                raise EcalcValidationException(
+                    f"Pipeline event CHANGE_FROM '{yaml_event.change_from}' does not refer to a known process unit."
+                ) from None
+
+            try:
+                self._reference_service.get_process_unit(yaml_event.change_to)
+            except Exception:
+                raise EcalcValidationException(
+                    f"Pipeline event CHANGE_TO '{yaml_event.change_to}' does not refer to a known process unit."
+                ) from None
+
+            # Validate optional REF points to a known process event
+            process_event_ref: str | None = yaml_event.ref if hasattr(yaml_event, "ref") and yaml_event.ref else None
+            if process_event_ref is not None and process_event_ref not in self._process_events_by_name:
+                raise EcalcValidationException(
+                    f"Pipeline event REF '{process_event_ref}' does not match any PROCESS_EVENT. "
+                    f"Available: {', '.join(sorted(self._process_events_by_name.keys()))}."
+                )
+
+            events.append(
+                PipelineEvent(
+                    action=PipelineEventAction(yaml_event.type.value),
+                    change_target=yaml_event.change_target,
+                    change_from=yaml_event.change_from,
+                    change_to=yaml_event.change_to,
+                    change_type=PipelineEventChangeType(yaml_event.change_type.value),
+                    process_event_ref=process_event_ref,
+                )
+            )
+
+        return events
 
     def map_process_simulation(
         self, yaml_process_simulation: YamlProcessSimulation, process_periods: list[Period]
@@ -368,11 +439,17 @@ class ProcessSimulationMapper:
 
                 process_pipeline_sections.append(ProcessPipelineSection(process_units=process_section_process_units))
 
+            # TODO: Simply events for now ...
+            pipeline_events = self._validate_and_map_pipeline_events(
+                yaml_pipeline=item,
+                unit_name_to_id=unit_name_to_id,
+            )
             # TODO: We should move this class to this module/layer
             # in particular because it creates necessary connections, which means that they will get new IDs
             process_pipeline = ProcessPipeline(
                 name=item.name,
                 process_pipeline_sections=process_pipeline_sections,
+                events=pipeline_events,
             )
 
             # Set up problem and problem sections

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -152,6 +152,8 @@ class YamlModel:
             fluid_service=NeqSimFluidService.instance(),
             resources=facility_resources,
             reference_service=self._get_reference_service(),
+            ecalc_events=self._configuration.ecalc_events,
+            process_events=self._configuration.process_events,
         )
         process_pipelines = []
         for yaml_process_simulation in self._configuration.process_simulations:

--- a/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
@@ -32,7 +32,7 @@ from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model im
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessSimulation
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlEcalcEvent, YamlProcessSimulation
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import YamlTimeSeriesCollection
@@ -46,6 +46,7 @@ _PROCESS_PIPELINES_KEY = "PROCESS_PIPELINES"
 _INLET_STREAMS_KEY = "INLET_STREAMS"
 _FLUID_MODELS_KEY = "FLUID_MODELS"
 _PROCESS_SIMULATIONS_KEY = "PROCESS_SIMULATIONS"
+_ECALC_EVENTS_KEY = "ECALC_EVENTS"
 _NEW_SECTIONS_WITH_FILE_REFS: tuple[str, ...] = (
     "PROCESS_UNITS",
     "PROCESS_PIPELINES",
@@ -477,6 +478,17 @@ class PyYamlYamlModel(YamlValidator, YamlConfiguration):
             except PydanticValidationError:
                 pass
         return process_simulations
+
+    @property
+    def ecalc_events(self) -> list[YamlEcalcEvent]:
+        ecalc_events: list[YamlEcalcEvent] = []
+        adapter = TypeAdapter(YamlEcalcEvent)
+        for ecalc_event in self._get_yaml_list_or_empty(_ECALC_EVENTS_KEY):
+            try:
+                ecalc_events.append(adapter.validate_python(ecalc_event))
+            except PydanticValidationError:
+                pass
+        return ecalc_events
 
     @property
     def start(self) -> datetime.datetime | None:

--- a/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
@@ -32,7 +32,11 @@ from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model im
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlEcalcEvent, YamlProcessSimulation
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
+    YamlEcalcEvent,
+    YamlProcessEvent,
+    YamlProcessSimulation,
+)
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import YamlTimeSeriesCollection
@@ -47,6 +51,7 @@ _INLET_STREAMS_KEY = "INLET_STREAMS"
 _FLUID_MODELS_KEY = "FLUID_MODELS"
 _PROCESS_SIMULATIONS_KEY = "PROCESS_SIMULATIONS"
 _ECALC_EVENTS_KEY = "ECALC_EVENTS"
+_PROCESS_EVENTS_KEY = "PROCESS_EVENTS"
 _NEW_SECTIONS_WITH_FILE_REFS: tuple[str, ...] = (
     "PROCESS_UNITS",
     "PROCESS_PIPELINES",
@@ -489,6 +494,17 @@ class PyYamlYamlModel(YamlValidator, YamlConfiguration):
             except PydanticValidationError:
                 pass
         return ecalc_events
+
+    @property
+    def process_events(self) -> list[YamlProcessEvent]:
+        process_events: list[YamlProcessEvent] = []
+        adapter = TypeAdapter(YamlProcessEvent)
+        for process_event in self._get_yaml_list_or_empty(_PROCESS_EVENTS_KEY):
+            try:
+                process_events.append(adapter.validate_python(process_event))
+            except PydanticValidationError:
+                pass
+        return process_events
 
     @property
     def start(self) -> datetime.datetime | None:

--- a/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
@@ -17,7 +17,7 @@ from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model im
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessSimulation
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlEcalcEvent, YamlProcessSimulation
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import (
@@ -96,6 +96,11 @@ class YamlValidator(abc.ABC):
     @property
     @abc.abstractmethod
     def process_simulations(self) -> Iterable[YamlProcessSimulation]:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def ecalc_events(self) -> list[YamlEcalcEvent]:
         pass
 
     @property

--- a/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
@@ -17,7 +17,11 @@ from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model im
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlEcalcEvent, YamlProcessSimulation
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
+    YamlEcalcEvent,
+    YamlProcessEvent,
+    YamlProcessSimulation,
+)
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import (
@@ -101,6 +105,11 @@ class YamlValidator(abc.ABC):
     @property
     @abc.abstractmethod
     def ecalc_events(self) -> list[YamlEcalcEvent]:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def process_events(self) -> list[YamlProcessEvent]:
         pass
 
     @property

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
@@ -8,7 +8,11 @@ from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model im
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlEcalcEvent, YamlProcessSimulation
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
+    YamlEcalcEvent,
+    YamlProcessEvent,
+    YamlProcessSimulation,
+)
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import YamlTimeSeriesCollection
@@ -83,6 +87,11 @@ class YamlAsset(YamlBase):
         default_factory=list,
         title="ECALC_EVENTS",
         description="Defines eCalc events associated with temporal model changes",
+    )
+    process_events: list[YamlProcessEvent] = Field(
+        default_factory=list,
+        title="PROCESS_EVENTS",
+        description="Defines process-specific events that reference global eCalc events.",
     )
     installations: list[YamlInstallation] = Field(
         ...,

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
@@ -8,7 +8,7 @@ from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model im
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessSimulation
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlEcalcEvent, YamlProcessSimulation
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import YamlTimeSeriesCollection
@@ -78,6 +78,11 @@ class YamlAsset(YamlBase):
         default_factory=list,
         title="PROCESS_SIMULATIONS",
         description="Defines one or more process simulations to be run.",
+    )
+    ecalc_events: list[YamlEcalcEvent] = Field(
+        default_factory=list,
+        title="ECALC_EVENTS",
+        description="Defines eCalc events associated with temporal model changes",
     )
     installations: list[YamlInstallation] = Field(
         ...,
@@ -174,6 +179,8 @@ class YamlAsset(YamlBase):
         if self.process_simulations is not None:
             for process_simulation in self.process_simulations:
                 references.append(process_simulation.name)
+
+        # TODO: Add ecalc events references?
 
         if self.fluid_models is not None:
             references.extend(self.fluid_models.keys())

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
@@ -1,7 +1,11 @@
-from typing import Literal, TypeVar
+from enum import StrEnum
+from typing import Annotated, Literal, TypeVar
+
+from pydantic import Field
 
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
+    ProcessEventReference,
     ProcessUnitReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
@@ -16,7 +20,69 @@ class YamlItem[TTarget](YamlBase):
     name: str | None = None
 
 
+class PipelineEventAction(StrEnum):
+    CHANGE = "CHANGE"
+    ADD = "ADD"
+    REMOVE = "REMOVE"
+
+
+class PipelineEventChangeType(StrEnum):
+    REBUNDLE = "REBUNDLE"
+
+
+class YamlPipelineEvent(YamlBase):
+    type: Annotated[
+        PipelineEventAction,
+        Field(
+            title="TYPE",
+            description="Action to perform: CHANGE, ADD, or REMOVE a process unit.",
+        ),
+    ]
+    change_target: Annotated[
+        ProcessUnitReference,
+        Field(
+            title="CHANGE_TARGET",
+            description="Name of the process unit in the pipeline to change.",
+        ),
+    ]
+    change_from: Annotated[
+        ProcessUnitReference,
+        Field(
+            title="CHANGE_FROM",
+            description="Reference to the existing process unit template being replaced.",
+        ),
+    ]
+    change_to: Annotated[
+        ProcessUnitReference,
+        Field(
+            title="CHANGE_TO",
+            description="Reference to the new process unit template to use.",
+        ),
+    ]
+    change_type: Annotated[
+        PipelineEventChangeType,
+        Field(
+            title="CHANGE_TYPE",
+            description="Nature of the change, e.g. REBUNDLE (chart change, same physical compressor).",
+        ),
+    ]
+    ref: Annotated[
+        ProcessEventReference,
+        Field(
+            title="REF",
+            description="Reference to a PROCESS_EVENT by name.",
+        ),
+    ]
+
+
 class YamlProcessPipeline(YamlBase):
     type: Literal["SERIAL"]
     name: str
     items: list[YamlItem[YamlProcessUnit]]
+    events: Annotated[
+        list[YamlPipelineEvent],
+        Field(
+            title="EVENTS",
+            description="Events that modify the pipeline over time, such as rebundling a compressor.",
+        ),
+    ] = []

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
@@ -5,3 +5,4 @@ Shared reference type aliases for YAML process types.
 type StreamRef = str
 type ProcessPipelineReference = str  # TODO: validate correct reference
 type ProcessUnitReference = str
+type EcalcEventReference = str

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
@@ -6,3 +6,4 @@ type StreamRef = str
 type ProcessPipelineReference = str  # TODO: validate correct reference
 type ProcessUnitReference = str
 type EcalcEventReference = str
+type ProcessEventReference = str

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Annotated
 
 from pydantic import Field
@@ -13,8 +14,53 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_references impor
     ProcessUnitReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution import YamlStreamDistribution
+from libecalc.presentation.yaml.yaml_types.yaml_default_datetime import YamlDefaultDatetime
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeType
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
+
+
+class EcalcEventType(StrEnum):
+    PROCESS = "PROCESS"
+    ENERGY = "ENERGY"
+    ALL = "ALL"
+
+
+class YamlEcalcEvent(YamlBase):
+    type: Annotated[
+        EcalcEventType,
+        Field(
+            title="TYPE",
+            description="Domain affected by this event, e.g. PROCESS, ENERGY, or ALL.",
+        ),
+    ]
+    start: Annotated[
+        YamlDefaultDatetime,
+        Field(
+            title="START",
+            description="Start date when this event takes effect.",
+        ),
+    ]
+    end: Annotated[
+        YamlDefaultDatetime,
+        Field(
+            title="END",
+            description="End date when this event ceases to be in effect.",
+        ),
+    ]
+    name: Annotated[
+        str,
+        Field(
+            title="NAME",
+            description="Short identifier for the event.",
+        ),
+    ]
+    description: Annotated[
+        str | None,
+        Field(
+            title="DESCRIPTION",
+            description="Human-readable description of the event and its purpose.",
+        ),
+    ] = None
 
 
 class YamlProcessConstraint(YamlBase):

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
@@ -41,13 +41,13 @@ class YamlEcalcEvent(YamlBase):
             description="Start date when this event takes effect.",
         ),
     ]
-    end: Annotated[
-        YamlDefaultDatetime,
-        Field(
-            title="END",
-            description="End date when this event ceases to be in effect.",
-        ),
-    ]
+    # end: Annotated[  # Temp remove. Should be defined by next (for now)
+    #    YamlDefaultDatetime,
+    #    Field(
+    #        title="END",
+    #        description="End date when this event ceases to be in effect.",
+    #    ),
+    # ]
     name: Annotated[
         str,
         Field(

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
@@ -41,13 +41,6 @@ class YamlEcalcEvent(YamlBase):
             description="Start date when this event takes effect.",
         ),
     ]
-    # end: Annotated[  # Temp remove. Should be defined by next (for now)
-    #    YamlDefaultDatetime,
-    #    Field(
-    #        title="END",
-    #        description="End date when this event ceases to be in effect.",
-    #    ),
-    # ]
     name: Annotated[
         str,
         Field(

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
@@ -10,6 +10,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import 
     YamlProcessPipeline,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
+    EcalcEventReference,
     ProcessPipelineReference,
     ProcessUnitReference,
 )
@@ -61,6 +62,42 @@ class YamlEcalcEvent(YamlBase):
             description="Human-readable description of the event and its purpose.",
         ),
     ] = None
+
+
+class ProcessEventType(StrEnum):
+    REBUNDLE = "REBUNDLE"
+    REVAMP = "REVAMP"
+
+
+class YamlProcessEvent(YamlBase):
+    type: Annotated[
+        ProcessEventType,
+        Field(
+            title="TYPE",
+            description="Type of process event, e.g. REBUNDLE, REVAMP.",
+        ),
+    ]
+    name: Annotated[
+        str,
+        Field(
+            title="NAME",
+            description="Short identifier for the process event.",
+        ),
+    ]
+    description: Annotated[
+        str | None,
+        Field(
+            title="DESCRIPTION",
+            description="Human-readable description of the process event.",
+        ),
+    ] = None
+    ref: Annotated[
+        EcalcEventReference,
+        Field(
+            title="REF",
+            description="Reference to a global ECALC_EVENT by name.",
+        ),
+    ]
 
 
 class YamlProcessConstraint(YamlBase):

--- a/src/libecalc/process/process_pipeline/process_pipeline.py
+++ b/src/libecalc/process/process_pipeline/process_pipeline.py
@@ -1,3 +1,4 @@
+import datetime
 from collections.abc import Sequence
 from enum import StrEnum
 from typing import Final, NewType, Self
@@ -5,6 +6,7 @@ from uuid import UUID
 
 from libecalc.common.ddd import value_object
 from libecalc.common.ddd.entity import Entity
+from libecalc.common.time_utils import Period
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 
@@ -28,11 +30,11 @@ class PipelineEvent:
     """Describes a change to a process unit in a pipeline, e.g. a compressor rebundle."""
 
     action: PipelineEventAction
-    change_target: str
-    change_from: str
-    change_to: str
+    change_target: ProcessUnitId
+    change_to: ProcessUnit  # Specification/definition
     change_type: PipelineEventChangeType
-    process_event_ref: str | None
+    change_time: datetime.datetime  # period only when evaluating "just before storing in db"
+    # process_event_ref: str | None
 
 
 class ProcessUnitConnection(Entity[ProcessUnitConnectionId]):
@@ -97,11 +99,13 @@ class ProcessPipeline(Entity[ProcessPipelineId]):
         self,
         name: str,
         process_pipeline_sections: Sequence[ProcessPipelineSection],
+        process_periods: list[Period],  # Sequential!
         process_pipeline_id: ProcessPipelineId | None = None,
         events: Sequence[PipelineEvent] | None = None,
     ):
         self._name = name
         self._process_pipeline_sections = process_pipeline_sections
+        self._process_periods = process_periods
         self._events: Sequence[PipelineEvent] = events or []
         self._process_unit_connections = ProcessPipeline._create_process_unit_connections(  # NOTE: this can currently only be used in mapper, to create connections first time!
             process_pipeline_sections=process_pipeline_sections
@@ -130,6 +134,9 @@ class ProcessPipeline(Entity[ProcessPipelineId]):
 
     def get_events(self) -> Sequence[PipelineEvent]:
         return self._events
+
+    def get_process_periods(self) -> list[Period]:
+        return self._process_periods
 
     @classmethod
     def _create_id(cls: type[Self]) -> ProcessPipelineId:

--- a/src/libecalc/process/process_pipeline/process_pipeline.py
+++ b/src/libecalc/process/process_pipeline/process_pipeline.py
@@ -1,7 +1,9 @@
 from collections.abc import Sequence
+from enum import StrEnum
 from typing import Final, NewType, Self
 from uuid import UUID
 
+from libecalc.common.ddd import value_object
 from libecalc.common.ddd.entity import Entity
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
@@ -9,6 +11,28 @@ from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessU
 ProcessPipelineId = NewType("ProcessPipelineId", UUID)
 ProcessPipelineSectionId = NewType("ProcessPipelineSectionId", UUID)
 ProcessUnitConnectionId = NewType("ProcessUnitConnectionId", UUID)
+
+
+class PipelineEventAction(StrEnum):
+    CHANGE = "CHANGE"
+    ADD = "ADD"
+    REMOVE = "REMOVE"
+
+
+class PipelineEventChangeType(StrEnum):
+    REBUNDLE = "REBUNDLE"
+
+
+@value_object
+class PipelineEvent:
+    """Describes a change to a process unit in a pipeline, e.g. a compressor rebundle."""
+
+    action: PipelineEventAction
+    change_target: str
+    change_from: str
+    change_to: str
+    change_type: PipelineEventChangeType
+    process_event_ref: str | None
 
 
 class ProcessUnitConnection(Entity[ProcessUnitConnectionId]):
@@ -74,9 +98,11 @@ class ProcessPipeline(Entity[ProcessPipelineId]):
         name: str,
         process_pipeline_sections: Sequence[ProcessPipelineSection],
         process_pipeline_id: ProcessPipelineId | None = None,
+        events: Sequence[PipelineEvent] | None = None,
     ):
         self._name = name
         self._process_pipeline_sections = process_pipeline_sections
+        self._events: Sequence[PipelineEvent] = events or []
         self._process_unit_connections = ProcessPipeline._create_process_unit_connections(  # NOTE: this can currently only be used in mapper, to create connections first time!
             process_pipeline_sections=process_pipeline_sections
         )
@@ -101,6 +127,9 @@ class ProcessPipeline(Entity[ProcessPipelineId]):
             for process_section in self.get_process_pipeline_sections()
             for process_unit in process_section.get_process_units()
         ]
+
+    def get_events(self) -> Sequence[PipelineEvent]:
+        return self._events
 
     @classmethod
     def _create_id(cls: type[Self]) -> ProcessPipelineId:

--- a/src/libecalc/process/process_solver/solver_assembly.py
+++ b/src/libecalc/process/process_solver/solver_assembly.py
@@ -104,6 +104,8 @@ def assemble_solver(
     pipeline = ProcessPipeline(
         name=pipeline_name,
         process_pipeline_sections=[ProcessPipelineSection(process_units=process_units)],
+        events=[],
+        process_periods=[],
     )
     runner = ProcessPipelineRunner(units=process_units, configuration_handlers=configuration_handlers)
 

--- a/tests/libecalc/conftest.py
+++ b/tests/libecalc/conftest.py
@@ -243,6 +243,8 @@ def process_pipeline_factory(name_factory):
         return ProcessPipeline(
             process_pipeline_sections=[ProcessPipelineSection(process_units=units)],
             name=name or name_factory("Pipeline"),
+            process_periods=[],
+            events=[],
         )
 
     return create_process_pipeline


### PR DESCRIPTION
Quite simply adding an initial support for events (name not decided, WIP), to:
- add necessary metadata for WHEN a change to an eCalc model occurs and WHY
- We only specify WHEN the change occurs. It will last until there is another event that either cancels it or builds on top of it. Therefore, the END date will be different for different parts of the system. A change in rate due to a tie-in, can for instance result in higher rate for a certain compressor, which requires it to be upgraded by rebundle/revamp or a parallell configuration to handle the increased rate. If there is another change in the future, such as lower rate again, and different conditions, we may change the parallell train back to a serial train, which has to be a new event. Other parts of the system may be affected by the initial event of a tie-in, but may not be affected by the second, when for instance we go into LPP (low production period, ie tail production) 
- as a global reason for a change may not make it clear whether it will affect process or energy, we also want to specify that - so a global event can have an event in either domain or both. instead of setting the same time, it must refer to the global event, to ensure that dates are not mixed up, but being consistent throughout the model
- every small physical change, such as rebundle in this case, must be related to a process event as well. Why do we do the rebundle, and when? 
- such an event, at pipeline level, will be related to a very specific change, such as changing a compressor chart. We decide whether a rebundle/revamp should result in changing the compressor (new ID), or same compressor, but with new capability (same ID). This may depend on user needs, and perhaps different users sees this differently? Therefore it is important to add semantics to changes, in order to make it possible to make good decisions on how this should affect physical and logical changes in an ecalc model.

So, this is currently solved by "strangling" this capabiltiy into the process simulation mapper, and I think that I will change this to be a part of a "temporal pipeline" instead, where it is the pipeline that "makes decision" on how an event affects it over time. In order to do that, we need to separate the classes we use for temporal and core domain, OR wrap domain classes with a temporal generic; if all temporal changes should work the same independently of what it wraps. I will focus on improving that on next part that requires temporal aspect, e.g. changign from a parallell to a serial configuration.

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
