### PR TITLE
chore: only run hooks on pre-commit unless specified

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 auto_update:
   cooldown_days: 3
 
+default_stages:
+  - "pre-commit"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0


### PR DESCRIPTION
Without a default stage all hooks will also run on commit-msg