### PR TITLE
chore: handle ecalc and process events

### DIFF
--- a/src/libecalc/ecalc_model/ecalc_event.py
+++ b/src/libecalc/ecalc_model/ecalc_event.py
@@ -16,16 +16,16 @@ class ProcessEventType(StrEnum):
 
 
 @value_object
+class ProcessEvent:
+    name: str
+    type: ProcessEventType
+    description: str | None
+
+
+@value_object
 class EcalcEvent:
     name: str
     type: EcalcEventType
     start: datetime
     description: str | None
-
-
-@value_object
-class ProcessEvent:
-    name: str
-    type: ProcessEventType
-    description: str | None
-    ecalc_event_ref: str  # name of the referenced EcalcEvent
+    process_events: list[ProcessEvent]

--- a/src/libecalc/ecalc_model/ecalc_event.py
+++ b/src/libecalc/ecalc_model/ecalc_event.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from enum import StrEnum
+
+from libecalc.common.ddd import value_object
+
+
+class EcalcEventType(StrEnum):
+    PROCESS = "PROCESS"
+    ENERGY = "ENERGY"
+    ALL = "ALL"
+
+
+class ProcessEventType(StrEnum):
+    REBUNDLE = "REBUNDLE"
+    REVAMP = "REVAMP"
+
+
+@value_object
+class EcalcEvent:
+    name: str
+    type: EcalcEventType
+    start: datetime
+    description: str | None
+
+
+@value_object
+class ProcessEvent:
+    name: str
+    type: ProcessEventType
+    description: str | None
+    ecalc_event_ref: str  # name of the referenced EcalcEvent

--- a/src/libecalc/ecalc_model/ecalc_event.py
+++ b/src/libecalc/ecalc_model/ecalc_event.py
@@ -4,15 +4,20 @@ from enum import StrEnum
 from libecalc.common.ddd import value_object
 
 
+# TODO: Unknown types or categories. Does it even make sense to specify in hierarchy?
+# We will figure out more soon
 class EcalcEventType(StrEnum):
-    PROCESS = "PROCESS"
-    ENERGY = "ENERGY"
-    ALL = "ALL"
+    OPERATIONAL_MEASUREMENT = "OPERATIONAL_MEASUREMENT"
+    ENERGY_EFFICIENCY_MEASUREMENT = "ENERGY_EFFICIENCY_MEASUREMENT"
+    CALIBRATION = "CALIBRATION"
+    TIE_IN = "TIE_IN"
+    OTHER = "OTHER"
 
 
 class ProcessEventType(StrEnum):
-    REBUNDLE = "REBUNDLE"
-    REVAMP = "REVAMP"
+    INCREASED_GAS_RATE = "INCREASED_GAS_RATE"
+    INCREASED_WATER_INJECTION = "INCREASED_WATER_INJECTION"
+    OTHER = "OTHER"
 
 
 @value_object
@@ -29,3 +34,21 @@ class EcalcEvent:
     start: datetime
     description: str | None
     process_events: list[ProcessEvent]
+
+
+class EcalcEventService:
+    def __init__(self, ecalc_events: list[EcalcEvent]):
+        self._ecalc_events = ecalc_events or []
+
+    def get_event_by_name(self, name: str) -> EcalcEvent | None:
+        for ecalc_event in self._ecalc_events:
+            if ecalc_event.name == name:
+                return ecalc_event
+        return None
+
+    def get_event_by_process_name(self, name: str) -> EcalcEvent | None:
+        for ecalc_event in self._ecalc_events:
+            for process_event in ecalc_event.process_events:
+                if process_event.name == name:
+                    return ecalc_event
+        return None

--- a/src/libecalc/presentation/yaml/mappers/ecalc_event_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/ecalc_event_mapper.py
@@ -1,0 +1,46 @@
+from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
+from libecalc.ecalc_model.ecalc_event import EcalcEvent, EcalcEventType, ProcessEvent, ProcessEventType
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlEcalcEvent, YamlProcessEvent
+
+
+class EcalcEventMapper:
+    # TODO: Currently no services needed
+
+    def map_events(
+        self, yaml_ecalc_events: list[YamlEcalcEvent], yaml_process_events: list[YamlProcessEvent]
+    ) -> list[EcalcEvent]:
+        ecalc_events_by_name: dict[str, list[ProcessEvent]] = {}
+        for yaml_event in yaml_ecalc_events:
+            if yaml_event.name in ecalc_events_by_name:
+                raise EcalcValidationException(
+                    f"Duplicate ECALC_EVENT name '{yaml_event.name}'. Event names must be unique."
+                )
+            ecalc_events_by_name[yaml_event.name] = []
+
+        for yaml_process_event in yaml_process_events:
+            if yaml_process_event.ref not in ecalc_events_by_name:
+                raise EcalcValidationException(
+                    f"PROCESS_EVENT '{yaml_process_event.name}' references ECALC_EVENT '{yaml_process_event.ref}' which does not exist. "
+                    f"Available: {', '.join(sorted(ecalc_events_by_name.keys()))}."
+                )
+            ecalc_events_by_name[yaml_process_event.ref].append(
+                ProcessEvent(
+                    name=yaml_process_event.name,
+                    type=ProcessEventType(yaml_process_event.type.value),
+                    description=yaml_process_event.description,
+                )
+            )
+
+        ecalc_events: list[EcalcEvent] = []
+        for yaml_event in yaml_ecalc_events:
+            ecalc_events.append(
+                EcalcEvent(
+                    name=yaml_event.name,
+                    type=EcalcEventType(yaml_event.type.value),
+                    start=yaml_event.start,
+                    description=yaml_event.description,
+                    process_events=ecalc_events_by_name[yaml_event.name],
+                )
+            )
+
+        return ecalc_events

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import assert_never, get_args
 
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
@@ -9,7 +8,7 @@ from libecalc.common.variables import ExpressionEvaluator
 from libecalc.domain.process.value_objects.chart.chart import ChartData
 from libecalc.domain.regularity import Regularity
 from libecalc.domain.resource import Resources
