### PR TITLE
fix: clarify difference between instance and definition references

### DIFF
--- a/src/libecalc/presentation/yaml/domain/reference_service.py
+++ b/src/libecalc/presentation/yaml/domain/reference_service.py
@@ -25,7 +25,7 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_trains import 
     YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnitDefinition
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 
 
@@ -80,7 +80,7 @@ class ReferenceService(Protocol):
     def get_process_pipeline(self, reference: str) -> YamlProcessPipeline: ...
 
     @abc.abstractmethod
-    def get_process_unit(self, reference: str) -> YamlProcessUnit: ...
+    def get_process_unit(self, reference: str) -> YamlProcessUnitDefinition: ...
 
     @abc.abstractmethod
     def get_stream(self, reference: str) -> YamlInletStream: ...

--- a/src/libecalc/presentation/yaml/mappers/process/build_sections.py
+++ b/src/libecalc/presentation/yaml/mappers/process/build_sections.py
@@ -3,7 +3,7 @@ from libecalc.presentation.yaml.mappers.process.process_partitioner import (
     MappedSection,
     ProcessPartitioner,
 )
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import InstanceReference
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessConstraint
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
@@ -25,7 +25,7 @@ class ProcessSectionBuilder:
     def partition_and_validate(
         self,
         process_unit_map: dict[ProcessUnitId, ProcessUnit],
-        unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
+        unit_name_to_id: dict[InstanceReference, ProcessUnitId],
         pipeline_constraints: list[YamlProcessConstraint],
     ) -> list[MappedSection]:
         sections = self._partitioner.partition(

--- a/src/libecalc/presentation/yaml/mappers/process/process_partitioner.py
+++ b/src/libecalc/presentation/yaml/mappers/process/process_partitioner.py
@@ -1,6 +1,6 @@
 from libecalc.common.ddd import value_object
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import InstanceReference
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessConstraint
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 from libecalc.process.process_units.compressor import Compressor
@@ -27,7 +27,7 @@ class ProcessPartitioner:
     @staticmethod
     def partition(
         process_unit_map: dict[ProcessUnitId, ProcessUnit],
-        unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
+        unit_name_to_id: dict[InstanceReference, ProcessUnitId],
         pipeline_constraints: list[YamlProcessConstraint],
     ) -> list[MappedSection]:
         process_units = list(process_unit_map.values())

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -45,20 +45,20 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import 
 from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import YamlCompositionFluidModel, YamlPredefinedFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
-    ProcessUnitReference,
+    InstanceReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlProcessSimulation,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
-    YamlCompressor,
+    YamlCompressorDefinition,
     YamlCompressorModelChart,
-    YamlLiquidRemover,
-    YamlMixer,
-    YamlPressureDropper,
-    YamlProcessUnit,
-    YamlSplitter,
-    YamlTemperatureSetter,
+    YamlLiquidRemoverDefinition,
+    YamlMixerDefinition,
+    YamlPressureDropperDefinition,
+    YamlProcessUnitDefinition,
+    YamlSplitterDefinition,
+    YamlTemperatureSetterDefinition,
 )
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream, YamlInletStreamRate
 from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import YamlFile
@@ -132,7 +132,7 @@ class ProcessSimulationMapper:
         self._resources = resources
         self._ecalc_event_service = ecalc_event_service
 
-    def _resolve_train_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
+    def _resolve_pipeline_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
         if isinstance(ref, str):
             return self._reference_service.get_process_pipeline(reference=ref)
         else:
@@ -173,7 +173,7 @@ class ProcessSimulationMapper:
                 yaml_curves, units=yaml_chart.units, control_margin=control_margin_fraction
             )
 
-    def _get_compressor(self, yaml_compressor: YamlCompressor) -> Compressor:
+    def _get_compressor(self, yaml_compressor: YamlCompressorDefinition) -> Compressor:
         chart: ChartData = self._get_compressor_chart(yaml_compressor_model_chart=yaml_compressor.compressor_model)
         return Compressor(
             compressor_chart=chart,
@@ -247,7 +247,7 @@ class ProcessSimulationMapper:
     def _validate_and_map_pipeline_events(
         self,
         yaml_pipeline: YamlProcessPipeline,
-        unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
+        unit_name_to_id: dict[InstanceReference, ProcessUnitId],
     ) -> list[PipelineEvent]:
         """Validate pipeline event references and map to domain objects."""
         events: list[PipelineEvent] = []
@@ -265,7 +265,7 @@ class ProcessSimulationMapper:
                 ) from None
 
             match change_to_yaml_process_unit:
-                case YamlCompressor():
+                case YamlCompressorDefinition():
                     change_to_unit = self._get_compressor(change_to_yaml_process_unit)
                 case _:
                     raise EcalcValidationException(
@@ -307,10 +307,10 @@ class ProcessSimulationMapper:
         for yaml_compressor_train_item in yaml_process_simulation.targets:
             problem_configuration_handlers = []
             shaft = VariableSpeedShaft()
-            item = self._resolve_train_reference(yaml_compressor_train_item.target)
+            item = self._resolve_pipeline_reference(yaml_compressor_train_item)
             process_unit_map: dict[ProcessUnitId, ProcessUnit] = {}
             compressor_ids: list[ProcessUnitId] = []
-            unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId] = {}
+            unit_name_to_id: dict[InstanceReference, ProcessUnitId] = {}
             problem_time_series_configurations: dict[
                 ProcessUnitId,
                 TimeSeriesTemperatureSetterConfiguration
@@ -319,33 +319,33 @@ class ProcessSimulationMapper:
                 | TimeSeriesSplitterConfiguration,
             ] = {}
 
-            for yaml_pipeline_item in item.items:
+            for yaml_pipeline_item in item.process_units:
                 yaml_process_unit = yaml_pipeline_item.target
                 process_unit_name = yaml_pipeline_item.name
                 if isinstance(yaml_process_unit, str):
                     yaml_process_unit = self._reference_service.get_process_unit(yaml_process_unit)
 
                 match yaml_process_unit:
-                    case YamlCompressor():
+                    case YamlCompressorDefinition():
                         unit = self._get_compressor(yaml_process_unit)
                         compressor_ids.append(unit.get_id())
 
-                    case YamlPressureDropper():
+                    case YamlPressureDropperDefinition():
                         unit = PressureDropper(fluid_service=self._fluid_service)
                         problem_time_series_configurations[unit.get_id()] = TimeSeriesPressureDropperConfiguration(
                             pressure_drop_in_bara=self._map_pressure(yaml_process_unit.pressure_drop)
                         )
 
