### PR TITLE
fix(libecalc): catch InsufficientInletPressureError in finders

### DIFF
--- a/src/libecalc/process/process_solver/finders/choke_delta_pressure_finders.py
+++ b/src/libecalc/process/process_solver/finders/choke_delta_pressure_finders.py
@@ -2,13 +2,14 @@ from collections.abc import Callable
 
 from libecalc.domain.process.compressor.core.train.utils.common import PRESSURE_CALCULATION_TOLERANCE
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import CompressorStonewallError
+from libecalc.process.process_pipeline.process_error import CompressorStonewallError, InsufficientInletPressureError
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import ChokeConfiguration
 from libecalc.process.process_solver.finder import Finder, Finding
 from libecalc.process.process_solver.search_strategies import RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     CompressorStonewallFailure,
+    InsufficientInletPressureFailure,
     TargetDirection,
     TargetPressureUnreachableFailure,
 )
@@ -38,21 +39,22 @@ class UpstreamChokeDeltaPressureFinder(Finder):
 
         # Upstream choking increase the rate (lower pressure, higher volume)
         # If we choke too much, to rate will exceed the capacity / stonewall
-        # If so, bisect to the highest ΔP that doesn't exceed stonewall
-        stonewall_error: CompressorStonewallError | None = None
+        # or downstream pressure drop becomes infeasible.
+        # If so, bisect to the highest ΔP that doesn't exceed capacity.
+        capacity_error: CompressorStonewallError | InsufficientInletPressureError | None = None
         try:
             outlet_pressure(self._boundary.max)
             search_max = self._boundary.max
-        except CompressorStonewallError as e:
-            stonewall_error = e
+        except (CompressorStonewallError, InsufficientInletPressureError) as e:
+            capacity_error = e
             lo, hi = self._boundary.min, self._boundary.max
             while hi - lo > PRESSURE_CALCULATION_TOLERANCE:
                 mid = (lo + hi) / 2
                 try:
                     outlet_pressure(mid)
                     lo = mid
-                except CompressorStonewallError as bisect_error:
-                    stonewall_error = bisect_error
+                except (CompressorStonewallError, InsufficientInletPressureError) as bisect_error:
+                    capacity_error = bisect_error
                     hi = mid
             search_max = lo
 
@@ -60,8 +62,15 @@ class UpstreamChokeDeltaPressureFinder(Finder):
         closest = ChokeConfiguration(delta_pressure=search_max)
 
         if max_pressure > self._target_pressure:
