### PR TITLE
fix: prevent infinite loop in common ASV single-speed solver

### DIFF
--- a/src/libecalc/domain/process/compressor/core/train/compressor_train_common_shaft.py
+++ b/src/libecalc/domain/process/compressor/core/train/compressor_train_common_shaft.py
@@ -1025,6 +1025,7 @@ class CompressorTrainCommonShaft(CompressorTrainModel):
                 inc += 0.1
                 if inc >= 1:
                     logger.error("Single speed train with Common ASV pressure control has no solution!")
+                    return _calculate_train_result_given_mass_rate(mass_rate_kg_per_hour=minimum_mass_rate_kg_per_hour)
                 train_result_for_mass_rate = _calculate_train_result_given_mass_rate(
                     mass_rate_kg_per_hour=minimum_mass_rate + inc * (maximum_mass_rate - minimum_mass_rate)
                 )


### PR DESCRIPTION
When no mass rate in the [min, max] range produces constant ASV-corrected mass rates across all stages, the `while`-loop incremented `inc` past 1.0 without ever exiting — logging an error on every iteration indefinitely.

Now returns the result at the original un-recirculated mass rate (`minimum_mass_rate_kg_per_hour`), which is reported with the appropriate failure status (e.g. `BELOW_MINIMUM_FLOW_RATE` or target pressure mismatch).

This is legacy code only — the new process simulation solver uses bounded bisection (`Bisect` with `max_iterations=20`).