-from libecalc.ecalc_model.ecalc_event import EcalcEvent
+from libecalc.ecalc_model.ecalc_event import EcalcEvent, EcalcEventService
 from libecalc.ecalc_model.process_simulation import (
     AntiSurgeConfig,
     CommonStreamDistributionConfig,
@@ -125,21 +124,13 @@ class ProcessSimulationMapper:
         reference_service: ReferenceService,
         process_simulation_period: Period,
         resources: Resources,
-        ecalc_events: list[EcalcEvent] | None = None,
+        ecalc_event_service: EcalcEventService,
     ):
         self._expression_evaluator = expression_evaluator.get_subset_for_period(process_simulation_period)
         self._fluid_service = fluid_service
         self._reference_service = reference_service
         self._resources = resources
-        self._ecalc_events = ecalc_events or []
-
-    def get_event_date_for_process_event(self, process_event_ref: str) -> datetime:
-        """Look up the effective date for a process event by name, traversing the ecalc event hierarchy."""
-        for ecalc_event in self._ecalc_events:
-            for pe in ecalc_event.process_events:
-                if pe.name == process_event_ref:
-                    return ecalc_event.start
-        raise EcalcValidationException(f"Process event '{process_event_ref}' not found in any ECALC_EVENT.")
+        self._ecalc_event_service = ecalc_event_service
 
     def _resolve_train_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
         if isinstance(ref, str):
@@ -256,23 +247,23 @@ class ProcessSimulationMapper:
     def _validate_and_map_pipeline_events(
         self,
         yaml_pipeline: YamlProcessPipeline,
-        process_unit_map: dict[ProcessUnitId, ProcessUnit],
         unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
     ) -> list[PipelineEvent]:
         """Validate pipeline event references and map to domain objects."""
         events: list[PipelineEvent] = []
 
         for yaml_event in yaml_pipeline.events:
-            if unit_name_to_id.get(yaml_event.change_target, None) is None:
+            ecalc_event: EcalcEvent | None = self._ecalc_event_service.get_event_by_process_name(yaml_event.ref)
+            if ecalc_event is None:
                 raise EcalcValidationException(
-                    f"Pipeline event CHANGE_TARGET '{yaml_event.change_target}' does not match any named item "
-                    f"in pipeline '{yaml_pipeline.name}'. Available items: {', '.join([str(item.name) for item in yaml_pipeline.items])}."
+                    f"Pipeline event '{yaml_event.ref}' does not match any known process event."
                 )
 
             if (change_to_yaml_process_unit := self._reference_service.get_process_unit(yaml_event.change_to)) is None:
                 raise EcalcValidationException(
                     f"Pipeline event CHANGE_TO '{yaml_event.change_to}' does not refer to a known process unit."
                 ) from None
+
             match change_to_yaml_process_unit:
                 case YamlCompressor():
                     change_to_unit = self._get_compressor(change_to_yaml_process_unit)
@@ -281,21 +272,13 @@ class ProcessSimulationMapper:
                         f"Pipeline event CHANGE_TO '{change_to_yaml_process_unit}' does not match any compressor (chart) unit."
                     )
 
-            # Resolve event date via the ecalc event hierarchy
-            process_event_ref: str | None = yaml_event.ref
-            if process_event_ref is None:
-                raise EcalcValidationException(
-                    f"Pipeline event in pipeline '{yaml_pipeline.name}' is missing a REF to a PROCESS_EVENT."
-                )
-            change_time = self.get_event_date_for_process_event(process_event_ref)
-
             events.append(
                 PipelineEvent(
                     action=PipelineEventAction(yaml_event.type.value),
                     change_target=unit_name_to_id[yaml_event.change_target],
                     change_to=change_to_unit,
                     change_type=PipelineEventChangeType(yaml_event.change_type.value),
-                    change_time=change_time,
+                    change_time=ecalc_event.start,
                 )
             )
 
