### PR TITLE
fix(libecalc): improve validation of pressures set to zero

### DIFF
--- a/src/libecalc/common/errors/ecalc_validation_error.py
+++ b/src/libecalc/common/errors/ecalc_validation_error.py
@@ -27,6 +27,10 @@ class ProcessPressureRatioValidationException(EcalcValidationException):
     pass
 
 
+class ProcessNonPositivePressureValidationException(EcalcValidationException):
+    pass
+
+
 class ProcessDischargePressureValidationException(EcalcValidationException):
     pass
 

--- a/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/consumer_function_mapper.py
@@ -10,6 +10,7 @@ from libecalc.common.consumption_type import ConsumptionType
 from libecalc.common.energy_usage_type import EnergyUsageType
 from libecalc.common.errors.ecalc_validation_error import (
     EcalcValidationException,
+    ProcessNonPositivePressureValidationException,
     ProcessPressureRatioValidationException,
 )
 from libecalc.common.errors.exceptions import InvalidResourceException
@@ -220,7 +221,7 @@ def map_rate_fractions(
     ]
 
 
-def validate_increasing_pressure(
+def validate_pressures(
     suction_pressure: ExpressionTimeSeriesPressure,
     discharge_pressure: ExpressionTimeSeriesPressure,
     intermediate_pressure: ExpressionTimeSeriesPressure | None = None,
@@ -240,8 +241,20 @@ def validate_increasing_pressure(
         if validation_mask[i]:
             sp = suction_pressure_values[i]
             dp = discharge_pressure_values[i]
+            if sp <= 0:
+                raise ProcessNonPositivePressureValidationException(
+                    message=f"Invalid pressure at timestep {i + 1}: suction pressure ({sp}) is non-positive, which is not physically possible."
+                )
+            if dp <= 0:
+                raise ProcessNonPositivePressureValidationException(
+                    message=f"Invalid pressure at timestep {i + 1}: discharge pressure ({dp}) is non-positive, which is not physically possible."
+                )
             if intermediate_pressure_values is not None:
                 ip = intermediate_pressure_values[i]
+                if ip <= 0:
+                    raise ProcessNonPositivePressureValidationException(
+                        message=f"Invalid pressure at timestep {i + 1}: intermediate pressure ({ip}) is non-positive, which is not physically possible."
+                    )
                 if not (sp <= ip <= dp):
                     raise ProcessPressureRatioValidationException(
                         message=f"Invalid pressures at index {i + 1}: suction pressure ({sp}) must be less than intermediate pressure ({ip}), which must be less than discharge pressure ({dp})."
@@ -1123,7 +1136,7 @@ class ConsumerFunctionMapper:
             validation_mask=pressure_validation_mask,
         )
 
-        validate_increasing_pressure(
+        validate_pressures(
             suction_pressure=suction_pressure,
             discharge_pressure=discharge_pressure,
         )
@@ -1211,7 +1224,7 @@ class ConsumerFunctionMapper:
             else None
         )
 
-        validate_increasing_pressure(
+        validate_pressures(
             suction_pressure=suction_pressure,
             discharge_pressure=discharge_pressure,
             intermediate_pressure=interstage_control_pressure,
@@ -1280,7 +1293,7 @@ class ConsumerFunctionMapper:
                 ),
                 validation_mask=validation_mask,
             )
-            if model.suction_pressure
+            if model.suction_pressure is not None
             else None
         )
 
@@ -1291,7 +1304,7 @@ class ConsumerFunctionMapper:
                 ),
                 validation_mask=validation_mask,
             )
-            if model.discharge_pressure
+            if model.discharge_pressure is not None
             else None
         )
         operational_data = CompressorOperationalTimeSeries.from_time_series(
@@ -1309,7 +1322,7 @@ class ConsumerFunctionMapper:
             raise InvalidConsumptionType(actual=consumption_type, expected=consumes)
 
         if suction_pressure is not None and discharge_pressure is not None:
-            validate_increasing_pressure(
+            validate_pressures(
                 suction_pressure=suction_pressure,
                 discharge_pressure=discharge_pressure,
             )
@@ -1453,7 +1466,7 @@ class ConsumerFunctionMapper:
                 ]
 
             for suction_pressure, discharge_pressure in zip(suction_pressures, discharge_pressures):
-                validate_increasing_pressure(
+                validate_pressures(
                     suction_pressure=suction_pressure,
                     discharge_pressure=discharge_pressure,
                 )
@@ -1615,7 +1628,7 @@ class ConsumerFunctionMapper:
                 ] * number_of_pumps
 
             for suction_pressure, discharge_pressure in zip(suction_pressures, discharge_pressures):
-                validate_increasing_pressure(
+                validate_pressures(
                     suction_pressure=suction_pressure,
                     discharge_pressure=discharge_pressure,
                 )

--- a/tests/libecalc/presentation/yaml/domain/test_time_series_pressure.py
+++ b/tests/libecalc/presentation/yaml/domain/test_time_series_pressure.py
@@ -9,7 +9,7 @@ from libecalc.presentation.yaml.domain.expression_time_series_pressure import (
     InvalidPressureException,
 )
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
-from libecalc.presentation.yaml.mappers.consumer_function_mapper import validate_increasing_pressure
+from libecalc.presentation.yaml.mappers.consumer_function_mapper import validate_pressures
 
 periods = [
     Period(start=datetime(2020, 1, 1), end=datetime(2021, 1, 1)),
@@ -44,7 +44,7 @@ def test_expressions_with_pressure_ratio_less_than_one(expression_evaluator_fact
     )
 
     with pytest.raises(ProcessPressureRatioValidationException):
-        validate_increasing_pressure(
+        validate_pressures(
             suction_pressure=ExpressionTimeSeriesPressure(
                 time_series_expression=TimeSeriesExpression(expression="SIM1;PS", expression_evaluator=evaluator)
             ),
@@ -54,7 +54,7 @@ def test_expressions_with_pressure_ratio_less_than_one(expression_evaluator_fact
         )
 
     with pytest.raises(ProcessPressureRatioValidationException):
-        validate_increasing_pressure(
+        validate_pressures(
             suction_pressure=ExpressionTimeSeriesPressure(
                 time_series_expression=TimeSeriesExpression(expression="SIM1;PS", expression_evaluator=evaluator)
             ),


### PR DESCRIPTION
 Today it is common among ecalc operators to set the rate (and often also pressures) to zero when a consumer should be switched off. At some point in the (not too distant) future, this will change - such that a consumer can be started and stopped in some other way.

The situation today is that it does not really matter what the pressure is when the rate is 0. No calculation will be performed. The code, however, currently treats a zero pressure as missing (None) - and an assert statement fails, due to pressure being required to be defined.

This PR changes the validation of pressures slightly such that the pressure is also required to be positive, but only if the rate is positive. If rate is non-positive, the pressure can be any number. 


## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