-                    case YamlTemperatureSetter():
+                    case YamlTemperatureSetterDefinition():
                         unit = TemperatureSetter(fluid_service=self._fluid_service)
                         problem_time_series_configurations[unit.get_id()] = TimeSeriesTemperatureSetterConfiguration(
                             temperature_in_celsius=self._map_temperature(yaml_process_unit.temperature)
                         )
 
-                    case YamlLiquidRemover():
+                    case YamlLiquidRemoverDefinition():
                         unit = LiquidRemover(fluid_service=self._fluid_service)
 
-                    case YamlMixer():
+                    case YamlMixerDefinition():
                         yaml_stream = self._resolve_stream_reference(yaml_process_unit.sidestream)
                         yaml_fluid_model = self._resolve_fluid_model_reference(yaml_stream.fluid_model)
                         unit = Mixer(fluid_service=self._fluid_service)
@@ -358,7 +358,7 @@ class ProcessSimulationMapper:
                             )
                         )
 
-                    case YamlSplitter():
+                    case YamlSplitterDefinition():
                         unit = Splitter(fluid_service=self._fluid_service)
                         problem_time_series_configurations[unit.get_id()] = TimeSeriesSplitterConfiguration(
                             offtake_rate=self._map_rate(yaml_process_unit.offtake_rate),
@@ -367,7 +367,7 @@ class ProcessSimulationMapper:
                     case _:
                         # Unreachable for valid YAML (pydantic discriminator rejects unknown types).
                         # Guards against bypassed parsing or new union variants missing a case.
-                        allowed_types = [t.__name__ for t in get_args(get_args(YamlProcessUnit)[0])]
+                        allowed_types = [t.__name__ for t in get_args(get_args(YamlProcessUnitDefinition)[0])]
                         raise EcalcValidationException(
                             f"Process unit of type '{type(yaml_process_unit).__name__}' is not allowed "
                             f"in a process pipeline. Allowed types are: {', '.join(allowed_types)}."

--- a/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
@@ -38,7 +38,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation impor
     YamlProcessSimulation,
     YamlPumpProcessSimulation,
 )
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnitDefinition
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import YamlTimeSeriesCollection
 from libecalc.presentation.yaml.yaml_types.yaml_default_datetime import YamlDefaultDatetime
@@ -451,13 +451,13 @@ class PyYamlYamlModel(YamlValidator, YamlConfiguration):
         return fluid_models
 
     @property
-    def process_units(self) -> dict[str, YamlProcessUnit]:
-        process_units: dict[str, YamlProcessUnit] = {}
+    def process_units(self) -> dict[str, YamlProcessUnitDefinition]:
+        process_units: dict[str, YamlProcessUnitDefinition] = {}
         raw = self._get_yaml_dict_or_empty(_PROCESS_UNITS_KEY)
 
         for name, unit_data in raw.items():
             try:
-                process_units[name] = TypeAdapter(YamlProcessUnit).validate_python(unit_data)
+                process_units[name] = TypeAdapter(YamlProcessUnitDefinition).validate_python(unit_data)
             except PydanticValidationError:
                 pass
         return process_units

--- a/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/yaml_model.py
@@ -23,7 +23,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation impor
     YamlProcessSimulation,
     YamlPumpProcessSimulation,
 )
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnitDefinition
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import (
     YamlTimeSeriesCollection,
@@ -90,7 +90,7 @@ class YamlValidator(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def process_units(self) -> dict[str, YamlProcessUnit]:
+    def process_units(self) -> dict[str, YamlProcessUnitDefinition]:
         pass
 
     @property

--- a/src/libecalc/presentation/yaml/yaml_reference_service.py
+++ b/src/libecalc/presentation/yaml/yaml_reference_service.py
@@ -30,7 +30,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation impor
     YamlProcessSimulation,
     YamlPumpProcessSimulation,
 )
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnitDefinition
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 
 logger = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ ReferenceType = (
     | YamlProcessPipeline
     | YamlProcessSimulation
     | YamlPumpProcessSimulation
-    | YamlProcessUnit
+    | YamlProcessUnitDefinition
 )
 
 # Some models are referenced by other models, for example a compressor model will reference compressor chart models
@@ -218,8 +218,8 @@ class YamlReferenceService(ReferenceService):
             raise InvalidReferenceException("stream", reference)
         return model
 
-    def get_process_unit(self, reference: str) -> YamlProcessUnit:
+    def get_process_unit(self, reference: str) -> YamlProcessUnitDefinition:
         model = self._resolve_yaml_reference(reference, "process unit")
-        if not isinstance(model, get_args(get_args(YamlProcessUnit)[0])):
+        if not isinstance(model, get_args(get_args(YamlProcessUnitDefinition)[0])):
             raise InvalidReferenceException("process unit", reference)
         return model

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
@@ -14,7 +14,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation impor
     YamlProcessSimulation,
     YamlPumpProcessSimulation,
 )
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnitDefinition
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import YamlTimeSeriesCollection
 from libecalc.presentation.yaml.yaml_types.yaml_default_datetime import YamlDefaultDatetime
@@ -69,7 +69,7 @@ class YamlAsset(YamlBase):
         description="Defines variables used in an energy usage model by means of expressions or constants."
         "\n\n$ECALC_DOCS_KEYWORDS_URL/VARIABLES",
     )
