### PR TITLE
refactor: separate process definitions from instance references

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/process/build_sections.py
+++ b/src/libecalc/presentation/yaml/mappers/process/build_sections.py
@@ -3,7 +3,7 @@ from libecalc.presentation.yaml.mappers.process.process_partitioner import (
     MappedSection,
     ProcessPartitioner,
 )
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitInstanceName
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessConstraint
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
@@ -25,7 +25,7 @@ class ProcessSectionBuilder:
     def partition_and_validate(
         self,
         process_unit_map: dict[ProcessUnitId, ProcessUnit],
-        unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
+        unit_name_to_id: dict[ProcessUnitInstanceName, ProcessUnitId],
         pipeline_constraints: list[YamlProcessConstraint],
     ) -> list[MappedSection]:
         sections = self._partitioner.partition(

--- a/src/libecalc/presentation/yaml/mappers/process/process_partitioner.py
+++ b/src/libecalc/presentation/yaml/mappers/process/process_partitioner.py
@@ -1,6 +1,6 @@
 from libecalc.common.ddd import value_object
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitInstanceName
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessConstraint
 from libecalc.process.process_pipeline.process_unit import ProcessUnit, ProcessUnitId
 from libecalc.process.process_units.compressor import Compressor
@@ -27,7 +27,7 @@ class ProcessPartitioner:
     @staticmethod
     def partition(
         process_unit_map: dict[ProcessUnitId, ProcessUnit],
-        unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
+        unit_name_to_id: dict[ProcessUnitInstanceName, ProcessUnitId],
         pipeline_constraints: list[YamlProcessConstraint],
     ) -> list[MappedSection]:
         process_units = list(process_unit_map.values())
@@ -40,7 +40,7 @@ class ProcessPartitioner:
                     raise EcalcValidationException("Only one constraint can target the process pipeline outlet.")
                 terminal_constraint = constraint
                 continue
-            unit_id = unit_name_to_id.get(constraint.process_unit)
+            unit_id = unit_name_to_id.get(ProcessUnitInstanceName(constraint.process_unit))
             if unit_id is None:
                 raise EcalcValidationException(f"Constraint references unknown unit '{constraint.process_unit}'.")
 

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -46,7 +46,6 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import 
 from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import YamlCompositionFluidModel, YamlPredefinedFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
-    ProcessPipelineInstanceName,
     ProcessPipelineInstanceReference,
     ProcessUnitInstanceName,
 )
@@ -312,7 +311,7 @@ class ProcessSimulationMapper:
             problem_configuration_handlers = []
             shaft = VariableSpeedShaft()
             item = self._resolve_train_reference(yaml_compressor_train_item.target)
-            pipeline_instance_name = yaml_compressor_train_item.name or ProcessPipelineInstanceName(item.name)
+            pipeline_instance_name = yaml_compressor_train_item.name
             process_unit_map: dict[ProcessUnitId, ProcessUnit] = {}
             compressor_ids: list[ProcessUnitId] = []
             unit_name_to_id: dict[ProcessUnitInstanceName, ProcessUnitId] = {}

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -39,13 +39,16 @@ from libecalc.presentation.yaml.mappers.fluid_mapper import (
 )
 from libecalc.presentation.yaml.mappers.model import InvalidChartResourceException
 from libecalc.presentation.yaml.mappers.process.build_sections import ProcessSectionBuilder
+from libecalc.presentation.yaml.resolvers.process_unit_resolver import ProcessUnitResolver
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
 from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import YamlCompositionFluidModel, YamlPredefinedFluidModel
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
-    ProcessUnitReference,
+    ProcessPipelineInstanceName,
+    ProcessPipelineInstanceReference,
+    ProcessUnitInstanceName,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlProcessSimulation,
@@ -131,6 +134,7 @@ class ProcessSimulationMapper:
         self._reference_service = reference_service
         self._resources = resources
         self._ecalc_event_service = ecalc_event_service
+        self._process_unit_resolver = ProcessUnitResolver(reference_service)
 
     def _resolve_train_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
         if isinstance(ref, str):
@@ -247,7 +251,7 @@ class ProcessSimulationMapper:
     def _validate_and_map_pipeline_events(
         self,
         yaml_pipeline: YamlProcessPipeline,
-        unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId],
+        unit_name_to_id: dict[ProcessUnitInstanceName, ProcessUnitId],
     ) -> list[PipelineEvent]:
         """Validate pipeline event references and map to domain objects."""
         events: list[PipelineEvent] = []
