### PR TITLE
feat: add reusable fluid definitions for process simulations

### DIFF
--- a/src/libecalc/ecalc_model/time_series_fluid_model.py
+++ b/src/libecalc/ecalc_model/time_series_fluid_model.py
@@ -40,9 +40,6 @@ class TimeSeriesFluidComposition:
             n_hexane=self.n_hexane.get_masked_values()[index],
         )
 
-    def get_periods(self) -> list[Period]:
-        return self.methane.get_periods()
-
 
 @value_object
 class TimeSeriesFluidModel:
@@ -55,6 +52,3 @@ class TimeSeriesFluidModel:
             eos_model=self.eos_model,
             composition=self.composition.get_value(period),
         )
-
-    def get_periods(self) -> list[Period]:
-        return self.composition.get_periods()

--- a/src/libecalc/ecalc_model/time_series_fluid_model.py
+++ b/src/libecalc/ecalc_model/time_series_fluid_model.py
@@ -40,6 +40,9 @@ class TimeSeriesFluidComposition:
             n_hexane=self.n_hexane.get_masked_values()[index],
         )
 
+    def get_periods(self) -> list[Period]:
+        return self.methane.get_periods()
+
 
 @value_object
 class TimeSeriesFluidModel:
@@ -52,3 +55,6 @@ class TimeSeriesFluidModel:
             eos_model=self.eos_model,
             composition=self.composition.get_value(period),
         )
+
+    def get_periods(self) -> list[Period]:
+        return self.composition.get_periods()

--- a/src/libecalc/ecalc_model/time_series_fluid_model.py
+++ b/src/libecalc/ecalc_model/time_series_fluid_model.py
@@ -1,0 +1,54 @@
+from libecalc.common.ddd import value_object
+from libecalc.common.errors.exceptions import ProgrammingError
+from libecalc.common.time_utils import Period
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
+from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
+
+
+@value_object
+class TimeSeriesFluidComposition:
+    water: TimeSeriesExpression
+    nitrogen: TimeSeriesExpression
+    CO2: TimeSeriesExpression
+    methane: TimeSeriesExpression
+    ethane: TimeSeriesExpression
+    propane: TimeSeriesExpression
+    i_butane: TimeSeriesExpression
+    n_butane: TimeSeriesExpression
+    i_pentane: TimeSeriesExpression
+    n_pentane: TimeSeriesExpression
+    n_hexane: TimeSeriesExpression
+
+    def get_value(self, period: Period) -> FluidComposition:
+        """Evaluate all component expressions and materialize the fluid composition for the given period."""
+        try:
+            index = self.methane.get_periods().index(period)
+        except ValueError as error:
+            raise ProgrammingError(f"Period {period} is not available for the fluid composition.") from error
+
+        return FluidComposition(
+            water=self.water.get_masked_values()[index],
+            nitrogen=self.nitrogen.get_masked_values()[index],
+            CO2=self.CO2.get_masked_values()[index],
+            methane=self.methane.get_masked_values()[index],
+            ethane=self.ethane.get_masked_values()[index],
+            propane=self.propane.get_masked_values()[index],
+            i_butane=self.i_butane.get_masked_values()[index],
+            n_butane=self.n_butane.get_masked_values()[index],
+            i_pentane=self.i_pentane.get_masked_values()[index],
+            n_pentane=self.n_pentane.get_masked_values()[index],
+            n_hexane=self.n_hexane.get_masked_values()[index],
+        )
+
+
+@value_object
+class TimeSeriesFluidModel:
+    eos_model: EoSModel
+    composition: TimeSeriesFluidComposition
+
+    def get_value(self, period: Period) -> FluidModel:
+        """Materialize a fluid model with the composition evaluated for the given period."""
+        return FluidModel(
+            eos_model=self.eos_model,
+            composition=self.composition.get_value(period),
+        )

--- a/src/libecalc/ecalc_model/time_series_stream.py
+++ b/src/libecalc/ecalc_model/time_series_stream.py
@@ -1,12 +1,12 @@
 from libecalc.common.ddd import value_object
+from libecalc.ecalc_model.time_series_fluid_model import TimeSeriesFluidModel
 from libecalc.presentation.yaml.domain.expression_time_series_flow_rate import ExpressionTimeSeriesFlowRate
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
-from libecalc.process.fluid_stream.fluid_model import FluidModel
 
 
 @value_object
 class TimeSeriesStream:
-    fluid_model: FluidModel
+    fluid_model: TimeSeriesFluidModel
     pressure_bara: TimeSeriesExpression
     temperature_kelvin: TimeSeriesExpression
     standard_rate_m3_per_day: ExpressionTimeSeriesFlowRate

--- a/src/libecalc/presentation/yaml/domain/reference_service.py
+++ b/src/libecalc/presentation/yaml/domain/reference_service.py
@@ -24,6 +24,7 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_trains import 
     YamlVariableSpeedCompressorTrain,
     YamlVariableSpeedCompressorTrainMultipleStreamsAndPressures,
 )
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import YamlFluidDefinition
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnitDefinition
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
@@ -54,6 +55,9 @@ class ReferenceService(Protocol):
 
     @abc.abstractmethod
     def get_fluid(self, reference: str) -> YamlFluidModel: ...
+
+    @abc.abstractmethod
+    def get_fluid_definition(self, reference: str) -> YamlFluidDefinition: ...
 
     @abc.abstractmethod
     def get_turbine(self, reference: str) -> YamlTurbine: ...

