### PR TITLE
chore: make ecalc compatible with numpy >= 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "pydantic<3",
     "PyYAML==6.*",
-    "numpy>=2.5,<3",
+    "numpy>=2,<3",
     "pandas>=2,<4",
     "scipy<2",
     "ruamel-yaml~=0.18",

--- a/uv.lock
+++ b/uv.lock
@@ -472,7 +472,7 @@ dev = [
 requires-dist = [
     { name = "jneqsim", specifier = ">=3.0.42" },
     { name = "networkx", specifier = "~=3.2" },
-    { name = "numpy", specifier = ">=2.5,<3" },
+    { name = "numpy", specifier = ">=2,<3" },
     { name = "orjson", specifier = "~=3.8" },
     { name = "pandas", specifier = ">=2,<4" },
     { name = "py4j", specifier = "~=0.10" },


### PR DESCRIPTION
## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