@@ -275,7 +279,7 @@ class ProcessSimulationMapper:
             events.append(
                 PipelineEvent(
                     action=PipelineEventAction(yaml_event.type.value),
-                    change_target=unit_name_to_id[yaml_event.change_target],
+                    change_target=unit_name_to_id[ProcessUnitInstanceName(yaml_event.change_target)],
                     change_to=change_to_unit,
                     change_type=PipelineEventChangeType(yaml_event.change_type.value),
                     change_time=ecalc_event.start,
@@ -308,9 +312,10 @@ class ProcessSimulationMapper:
             problem_configuration_handlers = []
             shaft = VariableSpeedShaft()
             item = self._resolve_train_reference(yaml_compressor_train_item.target)
+            pipeline_instance_name = yaml_compressor_train_item.name or ProcessPipelineInstanceName(item.name)
             process_unit_map: dict[ProcessUnitId, ProcessUnit] = {}
             compressor_ids: list[ProcessUnitId] = []
-            unit_name_to_id: dict[ProcessUnitReference, ProcessUnitId] = {}
+            unit_name_to_id: dict[ProcessUnitInstanceName, ProcessUnitId] = {}
             problem_time_series_configurations: dict[
                 ProcessUnitId,
                 TimeSeriesTemperatureSetterConfiguration
@@ -320,10 +325,9 @@ class ProcessSimulationMapper:
             ] = {}
 
             for yaml_pipeline_item in item.items:
-                yaml_process_unit = yaml_pipeline_item.target
-                process_unit_name = yaml_pipeline_item.name
-                if isinstance(yaml_process_unit, str):
-                    yaml_process_unit = self._reference_service.get_process_unit(yaml_process_unit)
+                resolved_process_unit = self._process_unit_resolver.resolve(yaml_pipeline_item)
+                process_unit_name = resolved_process_unit.name
+                yaml_process_unit = resolved_process_unit.specification
 
                 match yaml_process_unit:
                     case YamlCompressor():
@@ -394,10 +398,11 @@ class ProcessSimulationMapper:
             # from section, and keep track of them at pipeline level
             process_pipeline_sections: list[ProcessPipelineSection] = []
             process_problem_sections: list[ProcessProblemSection] = []
-            pipeline_constraints = yaml_process_simulation.constraints.get(item.name)
-
+            pipeline_constraints = yaml_process_simulation.constraints.get(
+                ProcessPipelineInstanceReference(pipeline_instance_name)
+            )
             if not pipeline_constraints:
-                raise EcalcValidationException(f"Missing constraint for process system '{item.name}'")
+                raise EcalcValidationException(f"Missing constraint for process system '{pipeline_instance_name}'")
 
             mapped_sections = section_builder.partition_and_validate(
                 process_unit_map=process_unit_map,
@@ -426,7 +431,7 @@ class ProcessSimulationMapper:
             # TODO: We should move this class to this module/layer
             # in particular because it creates necessary connections, which means that they will get new IDs
             process_pipeline = ProcessPipeline(
-                name=item.name,
+                name=pipeline_instance_name,
                 process_pipeline_sections=process_pipeline_sections,
                 events=pipeline_events,
                 process_periods=process_periods,
@@ -476,7 +481,7 @@ class ProcessSimulationMapper:
 
             predefined_configurations[process_pipeline.get_id()] = problem_time_series_configurations
 
-            process_pipeline_reference_to_id_map[item.name] = process_pipeline.get_id()
+            process_pipeline_reference_to_id_map[pipeline_instance_name] = process_pipeline.get_id()
             process_pipelines.append(process_pipeline)
             process_problems.append(
                 ProcessProblem(

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -135,7 +135,7 @@ class ProcessSimulationMapper:
         self._ecalc_event_service = ecalc_event_service
         self._process_unit_resolver = ProcessUnitResolver(reference_service)
 
-    def _resolve_train_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
+    def _resolve_pipeline_reference(self, ref: str | YamlProcessPipeline) -> YamlProcessPipeline:
         if isinstance(ref, str):
             return self._reference_service.get_process_pipeline(reference=ref)
         else:
@@ -307,11 +307,11 @@ class ProcessSimulationMapper:
 
         process_pipeline_reference_to_id_map: dict[str, ProcessPipelineId] = {}
         section_builder = ProcessSectionBuilder()
-        for yaml_compressor_train_item in yaml_process_simulation.targets:
+        for yaml_pipeline_target in yaml_process_simulation.targets:
             problem_configuration_handlers = []
             shaft = VariableSpeedShaft()
-            item = self._resolve_train_reference(yaml_compressor_train_item.target)
-            pipeline_instance_name = yaml_compressor_train_item.name
+            pipeline_definition = self._resolve_pipeline_reference(yaml_pipeline_target.target)
+            pipeline_instance_name = yaml_pipeline_target.name
             process_unit_map: dict[ProcessUnitId, ProcessUnit] = {}
             compressor_ids: list[ProcessUnitId] = []
             unit_name_to_id: dict[ProcessUnitInstanceName, ProcessUnitId] = {}
@@ -323,8 +323,8 @@ class ProcessSimulationMapper:
                 | TimeSeriesSplitterConfiguration,
             ] = {}
 
-            for yaml_pipeline_item in item.items:
-                resolved_process_unit = self._process_unit_resolver.resolve(yaml_pipeline_item)
+            for process_unit_instance in pipeline_definition.items:
+                resolved_process_unit = self._process_unit_resolver.resolve(process_unit_instance)
                 process_unit_name = resolved_process_unit.name
                 yaml_process_unit = resolved_process_unit.specification
 
@@ -424,7 +424,7 @@ class ProcessSimulationMapper:
 
             # TODO: Simply events for now ...
             pipeline_events = self._validate_and_map_pipeline_events(
-                yaml_pipeline=item,
+                yaml_pipeline=pipeline_definition,
                 unit_name_to_id=unit_name_to_id,
             )
             # TODO: We should move this class to this module/layer

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -323,7 +323,7 @@ class ProcessSimulationMapper:
                 | TimeSeriesSplitterConfiguration,
             ] = {}
 
-            for process_unit_instance in pipeline_definition.items:
+            for process_unit_instance in pipeline_definition.process_units:
                 resolved_process_unit = self._process_unit_resolver.resolve(process_unit_instance)
                 process_unit_name = resolved_process_unit.name
                 yaml_process_unit = resolved_process_unit.specification

--- a/src/libecalc/presentation/yaml/resolvers/process_unit_resolver.py
+++ b/src/libecalc/presentation/yaml/resolvers/process_unit_resolver.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from libecalc.presentation.yaml.domain.reference_service import ReferenceService
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessUnitItem
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessUnitInstance
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitInstanceName
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
 
@@ -16,7 +16,7 @@ class ProcessUnitResolver:
     def __init__(self, references: ReferenceService):
         self._references = references
 
-    def resolve(self, item: YamlProcessUnitItem) -> ResolvedProcessUnitItem:
+    def resolve(self, item: YamlProcessUnitInstance) -> ResolvedProcessUnitItem:
         specification = self._references.get_process_unit(item.target) if isinstance(item.target, str) else item.target
         return ResolvedProcessUnitItem(
             name=item.name,

--- a/src/libecalc/presentation/yaml/resolvers/process_unit_resolver.py
+++ b/src/libecalc/presentation/yaml/resolvers/process_unit_resolver.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from libecalc.presentation.yaml.domain.reference_service import ReferenceService
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessUnitItem
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitInstanceName
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnit
+
+
+@dataclass(frozen=True)
+class ResolvedProcessUnitItem:
+    name: ProcessUnitInstanceName | None
+    specification: YamlProcessUnit
+
+
+class ProcessUnitResolver:
+    def __init__(self, references: ReferenceService):
+        self._references = references
+
+    def resolve(self, item: YamlProcessUnitItem) -> ResolvedProcessUnitItem:
+        specification = self._references.get_process_unit(item.target) if isinstance(item.target, str) else item.target
+        return ResolvedProcessUnitItem(
+            name=item.name,
+            specification=specification,
+        )

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
@@ -69,14 +69,14 @@ class YamlAsset(YamlBase):
         description="Defines variables used in an energy usage model by means of expressions or constants."
         "\n\n$ECALC_DOCS_KEYWORDS_URL/VARIABLES",
     )
-    process_units: dict[str, YamlProcessUnit] = Field(
+    process_unit_definitions: dict[str, YamlProcessUnit] = Field(
         default_factory=dict,
-        title="PROCESS_UNITS",
+        title="PROCESS_UNIT_DEFINITIONS",
         description="Defines process units used in PROCESS_PIPELINES.",
     )
-    process_pipelines: dict[str, YamlProcessPipeline] = Field(
+    process_pipeline_definitions: dict[str, YamlProcessPipeline] = Field(
         default_factory=dict,
-        title="PROCESS_PIPELINES",
+        title="PROCESS_PIPELINE_DEFINITIONS",
         description="Defines process pipelines to use in process simulations.",
     )
     process_simulations: list[YamlProcessSimulation] = Field(
@@ -185,11 +185,11 @@ class YamlAsset(YamlBase):
             for fuel_type in self.fuel_types:
                 references.append(fuel_type.name)
 
-        if self.process_pipelines is not None:
-            references.extend(self.process_pipelines.keys())
+        if self.process_pipeline_definitions is not None:
+            references.extend(self.process_pipeline_definitions.keys())
 
-        if self.process_units is not None:
-            references.extend(self.process_units.keys())
+        if self.process_unit_definitions is not None:
+            references.extend(self.process_unit_definitions.keys())
 
         if self.process_simulations is not None:
             for process_simulation in self.process_simulations:

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
@@ -6,6 +6,9 @@ from pydantic import Field
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
     ProcessEventReference,
+    ProcessUnitDefinitionReference,
+    ProcessUnitInstanceName,
+    ProcessUnitInstanceReference,
     ProcessUnitReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
@@ -18,6 +21,11 @@ TTarget = TypeVar("TTarget")
 class YamlItem[TTarget](YamlBase):
     target: TTarget | ProcessUnitReference
     name: str | None = None
+
+
+class YamlProcessUnitItem(YamlBase):
+    name: ProcessUnitInstanceName | None = None
+    target: YamlProcessUnit | ProcessUnitDefinitionReference
 
 
 class PipelineEventAction(StrEnum):
@@ -39,21 +47,21 @@ class YamlPipelineEvent(YamlBase):
         ),
     ]
     change_target: Annotated[
-        ProcessUnitReference,
+        ProcessUnitInstanceReference,
         Field(
             title="CHANGE_TARGET",
             description="Name of the process unit in the pipeline to change.",
         ),
     ]
     change_from: Annotated[
-        ProcessUnitReference,
+        ProcessUnitDefinitionReference,
         Field(
             title="CHANGE_FROM",
             description="Reference to the existing process unit template being replaced.",
         ),
     ]
     change_to: Annotated[
-        ProcessUnitReference,
+        ProcessUnitDefinitionReference,
         Field(
             title="CHANGE_TO",
             description="Reference to the new process unit template to use.",
@@ -78,7 +86,7 @@ class YamlPipelineEvent(YamlBase):
 class YamlProcessPipeline(YamlBase):
     type: Literal["SERIAL"]
     name: str
-    items: list[YamlItem[YamlProcessUnit]]
+    items: list[YamlProcessUnitItem]
     events: Annotated[
         list[YamlPipelineEvent],
         Field(

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
@@ -78,7 +78,7 @@ class YamlPipelineEvent(YamlBase):
 class YamlProcessPipeline(YamlBase):
     type: Literal["SERIAL"]
     name: str
-    items: list[YamlProcessUnitInstance]
+    process_units: list[YamlProcessUnitInstance]
     events: Annotated[
         list[YamlPipelineEvent],
         Field(

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_pipeline.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Annotated, Literal, TypeVar
+from typing import Annotated, Literal
 
 from pydantic import Field
 
@@ -9,21 +9,13 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_references impor
     ProcessUnitDefinitionReference,
     ProcessUnitInstanceName,
     ProcessUnitInstanceReference,
-    ProcessUnitReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
     YamlProcessUnit,
 )
 
-TTarget = TypeVar("TTarget")
 
-
-class YamlItem[TTarget](YamlBase):
-    target: TTarget | ProcessUnitReference
-    name: str | None = None
-
-
-class YamlProcessUnitItem(YamlBase):
+class YamlProcessUnitInstance(YamlBase):
     name: ProcessUnitInstanceName | None = None
     target: YamlProcessUnit | ProcessUnitDefinitionReference
 
@@ -86,7 +78,7 @@ class YamlPipelineEvent(YamlBase):
 class YamlProcessPipeline(YamlBase):
     type: Literal["SERIAL"]
     name: str
-    items: list[YamlProcessUnitItem]
+    items: list[YamlProcessUnitInstance]
     events: Annotated[
         list[YamlPipelineEvent],
         Field(

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_references.py
@@ -2,9 +2,19 @@
 Shared reference type aliases for YAML process types.
 """
 
+from typing import NewType
+
 type StreamRef = str
 type ProcessPipelineReference = str  # TODO: validate correct reference
 type ProcessUnitReference = str
 type EcalcEventReference = str
 type ProcessEventReference = str
 type PumpChartReference = str
+
+ProcessUnitInstanceName = NewType("ProcessUnitInstanceName", str)
+ProcessUnitInstanceReference = NewType("ProcessUnitInstanceReference", str)
+ProcessUnitDefinitionReference = NewType("ProcessUnitDefinitionReference", str)
+
+ProcessPipelineInstanceName = NewType("ProcessPipelineInstanceName", str)
+ProcessPipelineInstanceReference = NewType("ProcessPipelineInstanceReference", str)
+ProcessPipelineDefinitionReference = NewType("ProcessPipelineDefinitionReference", str)

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
@@ -5,14 +5,13 @@ from pydantic import Field
 from libecalc.ecalc_model.ecalc_event import EcalcEventType, ProcessEventType
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import (
-    YamlItem,
-    YamlProcessPipeline,
-)
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
     EcalcEventReference,
-    ProcessPipelineReference,
-    ProcessUnitReference,
+    ProcessPipelineDefinitionReference,
+    ProcessPipelineInstanceName,
+    ProcessPipelineInstanceReference,
+    ProcessUnitInstanceReference,
     PumpChartReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution import YamlStreamDistribution
@@ -83,9 +82,14 @@ class YamlProcessEvent(YamlBase):
     ]
 
 
+class YamlProcessPipelineTarget(YamlBase):
+    name: ProcessPipelineInstanceName | None = None
+    target: YamlProcessPipeline | ProcessPipelineDefinitionReference
+
+
 class YamlProcessConstraint(YamlBase):
     process_unit: Annotated[
-        ProcessUnitReference | None,
+        ProcessUnitInstanceReference | None,
         Field(
             title="PROCESS_UNIT",
             description="Reference to a named unit within the pipeline. If omitted, the constraint applies to the last process unit in the pipeline section.",
@@ -117,12 +121,12 @@ class YamlProcessConstraint(YamlBase):
 class YamlProcessSimulation(YamlBase):
     name: str
     targets: Annotated[
-        list[YamlItem[YamlProcessPipeline]],
+        list[YamlProcessPipelineTarget],
         Field(title="TARGETS"),
     ]
     stream_distribution: YamlStreamDistribution
     constraints: Annotated[
-        dict[ProcessPipelineReference, list[YamlProcessConstraint]],
+        dict[ProcessPipelineInstanceReference, list[YamlProcessConstraint]],
         Field(
             title="CONSTRAINTS",
             description="Constraints per target. Key is pipeline name, value is list of constraints.",

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_process_simulation.py
@@ -83,7 +83,7 @@ class YamlProcessEvent(YamlBase):
 
 
 class YamlProcessPipelineTarget(YamlBase):
-    name: ProcessPipelineInstanceName | None = None
+    name: ProcessPipelineInstanceName
     target: YamlProcessPipeline | ProcessPipelineDefinitionReference
 
 

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_stream_distribution.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_stream_distribution.py
@@ -3,14 +3,14 @@ from typing import Literal, Annotated
 
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessPipelineReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessPipelineInstanceReference
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import StreamRef
 
 
 class YamlOverflow(YamlBase):
-    from_reference: ProcessPipelineReference
-    to_reference: ProcessPipelineReference
+    from_reference: ProcessPipelineInstanceReference
+    to_reference: ProcessPipelineInstanceReference
 
 
 class YamlCommonStreamSetting(YamlBase):

--- a/src/libecalc/testing/direct_reference_service.py
+++ b/src/libecalc/testing/direct_reference_service.py
@@ -50,10 +50,10 @@ class DirectReferenceService(ReferenceService):
         raise NotImplementedError()
 
     def get_process_pipeline(self, reference: str) -> YamlProcessPipeline:
-        raise NotImplementedError()
+        return self._resolve_reference(reference)
 
     def get_process_unit(self, reference: str) -> YamlProcessUnit:
-        raise NotImplementedError()
+        return self._resolve_reference(reference)
 
     def get_stream(self, reference: str) -> YamlInletStream:
-        raise NotImplementedError()
+        return self._resolve_reference(reference)

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -45,7 +45,7 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_chart import (
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import (
     YamlProcessPipeline,
-    YamlProcessUnitItem,
+    YamlProcessUnitInstance,
 )
 
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
@@ -252,7 +252,7 @@ class YamlProcessPipelineBuilder(Builder[YamlProcessPipeline]):
     def with_item(
         self, target: YamlProcessUnit | ProcessUnitDefinitionReference, name: ProcessUnitInstanceName | None = None
     ) -> Self:
-        self.items.append(YamlProcessUnitItem(name=name, target=target))
+        self.items.append(YamlProcessUnitInstance(name=name, target=target))
         return self
 
     def with_items(

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -13,6 +13,7 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_references impor
     ProcessUnitDefinitionReference,
     ProcessUnitInstanceName,
     ProcessUnitInstanceReference,
+    ProcessPipelineInstanceName,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlProcessConstraint,
@@ -466,7 +467,8 @@ class YamlProcessSimulationBuilder(Builder[YamlProcessSimulation]):
         anti_surge: AntiSurgeType = AntiSurgeType.INDIVIDUAL_ASV,
         outlet_pressure: YamlExpressionType = 100.0,
     ) -> Self:
-        self.targets.append(YamlProcessPipelineTarget(target=pipeline))
+        pipeline_instance_name = ProcessPipelineInstanceName(pipeline.name)
+        self.targets.append(YamlProcessPipelineTarget(name=pipeline_instance_name, target=pipeline))
         process_unit_name = pipeline.items[-1].name
         self.constraints[pipeline.name] = [
             YamlProcessConstraint(

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -242,26 +242,34 @@ class YamlProcessPipelineBuilder(Builder[YamlProcessPipeline]):
     def __init__(self):
         self.type = "SERIAL"
         self.name = None
-        self.items = []
+        self.process_units = []
         self.anti_surge = "INDIVIDUAL_ASV"
 
     def with_name(self, name: str) -> Self:
         self.name = name
         return self
 
-    def with_item(
-        self, target: YamlProcessUnit | ProcessUnitDefinitionReference, name: ProcessUnitInstanceName | None = None
+    def with_process_unit(
+        self,
+        target: YamlProcessUnit | ProcessUnitDefinitionReference,
+        name: str | None = None,
     ) -> Self:
-        self.items.append(YamlProcessUnitInstance(name=name, target=target))
+        instance_name = ProcessUnitInstanceName(name) if name is not None else None
+        self.process_units.append(
+            YamlProcessUnitInstance(
+                name=instance_name,
+                target=target,
+            )
+        )
         return self
 
-    def with_items(
-        self, items: list[tuple[ProcessUnitInstanceName | None, YamlProcessUnit | ProcessUnitDefinitionReference]]
+    def with_process_units(
+        self, process_units: list[tuple[str | None, YamlProcessUnit | ProcessUnitDefinitionReference]]
     ) -> Self:
         """Pass a list of validated process units (or string references).
         Each is wrapped in a YamlProcessUnitItem automatically."""
-        for name, target in items:
-            self.with_item(name=name, target=target)
+        for name, target in process_units:
+            self.with_process_unit(name=name, target=target)
         return self
 
     def with_anti_surge(self, anti_surge: str) -> Self:
@@ -272,20 +280,20 @@ class YamlProcessPipelineBuilder(Builder[YamlProcessPipeline]):
         self.name = "DefaultPipeline"
 
         return (
-            self.with_item(
-                name=ProcessUnitInstanceName("default_pressure_dropper"),
+            self.with_process_unit(
+                name="default_pressure_dropper",
                 target=YamlPressureDropperBuilder().with_test_data().validate(),
             )
-            .with_item(
-                name=ProcessUnitInstanceName("default_temperature_setter"),
+            .with_process_unit(
+                name="default_temperature_setter",
                 target=YamlTemperatureSetterBuilder().with_test_data().validate(),
             )
-            .with_item(
-                name=ProcessUnitInstanceName("default_liquid_remover"),
+            .with_process_unit(
+                name="default_liquid_remover",
                 target=YamlLiquidRemoverBuilder().with_test_data().validate(),
             )
-            .with_item(
-                name=ProcessUnitInstanceName("default_compressor"),
+            .with_process_unit(
+                name="default_compressor",
                 target=YamlCompressorBuilder().with_test_data().validate(),
             )
         )
@@ -469,7 +477,7 @@ class YamlProcessSimulationBuilder(Builder[YamlProcessSimulation]):
     ) -> Self:
         pipeline_instance_name = ProcessPipelineInstanceName(pipeline.name)
         self.targets.append(YamlProcessPipelineTarget(name=pipeline_instance_name, target=pipeline))
-        process_unit_name = pipeline.items[-1].name
+        process_unit_name = pipeline.process_units[-1].name
         self.constraints[pipeline.name] = [
             YamlProcessConstraint(
                 process_unit=(

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -1,4 +1,4 @@
-from typing import Self, Literal
+from typing import Self
 
 from libecalc.common.utils.rates import RateType
 from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
@@ -9,10 +9,15 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import (
     YamlFluidModelType,
     YamlPredefinedFluidModel,
 )
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
+    ProcessUnitDefinitionReference,
+    ProcessUnitInstanceName,
+    ProcessUnitInstanceReference,
+)
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlProcessConstraint,
     YamlProcessSimulation,
+    YamlProcessPipelineTarget,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_stream_distribution import (
     YamlCommonStreamDistribution,
@@ -38,8 +43,8 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_chart import (
 )
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import (
-    YamlItem,
     YamlProcessPipeline,
+    YamlProcessUnitItem,
 )
 
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
@@ -243,13 +248,17 @@ class YamlProcessPipelineBuilder(Builder[YamlProcessPipeline]):
         self.name = name
         return self
 
-    def with_item(self, target: YamlProcessUnit | ProcessUnitReference, name: str | None = None) -> Self:
-        self.items.append(YamlItem(name=name, target=target))
+    def with_item(
+        self, target: YamlProcessUnit | ProcessUnitDefinitionReference, name: ProcessUnitInstanceName | None = None
+    ) -> Self:
+        self.items.append(YamlProcessUnitItem(name=name, target=target))
         return self
 
-    def with_items(self, items: list[tuple[str | None, YamlProcessUnit | ProcessUnitReference]]) -> Self:
+    def with_items(
+        self, items: list[tuple[ProcessUnitInstanceName | None, YamlProcessUnit | ProcessUnitDefinitionReference]]
+    ) -> Self:
         """Pass a list of validated process units (or string references).
-        Each is wrapped in a YamlItem automatically."""
+        Each is wrapped in a YamlProcessUnitItem automatically."""
         for name, target in items:
             self.with_item(name=name, target=target)
         return self
@@ -263,13 +272,21 @@ class YamlProcessPipelineBuilder(Builder[YamlProcessPipeline]):
 
         return (
             self.with_item(
-                name="default_pressure_dropper", target=YamlPressureDropperBuilder().with_test_data().validate()
+                name=ProcessUnitInstanceName("default_pressure_dropper"),
+                target=YamlPressureDropperBuilder().with_test_data().validate(),
             )
             .with_item(
-                name="default_temperature_setter", target=YamlTemperatureSetterBuilder().with_test_data().validate()
+                name=ProcessUnitInstanceName("default_temperature_setter"),
+                target=YamlTemperatureSetterBuilder().with_test_data().validate(),
             )
-            .with_item(name="default_liquid_remover", target=YamlLiquidRemoverBuilder().with_test_data().validate())
-            .with_item(name="default_compressor", target=YamlCompressorBuilder().with_test_data().validate())
+            .with_item(
+                name=ProcessUnitInstanceName("default_liquid_remover"),
+                target=YamlLiquidRemoverBuilder().with_test_data().validate(),
+            )
+            .with_item(
+                name=ProcessUnitInstanceName("default_compressor"),
+                target=YamlCompressorBuilder().with_test_data().validate(),
+            )
         )
 
 
@@ -427,7 +444,7 @@ class YamlCommonStreamDistributionBuilder(Builder[YamlCommonStreamDistribution])
 class YamlProcessSimulationBuilder(Builder[YamlProcessSimulation]):
     def __init__(self):
         self.name: str | None = None
-        self.targets: list[YamlItem[YamlProcessPipeline]] = []
+        self.targets: list[YamlProcessPipelineTarget] = []
         self.stream_distribution = None
         self.constraints: dict[str, list[YamlProcessConstraint]] = {}
 
@@ -449,10 +466,13 @@ class YamlProcessSimulationBuilder(Builder[YamlProcessSimulation]):
         anti_surge: AntiSurgeType = AntiSurgeType.INDIVIDUAL_ASV,
         outlet_pressure: YamlExpressionType = 100.0,
     ) -> Self:
-        self.targets.append(YamlItem(target=pipeline))
+        self.targets.append(YamlProcessPipelineTarget(target=pipeline))
+        process_unit_name = pipeline.items[-1].name
         self.constraints[pipeline.name] = [
             YamlProcessConstraint(
-                process_unit=pipeline.items[-1].name,
+                process_unit=(
+                    ProcessUnitInstanceReference(process_unit_name) if process_unit_name is not None else None
+                ),
                 outlet_pressure=outlet_pressure,
                 pressure_control=pressure_control,
                 anti_surge=anti_surge,

--- a/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_process_simulation_mapper.py
@@ -5,6 +5,7 @@ import pytest
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
 from libecalc.common.time_utils import Period
 from libecalc.ecalc_model.process_simulation import Constraint
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import ProcessUnitInstanceReference
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlProcessConstraint
 from libecalc.process.process_solver.anti_surge.anti_surge_strategy import AntiSurgeType
 from libecalc.process.process_solver.pressure_control.pressure_control_strategy import PressureControlType
@@ -42,10 +43,10 @@ def _simple_pipeline(name: str = "train_1"):
     return (
         YamlProcessPipelineBuilder()
         .with_name(name)
-        .with_item(target=YamlPressureDropperBuilder().with_test_data().validate())
-        .with_item(target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(target=YamlLiquidRemoverBuilder().with_test_data().validate())
-        .with_item(target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(target=YamlPressureDropperBuilder().with_test_data().validate())
+        .with_process_unit(target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(target=YamlLiquidRemoverBuilder().with_test_data().validate())
+        .with_process_unit(target=YamlCompressorBuilder().with_test_data().validate())
         .validate()
     )
 
@@ -176,12 +177,12 @@ def test_mixer_and_splitter_are_placed_between_asv_loops(process_simulation_mapp
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
         .with_name("train_with_mixer_and_splitter")
-        .with_item(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
-        .with_item(target=YamlSplitterBuilder().with_test_data().validate())
-        .with_item(target=YamlMixerBuilder().with_test_data().validate())
-        .with_item(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(target=YamlSplitterBuilder().with_test_data().validate())
+        .with_process_unit(target=YamlMixerBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
         .validate()
     )
     yaml_simulation = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
@@ -294,11 +295,11 @@ def test_mapper_places_trailing_units_after_last_asv_loop(process_simulation_map
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
         .with_name("train_with_aftercooler")
-        .with_item(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
-        .with_item(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
-        .with_item(name="temp_setter_3", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_3", target=YamlTemperatureSetterBuilder().with_test_data().validate())
         .validate()
     )
     yaml_simulation = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
@@ -329,10 +330,10 @@ def test_duplicate_process_unit_names_not_allowed(process_simulation_mapper):
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
         .with_name("train_with_duplicate_unit_names")
-        .with_item(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
-        .with_item(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
         .validate()
     )
     yaml_simulation = _build_simulation_with_pipeline(yaml_pipeline, pressure_control="INDIVIDUAL_ASV_RATE")
@@ -376,18 +377,18 @@ def test_mapper_builds_multiple_process_problem_sections(process_simulation_mapp
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
         .with_name("train_with_intermediate_constraint")
-        .with_item(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
-        .with_item(target=YamlMixerBuilder().with_test_data().validate())
-        .with_item(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(target=YamlMixerBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
         .validate()
     )
 
     yaml_simulation = _build_simulation_with_pipeline(pipeline=yaml_pipeline, pressure_control="DOWNSTREAM_CHOKE")
 
     constraint = YamlProcessConstraint(
-        process_unit="compressor_1",
+        process_unit=ProcessUnitInstanceReference("compressor_1"),
         outlet_pressure=30,
         pressure_control="INDIVIDUAL_ASV_RATE",
         anti_surge=AntiSurgeType.INDIVIDUAL_ASV,

--- a/tests/libecalc/presentation/yaml/resolvers/test_process_unit_resolver.py
+++ b/tests/libecalc/presentation/yaml/resolvers/test_process_unit_resolver.py
@@ -1,0 +1,32 @@
+from unittest.mock import Mock
+
+from libecalc.presentation.yaml.domain.reference_service import ReferenceService
+from libecalc.presentation.yaml.resolvers.process_unit_resolver import ProcessUnitResolver
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessUnitItem
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
+    ProcessUnitDefinitionReference,
+    ProcessUnitInstanceName,
+)
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlLiquidRemover
+
+
+def test_resolves_process_unit_definition_reference():
+    """Resolve a global unit definition while preserving its local instance name."""
+    reference_service = Mock(spec=ReferenceService)
+    specification = YamlLiquidRemover(type="LIQUID_REMOVER")
+    definition_reference = ProcessUnitDefinitionReference("scrubber")
+    instance_name = ProcessUnitInstanceName("first_stage_scrubber")
+    reference_service.get_process_unit.return_value = specification
+
+    # Simulate the global definition lookup: "scrubber" -> specification.
+    resolved = ProcessUnitResolver(reference_service).resolve(
+        YamlProcessUnitItem(
+            name=instance_name,
+            target=definition_reference,
+        )
+    )
+
+    # Resolution replaces the definition reference but preserves local identity.
+    assert resolved.name == instance_name
+    assert resolved.specification == specification
+    reference_service.get_process_unit.assert_called_once_with(definition_reference)

--- a/tests/libecalc/presentation/yaml/resolvers/test_process_unit_resolver.py
+++ b/tests/libecalc/presentation/yaml/resolvers/test_process_unit_resolver.py
@@ -1,26 +1,23 @@
-from unittest.mock import Mock
-
-from libecalc.presentation.yaml.domain.reference_service import ReferenceService
 from libecalc.presentation.yaml.resolvers.process_unit_resolver import ProcessUnitResolver
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessUnitItem
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessUnitInstance
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
     ProcessUnitDefinitionReference,
     ProcessUnitInstanceName,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlLiquidRemover
+from libecalc.testing.direct_reference_service import DirectReferenceService
 
 
 def test_resolves_process_unit_definition_reference():
     """Resolve a global unit definition while preserving its local instance name."""
-    reference_service = Mock(spec=ReferenceService)
     specification = YamlLiquidRemover(type="LIQUID_REMOVER")
+    reference_service = DirectReferenceService(references={"scrubber": specification})
     definition_reference = ProcessUnitDefinitionReference("scrubber")
     instance_name = ProcessUnitInstanceName("first_stage_scrubber")
-    reference_service.get_process_unit.return_value = specification
 
     # Simulate the global definition lookup: "scrubber" -> specification.
     resolved = ProcessUnitResolver(reference_service).resolve(
-        YamlProcessUnitItem(
+        YamlProcessUnitInstance(
             name=instance_name,
             target=definition_reference,
         )
@@ -29,4 +26,3 @@ def test_resolves_process_unit_definition_reference():
     # Resolution replaces the definition reference but preserves local identity.
     assert resolved.name == instance_name
     assert resolved.specification == specification
-    reference_service.get_process_unit.assert_called_once_with(definition_reference)

--- a/tests/libecalc/process/test_mixer_integration.py
+++ b/tests/libecalc/process/test_mixer_integration.py
@@ -34,11 +34,11 @@ def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper, fluid_s
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
         .with_name("train_with_mixer")
-        .with_item(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
-        .with_item(target=yaml_mixer)
-        .with_item(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(target=yaml_mixer)
+        .with_process_unit(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
         .validate()
     )
 

--- a/tests/libecalc/process/test_splitter_integration.py
+++ b/tests/libecalc/process/test_splitter_integration.py
@@ -35,11 +35,11 @@ def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper, flui
     yaml_pipeline = (
         YamlProcessPipelineBuilder()
         .with_name("train_with_splitter")
-        .with_item(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
-        .with_item(target=yaml_splitter)
-        .with_item(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
-        .with_item(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(name="temp_setter_1", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_1", target=YamlCompressorBuilder().with_test_data().validate())
+        .with_process_unit(target=yaml_splitter)
+        .with_process_unit(name="temp_setter_2", target=YamlTemperatureSetterBuilder().with_test_data().validate())
+        .with_process_unit(name="compressor_2", target=YamlCompressorBuilder().with_test_data().validate())
         .validate()
     )
     yaml_simulation = (


### PR DESCRIPTION
### Summary

- Separates process instance names, instance references, and definition references.
- Renames reusable sections to `PROCESS_UNIT_DEFINITIONS` and `PROCESS_PIPELINE_DEFINITIONS`.
- Renames pipeline `ITEMS` to `PROCESS_UNITS`.
- Requires explicit pipeline instance names.
- Adds `ProcessUnitResolver` and resolver test coverage.

### Motivation

This is a first step toward resolving YAML references before domain mapping, with reusable definitions and local instances represented explicitly.

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