--- a/src/libecalc/presentation/yaml/mappers/fluid_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/fluid_mapper.py
@@ -1,6 +1,22 @@
+from typing import assert_never
+
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
+from libecalc.common.variables import ExpressionEvaluator
+from libecalc.ecalc_model.time_series_fluid_model import TimeSeriesFluidComposition, TimeSeriesFluidModel
+from libecalc.expression.expression import ExpressionType
+from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 from libecalc.presentation.yaml.yaml_keywords import EcalcYamlKeywords
-from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import YamlCompositionFluidModel, YamlPredefinedFluidModel
+from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import (
+    YamlCompositionFluidModel,
+    YamlEosModel,
+    YamlPredefinedFluidModel,
+)
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import (
+    YamlCompositionFluidDefinition,
+    YamlFluidComposition,
+    YamlFluidDefinition,
+    YamlPredefinedFluidDefinition,
+)
 from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition, FluidModel
 
 """
@@ -119,5 +135,71 @@ def composition_fluid_model_mapper(
             i_pentane=user_defined_composition.i_pentane,
             n_pentane=user_defined_composition.n_pentane,
             n_hexane=user_defined_composition.n_hexane,
+        ),
+    )
+
+
+def fluid_definition_mapper(
+    definition: YamlFluidDefinition,
+    expression_evaluator: ExpressionEvaluator,
+) -> TimeSeriesFluidModel:
+    match definition:
+        case YamlPredefinedFluidDefinition():
+            return predefined_fluid_definition_mapper(definition, expression_evaluator)
+        case YamlCompositionFluidDefinition():
+            return composition_fluid_definition_mapper(definition, expression_evaluator)
+        case _:
+            assert_never(definition)
+
+
+def predefined_fluid_definition_mapper(
+    model_config: YamlPredefinedFluidDefinition,
+    expression_evaluator: ExpressionEvaluator,
+) -> TimeSeriesFluidModel:
+    predefined_composition = _predefined_fluid_composition_mapper[model_config.gas_type]
+
+    return _create_time_series_fluid_model(
+        eos_model_type=model_config.eos_model,
+        composition=predefined_composition,
+        expression_evaluator=expression_evaluator,
+    )
+
+
+def composition_fluid_definition_mapper(
+    model_config: YamlCompositionFluidDefinition,
+    expression_evaluator: ExpressionEvaluator,
+) -> TimeSeriesFluidModel:
+    return _create_time_series_fluid_model(
+        eos_model_type=model_config.eos_model,
+        composition=model_config.composition,
+        expression_evaluator=expression_evaluator,
+    )
+
+
+def _create_time_series_fluid_model(
+    eos_model_type: YamlEosModel,
+    composition: FluidComposition | YamlFluidComposition,
+    expression_evaluator: ExpressionEvaluator,
+) -> TimeSeriesFluidModel:
+    def time_series_expression(expression: ExpressionType) -> TimeSeriesExpression:
+        return TimeSeriesExpression(
+            expression=expression,
+            expression_evaluator=expression_evaluator,
+        )
+
+    return TimeSeriesFluidModel(
+        eos_model=_eos_model_mapper[eos_model_type],
+        composition=TimeSeriesFluidComposition(
+            water=time_series_expression(composition.water),
+            nitrogen=time_series_expression(composition.nitrogen),
+            CO2=time_series_expression(composition.CO2),
+            methane=time_series_expression(composition.methane),
+            ethane=time_series_expression(composition.ethane),
+            propane=time_series_expression(composition.propane),
+            i_butane=time_series_expression(composition.i_butane),
+            n_butane=time_series_expression(composition.n_butane),
+            i_pentane=time_series_expression(composition.i_pentane),
+            n_pentane=time_series_expression(composition.n_pentane),
+            n_hexane=time_series_expression(composition.n_hexane),
         ),
     )

--- a/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
+++ b/src/libecalc/presentation/yaml/mappers/process_simulation_mapper.py
@@ -26,6 +26,7 @@ from libecalc.ecalc_model.time_series_configuration import (
     TimeSeriesSplitterConfiguration,
     TimeSeriesTemperatureSetterConfiguration,
 )
+from libecalc.ecalc_model.time_series_fluid_model import TimeSeriesFluidModel
 from libecalc.ecalc_model.time_series_stream import TimeSeriesStream
 from libecalc.expression.expression import ExpressionType
 from libecalc.presentation.yaml.domain.expression_time_series_flow_rate import ExpressionTimeSeriesFlowRate
@@ -33,18 +34,15 @@ from libecalc.presentation.yaml.domain.reference_service import ReferenceService
 from libecalc.presentation.yaml.domain.time_series_expression import TimeSeriesExpression
 from libecalc.presentation.yaml.mappers.charts.user_defined_chart_data import UserDefinedChartData
 from libecalc.presentation.yaml.mappers.consumer_function_mapper import handle_condition_list
-from libecalc.presentation.yaml.mappers.fluid_mapper import (
-    composition_fluid_model_mapper,
-    predefined_fluid_model_mapper,
-)
+from libecalc.presentation.yaml.mappers.fluid_mapper import fluid_definition_mapper
 from libecalc.presentation.yaml.mappers.model import InvalidChartResourceException
 from libecalc.presentation.yaml.mappers.process.build_sections import ProcessSectionBuilder
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
-from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
 from libecalc.presentation.yaml.yaml_types.models.yaml_compressor_stages import YamlControlMarginUnits
-from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import YamlCompositionFluidModel, YamlPredefinedFluidModel
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import YamlFluidDefinition
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import (
+    DefinitionReference,
     InstanceReference,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
@@ -62,7 +60,6 @@ from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
 )
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream, YamlInletStreamRate
 from libecalc.presentation.yaml.yaml_types.yaml_data_or_file import YamlFile
-from libecalc.process.fluid_stream.fluid_model import FluidModel
 from libecalc.process.fluid_stream.fluid_service import FluidService
 from libecalc.process.fluid_stream.fluid_stream import FluidStream
 from libecalc.process.process_pipeline.process_pipeline import (
@@ -186,11 +183,13 @@ class ProcessSimulationMapper:
         else:
             return ref
 
-    def _resolve_fluid_model_reference(self, ref: str | YamlFluidModel) -> YamlFluidModel:
-        if isinstance(ref, str):
-            return self._reference_service.get_fluid(reference=ref)
-        else:
-            return ref
+    def _resolve_fluid_definition(
+        self,
+        reference: DefinitionReference | YamlFluidDefinition,
+    ) -> YamlFluidDefinition:
+        if isinstance(reference, str):
+            return self._reference_service.get_fluid_definition(reference)
+        return reference
 
     def _map_conditions(
         self, conditions: YamlExpressionType | list[YamlExpressionType] | None
@@ -235,14 +234,14 @@ class ProcessSimulationMapper:
             expression=temperature,
         )
 
-    def _map_fluid_model(self, yaml_fluid_model: YamlFluidModel) -> FluidModel:
-        match yaml_fluid_model:
-            case YamlPredefinedFluidModel():
-                return predefined_fluid_model_mapper(yaml_fluid_model)
-            case YamlCompositionFluidModel():
-                return composition_fluid_model_mapper(yaml_fluid_model)
-            case _:
-                assert_never(yaml_fluid_model)
+    def _map_fluid_definition(
+        self,
+        fluid_definition: YamlFluidDefinition,
+    ) -> TimeSeriesFluidModel:
+        return fluid_definition_mapper(
+            fluid_definition,
+            expression_evaluator=self._expression_evaluator,
+        )
 
     def _validate_and_map_pipeline_events(
         self,
@@ -347,14 +346,14 @@ class ProcessSimulationMapper:
 
                     case YamlMixerDefinition():
                         yaml_stream = self._resolve_stream_reference(yaml_process_unit.sidestream)
-                        yaml_fluid_model = self._resolve_fluid_model_reference(yaml_stream.fluid_model)
+                        yaml_fluid_definition = self._resolve_fluid_definition(yaml_stream.fluid)
                         unit = Mixer(fluid_service=self._fluid_service)
                         problem_time_series_configurations[unit.get_id()] = TimeSeriesMixerConfiguration(
                             sidestream=TimeSeriesStream(
                                 pressure_bara=self._map_pressure(yaml_stream.pressure),
                                 standard_rate_m3_per_day=self._map_rate(yaml_stream.rate),
                                 temperature_kelvin=self._map_temperature(yaml_stream.temperature),
-                                fluid_model=self._map_fluid_model(yaml_fluid_model),
+                                fluid_model=self._map_fluid_definition(yaml_fluid_definition),
                             )
                         )
 
@@ -539,12 +538,12 @@ class ProcessSimulationMapper:
                     )
 
                 yaml_stream = self._resolve_stream_reference(yaml_stream_distribution.inlet_stream)
-                yaml_fluid_model = self._resolve_fluid_model_reference(yaml_stream.fluid_model)
+                yaml_fluid_definition = self._resolve_fluid_definition(yaml_stream.fluid)
                 inlet_stream = TimeSeriesStream(
                     pressure_bara=self._map_pressure(yaml_stream.pressure),
                     standard_rate_m3_per_day=self._map_rate(yaml_stream.rate),
                     temperature_kelvin=self._map_temperature(yaml_stream.temperature),
-                    fluid_model=self._map_fluid_model(yaml_fluid_model),
+                    fluid_model=self._map_fluid_definition(yaml_fluid_definition),
                 )
                 stream_distribution = CommonStreamDistributionConfig(
                     inlet_stream=inlet_stream,
@@ -554,13 +553,13 @@ class ProcessSimulationMapper:
                 inlet_streams = []
                 for inlet_stream in yaml_stream_distribution.inlet_streams:
                     yaml_stream = self._resolve_stream_reference(inlet_stream)
-                    yaml_fluid_model = self._resolve_fluid_model_reference(yaml_stream.fluid_model)
+                    yaml_fluid_definition = self._resolve_fluid_definition(yaml_stream.fluid)
                     inlet_streams.append(
                         TimeSeriesStream(
                             pressure_bara=self._map_pressure(yaml_stream.pressure),
                             standard_rate_m3_per_day=self._map_rate(yaml_stream.rate),
                             temperature_kelvin=self._map_temperature(yaml_stream.temperature),
-                            fluid_model=self._map_fluid_model(yaml_fluid_model),
+                            fluid_model=self._map_fluid_definition(yaml_fluid_definition),
                         )
                     )
                 stream_distribution = IndividualStreamDistributionConfig(

--- a/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
+++ b/src/libecalc/presentation/yaml/yaml_models/pyyaml_yaml_model.py
@@ -31,6 +31,7 @@ from libecalc.presentation.yaml.yaml_types.components.yaml_installation import Y
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import YamlFacilityModel
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import YamlFluidDefinition
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlEcalcEvent,
@@ -51,6 +52,7 @@ _PROCESS_UNITS_KEY = "PROCESS_UNITS"
 _PROCESS_PIPELINES_KEY = "PROCESS_PIPELINES"
 _INLET_STREAMS_KEY = "INLET_STREAMS"
 _FLUID_MODELS_KEY = "FLUID_MODELS"
+_FLUIDS_KEY = "FLUIDS"
 _PROCESS_SIMULATIONS_KEY = "PROCESS_SIMULATIONS"
 _ECALC_EVENTS_KEY = "ECALC_EVENTS"
 _PROCESS_EVENTS_KEY = "PROCESS_EVENTS"
@@ -456,17 +458,25 @@ class PyYamlYamlModel(YamlValidator, YamlConfiguration):
     @property
     def definitions(self) -> YamlDefinitions:
         process_units: dict[str, YamlProcessUnitDefinition] = {}
+        fluids: dict[str, YamlFluidDefinition] = {}
         definitions = (
             self._internal_datamodel.get(_DEFINITIONS_KEY, {}) if isinstance(self._internal_datamodel, dict) else {}
         )
-        raw = definitions.get(_PROCESS_UNITS_KEY, {}) if isinstance(definitions, dict) else {}
+        raw_process_units = definitions.get(_PROCESS_UNITS_KEY, {}) if isinstance(definitions, dict) else {}
+        raw_fluids = definitions.get(_FLUIDS_KEY, {}) if isinstance(definitions, dict) else {}
 
-        for name, unit_data in raw.items():
+        for name, unit_data in raw_process_units.items():
             try:
                 process_units[name] = TypeAdapter(YamlProcessUnitDefinition).validate_python(unit_data)
             except PydanticValidationError:
                 pass
-        return YamlDefinitions(process_units=process_units)
+        for name, fluid_data in raw_fluids.items():
+            try:
+                fluids[name] = TypeAdapter(YamlFluidDefinition).validate_python(fluid_data)
+            except PydanticValidationError:
+                pass
+
+        return YamlDefinitions(process_units=process_units, fluids=fluids)
 
     @property
     def process_pipelines(self) -> dict[str, YamlProcessPipeline]:

--- a/src/libecalc/presentation/yaml/yaml_reference_service.py
+++ b/src/libecalc/presentation/yaml/yaml_reference_service.py
@@ -25,6 +25,7 @@ from libecalc.presentation.yaml.yaml_types.models import (
     YamlTurbine,
 )
 from libecalc.presentation.yaml.yaml_types.models.yaml_enums import YamlModelType
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import YamlFluidDefinition
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlProcessSimulation,
@@ -45,6 +46,7 @@ type ReferenceType = (
     | YamlProcessSimulation
     | YamlPumpProcessSimulation
     | YamlProcessUnitDefinition
+    | YamlFluidDefinition
 )
 
 # Some models are referenced by other models, for example a compressor model will reference compressor chart models
@@ -117,6 +119,12 @@ class YamlReferenceService(ReferenceService):
             references[process_unit_key] = process_unit
             reference_yaml_context[process_unit_key] = process_unit_path
 
+        fluids_path = YamlPath(keys=("DEFINITIONS", "FLUIDS"))
+        for fluid_key, fluid in configuration.definitions.fluids.items():
+            fluid_path = fluids_path.append(fluid_key)
+            references[fluid_key] = fluid
+            reference_yaml_context[fluid_key] = fluid_path
+
         process_pipelines_path = YamlPath(keys=("PROCESS_PIPELINES",))
         for process_pipeline_key, process_pipeline in configuration.process_pipelines.items():
             process_pipeline_path = process_pipelines_path.append(process_pipeline_key)
@@ -153,6 +161,12 @@ class YamlReferenceService(ReferenceService):
         if not isinstance(model, get_args(get_args(YamlFluidModel)[0])):
             raise InvalidReferenceException("fluid model", reference)
         return model
+
+    def get_fluid_definition(self, reference: str) -> YamlFluidDefinition:
+        fluid = self._resolve_yaml_reference(reference, "fluid definition")
+        if not isinstance(fluid, get_args(get_args(YamlFluidDefinition)[0])):
+            raise InvalidReferenceException("fluid definition", reference)
+        return fluid
 
     def get_turbine(self, reference: str) -> YamlTurbine:
         model = self._resolve_yaml_reference(reference, "turbine model")

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
@@ -194,40 +194,31 @@ class YamlAsset(YamlBase):
     def validate_unique_references(self):
         references = []
 
-        if self.facility_inputs is not None:
-            for facility_input in self.facility_inputs:
-                references.append(facility_input.name)
+        for facility_input in self.facility_inputs:
+            references.append(facility_input.name)
 
-        if self.models is not None:
-            for model in self.models:
-                references.append(model.name)
+        for model in self.models:
+            references.append(model.name)
 
-        if self.fuel_types is not None:
-            for fuel_type in self.fuel_types:
-                references.append(fuel_type.name)
+        for fuel_type in self.fuel_types:
+            references.append(fuel_type.name)
 
-        if self.process_pipelines is not None:
-            references.extend(self.process_pipelines.keys())
+        references.extend(self.process_pipelines.keys())
 
-        if self.definitions and self.definitions.process_units is not None:
-            references.extend(self.definitions.process_units.keys())
-            references.extend(self.definitions.fluids.keys())
+        references.extend(self.definitions.process_units.keys())
+        references.extend(self.definitions.fluids.keys())
 
-        if self.process_simulations is not None:
-            for process_simulation in self.process_simulations:
-                references.append(process_simulation.name)
+        for process_simulation in self.process_simulations:
+            references.append(process_simulation.name)
 
-        if self.pump_process_simulations is not None:
-            for pump_process_simulation in self.pump_process_simulations:
-                references.append(pump_process_simulation.name)
+        for pump_process_simulation in self.pump_process_simulations:
+            references.append(pump_process_simulation.name)
 
         # TODO: Add ecalc events references?
 
-        if self.fluid_models is not None:
-            references.extend(self.fluid_models.keys())
+        references.extend(self.fluid_models.keys())
 
-        if self.inlet_streams is not None:
-            references.extend(self.inlet_streams.keys())
+        references.extend(self.inlet_streams.keys())
 
         duplicated_references = get_duplicates(references)
 

--- a/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
+++ b/src/libecalc/presentation/yaml/yaml_types/components/yaml_asset.py
@@ -7,6 +7,7 @@ from libecalc.presentation.yaml.yaml_types.components.yaml_installation import Y
 from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model import YamlFacilityModel
 from libecalc.presentation.yaml.yaml_types.fuel_type.yaml_fuel_type import YamlFuelType
 from libecalc.presentation.yaml.yaml_types.models import YamlConsumerModel, YamlFluidModel
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import YamlFluidDefinition
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlEcalcEvent,
@@ -35,6 +36,12 @@ class YamlDefinitions(YamlBase):
         description="Defines process units used in PROCESS_PIPELINES.",
     )
 
+    fluids: dict[str, YamlFluidDefinition] = Field(
+        default_factory=dict,
+        title="FLUIDS",
+        description="Defines fluids that can be referenced in inlet streams.",
+    )
+
 
 class YamlAsset(YamlBase):
     """An eCalc™ yaml file"""
@@ -46,7 +53,7 @@ class YamlAsset(YamlBase):
     definitions: YamlDefinitions = Field(
         default_factory=YamlDefinitions,
         title="DEFINITIONS",
-        description="Contains reusable definitions such as process units.",
+        description="Contains reusable definitions such as process units and fluids.",
     )
     time_series: list[YamlTimeSeriesCollection] = Field(
         default_factory=list,
@@ -204,6 +211,7 @@ class YamlAsset(YamlBase):
 
         if self.definitions and self.definitions.process_units is not None:
             references.extend(self.definitions.process_units.keys())
+            references.extend(self.definitions.fluids.keys())
 
         if self.process_simulations is not None:
             for process_simulation in self.process_simulations:

--- a/src/libecalc/presentation/yaml/yaml_types/process/yaml_fluid_definitions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/process/yaml_fluid_definitions.py
@@ -1,0 +1,45 @@
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from libecalc.presentation.yaml.yaml_types import YamlBase
+from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
+from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import (
+    YamlEosModel,
+    YamlFluidModelType,
+    YamlPredefinedFluidType,
+)
+
+
+class YamlFluidComposition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    water: YamlExpressionType = 0.0
+    nitrogen: YamlExpressionType = 0.0
+    CO2: YamlExpressionType = 0.0
+    methane: YamlExpressionType
+    ethane: YamlExpressionType = 0.0
+    propane: YamlExpressionType = 0.0
+    i_butane: YamlExpressionType = 0.0
+    n_butane: YamlExpressionType = 0.0
+    i_pentane: YamlExpressionType = 0.0
+    n_pentane: YamlExpressionType = 0.0
+    n_hexane: YamlExpressionType = 0.0
+
+
+class YamlPredefinedFluidDefinition(YamlBase):
+    type: Literal[YamlFluidModelType.PREDEFINED]
+    eos_model: YamlEosModel = YamlEosModel.SRK
+    gas_type: YamlPredefinedFluidType = YamlPredefinedFluidType.MEDIUM
+
+
+class YamlCompositionFluidDefinition(YamlBase):
+    type: Literal[YamlFluidModelType.COMPOSITION]
+    eos_model: YamlEosModel = YamlEosModel.SRK
+    composition: YamlFluidComposition
+
+
+YamlFluidDefinition = Annotated[
+    YamlPredefinedFluidDefinition | YamlCompositionFluidDefinition,
+    Field(discriminator="type"),
+]

--- a/src/libecalc/presentation/yaml/yaml_types/streams/yaml_inlet_stream.py
+++ b/src/libecalc/presentation/yaml/yaml_types/streams/yaml_inlet_stream.py
@@ -6,8 +6,8 @@ from pydantic import ConfigDict, Field, model_validator
 from libecalc.common.utils.rates import RateType
 from libecalc.presentation.yaml.yaml_types import YamlBase
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
-from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
-from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import InstanceReference
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import YamlFluidDefinition
+from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import DefinitionReference, InstanceReference
 
 FluidModelReference = str
 
@@ -67,10 +67,10 @@ class YamlInletStream(YamlBase):
         title="NAME",
         description="Unique name of the inlet stream.",
     )
-    fluid_model: FluidModelReference | YamlFluidModel = Field(
+    fluid: DefinitionReference | YamlFluidDefinition = Field(
         ...,
-        title="FLUID_MODEL",
-        description="Reference to a fluid model (e.g. defined in MODELS/FLUID_MODELS elsewhere).",
+        title="FLUID",
+        description="Reference to a fluid definition.",
     )
 
     temperature: YamlExpressionType = Field(

--- a/src/libecalc/presentation/yaml/yaml_types/streams/yaml_inlet_stream.py
+++ b/src/libecalc/presentation/yaml/yaml_types/streams/yaml_inlet_stream.py
@@ -9,8 +9,6 @@ from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type impor
 from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import YamlFluidDefinition
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import DefinitionReference, InstanceReference
 
-FluidModelReference = str
-
 
 class YamlStreamRateUnit(enum.StrEnum):
     SM3_PER_DAY = "SM3_PER_DAY"

--- a/src/libecalc/testing/direct_reference_service.py
+++ b/src/libecalc/testing/direct_reference_service.py
@@ -10,6 +10,7 @@ from libecalc.presentation.yaml.yaml_types.facility_model.yaml_facility_model im
     YamlTabularModel,
 )
 from libecalc.presentation.yaml.yaml_types.models import YamlCompressorChart, YamlFluidModel, YamlTurbine
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import YamlFluidDefinition
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_pipeline import YamlProcessPipeline
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import YamlProcessUnitDefinition
 from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
@@ -53,6 +54,9 @@ class DirectReferenceService(ReferenceService):
         return self._resolve_reference(reference)
 
     def get_process_unit(self, reference: str) -> YamlProcessUnitDefinition:
+        return self._resolve_reference(reference)
+
+    def get_fluid_definition(self, reference: str) -> YamlFluidDefinition:
         return self._resolve_reference(reference)
 
     def get_stream(self, reference: str) -> YamlInletStream:

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -9,6 +9,10 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import (
     YamlFluidModelType,
     YamlPredefinedFluidModel,
 )
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import (
+    YamlFluidDefinition,
+    YamlPredefinedFluidDefinition,
+)
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import DefinitionReference, InstanceReference
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
     YamlProcessConstraint,
@@ -278,17 +282,11 @@ class YamlProcessPipelineBuilder(Builder[YamlProcessPipeline]):
 # ---------------------------------------------------------------------------
 
 
-class YamlPredefinedFluidModelBuilder(Builder[YamlPredefinedFluidModel]):
+class YamlPredefinedFluidDefinitionBuilder(Builder[YamlPredefinedFluidDefinition]):
     def __init__(self):
-        self.name = None
-        self.type = YamlModelType.FLUID
-        self.fluid_model_type = YamlFluidModelType.PREDEFINED
+        self.type = YamlFluidModelType.PREDEFINED
         self.eos_model = None
         self.gas_type = None
-
-    def with_name(self, name: str) -> Self:
-        self.name = name
-        return self
 
     def with_eos_model(self, eos_model: YamlEosModel) -> Self:
         self.eos_model = eos_model
@@ -299,7 +297,6 @@ class YamlPredefinedFluidModelBuilder(Builder[YamlPredefinedFluidModel]):
         return self
 
     def with_test_data(self) -> Self:
-        self.name = "DefaultFluidModel"
         self.eos_model = YamlEosModel.SRK
         self.gas_type = YamlPredefinedFluidType.MEDIUM
         return self
@@ -338,7 +335,7 @@ class YamlInletStreamRateBuilder(Builder[YamlInletStreamRate]):
 class YamlInletStreamBuilder(Builder[YamlInletStream]):
     def __init__(self):
         self.name = None
-        self.fluid_model = None
+        self.fluid = None
         self.pressure = None
         self.temperature = None
         self.rate = None
@@ -347,8 +344,8 @@ class YamlInletStreamBuilder(Builder[YamlInletStream]):
         self.name = name
         return self
 
-    def with_fluid_model(self, fluid_model: str | YamlFluidModel) -> Self:
-        self.fluid_model = fluid_model
+    def with_fluid(self, fluid_definition: DefinitionReference | YamlFluidDefinition) -> Self:
+        self.fluid = fluid_definition
         return self
 
     def with_pressure(self, pressure: YamlExpressionType) -> Self:
@@ -365,7 +362,7 @@ class YamlInletStreamBuilder(Builder[YamlInletStream]):
 
     def with_test_data(self) -> Self:
         self.name = "DefaultInletStream"
-        self.fluid_model = YamlPredefinedFluidModelBuilder().with_test_data().validate()
+        self.fluid = YamlPredefinedFluidDefinitionBuilder().with_test_data().validate()
         self.pressure = 20.0
         self.temperature = 30.0
         self.rate = YamlInletStreamRateBuilder().with_test_data().validate()

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -9,6 +9,8 @@ from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import (
 from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import (
     YamlFluidDefinition,
     YamlPredefinedFluidDefinition,
+    YamlCompositionFluidDefinition,
+    YamlFluidComposition,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_references import DefinitionReference, InstanceReference
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import (
@@ -296,6 +298,35 @@ class YamlPredefinedFluidDefinitionBuilder(Builder[YamlPredefinedFluidDefinition
     def with_test_data(self) -> Self:
         self.eos_model = YamlEosModel.SRK
         self.gas_type = YamlPredefinedFluidType.MEDIUM
+        return self
+
+
+class YamlCompositionFluidDefinitionBuilder(Builder[YamlCompositionFluidDefinition]):
+    def __init__(self):
+        self.type = YamlFluidModelType.COMPOSITION
+        self.eos_model = None
+        self.composition = None
+
+    def with_eos_model(
+        self,
+        eos_model: YamlEosModel,
+    ) -> Self:
+        self.eos_model = eos_model
+        return self
+
+    def with_composition(
+        self,
+        composition: YamlFluidComposition,
+    ) -> Self:
+        self.composition = composition
+        return self
+
+    def with_test_data(self) -> Self:
+        self.eos_model = YamlEosModel.SRK
+        self.composition = YamlFluidComposition(
+            methane=90.0,
+            ethane=10.0,
+        )
         return self
 
 

--- a/src/libecalc/testing/process_builders.py
+++ b/src/libecalc/testing/process_builders.py
@@ -1,13 +1,10 @@
 from typing import Self
 
 from libecalc.common.utils.rates import RateType
-from libecalc.presentation.yaml.yaml_types.models import YamlFluidModel
-from libecalc.presentation.yaml.yaml_types.models.yaml_enums import YamlModelType
 from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import (
     YamlEosModel,
     YamlPredefinedFluidType,
     YamlFluidModelType,
-    YamlPredefinedFluidModel,
 )
 from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import (
     YamlFluidDefinition,
@@ -278,7 +275,7 @@ class YamlProcessPipelineBuilder(Builder[YamlProcessPipeline]):
 
 
 # ---------------------------------------------------------------------------
-# Fluid model builders
+# Fluid definition builders
 # ---------------------------------------------------------------------------
 
 

--- a/src/libecalc/testing/yaml_builder.py
+++ b/src/libecalc/testing/yaml_builder.py
@@ -19,7 +19,7 @@ from libecalc.presentation.yaml.yaml_types.components.legacy.energy_usage_model.
 )
 from libecalc.presentation.yaml.yaml_types.components.legacy.yaml_electricity_consumer import YamlElectricityConsumer
 from libecalc.presentation.yaml.yaml_types.components.legacy.yaml_fuel_consumer import YamlFuelConsumer
-from libecalc.presentation.yaml.yaml_types.components.yaml_asset import YamlAsset
+from libecalc.presentation.yaml.yaml_types.components.yaml_asset import YamlAsset, YamlDefinitions
 from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
 from libecalc.presentation.yaml.yaml_types.components.yaml_generator_set import YamlGeneratorSet
 from libecalc.presentation.yaml.yaml_types.components.yaml_installation import (
@@ -49,6 +49,7 @@ from libecalc.presentation.yaml.yaml_types.models.model_reference_validation imp
     GeneratorSetModelReference,
 )
 from libecalc.presentation.yaml.yaml_types.models.yaml_enums import YamlModelType
+from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import YamlInletStream
 from libecalc.presentation.yaml.yaml_types.time_series.yaml_time_series import (
     YamlDefaultTimeSeriesCollection,
     YamlTimeSeriesCollection,
@@ -736,6 +737,8 @@ class YamlAssetBuilder(Builder[YamlAsset]):
         self.fuel_types = []
         self.variables = None
         self.installations = []
+        self.definitions: YamlDefinitions | None = None
+        self.inlet_streams: dict[str, YamlInletStream] | None = None
         self.start = None
         self.end = None
 
@@ -751,6 +754,8 @@ class YamlAssetBuilder(Builder[YamlAsset]):
         self.fuel_types = [fuel_types_builder.validate()]
 
         self.variables = None
+        self.definitions = None
+        self.inlet_streams = None
 
         # Create and populate a list of YamlInstallation test instances
         installations_builder = YamlInstallationBuilder().with_test_data()
@@ -791,6 +796,17 @@ class YamlAssetBuilder(Builder[YamlAsset]):
             new_installations.append(installation)
 
         self.installations = new_installations
+        return self
+
+    def with_definitions(self, definitions: YamlDefinitions) -> Self:
+        self.definitions = definitions
+        return self
+
+    def with_inlet_streams(
+        self,
+        inlet_streams: dict[str, YamlInletStream],
+    ) -> Self:
+        self.inlet_streams = inlet_streams
         return self
 
     def with_start(self, start: str):

--- a/tests/libecalc/expression/test_extract_expressions.py
+++ b/tests/libecalc/expression/test_extract_expressions.py
@@ -33,7 +33,7 @@ class TestExtractExpressionReferences:
     def test_nested_pydantic_model(self):
         stream = YamlInletStream(
             name="test_stream",
-            fluid_model="my_fluid",
+            fluid="my_fluid",
             temperature="SIM1;TEMP_IN",
             pressure="SIM1;PRESSURE_IN",
             rate=YamlInletStreamRate(

--- a/tests/libecalc/expression/test_extract_expressions.py
+++ b/tests/libecalc/expression/test_extract_expressions.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel
 
 from libecalc.expression.extract_expressions import extract_expression_references
+from libecalc.presentation.yaml.yaml_types.components.yaml_asset import YamlDefinitions
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import YamlFluidComposition
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_simulation import YamlPumpProcessInlet
 from libecalc.presentation.yaml.yaml_types.process.yaml_process_units import (
     YamlPressureDropperDefinition,
@@ -11,6 +13,7 @@ from libecalc.presentation.yaml.yaml_types.streams.yaml_inlet_stream import (
     YamlInletStream,
     YamlInletStreamRate,
 )
+from libecalc.testing.process_builders import YamlCompositionFluidDefinitionBuilder
 
 
 class TestExtractExpressionReferences:
@@ -110,3 +113,24 @@ class TestExtractExpressionReferences:
         model = ModelWithDict(expressions={"a": "SIM1;RATE", "b": "SIM2;PRESSURE"})
         refs = extract_expression_references(model)
         assert refs == {"SIM1;RATE", "SIM2;PRESSURE"}
+
+    def test_extracts_references_from_fluid_definitions(self):
+        """Fluid composition expressions are included when extracting dependencies from definitions."""
+        fluid_definition = (
+            YamlCompositionFluidDefinitionBuilder()
+            .with_composition(
+                YamlFluidComposition(
+                    methane="FEED;METHANE",
+                    ethane="FEED;ETHANE {*} 0.5",
+                )
+            )
+            .validate()
+        )
+        definitions = YamlDefinitions(
+            fluids={"feed_gas": fluid_definition},
+        )
+
+        assert extract_expression_references(definitions) == {
+            "FEED;METHANE",
+            "FEED;ETHANE",
+        }

--- a/tests/libecalc/presentation/yaml/mappers/test_fluid_mapper.py
+++ b/tests/libecalc/presentation/yaml/mappers/test_fluid_mapper.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+from libecalc.common.time_utils import Period
+from libecalc.presentation.yaml.mappers.fluid_mapper import fluid_definition_mapper
+from libecalc.presentation.yaml.yaml_types.models.yaml_fluid import YamlEosModel
+from libecalc.presentation.yaml.yaml_types.process.yaml_fluid_definitions import (
+    YamlFluidComposition,
+)
+from libecalc.process.fluid_stream.fluid_model import EoSModel, FluidComposition
+from libecalc.testing.process_builders import YamlCompositionFluidDefinitionBuilder
+
+
+def test_composition_fluid_is_materialized_for_each_period(
+    expression_evaluator_factory,
+):
+    periods = [
+        Period(
+            start=datetime(2020, 1, 1),
+            end=datetime(2021, 1, 1),
+        ),
+        Period(
+            start=datetime(2021, 1, 1),
+            end=datetime(2022, 1, 1),
+        ),
+    ]
+    evaluator = expression_evaluator_factory.from_periods(
+        periods=periods,
+        variables={
+            "FEED;METHANE": [90.0, 80.0],
+            "FEED;ETHANE": [10.0, 20.0],
+        },
+    )
+    definition = (
+        YamlCompositionFluidDefinitionBuilder()
+        .with_test_data()
+        .with_eos_model(YamlEosModel.PR)
+        .with_composition(
+            YamlFluidComposition(
+                methane="FEED;METHANE",
+                ethane="FEED;ETHANE",
+            )
+        )
+        .validate()
+    )
+
+    time_series_fluid = fluid_definition_mapper(
+        definition,
+        expression_evaluator=evaluator,
+    )
+
+    assert time_series_fluid.get_value(periods[0]).eos_model == EoSModel.PR
+    assert time_series_fluid.get_value(periods[0]).composition == FluidComposition(
+        methane=90.0,
+        ethane=10.0,
+    )
+    assert time_series_fluid.get_value(periods[1]).composition == FluidComposition(
+        methane=80.0,
+        ethane=20.0,
+    )

--- a/tests/libecalc/presentation/yaml/yaml_types/process/test_yaml_fluid_definitions.py
+++ b/tests/libecalc/presentation/yaml/yaml_types/process/test_yaml_fluid_definitions.py
@@ -1,0 +1,50 @@
+from libecalc.presentation.yaml.mappers.yaml_path import YamlPath
+from libecalc.presentation.yaml.yaml_reference_service import YamlReferenceService
+from libecalc.presentation.yaml.yaml_types.components.yaml_asset import YamlDefinitions
+from libecalc.testing.process_builders import YamlInletStreamBuilder, YamlPredefinedFluidDefinitionBuilder
+from libecalc.testing.yaml_builder import YamlAssetBuilder
+
+
+def test_inlet_stream_fluid_reference_resolves_definition(
+    yaml_asset_configuration_service_factory,
+):
+    """Fluids declared in DEFINITIONS are parsed and resolvable from INLET_STREAMS."""
+    fluid_definition = YamlPredefinedFluidDefinitionBuilder().with_test_data().validate()
+    inlet_stream = YamlInletStreamBuilder().with_test_data().with_name("main_stream").with_fluid("feed_gas").validate()
+    asset = (
+        YamlAssetBuilder()
+        .with_test_data()
+        .with_definitions(
+            YamlDefinitions(
+                fluids={"feed_gas": fluid_definition},
+            )
+        )
+        .with_inlet_streams(
+            {"main_stream": inlet_stream},
+        )
+        .validate()
+    )
+
+    configuration = yaml_asset_configuration_service_factory(
+        asset,
+        name="model.yaml",
+    ).get_configuration()
+
+    parsed_fluid = configuration.definitions.fluids["feed_gas"]
+    parsed_stream = configuration.inlet_streams["main_stream"]
+
+    reference_service = YamlReferenceService(configuration)
+    resolved_fluid = reference_service.get_fluid_definition(
+        parsed_stream.fluid,
+    )
+
+    # The fluid was parsed from the DEFINITIONS.FLUIDS dictionary.
+    assert parsed_fluid == fluid_definition
+
+    # The inlet-stream reference resolves to that parsed definition.
+    assert resolved_fluid == parsed_fluid
+
+    # Validation errors can be associated with the correct YAML location.
+    assert reference_service.get_yaml_path("feed_gas") == YamlPath(
+        keys=("DEFINITIONS", "FLUIDS", "feed_gas"),
+    )

--- a/tests/libecalc/process/test_mixer_integration.py
+++ b/tests/libecalc/process/test_mixer_integration.py
@@ -74,7 +74,7 @@ def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper_factory,
                 ts = config.sidestream
                 unit.set_stream(
                     fluid_service.create_stream_from_standard_rate(
-                        fluid_model=ts.fluid_model,
+                        fluid_model=ts.fluid_model.get_value(PERIOD),
                         pressure_bara=ts.pressure_bara.get_masked_values()[0],
                         temperature_kelvin=ts.temperature_kelvin.get_masked_values()[0],
                         standard_rate_m3_per_day=ts.standard_rate_m3_per_day.get_stream_day_values()[0],
@@ -83,7 +83,7 @@ def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper_factory,
 
     # -- Run pipeline --
     inlet_stream = fluid_service.create_stream_from_standard_rate(
-        fluid_model=simulation.get_inlet_streams()[0].fluid_model,
+        fluid_model=simulation.get_inlet_streams()[0].fluid_model.get_value(PERIOD),
         pressure_bara=20.0,
         temperature_kelvin=303.15,
         standard_rate_m3_per_day=2_000_000,
@@ -93,7 +93,7 @@ def test_yaml_mixer_maps_to_runnable_pipeline(process_simulation_mapper_factory,
 
     sidestream_rate_sm3_per_day = yaml_mixer.sidestream.rate.value
     expected_sidestream_mass_rate = fluid_service.standard_rate_to_mass_rate(
-        fluid_model=simulation.get_inlet_streams()[0].fluid_model,
+        fluid_model=simulation.get_inlet_streams()[0].fluid_model.get_value(PERIOD),
         standard_rate_m3_per_day=sidestream_rate_sm3_per_day,
     )
 

--- a/tests/libecalc/process/test_splitter_integration.py
+++ b/tests/libecalc/process/test_splitter_integration.py
@@ -74,7 +74,7 @@ def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper_facto
 
     # -- Run pipeline --
     inlet_stream = fluid_service.create_stream_from_standard_rate(
-        fluid_model=simulation.get_inlet_streams()[0].fluid_model,
+        fluid_model=simulation.get_inlet_streams()[0].fluid_model.get_value(PERIOD),
         pressure_bara=20.0,
         temperature_kelvin=303.15,
         standard_rate_m3_per_day=2_000_000,
@@ -85,7 +85,7 @@ def test_yaml_splitter_maps_to_runnable_pipeline(process_simulation_mapper_facto
     # -- Assert: mass is conserved — outlet = inlet - offtake --
     offtake_rate_sm3_per_day = yaml_splitter.offtake_rate.value
     expected_offtake_mass_rate = fluid_service.standard_rate_to_mass_rate(
-        fluid_model=simulation.get_inlet_streams()[0].fluid_model,
+        fluid_model=simulation.get_inlet_streams()[0].fluid_model.get_value(PERIOD),
         standard_rate_m3_per_day=offtake_rate_sm3_per_day,
     )
 


### PR DESCRIPTION
## Summary

Adds reusable fluid definitions for process simulations under `DEFINITIONS.FLUIDS`.

- Supports predefined and user-defined compositions.
- Allows fluid composition components to be expressions.
- Lets `INLET_STREAMS.FLUID` reference a reusable fluid definition.
- Maps definitions to `TimeSeriesFluidModel` and materializes a concrete `FluidModel` for a given period.
- Extends YAML parsing, reference handling and process simulation mapping.

Legacy `FLUID_MODELS` remains unchanged for now.

--- 

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
