### PR TITLE
ci: handle dry-run release-please gracefully in publish

### DIFF
--- a/.github/workflows/publish-libecalc.yml
+++ b/.github/workflows/publish-libecalc.yml
@@ -33,11 +33,18 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download release-please outputs
+        id: download-artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
         with:
           name: release-please-outputs
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Default outputs when artifact is missing (e.g. dry-run)
+        if: ${{ steps.download-artifact.outcome == 'failure' }}
+        run: |
+          echo "No artifact found (likely a dry-run). Defaulting to release_created=false."
+          echo '{"release_created":"false"}' > outputs.json
       - name: list contents
         run: ls -al
       - name: echo artifact


### PR DESCRIPTION
When dry-run is run, there is no release artifact. Check this and handle it gracefully. It was forgotten that it was event based on completion and not on success etc (not a possible state)

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
