### PR TITLE
ci: need to explicitly set gh token for release-please cli

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -87,6 +87,7 @@ jobs:
           package-manager-cache: 'false'
       - name: Dry run - show planned release
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSIONING_STRATEGY: ${{ needs.get_versioning_strategy.outputs.versioning_strategy }}
           REPO_URL: ${{ github.repository }}
           TARGET_BRANCH: ${{ github.ref_name }}
@@ -99,6 +100,7 @@ jobs:
           echo "Versioning strategy: ${VERSIONING_STRATEGY}"
           echo ""
           OUTPUT=$(npx release-please@17.11.2 release-pr \
+            --token="${GITHUB_TOKEN}" \
             --repo-url="${REPO_URL}" \
             --target-branch="${TARGET_BRANCH}" \
             --config-file="release-please-config.json" \


### PR DESCRIPTION
## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