@@ -439,7 +422,6 @@ class ProcessSimulationMapper:
             pipeline_events = self._validate_and_map_pipeline_events(
                 yaml_pipeline=item,
                 unit_name_to_id=unit_name_to_id,
-                process_unit_map=process_unit_map,
             )
             # TODO: We should move this class to this module/layer
             # in particular because it creates necessary connections, which means that they will get new IDs

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -9,6 +9,7 @@ from libecalc.common.variables import ExpressionEvaluator
 from libecalc.domain.process.value_objects.chart.chart import ChartData
 from libecalc.domain.regularity import Regularity
 from libecalc.domain.resource import Resources
+from libecalc.ecalc_model.ecalc_event import EcalcEvent
 from libecalc.ecalc_model.process_simulation import (
     AntiSurgeConfig,
     CommonStreamDistributionConfig,
@@ -124,13 +125,21 @@ class ProcessSimulationMapper:
         reference_service: ReferenceService,
         process_simulation_period: Period,
         resources: Resources,
-        process_event_dates: dict[str, datetime] | None = None,
+        ecalc_events: list[EcalcEvent] | None = None,
     ):
         self._expression_evaluator = expression_evaluator.get_subset_for_period(process_simulation_period)
         self._fluid_service = fluid_service
         self._reference_service = reference_service
         self._resources = resources
-        self._process_event_dates: dict[str, datetime] = process_event_dates or {}
+        self._ecalc_events = ecalc_events or []
+
+    def get_event_date_for_process_event(self, process_event_ref: str) -> datetime:
+        """Look up the effective date for a process event by name, traversing the ecalc event hierarchy."""
+        for ecalc_event in self._ecalc_events:
+            for pe in ecalc_event.process_events:
+                if pe.name == process_event_ref:
+                    return ecalc_event.start
+        raise EcalcValidationException(f"Process event '{process_event_ref}' not found in any ECALC_EVENT.")
 
     def _resolve_train_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
         if isinstance(ref, str):
@@ -272,13 +281,13 @@ class ProcessSimulationMapper:
                         f"Pipeline event CHANGE_TO '{change_to_yaml_process_unit}' does not match any compressor (chart) unit."
                     )
 
-            # Resolve event date from the process_event_dates lookup
+            # Resolve event date via the ecalc event hierarchy
             process_event_ref: str | None = yaml_event.ref
-            if process_event_ref is None or process_event_ref not in self._process_event_dates:
+            if process_event_ref is None:
                 raise EcalcValidationException(
-                    f"Pipeline event REF '{process_event_ref}' does not match any PROCESS_EVENT. "
-                    f"Available: {', '.join(sorted(self._process_event_dates.keys()))}."
+                    f"Pipeline event in pipeline '{yaml_pipeline.name}' is missing a REF to a PROCESS_EVENT."
                 )
+            change_time = self.get_event_date_for_process_event(process_event_ref)
 
             events.append(
                 PipelineEvent(
@@ -286,7 +295,7 @@ class ProcessSimulationMapper:
                     change_target=unit_name_to_id[yaml_event.change_target],
                     change_to=change_to_unit,
                     change_type=PipelineEventChangeType(yaml_event.change_type.value),
-                    change_time=self._process_event_dates[process_event_ref],
+                    change_time=change_time,
                 )
             )
 

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import assert_never, get_args
 
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
@@ -47,8 +48,6 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_references impor
     ProcessUnitReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
-    YamlEcalcEvent,
-    YamlProcessEvent,
     YamlProcessSimulation,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
@@ -125,23 +124,13 @@ class ProcessSimulationMapper:
         reference_service: ReferenceService,
         process_simulation_period: Period,
         resources: Resources,
-        ecalc_events: list[YamlEcalcEvent] | None = None,
-        process_events: list[YamlProcessEvent] | None = None,
+        process_event_dates: dict[str, datetime] | None = None,
     ):
         self._expression_evaluator = expression_evaluator.get_subset_for_period(process_simulation_period)
         self._fluid_service = fluid_service
         self._reference_service = reference_service
         self._resources = resources
-        self._ecalc_events_by_name: dict[str, YamlEcalcEvent] = {e.name: e for e in (ecalc_events or [])}
-        self._process_events_by_name: dict[str, YamlProcessEvent] = {e.name: e for e in (process_events or [])}
-
-        # Validate that all PROCESS_EVENT REFs point to known ECALC_EVENTs
-        for pe in process_events or []:
-            if pe.ref not in self._ecalc_events_by_name:
-                raise EcalcValidationException(
-                    f"PROCESS_EVENT '{pe.name}' references ECALC_EVENT '{pe.ref}' which does not exist. "
-                    f"Available: {', '.join(sorted(self._ecalc_events_by_name.keys()))}."
-                )
+        self._process_event_dates: dict[str, datetime] = process_event_dates or {}
 
     def _resolve_train_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
         if isinstance(ref, str):
