### PR TITLE
chore: add context to logger message in validation

### DIFF
--- a/src/libecalc/presentation/yaml/domain/time_series_resource.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_resource.py
@@ -216,10 +216,9 @@ class TimeSeriesResource(Resource):
                 )
 
         if message:
-            err = ValueError(
-                message + " Note: All line numbers exclude headers and comments, and may therefore be a bit off."
-            )
-            logger.info("Date parsing went wrong!", exc_info=err)
+            message += " Note: All line numbers exclude headers and comments, and may therefore be a bit off."
+            err = ValueError(message)
+            logger.exception(f"Date parsing went wrong: {message}")
             raise err
         raise ValueError(
             "The provided dates doesn't match any of the accepted date formats, "

--- a/src/libecalc/presentation/yaml/domain/time_series_resource.py
+++ b/src/libecalc/presentation/yaml/domain/time_series_resource.py
@@ -217,9 +217,7 @@ class TimeSeriesResource(Resource):
 
         if message:
             message += " Note: All line numbers exclude headers and comments, and may therefore be a bit off."
-            err = ValueError(message)
-            logger.exception(f"Date parsing went wrong: {message}")
-            raise err
+            raise ValueError(message)
         raise ValueError(
             "The provided dates doesn't match any of the accepted date formats, "
             "or contains inconsistently formatted dates. "


### PR DESCRIPTION
## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