-    process_units: dict[str, YamlProcessUnit] = Field(
+    process_units: dict[str, YamlProcessUnitDefinition] = Field(
         default_factory=dict,
         title="PROCESS_UNITS",
         description="Defines process units used in PROCESS_PIPELINES.",

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
@@ -1,23 +1,23 @@
 from enum import StrEnum
-from typing import Annotated, Literal, TypeVar
+from typing import Annotated, TypeVar
 
 from pydantic import Field
 
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
-    ProcessEventReference,
-    ProcessUnitReference,
+    DefinitionReference,
+    InstanceReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
-    YamlProcessUnit,
+    YamlProcessUnitDefinition,
 )
 
 TTarget = TypeVar("TTarget")
 
 
-class YamlItem[TTarget](YamlBase):
-    target: TTarget | ProcessUnitReference
-    name: str | None = None
+class YamlProcessUnitInstance[TTarget](YamlBase):
+    target: TTarget | DefinitionReference
+    name: InstanceReference | None = None
 
 
 class PipelineEventAction(StrEnum):
@@ -39,21 +39,21 @@ class YamlPipelineEvent(YamlBase):
         ),
     ]
     change_target: Annotated[
-        ProcessUnitReference,
+        InstanceReference,
         Field(
             title="CHANGE_TARGET",
             description="Name of the process unit in the pipeline to change.",
         ),
     ]
     change_from: Annotated[
-        ProcessUnitReference,
+        DefinitionReference,
         Field(
             title="CHANGE_FROM",
             description="Reference to the existing process unit template being replaced.",
         ),
     ]
     change_to: Annotated[
-        ProcessUnitReference,
+        DefinitionReference,
         Field(
             title="CHANGE_TO",
             description="Reference to the new process unit template to use.",
@@ -67,7 +67,7 @@ class YamlPipelineEvent(YamlBase):
         ),
     ]
     ref: Annotated[
-        ProcessEventReference,
+        InstanceReference,
         Field(
             title="REF",
             description="Reference to a PROCESS_EVENT by name.",
@@ -76,9 +76,8 @@ class YamlPipelineEvent(YamlBase):
 
 
 class YamlProcessPipeline(YamlBase):
-    type: Literal["SERIAL"]
-    name: str
-    items: list[YamlItem[YamlProcessUnit]]
+    name: InstanceReference
+    process_units: list[YamlProcessUnitInstance[YamlProcessUnitDefinition]]
     events: Annotated[
         list[YamlPipelineEvent],
         Field(

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
@@ -2,9 +2,5 @@
 Shared reference type aliases for YAML process types.
 """
 
-type StreamRef = str
-type ProcessPipelineReference = str  # TODO: validate correct reference
-type ProcessUnitReference = str
-type EcalcEventReference = str
-type ProcessEventReference = str
-type PumpChartReference = str
+type InstanceReference = str
+type DefinitionReference = str

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
@@ -5,15 +5,9 @@ from pydantic import Field
 from libecalc.ecalc_model.ecalc_event import EcalcEventType, ProcessEventType
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import (
-    YamlItem,
-    YamlProcessPipeline,
-)
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
-    EcalcEventReference,
-    ProcessPipelineReference,
-    ProcessUnitReference,
-    PumpChartReference,
+    DefinitionReference,
+    InstanceReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution import YamlStreamDistribution
 from libecalc.presentation.yaml.yaml_types.yaml_default_datetime import YamlDefaultDatetime
@@ -37,7 +31,7 @@ class YamlEcalcEvent(YamlBase):
         ),
     ]
     name: Annotated[
-        str,
+        InstanceReference,
         Field(
             title="NAME",
             description="Short identifier for the event.",
@@ -75,7 +69,7 @@ class YamlProcessEvent(YamlBase):
         ),
     ] = None
     ref: Annotated[
-        EcalcEventReference,
+        InstanceReference,
         Field(
             title="REF",
             description="Reference to a global ECALC_EVENT by name.",
@@ -85,7 +79,7 @@ class YamlProcessEvent(YamlBase):
 
 class YamlProcessConstraint(YamlBase):
     process_unit: Annotated[
-        ProcessUnitReference | None,
+        InstanceReference | None,
         Field(
             title="PROCESS_UNIT",
             description="Reference to a named unit within the pipeline. If omitted, the constraint applies to the last process unit in the pipeline section.",
@@ -117,12 +111,12 @@ class YamlProcessConstraint(YamlBase):
 class YamlProcessSimulation(YamlBase):
     name: str
     targets: Annotated[
-        list[YamlItem[YamlProcessPipeline]],
+        list[InstanceReference],
         Field(title="TARGETS"),
     ]
     stream_distribution: YamlStreamDistribution
     constraints: Annotated[
-        dict[ProcessPipelineReference, list[YamlProcessConstraint]],
+        dict[InstanceReference, list[YamlProcessConstraint]],
         Field(
             title="CONSTRAINTS",
             description="Constraints per target. Key is pipeline name, value is list of constraints.",
@@ -132,7 +126,7 @@ class YamlProcessSimulation(YamlBase):
 
 class YamlPumpProcessModel(YamlBase):
     chart: Annotated[
-        PumpChartReference,
+        DefinitionReference,
         Field(
             title="CHART",
             description="Reference to a pump chart defined in FACILITY_INPUTS.",

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_units.py
@@ -6,7 +6,7 @@ from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_chart import UnitsField, YamlCurve, YamlUnits
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
-from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution import StreamRef
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import InstanceReference
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream, YamlInletStreamRate
 from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import DataOrFile
 
@@ -30,7 +30,7 @@ class YamlCompressorModelChart(YamlBase):
     control_margin: YamlControlMargin
 
 
-class YamlCompressor(YamlBase):
+class YamlCompressorDefinition(YamlBase):
     """
     A Compressor process unit
     """
@@ -39,7 +39,7 @@ class YamlCompressor(YamlBase):
     compressor_model: YamlCompressorModelChart
 
 
-class YamlPressureDropper(YamlBase):
+class YamlPressureDropperDefinition(YamlBase):
     """A pressure dropper unit — reduces stream pressure by a fixed amount."""
 
     type: Literal["PRESSURE_DROPPER"]
@@ -52,7 +52,7 @@ class YamlPressureDropper(YamlBase):
     ]
 
 
-class YamlTemperatureSetter(YamlBase):
+class YamlTemperatureSetterDefinition(YamlBase):
     """A temperature setter unit — forces the stream to a specified temperature."""
 
     type: Literal["TEMPERATURE_SETTER"]
@@ -65,7 +65,7 @@ class YamlTemperatureSetter(YamlBase):
     ]
 
 
-class YamlLiquidRemover(YamlBase):
+class YamlLiquidRemoverDefinition(YamlBase):
     """A liquid remover (scrubber) unit — removes any condensed liquid from
     the stream, leaving only the gas phase.
 
@@ -75,13 +75,13 @@ class YamlLiquidRemover(YamlBase):
     type: Literal["LIQUID_REMOVER"]
 
 
-class YamlMixer(YamlBase):
+class YamlMixerDefinition(YamlBase):
     """Mixes an external sidestream into the through-stream at an
     intermediate point in the pipeline."""
 
     type: Literal["MIXER"]
     sidestream: Annotated[
-        StreamRef | YamlInletStream,
+        InstanceReference | YamlInletStream,
         Field(
             description="Sidestream to mix in. Either a reference to a named stream or an inline stream definition.",
             title="INLET_STREAM",
@@ -89,7 +89,7 @@ class YamlMixer(YamlBase):
     ]
 
 
-class YamlSplitter(YamlBase):
+class YamlSplitterDefinition(YamlBase):
     """Removes a fixed rate from the through-stream at an
     intermediate point in the pipeline (e.g. fuel gas offtake)."""
 
@@ -103,7 +103,12 @@ class YamlSplitter(YamlBase):
     ]
 
 
-YamlProcessUnit = Annotated[
-    YamlCompressor | YamlPressureDropper | YamlTemperatureSetter | YamlLiquidRemover | YamlMixer | YamlSplitter,
+YamlProcessUnitDefinition = Annotated[
+    YamlCompressorDefinition
+    | YamlPressureDropperDefinition
+    | YamlTemperatureSetterDefinition
+    | YamlLiquidRemoverDefinition
+    | YamlMixerDefinition
+    | YamlSplitterDefinition,
     Field(discriminator="type"),
 ]

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_stream_distribution.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_stream_distribution.py
@@ -3,14 +3,13 @@ from typing import Literal, Annotated
 
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessPipelineReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import InstanceReference
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import StreamRef
 
 
 class YamlOverflow(YamlBase):
-    from_reference: ProcessPipelineReference
-    to_reference: ProcessPipelineReference
+    from_reference: InstanceReference
+    to_reference: InstanceReference
 
 
 class YamlCommonStreamSetting(YamlBase):
@@ -20,13 +19,13 @@ class YamlCommonStreamSetting(YamlBase):
 
 class YamlCommonStreamDistribution(YamlBase):
     method: Literal["COMMON_STREAM"]
-    inlet_stream: StreamRef | YamlInletStream
+    inlet_stream: InstanceReference | YamlInletStream
     settings: list[YamlCommonStreamSetting]
 
 
 class YamlIndividualStreamDistribution(YamlBase):
     method: Literal["INDIVIDUAL_STREAMS"]
-    inlet_streams: list[StreamRef | YamlInletStream]
+    inlet_streams: list[InstanceReference | YamlInletStream]
 
 
 YamlStreamDistribution = Annotated[

--- a/src/libecalc/presentation/yaml/yaml_types/streams/yaml_inlet_stream.py
+++ b/src/libecalc/presentation/yaml/yaml_types/streams/yaml_inlet_stream.py
@@ -7,7 +7,7 @@ from libecalc.common.utils.rates import RateType
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import StreamRef
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import InstanceReference
 
 FluidModelReference = str
 
@@ -62,7 +62,7 @@ class YamlInletStream(YamlBase):
     Represents an inlet stream definition that can be referenced by process system and stream distribution.
     """
 
-    name: StreamRef = Field(
+    name: InstanceReference = Field(
         ...,
         title="NAME",
         description="Unique name of the inlet stream.",

--- a/src/libecalc/testing/direct_reference_service.py
+++ b/src/libecalc/testing/direct_reference_service.py
@@ -11,7 +11,7 @@ from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model im
 )
 from libecalc.presentation.yaml.yaml_types.models import YamlCompressorChart, YamlFluidModel, YamlTurbine
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnitDefinition
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 
 
@@ -50,10 +50,10 @@ class DirectReferenceService(ReferenceService):
         raise NotImplementedError()
 
     def get_process_pipeline(self, reference: str) -> YamlProcessPipeline:
-        raise NotImplementedError()
+        return self._resolve_reference(reference)
 
-    def get_process_unit(self, reference: str) -> YamlProcessUnit:
-        raise NotImplementedError()
+    def get_process_unit(self, reference: str) -> YamlProcessUnitDefinition:
+        return self._resolve_reference(reference)
 
     def get_stream(self, reference: str) -> YamlInletStream:
-        raise NotImplementedError()
+        return self._resolve_reference(reference)

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -1,4 +1,4 @@
-from typing import Self, Literal
+from typing import Self
 
 from libecalc.common.utils.rates import RateType
 from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
@@ -9,7 +9,7 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import (
     YamlFluidModelType,
     YamlPredefinedFluidModel,
 )
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import DefinitionReference, InstanceReference
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlProcessConstraint,
     YamlProcessSimulation,
@@ -38,21 +38,21 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_chart import (
 )
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import (
-    YamlItem,
+    YamlProcessUnitInstance,
     YamlProcessPipeline,
 )
 
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
-    YamlLiquidRemover,
-    YamlTemperatureSetter,
-    YamlPressureDropper,
+    YamlLiquidRemoverDefinition,
+    YamlTemperatureSetterDefinition,
+    YamlPressureDropperDefinition,
     YamlCompressorModelChart,
-    YamlCompressor,
+    YamlCompressorDefinition,
     YamlControlMargin,
     YamlCompressorChart,
-    YamlProcessUnit,
-    YamlMixer,
-    YamlSplitter,
+    YamlProcessUnitDefinition,
+    YamlMixerDefinition,
+    YamlSplitterDefinition,
 )
 
 
@@ -140,7 +140,7 @@ class YamlCompressorModelChartBuilder(Builder[YamlCompressorModelChart]):
 # ---------------------------------------------------------------------------
 
 
-class YamlCompressorBuilder(Builder[YamlCompressor]):
+class YamlCompressorBuilder(Builder[YamlCompressorDefinition]):
     def __init__(self):
         self.type = "COMPRESSOR"
         self.compressor_model = None
@@ -154,7 +154,7 @@ class YamlCompressorBuilder(Builder[YamlCompressor]):
         return self
 
 
-class YamlPressureDropperBuilder(Builder[YamlPressureDropper]):
+class YamlPressureDropperBuilder(Builder[YamlPressureDropperDefinition]):
     def __init__(self):
         self.type = "PRESSURE_DROPPER"
         self.pressure_drop = None
@@ -168,7 +168,7 @@ class YamlPressureDropperBuilder(Builder[YamlPressureDropper]):
         return self
 
 
-class YamlTemperatureSetterBuilder(Builder[YamlTemperatureSetter]):
+class YamlTemperatureSetterBuilder(Builder[YamlTemperatureSetterDefinition]):
     def __init__(self):
         self.type = "TEMPERATURE_SETTER"
         self.temperature = None
@@ -182,7 +182,7 @@ class YamlTemperatureSetterBuilder(Builder[YamlTemperatureSetter]):
         return self
 
 
-class YamlLiquidRemoverBuilder(Builder[YamlLiquidRemover]):
+class YamlLiquidRemoverBuilder(Builder[YamlLiquidRemoverDefinition]):
     def __init__(self):
         self.type = "LIQUID_REMOVER"
 
@@ -193,7 +193,7 @@ class YamlLiquidRemoverBuilder(Builder[YamlLiquidRemover]):
         return self
 
 
-class YamlMixerBuilder(Builder[YamlMixer]):
+class YamlMixerBuilder(Builder[YamlMixerDefinition]):
     def __init__(self):
         self.type = "MIXER"
         self.sidestream = None
@@ -213,7 +213,7 @@ class YamlMixerBuilder(Builder[YamlMixer]):
         return self
 
 
-class YamlSplitterBuilder(Builder[YamlSplitter]):
+class YamlSplitterBuilder(Builder[YamlSplitterDefinition]):
     def __init__(self):
         self.type = "SPLITTER"
         self.offtake_rate = None
@@ -236,18 +236,18 @@ class YamlProcessPipelineBuilder(Builder[YamlProcessPipeline]):
     def __init__(self):
         self.type = "SERIAL"
         self.name = None
-        self.items = []
+        self.process_units = []
         self.anti_surge = "INDIVIDUAL_ASV"
 
     def with_name(self, name: str) -> Self:
         self.name = name
         return self
 
-    def with_item(self, target: YamlProcessUnit | ProcessUnitReference, name: str | None = None) -> Self:
-        self.items.append(YamlItem(name=name, target=target))
+    def with_item(self, target: YamlProcessUnitDefinition | DefinitionReference, name: str | None = None) -> Self:
+        self.process_units.append(YamlProcessUnitInstance(name=name, target=target))
         return self
 
-    def with_items(self, items: list[tuple[str | None, YamlProcessUnit | ProcessUnitReference]]) -> Self:
+    def with_items(self, items: list[tuple[str | None, YamlProcessUnitDefinition | DefinitionReference]]) -> Self:
         """Pass a list of validated process units (or string references).
         Each is wrapped in a YamlItem automatically."""
         for name, target in items:
@@ -427,9 +427,10 @@ class YamlCommonStreamDistributionBuilder(Builder[YamlCommonStreamDistribution])
 class YamlProcessSimulationBuilder(Builder[YamlProcessSimulation]):
     def __init__(self):
         self.name: str | None = None
-        self.targets: list[YamlItem[YamlProcessPipeline]] = []
+        self.targets: list[InstanceReference] = []
         self.stream_distribution = None
-        self.constraints: dict[str, list[YamlProcessConstraint]] = {}
+        self.constraints: dict[InstanceReference, list[YamlProcessConstraint]] = {}
+        self._pipelines: dict[str, YamlProcessPipeline] = {}
 
     def with_name(self, name: str) -> Self:
         self.name = name
@@ -449,10 +450,11 @@ class YamlProcessSimulationBuilder(Builder[YamlProcessSimulation]):
         anti_surge: AntiSurgeType = AntiSurgeType.INDIVIDUAL_ASV,
         outlet_pressure: YamlExpressionType = 100.0,
     ) -> Self:
-        self.targets.append(YamlItem(target=pipeline))
+        self.targets.append(pipeline.name)
+        self._pipelines[pipeline.name] = pipeline
         self.constraints[pipeline.name] = [
             YamlProcessConstraint(
-                process_unit=pipeline.items[-1].name,
+                process_unit=pipeline.process_units[-1].name,
                 outlet_pressure=outlet_pressure,
                 pressure_control=pressure_control,
                 anti_surge=anti_surge,
@@ -466,3 +468,7 @@ class YamlProcessSimulationBuilder(Builder[YamlProcessSimulation]):
         self.with_pipeline(pipeline)
         self.stream_distribution = YamlIndividualStreamDistributionBuilder().with_test_data().validate()
         return self
+
+    def get_pipeline_references(self) -> dict[str, YamlProcessPipeline]:
+        """Return a dict of pipeline name -> pipeline object for use with DirectReferenceService."""
+        return dict(self._pipelines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -676,23 +676,27 @@ def patch_uuid():
 
 
 @pytest.fixture
-def process_simulation_mapper(
+def process_simulation_mapper_factory(
     fluid_service,
     expression_evaluator_factory,
 ):
     """
-    Minimal ProcessSimulationMapper for testing.
+    Factory fixture that returns a ProcessSimulationMapper.
+    Call with references dict to register pipelines/units for reference resolution.
+    Call without arguments for backward compatibility (empty references).
     """
     period = Period(start=datetime(2020, 1, 1), end=datetime(2030, 1, 1))
-
     expression_evaluator = expression_evaluator_factory.from_periods(periods=[period])
-    reference_service = DirectReferenceService(references={})
 
-    return ProcessSimulationMapper(
-        expression_evaluator=expression_evaluator,
-        fluid_service=fluid_service,
-        reference_service=reference_service,
-        process_simulation_period=period,
-        resources={},
-        ecalc_event_service=EcalcEventService(ecalc_events=[]),
-    )
+    def _create(references: dict | None = None):
+        reference_service = DirectReferenceService(references=references or {})
+        return ProcessSimulationMapper(
+            expression_evaluator=expression_evaluator,
+            fluid_service=fluid_service,
+            reference_service=reference_service,
+            process_simulation_period=period,
+            resources={},
+            ecalc_event_service=EcalcEventService(ecalc_events=[]),
+        )
+
+    return _create

--- a/tests/libecalc/expression/test_extract_expressions.py
+++ b/tests/libecalc/expression/test_extract_expressions.py
@@ -3,8 +3,8 @@ from pydantic import BaseModel
 from libecalc.expression.extract_expressions import extract_expression_references
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlPumpProcessInlet
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
-    YamlPressureDropper,
-    YamlTemperatureSetter,
+    YamlPressureDropperDefinition,
+    YamlTemperatureSetterDefinition,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution import YamlCommonStreamSetting
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import (
@@ -15,19 +15,19 @@ from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import (
 
 class TestExtractExpressionReferences:
     def test_single_expression_field(self):
-        model = YamlPressureDropper(type="PRESSURE_DROPPER", pressure_drop="SIM1;DP")
+        model = YamlPressureDropperDefinition(type="PRESSURE_DROPPER", pressure_drop="SIM1;DP")
         assert extract_expression_references(model) == {"SIM1;DP"}
 
     def test_numeric_expression_has_no_references(self):
-        model = YamlPressureDropper(type="PRESSURE_DROPPER", pressure_drop=5.0)
+        model = YamlPressureDropperDefinition(type="PRESSURE_DROPPER", pressure_drop=5.0)
         assert extract_expression_references(model) == set()
 
     def test_expression_with_arithmetic(self):
-        model = YamlTemperatureSetter(type="TEMPERATURE_SETTER", temperature="SIM1;TEMP {*} 1.1 {+} 5")
+        model = YamlTemperatureSetterDefinition(type="TEMPERATURE_SETTER", temperature="SIM1;TEMP {*} 1.1 {+} 5")
         assert extract_expression_references(model) == {"SIM1;TEMP"}
 
     def test_multiple_references_in_one_expression(self):
-        model = YamlPressureDropper(type="PRESSURE_DROPPER", pressure_drop="SIM1;DP {+} SIM2;DP_EXTRA")
+        model = YamlPressureDropperDefinition(type="PRESSURE_DROPPER", pressure_drop="SIM1;DP {+} SIM2;DP_EXTRA")
         assert extract_expression_references(model) == {"SIM1;DP", "SIM2;DP_EXTRA"}
 
     def test_nested_pydantic_model(self):
@@ -96,7 +96,7 @@ class TestExtractExpressionReferences:
         assert extract_expression_references(model) == set()
 
     def test_var_references(self):
-        model = YamlPressureDropper(type="PRESSURE_DROPPER", pressure_drop="$var.regularity {*} SIM1;DP")
+        model = YamlPressureDropperDefinition(type="PRESSURE_DROPPER", pressure_drop="$var.regularity {*} SIM1;DP")
         refs = extract_expression_references(model)
         assert refs == {"$var.regularity", "SIM1;DP"}
 

--- a/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
@@ -56,8 +56,9 @@ def _build_simulation_with_pipeline(
     pressure_control: PressureControlType = "DOWNSTREAM_CHOKE",
     outlet_pressure: float = 100.0,
 ):
-    """Build a YamlProcessSimulation with one pipeline and default stream distribution."""
-    return (
+    """Build a YamlProcessSimulation with one pipeline and default stream distribution.
+    Returns (simulation, pipeline_references) tuple."""
+    builder = (
         YamlProcessSimulationBuilder()
         .with_name(name)
         .with_pipeline(
@@ -66,8 +67,8 @@ def _build_simulation_with_pipeline(
             outlet_pressure=outlet_pressure,
         )
         .with_stream_distribution(YamlCommonStreamDistributionBuilder().with_test_data().validate())
-        .validate()
     )
+    return builder.validate(), builder.get_pipeline_references()
 
 
 # ---------------------------------------------------------------------------
@@ -75,9 +76,9 @@ def _build_simulation_with_pipeline(
 # ---------------------------------------------------------------------------
 
 
-def test_mapper_returns_one_pipeline_per_target(process_simulation_mapper):
+def test_mapper_returns_one_pipeline_per_target(process_simulation_mapper_factory):
     """One ProcessPipeline is produced per YAML target."""
-    yaml_simulation = (
+    builder = (
         YamlProcessSimulationBuilder()
         .with_name("multi")
         .with_pipeline(_simple_pipeline("train_a"))
@@ -85,10 +86,10 @@ def test_mapper_returns_one_pipeline_per_target(process_simulation_mapper):
         .with_stream_distribution(
             YamlCommonStreamDistributionBuilder().with_test_data().with_rate_fractions([0.5, 0.5]).validate()
         )
-        .validate()
     )
+    yaml_simulation = builder.validate()
 
-    pipelines, _ = process_simulation_mapper.map_process_simulation(
+    pipelines, _ = process_simulation_mapper_factory(builder.get_pipeline_references()).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )
@@ -102,12 +103,12 @@ def test_mapper_returns_one_pipeline_per_target(process_simulation_mapper):
 # ---------------------------------------------------------------------------
 
 
-def test_mapper_wraps_compressor_segment_with_mixer_and_splitter(process_simulation_mapper):
+def test_mapper_wraps_compressor_segment_with_mixer_and_splitter(process_simulation_mapper_factory):
     """Each compressor segment is wrapped with DirectMixer + DirectSplitter to enable
     ASV recirculation. This is not visible in YAML but added by the mapper."""
-    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline())
+    yaml_simulation, refs = _build_simulation_with_pipeline(_simple_pipeline())
 
-    pipelines, _ = process_simulation_mapper.map_process_simulation(
+    pipelines, _ = process_simulation_mapper_factory(refs).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )
@@ -121,11 +122,11 @@ def test_mapper_wraps_compressor_segment_with_mixer_and_splitter(process_simulat
     assert splitter_index > compressor_index
 
 
-def test_mapper_preserves_yaml_unit_order_inside_segment(process_simulation_mapper):
+def test_mapper_preserves_yaml_unit_order_inside_segment(process_simulation_mapper_factory):
     """User-defined units appear in the order specified in YAML."""
-    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline())
+    yaml_simulation, refs = _build_simulation_with_pipeline(_simple_pipeline())
 
-    pipelines, _ = process_simulation_mapper.map_process_simulation(
+    pipelines, _ = process_simulation_mapper_factory(refs).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )
@@ -141,11 +142,11 @@ def test_mapper_preserves_yaml_unit_order_inside_segment(process_simulation_mapp
     assert position_of(LiquidRemover) < position_of(Compressor)
 
 
-def test_mapper_adds_choke_for_downstream_choke_pressure_control(process_simulation_mapper):
+def test_mapper_adds_choke_for_downstream_choke_pressure_control(process_simulation_mapper_factory):
     """DOWNSTREAM_CHOKE pressure control adds a Choke at the end of the pipeline."""
-    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline(), pressure_control="DOWNSTREAM_CHOKE")
+    yaml_simulation, refs = _build_simulation_with_pipeline(_simple_pipeline(), pressure_control="DOWNSTREAM_CHOKE")
 
-    pipelines, _ = process_simulation_mapper.map_process_simulation(
+    pipelines, _ = process_simulation_mapper_factory(refs).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )
@@ -156,11 +157,11 @@ def test_mapper_adds_choke_for_downstream_choke_pressure_control(process_simulat
     assert isinstance(units[-1], Outlet)
 
 
-def test_mapper_adds_choke_for_upstream_choke_pressure_control(process_simulation_mapper):
+def test_mapper_adds_choke_for_upstream_choke_pressure_control(process_simulation_mapper_factory):
     """UPSTREAM_CHOKE pressure control adds a Choke at the very start of the pipeline."""
-    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline(), pressure_control="UPSTREAM_CHOKE")
+    yaml_simulation, refs = _build_simulation_with_pipeline(_simple_pipeline(), pressure_control="UPSTREAM_CHOKE")
 
-    pipelines, _ = process_simulation_mapper.map_process_simulation(
+    pipelines, _ = process_simulation_mapper_factory(refs).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )
@@ -171,7 +172,7 @@ def test_mapper_adds_choke_for_upstream_choke_pressure_control(process_simulatio
     assert isinstance(units[-1], Outlet)
 
 
-def test_mixer_and_splitter_are_placed_between_asv_loops(process_simulation_mapper):
+def test_mixer_and_splitter_are_placed_between_asv_loops(process_simulation_mapper_factory):
     """Mixer and Splitter must sit between ASV recirculation loops, not inside one."""
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
@@ -184,9 +185,9 @@ def test_mixer_and_splitter_are_placed_between_asv_loops(process_simulation_mapp
         .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
         .validate()
     )
-    yaml_simulation = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
+    yaml_simulation, refs = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
 
-    pipelines, _ = process_simulation_mapper.map_process_simulation(
+    pipelines, _ = process_simulation_mapper_factory(refs).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )
@@ -215,72 +216,72 @@ def test_mixer_and_splitter_are_placed_between_asv_loops(process_simulation_mapp
 # ---------------------------------------------------------------------------
 
 
-def test_incompatible_strategies_raises_validation_exception(process_simulation_mapper):
+def test_incompatible_strategies_raises_validation_exception(process_simulation_mapper_factory):
     """Test that incompatible ANTI_SURGE and PRESSURE_CONTROL strategies raise exception."""
-    mapper = process_simulation_mapper
-
-    yaml_simulation = YamlProcessSimulationBuilder().with_test_data().validate()
+    builder = YamlProcessSimulationBuilder().with_test_data()
+    yaml_simulation = builder.validate()
 
     # Use incompatible combinations
-    pipeline = yaml_simulation.targets[0].target
+    pipeline_name = yaml_simulation.targets[0]
 
-    constraint = yaml_simulation.constraints[pipeline.name][0]
+    constraint = yaml_simulation.constraints[pipeline_name][0]
     constraint.anti_surge = "INDIVIDUAL_ASV"
     constraint.pressure_control = "COMMON_ASV"
 
     # Check that validation fails
+    mapper = process_simulation_mapper_factory(builder.get_pipeline_references())
     with pytest.raises(EcalcValidationException) as exc_info:
         mapper.map_process_simulation(yaml_simulation, process_periods=[PERIOD])
 
     assert "PRESSURE_CONTROL 'COMMON_ASV' requires ANTI_SURGE 'COMMON_ASV', got 'INDIVIDUAL_ASV'" in str(exc_info.value)
 
 
-def test_incompatible_common_asv_with_individual_asv_rate(process_simulation_mapper):
+def test_incompatible_common_asv_with_individual_asv_rate(process_simulation_mapper_factory):
     """Test that COMMON_ASV anti-surge + INDIVIDUAL_ASV_RATE pressure control raises exception."""
-    mapper = process_simulation_mapper
+    builder = YamlProcessSimulationBuilder().with_test_data()
+    yaml_simulation = builder.validate()
 
-    yaml_simulation = YamlProcessSimulationBuilder().with_test_data().validate()
+    pipeline_name = yaml_simulation.targets[0]
 
-    pipeline = yaml_simulation.targets[0].target
-
-    constraint = yaml_simulation.constraints[pipeline.name][0]
+    constraint = yaml_simulation.constraints[pipeline_name][0]
     constraint.anti_surge = "COMMON_ASV"
     constraint.pressure_control = "INDIVIDUAL_ASV_RATE"
 
+    mapper = process_simulation_mapper_factory(builder.get_pipeline_references())
     with pytest.raises(EcalcValidationException):
         mapper.map_process_simulation(yaml_simulation, process_periods=[PERIOD])
 
 
-def test_incompatible_common_asv_with_individual_asv_pressure(process_simulation_mapper):
+def test_incompatible_common_asv_with_individual_asv_pressure(process_simulation_mapper_factory):
     """Test that COMMON_ASV anti-surge + INDIVIDUAL_ASV_PRESSURE pressure control raises exception."""
-    mapper = process_simulation_mapper
+    builder = YamlProcessSimulationBuilder().with_test_data()
+    yaml_simulation = builder.validate()
 
-    yaml_simulation = YamlProcessSimulationBuilder().with_test_data().validate()
+    pipeline_name = yaml_simulation.targets[0]
 
-    pipeline = yaml_simulation.targets[0].target
-
-    constraint = yaml_simulation.constraints[pipeline.name][0]
+    constraint = yaml_simulation.constraints[pipeline_name][0]
     constraint.anti_surge = "COMMON_ASV"
     constraint.pressure_control = "INDIVIDUAL_ASV_PRESSURE"
 
+    mapper = process_simulation_mapper_factory(builder.get_pipeline_references())
     with pytest.raises(EcalcValidationException):
         mapper.map_process_simulation(yaml_simulation, process_periods=[PERIOD])
 
 
-def test_compatible_strategies_succeeds(process_simulation_mapper):
+def test_compatible_strategies_succeeds(process_simulation_mapper_factory):
     """Test that compatible strategies pass validation."""
-    mapper = process_simulation_mapper
-
-    yaml_simulation = YamlProcessSimulationBuilder().with_test_data().validate()
+    builder = YamlProcessSimulationBuilder().with_test_data()
+    yaml_simulation = builder.validate()
 
     # Use compatible combinations
-    pipeline = yaml_simulation.targets[0].target
+    pipeline_name = yaml_simulation.targets[0]
 
-    constraint = yaml_simulation.constraints[pipeline.name][0]
+    constraint = yaml_simulation.constraints[pipeline_name][0]
     constraint.anti_surge = "INDIVIDUAL_ASV"
     constraint.pressure_control = "INDIVIDUAL_ASV_PRESSURE"
 
     # Run without exception
+    mapper = process_simulation_mapper_factory(builder.get_pipeline_references())
     mapper.map_process_simulation(yaml_simulation, process_periods=[PERIOD])
 
 
@@ -289,7 +290,7 @@ def test_compatible_strategies_succeeds(process_simulation_mapper):
 # ---------------------------------------------------------------------------
 
 
-def test_mapper_places_trailing_units_after_last_asv_loop(process_simulation_mapper):
+def test_mapper_places_trailing_units_after_last_asv_loop(process_simulation_mapper_factory):
     """Units after the last compressor are placed outside any ASV recirculation loop."""
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
@@ -301,9 +302,9 @@ def test_mapper_places_trailing_units_after_last_asv_loop(process_simulation_map
         .with_item(name="temp_setter_3", target=YamlTemperatureSetterBuilder().with_test_data().validate())
         .validate()
     )
-    yaml_simulation = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
+    yaml_simulation, refs = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
 
-    pipelines, _ = process_simulation_mapper.map_process_simulation(
+    pipelines, _ = process_simulation_mapper_factory(refs).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )
@@ -324,7 +325,7 @@ def test_mapper_places_trailing_units_after_last_asv_loop(process_simulation_map
 # ---------------------------------------------------------------------------
 
 
-def test_duplicate_process_unit_names_not_allowed(process_simulation_mapper):
+def test_duplicate_process_unit_names_not_allowed(process_simulation_mapper_factory):
     """Duplicate process unit names are not allowed within a process."""
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
@@ -335,10 +336,10 @@ def test_duplicate_process_unit_names_not_allowed(process_simulation_mapper):
         .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
         .validate()
     )
-    yaml_simulation = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
+    yaml_simulation, refs = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
 
     with pytest.raises(EcalcValidationException) as exc_info:
-        process_simulation_mapper.map_process_simulation(yaml_simulation, process_periods=[PERIOD])
+        process_simulation_mapper_factory(refs).map_process_simulation(yaml_simulation, process_periods=[PERIOD])
 
     assert "Duplicate process unit name 'temp_setter_1'" in str(exc_info.value)
 
@@ -348,10 +349,10 @@ def test_duplicate_process_unit_names_not_allowed(process_simulation_mapper):
 # ---------------------------------------------------------------------------
 
 
-def test_mapper_builds_single_process_problem_section(process_simulation_mapper):
+def test_mapper_builds_single_process_problem_section(process_simulation_mapper_factory):
     """A single constraint pipeline produces one ProcessProblemSection."""
-    yaml_simulation = _build_simulation_with_pipeline(_simple_pipeline())
-    _, simulation = process_simulation_mapper.map_process_simulation(
+    yaml_simulation, refs = _build_simulation_with_pipeline(_simple_pipeline())
+    _, simulation = process_simulation_mapper_factory(refs).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )
@@ -371,7 +372,7 @@ def test_mapper_builds_single_process_problem_section(process_simulation_mapper)
     # assert any(isinstance(h, RecirculationLoop) for h in section.configuration_handlers)
 
 
-def test_mapper_builds_multiple_process_problem_sections(process_simulation_mapper):
+def test_mapper_builds_multiple_process_problem_sections(process_simulation_mapper_factory):
     """Each mapped process section becomes a ProcessProblemSection"""
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
@@ -384,7 +385,7 @@ def test_mapper_builds_multiple_process_problem_sections(process_simulation_mapp
         .validate()
     )
 
-    yaml_simulation = _build_simulation_with_pipeline(pipeline=yaml_pipeline, pressure_control="DOWNSTREAM_CHOKE")
+    yaml_simulation, refs = _build_simulation_with_pipeline(pipeline=yaml_pipeline, pressure_control="DOWNSTREAM_CHOKE")
 
     constraint = YamlProcessConstraint(
         process_unit="compressor_1",
@@ -394,7 +395,7 @@ def test_mapper_builds_multiple_process_problem_sections(process_simulation_mapp
     )
     yaml_simulation.constraints[yaml_pipeline.name].insert(0, constraint)
 
-    _, simulation = process_simulation_mapper.map_process_simulation(
+    _, simulation = process_simulation_mapper_factory(refs).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )

--- a/tests/libecalc/process/test_mixer_integration.py
+++ b/tests/libecalc/process/test_mixer_integration.py
@@ -20,7 +20,7 @@ from libecalc.testing.process_builders import (
 PERIOD = Period(start=datetime(2020, 1, 1), end=datetime(2030, 1, 1))
 
 
-def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper, fluid_service):
+def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper_factory, fluid_service):
     """
     Verify that a Mixer defined in YAML survives the full chain:
     YAML → mapper → runtime configuration → pipeline execution.
@@ -42,16 +42,16 @@ def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper, fluid_s
         .validate()
     )
 
-    yaml_simulation = (
+    builder = (
         YamlProcessSimulationBuilder()
         .with_name("mixer_test")
         .with_pipeline(yaml_pipeline)
         .with_stream_distribution(YamlIndividualStreamDistributionBuilder().with_test_data().validate())
-        .validate()
     )
+    yaml_simulation = builder.validate()
 
     # -- Map to process domain objects --
-    pipelines, simulation = process_simulation_mapper.map_process_simulation(
+    pipelines, simulation = process_simulation_mapper_factory(builder.get_pipeline_references()).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )

--- a/tests/libecalc/process/test_splitter_integration.py
+++ b/tests/libecalc/process/test_splitter_integration.py
@@ -22,7 +22,7 @@ from libecalc.testing.process_builders import (
 PERIOD = Period(start=datetime(2020, 1, 1), end=datetime(2030, 1, 1))
 
 
-def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper, fluid_service):
+def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper_factory, fluid_service):
     """Verify that a Splitter defined in YAML survives the full chain:
     YAML → mapper → runtime configuration → pipeline execution.
 
@@ -42,16 +42,16 @@ def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper, flui
         .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
         .validate()
     )
-    yaml_simulation = (
+    builder = (
         YamlProcessSimulationBuilder()
         .with_name("splitter_test")
         .with_pipeline(yaml_pipeline)
         .with_stream_distribution(YamlCommonStreamDistributionBuilder().with_test_data().validate())
-        .validate()
     )
+    yaml_simulation = builder.validate()
 
     # -- Map to domain objects --
-    pipelines, simulation = process_simulation_mapper.map_process_simulation(
+    pipelines, simulation = process_simulation_mapper_factory(builder.get_pipeline_references()).map_process_simulation(
         yaml_process_simulation=yaml_simulation,
         process_periods=[PERIOD],
     )


### PR DESCRIPTION
This changes instance references to be required, while definition
references are optional. It also changes the instance reference from
process simulation to pipeline by removing the TARGET key.