@@ -270,7 +259,7 @@ class ProcessSimulationMapper:
                     f"Pipeline event CHANGE_TARGET '{yaml_event.change_target}' does not match any named item "
                     f"in pipeline '{yaml_pipeline.name}'. Available items: {', '.join([str(item.name) for item in yaml_pipeline.items])}."
                 )
-            #
+
             if (change_to_yaml_process_unit := self._reference_service.get_process_unit(yaml_event.change_to)) is None:
                 raise EcalcValidationException(
                     f"Pipeline event CHANGE_TO '{yaml_event.change_to}' does not refer to a known process unit."
@@ -283,16 +272,13 @@ class ProcessSimulationMapper:
                         f"Pipeline event CHANGE_TO '{change_to_yaml_process_unit}' does not match any compressor (chart) unit."
                     )
 
-            # Validate optional REF points to a known process event
+            # Resolve event date from the process_event_dates lookup
             process_event_ref: str | None = yaml_event.ref
-            if process_event_ref is None or process_event_ref not in self._process_events_by_name:
+            if process_event_ref is None or process_event_ref not in self._process_event_dates:
                 raise EcalcValidationException(
                     f"Pipeline event REF '{process_event_ref}' does not match any PROCESS_EVENT. "
-                    f"Available: {', '.join(sorted(self._process_events_by_name.keys()))}."
+                    f"Available: {', '.join(sorted(self._process_event_dates.keys()))}."
                 )
-            process_event = self._process_events_by_name[process_event_ref]
-            # NOTE: We have verified that all process events have correct refs already
-            ecalc_event = self._ecalc_events_by_name[process_event.ref]
 
             events.append(
                 PipelineEvent(
@@ -300,7 +286,7 @@ class ProcessSimulationMapper:
                     change_target=unit_name_to_id[yaml_event.change_target],
                     change_to=change_to_unit,
                     change_type=PipelineEventChangeType(yaml_event.change_type.value),
-                    change_time=ecalc_event.start,
+                    change_time=self._process_event_dates[process_event_ref],
                 )
             )
 

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -158,11 +158,7 @@ class YamlModel:
         process_simulations = []
         facility_resources, _ = self._resource_service.get_facility_resources()
 
-        # Build event name → date lookup for the mapper
-        ecalc_events, process_events = self.get_events()
-        ecalc_event_dates = {event.name: event.start for event in ecalc_events}
-        # Map process event name → ecalc event date (the effective date)
-        process_event_dates = {pe.name: ecalc_event_dates[pe.ecalc_event_ref] for pe in process_events}
+        ecalc_events = self.get_events()
 
         mapper = ProcessSimulationMapper(
             expression_evaluator=self.get_expression_evaluator(),
@@ -170,7 +166,7 @@ class YamlModel:
             fluid_service=NeqSimFluidService.instance(),
             resources=facility_resources,
             reference_service=self._get_reference_service(),
-            process_event_dates=process_event_dates,
+            ecalc_events=ecalc_events,
         )
         process_pipelines = []
         for yaml_process_simulation in self._configuration.process_simulations:
@@ -182,41 +178,46 @@ class YamlModel:
 
         return process_pipelines, process_simulations
 
-    def get_events(self) -> tuple[list[EcalcEvent], list[ProcessEvent]]:
+    def get_events(self) -> list[EcalcEvent]:
         """Parse and validate ECALC_EVENTS and PROCESS_EVENTS from YAML, returning domain value objects."""
         yaml_ecalc_events = self._configuration.ecalc_events
         yaml_process_events = self._configuration.process_events
 
-        ecalc_events_by_name: dict[str, EcalcEvent] = {}
+        ecalc_events_by_name: dict[str, list[ProcessEvent]] = {}
         for yaml_event in yaml_ecalc_events:
             if yaml_event.name in ecalc_events_by_name:
                 raise EcalcValidationException(
                     f"Duplicate ECALC_EVENT name '{yaml_event.name}'. Event names must be unique."
                 )
-            ecalc_events_by_name[yaml_event.name] = EcalcEvent(
-                name=yaml_event.name,
-                type=EcalcEventType(yaml_event.type.value),
-                start=yaml_event.start,
-                description=yaml_event.description,
-            )
+            ecalc_events_by_name[yaml_event.name] = []
 
-        process_events: list[ProcessEvent] = []
         for yaml_pe in yaml_process_events:
             if yaml_pe.ref not in ecalc_events_by_name:
                 raise EcalcValidationException(
                     f"PROCESS_EVENT '{yaml_pe.name}' references ECALC_EVENT '{yaml_pe.ref}' which does not exist. "
                     f"Available: {', '.join(sorted(ecalc_events_by_name.keys()))}."
                 )