-            if stonewall_error is not None:
-                return Finding(configuration=closest, failure=CompressorStonewallFailure.from_error(stonewall_error))
+            if capacity_error is not None:
+                if isinstance(capacity_error, CompressorStonewallError):
+                    return Finding(configuration=closest, failure=CompressorStonewallFailure.from_error(capacity_error))
+                if isinstance(capacity_error, InsufficientInletPressureError):
+                    return Finding(
+                        configuration=closest,
+                        failure=InsufficientInletPressureFailure.from_error(capacity_error),
+                    )
+                raise capacity_error
             return Finding(
                 configuration=closest,
                 failure=TargetPressureUnreachableFailure(

--- a/src/libecalc/process/process_solver/finders/recirculation_loop_rate_finder.py
+++ b/src/libecalc/process/process_solver/finders/recirculation_loop_rate_finder.py
@@ -2,7 +2,11 @@ from collections.abc import Callable
 from typing import Literal
 
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import CompressorStonewallError, CompressorSurgeError
+from libecalc.process.process_pipeline.process_error import (
+    CompressorStonewallError,
+    CompressorSurgeError,
+    InsufficientInletPressureError,
+)
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import RecirculationConfiguration
 from libecalc.process.process_solver.finder import Finder, Finding
@@ -10,6 +14,7 @@ from libecalc.process.process_solver.float_constraint import FloatConstraint
 from libecalc.process.process_solver.search_strategies import Bisect, BisectResult, RootFindingStrategy
 from libecalc.process.process_solver.solver import (
     CompressorStonewallFailure,
+    InsufficientInletPressureFailure,
     TargetDirection,
     TargetPressureUnreachableFailure,
 )
@@ -36,6 +41,12 @@ class RecirculationLoopRateFinder(Finder):
             return Finding(
                 configuration=RecirculationConfiguration(recirculation_rate=self._recirculation_rate_boundary.min),
                 failure=CompressorStonewallFailure.from_error(e),
+            )
+        except InsufficientInletPressureError as e:
+            # Pressure infeasible at minimum recirculation; adding more flow won't fix pressure.
+            return Finding(
+                configuration=RecirculationConfiguration(recirculation_rate=self._recirculation_rate_boundary.min),
+                failure=InsufficientInletPressureFailure.from_error(e),
             )
 
         target_pressure = self._target_pressure
@@ -126,5 +137,5 @@ class RecirculationLoopRateFinder(Finder):
             return BisectResult(higher=mode != "minimize", accepted=True)
         except CompressorSurgeError:
             return BisectResult(higher=True, accepted=False)
-        except CompressorStonewallError:
+        except (CompressorStonewallError, InsufficientInletPressureError):
             return BisectResult(higher=False, accepted=False)

--- a/src/libecalc/process/process_solver/finders/shaft_speed_finder.py
+++ b/src/libecalc/process/process_solver/finders/shaft_speed_finder.py
@@ -3,7 +3,11 @@ from collections.abc import Callable
 
 from libecalc.domain.process.compressor.core.exceptions import CompressorThermodynamicCalculationError
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
-from libecalc.process.process_pipeline.process_error import CompressorStonewallError, CompressorSurgeError
+from libecalc.process.process_pipeline.process_error import (
+    CompressorStonewallError,
+    CompressorSurgeError,
+    InsufficientInletPressureError,
+)
 from libecalc.process.process_solver.boundary import Boundary
 from libecalc.process.process_solver.configuration import SpeedConfiguration
 from libecalc.process.process_solver.finder import Finder, Finding
@@ -11,6 +15,7 @@ from libecalc.process.process_solver.search_strategies import Bisect, BisectResu
 from libecalc.process.process_solver.solver import (
     CompressorStonewallFailure,
     CompressorSurgeFailure,
+    InsufficientInletPressureFailure,
     TargetDirection,
     TargetPressureUnreachableFailure,
     ThermodynamicCalculationFailure,
@@ -60,6 +65,12 @@ class ShaftSpeedFinder(Finder[SpeedConfiguration]):
                 boundary=Boundary(min=self._boundary.min, max=valid_max),
                 target_pressure=self._target_pressure,
             ).find(func)
+        except InsufficientInletPressureError as e:
+            logger.debug(f"Insufficient inlet pressure at maximum speed: {max_speed_configuration}")
+            return Finding(
+                configuration=max_speed_configuration,
+                failure=InsufficientInletPressureFailure.from_error(e),
+            )
 
         if maximum_speed_outlet_stream.pressure_bara < self._target_pressure:
             return Finding(
@@ -81,6 +92,13 @@ class ShaftSpeedFinder(Finder[SpeedConfiguration]):
             min_config = SpeedConfiguration(speed=self._boundary.min)
             logger.debug(f"No solution found for minimum speed: {min_config}")
             return Finding(configuration=min_config, failure=CompressorStonewallFailure.from_error(e))
+        except InsufficientInletPressureError as e:
+            min_config = SpeedConfiguration(speed=self._boundary.min)
+            logger.debug(f"Insufficient inlet pressure at minimum speed: {min_config}")
+            return Finding(
+                configuration=min_config,
+                failure=InsufficientInletPressureFailure.from_error(e),
+            )
 
         if minimum_speed_outlet_stream.pressure_bara > self._target_pressure:
             return Finding(
@@ -116,7 +134,12 @@ class ShaftSpeedFinder(Finder[SpeedConfiguration]):
         try:
             func(SpeedConfiguration(speed=speed))
             return True
-        except (CompressorThermodynamicCalculationError, CompressorStonewallError, CompressorSurgeError):
+        except (
+            CompressorThermodynamicCalculationError,
+            CompressorStonewallError,
+            CompressorSurgeError,
+            InsufficientInletPressureError,
+        ):
             return False
 
     def _find_min_within_capacity_speed(
@@ -124,22 +147,27 @@ class ShaftSpeedFinder(Finder[SpeedConfiguration]):
     ) -> tuple[SpeedConfiguration, FluidStream]:
         """Return the lowest speed configuration within flow capacity, and its outlet stream.
 
-        ``CompressorStonewallError`` and ``CompressorThermodynamicCalculationError`` at the boundary
-        minimum are recoverable: higher speed raises the stonewall limit or enters the valid
-        EOS range; search upward.
+        ``CompressorStonewallError``, ``CompressorThermodynamicCalculationError``, and
+        ``InsufficientInletPressureError`` at the boundary minimum are recoverable:
+        higher speed raises the stonewall limit or enters the valid EOS/pressure range;
+        search upward.
         """
         minimum_speed_configuration = SpeedConfiguration(speed=self._boundary.min)
         try:
             minimum_result = func(minimum_speed_configuration)
             return minimum_speed_configuration, minimum_result
-        except (CompressorStonewallError, CompressorThermodynamicCalculationError) as e:
+        except (CompressorStonewallError, CompressorThermodynamicCalculationError, InsufficientInletPressureError) as e:
             logger.debug(f"No solution found for minimum speed: {self._boundary.min}", exc_info=e)
 
             def bool_speed_func(x: float) -> BisectResult:
                 try:
                     func(SpeedConfiguration(speed=x))
                     return BisectResult(higher=False, accepted=True)
-                except (CompressorStonewallError, CompressorThermodynamicCalculationError):
+                except (
+                    CompressorStonewallError,
+                    CompressorThermodynamicCalculationError,
+                    InsufficientInletPressureError,
+                ):
                     return BisectResult(higher=True, accepted=False)
                 except CompressorSurgeError:
                     return BisectResult(higher=False, accepted=False)

--- a/src/libecalc/process/process_solver/pipeline_section_solver.py
+++ b/src/libecalc/process/process_solver/pipeline_section_solver.py
@@ -18,6 +18,7 @@ from libecalc.process.process_solver.solver import (
     CompressorStonewallFailure,
     CompressorSurgeFailure,
     ConvergenceFailure,
+    InsufficientInletPressureFailure,
     Solution,
     TargetDirection,
     TargetPressureUnreachableFailure,
@@ -112,7 +113,13 @@ class PipelineSectionSolver(PipelineSolver):
         )
 
         if isinstance(
-            speed_finding.failure, (CompressorStonewallFailure, CompressorSurgeFailure, ThermodynamicCalculationFailure)
+            speed_finding.failure,
+            (
+                CompressorStonewallFailure,
+                CompressorSurgeFailure,
+                ThermodynamicCalculationFailure,
+                InsufficientInletPressureFailure,
+            ),
         ):
             return Solution(configuration=[shaft_config], failure=speed_finding.failure)
 

--- a/src/libecalc/process/process_solver/solver.py
+++ b/src/libecalc/process/process_solver/solver.py
@@ -107,6 +107,14 @@ class InsufficientInletPressureFailure(SolverFailure):
     inlet_pressure_bara: float | None = None
     required_delta_pressure_bara: float | None = None
 
+    @classmethod
+    def from_error(cls, e: InsufficientInletPressureError) -> Self:
+        return cls(
+            process_unit_id=e.process_unit_id,
+            inlet_pressure_bara=e.inlet_pressure_bara,
+            required_delta_pressure_bara=e.required_delta_pressure_bara,
+        )
+
 
 @dataclass
 class OfftakeExceedsInletFailure(SolverFailure):
@@ -131,11 +139,7 @@ def process_error_to_failure(e: ProcessError) -> SolverFailure:
             process_unit_id=e.process_unit_id, available_rate=e.available_rate, offtake_rate=e.offtake_rate
         )
     if isinstance(e, InsufficientInletPressureError):
-        return InsufficientInletPressureFailure(
-            process_unit_id=e.process_unit_id,
-            inlet_pressure_bara=e.inlet_pressure_bara,
-            required_delta_pressure_bara=e.required_delta_pressure_bara,
-        )
+        return InsufficientInletPressureFailure.from_error(e)
     if isinstance(e, CompressorThermodynamicCalculationError):
         return ThermodynamicCalculationFailure(reason=str(e))
     if isinstance(e, CompressorStonewallError):

--- a/tests/libecalc/process/process_solver/finders/test_insufficient_inlet_pressure.py
+++ b/tests/libecalc/process/process_solver/finders/test_insufficient_inlet_pressure.py
@@ -1,0 +1,36 @@
+"""Regression: InsufficientInletPressureError must not crash finders."""
+
+from libecalc.process.process_pipeline.process_error import InsufficientInletPressureError
+from libecalc.process.process_pipeline.process_unit import ProcessUnit
+from libecalc.process.process_solver.boundary import Boundary
+from libecalc.process.process_solver.finders.shaft_speed_finder import ShaftSpeedFinder, SpeedConfiguration
+from libecalc.process.process_solver.solver import InsufficientInletPressureFailure
+
+DROPPER_ID = ProcessUnit._create_id()
+
+
+def test_shaft_speed_finder_catches_insufficient_inlet_pressure(
+    search_strategy_factory,
+    root_finding_strategy,
+):
+    """ShaftSpeedFinder returns a failure when func raises InsufficientInletPressureError."""
+
+    def func(_config: SpeedConfiguration):
+        raise InsufficientInletPressureError(
+            process_unit_id=DROPPER_ID,
+            inlet_pressure_bara=25.0,
+            required_delta_pressure_bara=75.0,
+        )
+
+    finder = ShaftSpeedFinder(
+        search_strategy=search_strategy_factory(tolerance=1.0),
+        root_finding_strategy=root_finding_strategy,
+        boundary=Boundary(min=50, max=100),
+        target_pressure=40.0,
+    )
+
+    finding = finder.find(func)
+
+    assert finding.failure is not None
+    assert isinstance(finding.failure, InsufficientInletPressureFailure)
+    assert finding.failure.process_unit_id == DROPPER_ID


### PR DESCRIPTION
When equinor/ecalc#1576 was closed, it was overlooked that the finder-level error handling had not made it to main. The rest of that PR's content is already included in main.