-            process_events.append(
+            ecalc_events_by_name[yaml_pe.ref].append(
                 ProcessEvent(
                     name=yaml_pe.name,
                     type=ProcessEventType(yaml_pe.type.value),
                     description=yaml_pe.description,
-                    ecalc_event_ref=yaml_pe.ref,
                 )
             )
 
-        return list(ecalc_events_by_name.values()), process_events
+        ecalc_events: list[EcalcEvent] = []
+        for yaml_event in yaml_ecalc_events:
+            ecalc_events.append(
+                EcalcEvent(
+                    name=yaml_event.name,
+                    type=EcalcEventType(yaml_event.type.value),
+                    start=yaml_event.start,
+                    description=yaml_event.description,
+                    process_events=ecalc_events_by_name[yaml_event.name],
+                )
+            )
+
+        return ecalc_events
 
     def get_pump_process_simulations(
         self,

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -37,9 +37,7 @@ from libecalc.domain.process.pump.pump import PumpModel
 from libecalc.domain.regularity import Regularity
 from libecalc.ecalc_model.ecalc_event import (
     EcalcEvent,
-    EcalcEventType,
-    ProcessEvent,
-    ProcessEventType,
+    EcalcEventService,
 )
 from libecalc.ecalc_model.process_simulation import ProcessSimulation
 from libecalc.presentation.yaml.domain.category_service import CategoryService
@@ -50,6 +48,7 @@ from libecalc.presentation.yaml.domain.reference_service import ReferenceService
 from libecalc.presentation.yaml.domain.time_series_collections import TimeSeriesCollections
 from libecalc.presentation.yaml.domain.time_series_resource import TimeSeriesResource
 from libecalc.presentation.yaml.mappers.component_mapper import EcalcModelMapper
+from libecalc.presentation.yaml.mappers.ecalc_event_mapper import EcalcEventMapper
 from libecalc.presentation.yaml.mappers.process_simulation_mapper import ProcessSimulationMapper
 from libecalc.presentation.yaml.mappers.pump_process_simulation_mapper import PumpProcessSimulationMapper
 from libecalc.presentation.yaml.mappers.variables_mapper import map_yaml_to_variables
@@ -153,12 +152,12 @@ class YamlModel:
 
         self._id = uuid.uuid4()  # ID used for "asset" energy container, which is the same as model?
 
-    def get_process_simulations(self) -> tuple[list[ProcessPipeline], list[ProcessSimulation]]:
+    def get_process_simulations(
+        self, ecalc_event_service: EcalcEventService
+    ) -> tuple[list[ProcessPipeline], list[ProcessSimulation]]:
         self.validate_for_run()
         process_simulations = []
         facility_resources, _ = self._resource_service.get_facility_resources()
-
-        ecalc_events = self.get_events()
 
         mapper = ProcessSimulationMapper(
             expression_evaluator=self.get_expression_evaluator(),
@@ -166,7 +165,7 @@ class YamlModel:
             fluid_service=NeqSimFluidService.instance(),
             resources=facility_resources,
             reference_service=self._get_reference_service(),
-            ecalc_events=ecalc_events,
+            ecalc_event_service=ecalc_event_service,
         )
         process_pipelines = []
         for yaml_process_simulation in self._configuration.process_simulations:
@@ -179,45 +178,9 @@ class YamlModel:
         return process_pipelines, process_simulations
 
     def get_events(self) -> list[EcalcEvent]:
-        """Parse and validate ECALC_EVENTS and PROCESS_EVENTS from YAML, returning domain value objects."""
-        yaml_ecalc_events = self._configuration.ecalc_events
-        yaml_process_events = self._configuration.process_events
-
-        ecalc_events_by_name: dict[str, list[ProcessEvent]] = {}
-        for yaml_event in yaml_ecalc_events:
-            if yaml_event.name in ecalc_events_by_name:
-                raise EcalcValidationException(
-                    f"Duplicate ECALC_EVENT name '{yaml_event.name}'. Event names must be unique."
-                )
-            ecalc_events_by_name[yaml_event.name] = []
-
-        for yaml_pe in yaml_process_events:
-            if yaml_pe.ref not in ecalc_events_by_name:
-                raise EcalcValidationException(
-                    f"PROCESS_EVENT '{yaml_pe.name}' references ECALC_EVENT '{yaml_pe.ref}' which does not exist. "
-                    f"Available: {', '.join(sorted(ecalc_events_by_name.keys()))}."
-                )
-            ecalc_events_by_name[yaml_pe.ref].append(
-                ProcessEvent(
-                    name=yaml_pe.name,
-                    type=ProcessEventType(yaml_pe.type.value),
-                    description=yaml_pe.description,
-                )
-            )
-
-        ecalc_events: list[EcalcEvent] = []
-        for yaml_event in yaml_ecalc_events:
-            ecalc_events.append(
-                EcalcEvent(
-                    name=yaml_event.name,
-                    type=EcalcEventType(yaml_event.type.value),
-                    start=yaml_event.start,
-                    description=yaml_event.description,
-                    process_events=ecalc_events_by_name[yaml_event.name],
-                )
-            )
-
-        return ecalc_events
+        return EcalcEventMapper().map_events(
+            yaml_ecalc_events=self._configuration.ecalc_events, yaml_process_events=self._configuration.process_events
+        )
 
     def get_pump_process_simulations(
         self,

--- a/src/libecalc/presentation/yaml/model.py
+++ b/src/libecalc/presentation/yaml/model.py
@@ -35,6 +35,12 @@ from libecalc.domain.process.evaluation_input import (
 )
 from libecalc.domain.process.pump.pump import PumpModel
 from libecalc.domain.regularity import Regularity
+from libecalc.ecalc_model.ecalc_event import (
+    EcalcEvent,
+    EcalcEventType,
+    ProcessEvent,
+    ProcessEventType,
+)
 from libecalc.ecalc_model.process_simulation import ProcessSimulation
 from libecalc.presentation.yaml.domain.category_service import CategoryService
 from libecalc.presentation.yaml.domain.container_info import ContainerInfo
@@ -151,14 +157,20 @@ class YamlModel:
         self.validate_for_run()
         process_simulations = []
         facility_resources, _ = self._resource_service.get_facility_resources()
+
+        # Build event name → date lookup for the mapper
+        ecalc_events, process_events = self.get_events()
+        ecalc_event_dates = {event.name: event.start for event in ecalc_events}
+        # Map process event name → ecalc event date (the effective date)
+        process_event_dates = {pe.name: ecalc_event_dates[pe.ecalc_event_ref] for pe in process_events}
+
         mapper = ProcessSimulationMapper(
             expression_evaluator=self.get_expression_evaluator(),
             process_simulation_period=self.period,
             fluid_service=NeqSimFluidService.instance(),
             resources=facility_resources,
             reference_service=self._get_reference_service(),
-            ecalc_events=self._configuration.ecalc_events,
-            process_events=self._configuration.process_events,
+            process_event_dates=process_event_dates,
         )
         process_pipelines = []
         for yaml_process_simulation in self._configuration.process_simulations:
@@ -169,6 +181,42 @@ class YamlModel:
             process_simulations.append(process_simulation)
 
         return process_pipelines, process_simulations
+
+    def get_events(self) -> tuple[list[EcalcEvent], list[ProcessEvent]]:
+        """Parse and validate ECALC_EVENTS and PROCESS_EVENTS from YAML, returning domain value objects."""
+        yaml_ecalc_events = self._configuration.ecalc_events
+        yaml_process_events = self._configuration.process_events
+
+        ecalc_events_by_name: dict[str, EcalcEvent] = {}
+        for yaml_event in yaml_ecalc_events:
+            if yaml_event.name in ecalc_events_by_name:
+                raise EcalcValidationException(
+                    f"Duplicate ECALC_EVENT name '{yaml_event.name}'. Event names must be unique."
+                )
+            ecalc_events_by_name[yaml_event.name] = EcalcEvent(
+                name=yaml_event.name,
+                type=EcalcEventType(yaml_event.type.value),
+                start=yaml_event.start,
+                description=yaml_event.description,
+            )
+
+        process_events: list[ProcessEvent] = []
+        for yaml_pe in yaml_process_events:
+            if yaml_pe.ref not in ecalc_events_by_name:
+                raise EcalcValidationException(
+                    f"PROCESS_EVENT '{yaml_pe.name}' references ECALC_EVENT '{yaml_pe.ref}' which does not exist. "
+                    f"Available: {', '.join(sorted(ecalc_events_by_name.keys()))}."
+                )
+            process_events.append(
+                ProcessEvent(
+                    name=yaml_pe.name,
+                    type=ProcessEventType(yaml_pe.type.value),
+                    description=yaml_pe.description,
+                    ecalc_event_ref=yaml_pe.ref,
+                )
+            )
+
+        return list(ecalc_events_by_name.values()), process_events
 
     def get_pump_process_simulations(
         self,

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
@@ -1,8 +1,8 @@
-from enum import StrEnum
 from typing import Annotated, Literal
 
 from pydantic import Field
 
+from libecalc.ecalc_model.ecalc_event import EcalcEventType, ProcessEventType
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import (
@@ -19,12 +19,6 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution impo
 from libecalc.presentation.yaml.yaml_types.yaml_default_datetime import YamlDefaultDatetime
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeType
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
-
-
-class EcalcEventType(StrEnum):
-    PROCESS = "PROCESS"
-    ENERGY = "ENERGY"
-    ALL = "ALL"
 
 
 class YamlEcalcEvent(YamlBase):
@@ -56,11 +50,6 @@ class YamlEcalcEvent(YamlBase):
             description="Human-readable description of the event and its purpose.",
         ),
     ] = None
-
-
-class ProcessEventType(StrEnum):
-    REBUNDLE = "REBUNDLE"
-    REVAMP = "REVAMP"
 
 
 class YamlProcessEvent(YamlBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from libecalc.common.utils.rates import RateType
 from libecalc.common.variables import ExpressionEvaluator, VariablesMap
 from libecalc.domain.regularity import Regularity
 from libecalc.domain.resource import Resource
+from libecalc.ecalc_model.ecalc_event import EcalcEventService
 from libecalc.examples import advanced, drogon, simple
 from libecalc.expression.expression import ExpressionType
 from libecalc.fixtures import YamlCase
@@ -693,4 +694,5 @@ def process_simulation_mapper(
         reference_service=reference_service,
         process_simulation_period=period,
         resources={},
+        ecalc_event_service=EcalcEventService(ecalc_events=[]),
     )

--- a/tests/libecalc/ecalc_model/test_ecalc_event.py
+++ b/tests/libecalc/ecalc_model/test_ecalc_event.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+
+from libecalc.ecalc_model.ecalc_event import (
+    EcalcEvent,
+    EcalcEventService,
+    EcalcEventType,
+    ProcessEvent,
+    ProcessEventType,
+)
+
+
+class TestEcalcEventService:
+    def _make_service(self) -> EcalcEventService:
+        events = [
+            EcalcEvent(
+                name="EVENT_1",
+                type=EcalcEventType.TIE_IN,
+                start=datetime(2025, 1, 1),
+                description=None,
+                process_events=[
+                    ProcessEvent(name="PE_A", type=ProcessEventType.INCREASED_GAS_RATE, description=None),
+                    ProcessEvent(name="PE_B", type=ProcessEventType.OTHER, description=None),
+                ],
+            ),
+            EcalcEvent(
+                name="EVENT_2",
+                type=EcalcEventType.OTHER,
+                start=datetime(2028, 6, 1),
+                description=None,
+                process_events=[
+                    ProcessEvent(name="PE_C", type=ProcessEventType.INCREASED_WATER_INJECTION, description=None),
+                ],
+            ),
+        ]
+        return EcalcEventService(ecalc_events=events)
+
+    def test_get_event_by_name_found(self):
+        service = self._make_service()
+        event = service.get_event_by_name("EVENT_1")
+        assert event is not None
+        assert event.name == "EVENT_1"
+        assert event.start == datetime(2025, 1, 1)
+
+    def test_get_event_by_name_not_found(self):
+        service = self._make_service()
+        assert service.get_event_by_name("NONEXISTENT") is None
+
+    def test_get_event_by_process_name_found(self):
+        service = self._make_service()
+        event = service.get_event_by_process_name("PE_A")
+        assert event is not None
+        assert event.name == "EVENT_1"
+
+    def test_get_event_by_process_name_second_event(self):
+        service = self._make_service()
+        event = service.get_event_by_process_name("PE_C")
+        assert event is not None
+        assert event.name == "EVENT_2"
+        assert event.start == datetime(2028, 6, 1)
+
+    def test_get_event_by_process_name_not_found(self):
+        service = self._make_service()
+        assert service.get_event_by_process_name("NONEXISTENT") is None
+
+    def test_empty_service(self):
+        service = EcalcEventService(ecalc_events=[])
+        assert service.get_event_by_name("ANY") is None
+        assert service.get_event_by_process_name("ANY") is None

--- a/tests/libecalc/presentation/yaml/mappers/test_ecalc_event_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_ecalc_event_mapper.py
@@ -1,0 +1,148 @@
+from datetime import datetime
+
+import pytest
+
+from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
+from libecalc.ecalc_model.ecalc_event import (
+    EcalcEventType,
+    ProcessEventType,
+)
+from libecalc.presentation.yaml.mappers.ecalc_event_mapper import EcalcEventMapper
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
+    YamlEcalcEvent,
+    YamlProcessEvent,
+)
+
+
+def _yaml_ecalc_event(
+    name: str = "HIGH_RATE_EVENT",
+    event_type: EcalcEventType = EcalcEventType.TIE_IN,
+    start: datetime = datetime(2025, 1, 1),
+    description: str | None = "Test event",
+) -> YamlEcalcEvent:
+    return YamlEcalcEvent(type=event_type, start=start, name=name, description=description)
+
+
+def _yaml_process_event(
+    name: str = "COMPRESSOR_REBUNDLE",
+    event_type: ProcessEventType = ProcessEventType.INCREASED_GAS_RATE,
+    ref: str = "HIGH_RATE_EVENT",
+    description: str | None = "Increased gas rate event",
+) -> YamlProcessEvent:
+    return YamlProcessEvent(type=event_type, name=name, description=description, ref=ref)
+
+
+class TestEcalcEventMapper:
+    def test_maps_single_ecalc_event_without_process_events(self):
+        mapper = EcalcEventMapper()
+        ecalc_events = mapper.map_events(
+            yaml_ecalc_events=[_yaml_ecalc_event()],
+            yaml_process_events=[],
+        )
+
+        assert len(ecalc_events) == 1
+        event = ecalc_events[0]
+        assert event.name == "HIGH_RATE_EVENT"
+        assert event.type == EcalcEventType.TIE_IN
+        assert event.start == datetime(2025, 1, 1)
+        assert event.description == "Test event"
+        assert event.process_events == []
+
+    def test_maps_ecalc_event_with_nested_process_events(self):
+        mapper = EcalcEventMapper()
+        ecalc_events = mapper.map_events(
+            yaml_ecalc_events=[_yaml_ecalc_event()],
+            yaml_process_events=[_yaml_process_event()],
+        )
+
+        assert len(ecalc_events) == 1
+        event = ecalc_events[0]
+        assert len(event.process_events) == 1
+
+        pe = event.process_events[0]
+        assert pe.name == "COMPRESSOR_REBUNDLE"
+        assert pe.type == ProcessEventType.INCREASED_GAS_RATE
+        assert pe.description == "Increased gas rate event"
+
+    def test_maps_multiple_process_events_to_same_ecalc_event(self):
+        mapper = EcalcEventMapper()
+        ecalc_events = mapper.map_events(
+            yaml_ecalc_events=[_yaml_ecalc_event(name="PHASE_2")],
+            yaml_process_events=[
+                _yaml_process_event(name="PE_A", ref="PHASE_2"),
+                _yaml_process_event(name="PE_B", ref="PHASE_2", event_type=ProcessEventType.INCREASED_WATER_INJECTION),
+            ],
+        )
+
+        assert len(ecalc_events) == 1
+        assert len(ecalc_events[0].process_events) == 2
+        assert ecalc_events[0].process_events[0].name == "PE_A"
+        assert ecalc_events[0].process_events[1].name == "PE_B"
+        assert ecalc_events[0].process_events[1].type == ProcessEventType.INCREASED_WATER_INJECTION
+
+    def test_maps_multiple_ecalc_events_with_distributed_process_events(self):
+        mapper = EcalcEventMapper()
+        ecalc_events = mapper.map_events(
+            yaml_ecalc_events=[
+                _yaml_ecalc_event(name="EVENT_1", start=datetime(2025, 1, 1)),
+                _yaml_ecalc_event(name="EVENT_2", start=datetime(2028, 6, 1)),
+            ],
+            yaml_process_events=[
+                _yaml_process_event(name="PE_FOR_1", ref="EVENT_1"),
+                _yaml_process_event(name="PE_FOR_2", ref="EVENT_2"),
+            ],
+        )
+
+        assert len(ecalc_events) == 2
+        assert ecalc_events[0].name == "EVENT_1"
+        assert len(ecalc_events[0].process_events) == 1
+        assert ecalc_events[0].process_events[0].name == "PE_FOR_1"
+
+        assert ecalc_events[1].name == "EVENT_2"
+        assert len(ecalc_events[1].process_events) == 1
+        assert ecalc_events[1].process_events[0].name == "PE_FOR_2"
+
+    def test_empty_events_returns_empty_list(self):
+        mapper = EcalcEventMapper()
+        ecalc_events = mapper.map_events(yaml_ecalc_events=[], yaml_process_events=[])
+        assert ecalc_events == []
+
+    def test_description_is_optional(self):
+        mapper = EcalcEventMapper()
+        events = mapper.map_events(
+            yaml_ecalc_events=[_yaml_ecalc_event(description=None)],
+            yaml_process_events=[_yaml_process_event(description=None)],
+        )
+
+        assert events[0].description is None
+        assert events[0].process_events[0].description is None
+
+    def test_duplicate_ecalc_event_name_raises(self):
+        mapper = EcalcEventMapper()
+        with pytest.raises(EcalcValidationException, match="Duplicate ECALC_EVENT name 'SAME_NAME'"):
+            mapper.map_events(
+                yaml_ecalc_events=[
+                    _yaml_ecalc_event(name="SAME_NAME"),
+                    _yaml_ecalc_event(name="SAME_NAME"),
+                ],
+                yaml_process_events=[],
+            )
+
+    def test_process_event_referencing_nonexistent_ecalc_event_raises(self):
+        mapper = EcalcEventMapper()
+        with pytest.raises(EcalcValidationException, match="does not exist"):
+            mapper.map_events(
+                yaml_ecalc_events=[_yaml_ecalc_event(name="EXISTING")],
+                yaml_process_events=[_yaml_process_event(ref="NONEXISTENT")],
+            )
+
+    def test_process_event_error_message_lists_available_events(self):
+        mapper = EcalcEventMapper()
+        with pytest.raises(EcalcValidationException, match="Available: EVENT_A, EVENT_B"):
+            mapper.map_events(
+                yaml_ecalc_events=[
+                    _yaml_ecalc_event(name="EVENT_A"),
+                    _yaml_ecalc_event(name="EVENT_B"),
+                ],
+                yaml_process_events=[_yaml_process_event(ref="WRONG_REF")],
+            )


### PR DESCRIPTION
We also need to handle events separate from when referign to them when e.g. doing a rebundle in a compressor. We want to handle them separately, for separate processing. Some refactoring along the way, to make the code cleaner and more testable.

## Type of Work

- [x] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
