### PR TITLE
fix(libecalc): bound pump head to the chart envelope max

### DIFF
--- a/src/libecalc/process/pump/pump.py
+++ b/src/libecalc/process/pump/pump.py
@@ -5,10 +5,24 @@ follows directly from the pressure rise and the density (``head = (p_d - p_s) / 
 pump chart supplies the efficiency and the feasible operating window. Everything is closed-form:
 the operating point is read off the chart envelope, so there is no solver and no iteration.
 
-When the pump cannot sit exactly on the target - a single-speed pump is pinned to its curve, and a
-variable-speed pump cannot deliver less head than its minimum-speed curve - it delivers a higher
-(operating) head than required. The result exposes both the required and the operating discharge
-pressure; the excess would be dropped by a downstream choke.
+When the pump cannot sit exactly on the target, the head is bounded to the chart envelope in both
+directions:
+
+- Below the envelope - a single-speed pump is pinned to its curve, and a variable-speed pump
+  cannot deliver less head than its minimum-speed curve - it delivers a higher (operating) head
+  than required. The excess would be dropped by a downstream choke (``choke_pressure_drop_bara``).
+- Above the envelope - neither pump type can deliver more head than its maximum-speed curve - the
+  operating head is capped there, so the delivered discharge pressure falls short of what was
+  required (``pressure_shortfall_bara``). ``failure_status`` is derived from the required head, so
+  it reports the infeasibility independently of the cap.
+
+The result exposes both the required and the operating discharge pressure so a caller can tell
+these regimes apart. The rate itself is never capped - only the head is. A rate above the chart's
+own maximum rate is flagged separately, via ``PumpFailureStatus.ABOVE_MAXIMUM_PUMP_RATE``. At such
+a rate, the head cap itself is also less reliable: ``Chart.maximum_head_as_function_of_rate``
+does not extrapolate the curve's declining trend past its highest measured rate - it holds the head
+flat at the value from that highest-rate point instead. For example, if the curve's highest-rate
+point is 927 m3/h, evaluating the pump at 1200 m3/h uses that same 927 m3/h head value as the cap.
 """
 
 from __future__ import annotations
@@ -51,9 +65,10 @@ class PumpEvaluationResult:
             ``None`` when not running.
         required_head_joule_per_kg: Head implied by the suction and required discharge pressures,
             ``(p_d - p_s) / rho`` [J/kg].
-        operational_head_joule_per_kg: Actual head the pump operates at [J/kg], after min-head
-            choking. It exceeds the required head when the pump cannot deliver less head than its
-            (minimum-speed) curve at the operating rate; otherwise it equals the required head.
+        operational_head_joule_per_kg: Actual head the pump operates at [J/kg], bounded to the
+            chart envelope. Exceeds the required head when the pump cannot deliver less head than
+            its minimum-speed curve at the operating rate; falls below it when the required head
+            exceeds the maximum-speed curve; otherwise equals the required head.
         operational_volumetric_rate_m3_per_hour: Volumetric rate the pump operates at
             [m3/h], i.e. the requested rate raised to the minimum flow when recirculating.
         recirculation_rate_m3_per_hour: Internal recirculation [m3/h] to maintain the minimum flow
@@ -61,7 +76,9 @@ class PumpEvaluationResult:
         required_discharge_pressure_bara: Discharge pressure the pump was asked to deliver [bara].
         operational_discharge_pressure_bara: Discharge pressure the pump actually delivers [bara],
             from the operational head. Exceeds the required discharge pressure when the pump
-            over-delivers head; the difference is what a downstream choke would drop.
+            over-delivers head (see ``choke_pressure_drop_bara``); falls short of it when the
+            required head is above the chart's capacity at the operating rate (see
+            ``pressure_shortfall_bara``).
         speed_rpm: Operating speed [rpm] of the pump (the speed curve through the operating point);
             the single curve's speed for a single-speed pump, ``None`` when not running.
         failure_status: Feasibility outcome; ``NO_FAILURE`` when within the chart envelope.
@@ -94,6 +111,15 @@ class PumpEvaluationResult:
         The excess the pump over-delivers = operational minus required discharge pressure (>= 0).
         """
         return max(0.0, self.operational_discharge_pressure_bara - self.required_discharge_pressure_bara)
+
+    @property
+    def pressure_shortfall_bara(self) -> float:
+        """Pressure the pump falls short of the required discharge pressure [bara].
+
+        Non-zero only when the duty is above the pump's capacity at the operating rate: the head is
+        bounded by the chart's maximum-speed curve, so the delivered pressure is lower than required.
+        """
+        return max(0.0, self.required_discharge_pressure_bara - self.operational_discharge_pressure_bara)
 
 
 class Pump(Entity[ProcessUnitId], LiquidStreamPropagator):
@@ -211,7 +237,12 @@ class Pump(Entity[ProcessUnitId], LiquidStreamPropagator):
         )
 
         minimum_head_at_rate = float(self._pump_chart.minimum_head_as_function_of_rate(operating_rate_m3_per_hour))
-        operational_head = max(required_head, minimum_head_at_rate)
+        maximum_head_at_rate = float(self._pump_chart.maximum_head_as_function_of_rate(operating_rate_m3_per_hour))
+
+        # The pump cannot deliver less head than its (minimum-speed) curve, nor more than its
+        # (maximum-speed) curve. Below the curve the surplus is dropped by a downstream choke; above it
+        # the pump simply falls short of the duty - see ``pressure_shortfall_bara``.
+        operational_head = min(max(required_head, minimum_head_at_rate), maximum_head_at_rate)
 
         efficiency = self._efficiency(
             rate_m3_per_hour=operating_rate_m3_per_hour,
@@ -227,7 +258,6 @@ class Pump(Entity[ProcessUnitId], LiquidStreamPropagator):
         operational_discharge_pressure_bara = inlet_stream.pressure_bara + Unit.PASCAL.to(Unit.BARA)(
             operational_head * density
         )
-        maximum_head_at_rate = float(self._pump_chart.maximum_head_as_function_of_rate(operating_rate_m3_per_hour))
 
         return PumpEvaluationResult(
             inlet_stream=inlet_stream,
@@ -242,7 +272,7 @@ class Pump(Entity[ProcessUnitId], LiquidStreamPropagator):
             operational_discharge_pressure_bara=operational_discharge_pressure_bara,
             speed_rpm=speed_rpm,
             failure_status=self._determine_failure_status(
-                head_joule_per_kg=operational_head,
+                head_joule_per_kg=required_head,
                 maximum_head_at_rate=maximum_head_at_rate,
                 rate_m3_per_hour=operating_rate_m3_per_hour,
             ),

--- a/tests/libecalc/process/pump/test_pump.py
+++ b/tests/libecalc/process/pump/test_pump.py
@@ -3,6 +3,7 @@ import pytest
 from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.domain.process.pump.pump import PumpModel
+from libecalc.domain.process.value_objects.chart import Chart
 from libecalc.domain.process.value_objects.chart.chart import ChartCurve
 from libecalc.process.process_pipeline.process_unit import ProcessUnitId
 from libecalc.process.pump.exceptions import NonPositivePressureException
@@ -71,18 +72,20 @@ def _inlet(rate_m3_per_hour, suction_pressure, density=DENSITY):
     )
 
 
-@pytest.mark.parametrize("chart_name", ["single_speed_chart", "variable_speed_chart"])
 @pytest.mark.parametrize(
-    "rate_m3h, suction, discharge",
+    "chart_name, rate_m3h, suction, discharge",
     [
-        (600, 5.0, 100.0),  # normal
-        (150, 5.0, 100.0),  # below min flow -> recirculation
-        (600, 5.0, 50.0),  # required head below curve -> over-delivery / choke
-        (600, 5.0, 250.0),  # required head above curve -> infeasible
-        (1200, 5.0, 100.0),  # rate above max -> infeasible
+        ("single_speed_chart", 600, 5.0, 100.0),  # normal
+        ("single_speed_chart", 150, 5.0, 100.0),  # below min flow -> recirculation
+        ("single_speed_chart", 600, 5.0, 50.0),  # required head below curve -> over-delivery / choke
+        ("variable_speed_chart", 600, 5.0, 100.0),  # normal
+        ("variable_speed_chart", 150, 5.0, 100.0),  # below min flow -> recirculation
+        ("variable_speed_chart", 600, 5.0, 50.0),  # required head below curve -> over-delivery / choke
+        ("variable_speed_chart", 1200, 5.0, 100.0),  # rate above max, but head still within the max-speed curve
     ],
 )
 def test_power_matches_legacy(request, chart_name, rate_m3h, suction, discharge):
+    """Parity with the legacy pump for every point the pump can actually serve."""
     chart_data = request.getfixturevalue(chart_name)
     pump = Pump(chart_data, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
     legacy_power, _, _ = PumpModel(pump_chart=chart_data).simulate(
@@ -90,6 +93,28 @@ def test_power_matches_legacy(request, chart_name, rate_m3h, suction, discharge)
     )
     result = pump.evaluate(_inlet(rate_m3h, suction), discharge_pressure_bara=discharge)
     assert result.shaft_power_mw == pytest.approx(legacy_power)
+
+
+@pytest.mark.parametrize(
+    "chart_name, rate_m3h, discharge, legacy_power",
+    [
+        ("single_speed_chart", 600, 250.0, 8.580233942705052),
+        ("single_speed_chart", 1200, 100.0, 4.490451881262998),
+        ("variable_speed_chart", 600, 250.0, 6.904430715116509),
+    ],
+)
+def test_power_diverges_from_legacy_above_chart_capacity(request, chart_name, rate_m3h, discharge, legacy_power):
+    """Above the envelope we deliberately bound the head, where legacy did not.
+
+    Legacy computes power at the requested (unachievable) head; we compute it at the pump's actual
+    capacity. These periods are flagged is_valid = False either way.
+    """
+    chart_data = request.getfixturevalue(chart_name)
+    pump = Pump(chart_data, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    result = pump.evaluate(_inlet(rate_m3h, 5.0), discharge_pressure_bara=discharge)
+
+    assert not result.is_valid
+    assert result.shaft_power_mw < legacy_power  # bounded below the legacy value
 
 
 def test_recirculation_up_to_minimum_flow(single_speed_chart):
@@ -117,6 +142,44 @@ def test_over_delivery_exposes_operating_vs_required_and_choke(single_speed_char
         result.operational_discharge_pressure_bara - result.required_discharge_pressure_bara
     )
     assert result.is_valid
+
+
+def test_head_is_bounded_by_chart_maximum(single_speed_chart):
+    # A duty above the chart's capacity is bounded to the maximum-speed curve, not left unbounded.
+    pump = Pump(single_speed_chart, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    result = pump.evaluate(_inlet(666, suction_pressure=5.0), discharge_pressure_bara=250.0)
+
+    max_head = float(Chart(single_speed_chart).maximum_head_as_function_of_rate(666.0))
+    assert result.operational_head_joule_per_kg == pytest.approx(max_head)
+    assert result.required_head_joule_per_kg > result.operational_head_joule_per_kg
+    assert result.operational_discharge_pressure_bara < result.required_discharge_pressure_bara
+    assert result.pressure_shortfall_bara > 0
+    assert result.choke_pressure_drop_bara == 0.0
+
+
+@pytest.mark.parametrize(
+    "discharge, expect_choke, expect_shortfall",
+    [
+        (50.0, True, False),  # below the min-speed curve -> over-delivery, choked
+        (250.0, False, True),  # above the max-speed curve -> shortfall
+    ],
+)
+def test_choke_and_shortfall_are_mutually_exclusive(variable_speed_chart, discharge, expect_choke, expect_shortfall):
+    pump = Pump(variable_speed_chart, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    result = pump.evaluate(_inlet(666, suction_pressure=5.0), discharge_pressure_bara=discharge)
+
+    assert not (result.choke_pressure_drop_bara > 0 and result.pressure_shortfall_bara > 0)
+    assert (result.choke_pressure_drop_bara > 0) is expect_choke
+    assert (result.pressure_shortfall_bara > 0) is expect_shortfall
+
+
+def test_efficiency_above_capacity_is_taken_at_the_operating_rate(single_speed_chart):
+    # The clamped point lies on the curve, so efficiency is exact, not projected from a different rate.
+    pump = Pump(single_speed_chart, minimum_flow_rate_m3_per_hour=CHART_MIN_FLOW)
+    result = pump.evaluate(_inlet(666, suction_pressure=5.0), discharge_pressure_bara=250.0)
+    chart = Chart(single_speed_chart)
+    expected = float(chart.curves[0].efficiency_as_function_of_rate(666.0))
+    assert result.efficiency == pytest.approx(expected, rel=1e-3)
 
 
 def test_variable_speed_in_band_sits_on_target_with_interpolated_speed(variable_speed_chart):

--- a/tests/libecalc/process/pump/test_pump_process_simulation.py
+++ b/tests/libecalc/process/pump/test_pump_process_simulation.py
@@ -117,6 +117,20 @@ def test_recirculation_raises_operating_flow_between_mixer_and_splitter(simulati
     assert mixer_to_pump.mass_rate_kg_per_h > inlet_to_mixer.mass_rate_kg_per_h
 
 
+def test_shortfall_outlet_stream_is_at_the_deliverable_pressure(simulation):
+    # Duty above the pump's capacity -> outlet edge must carry the operational (lower) pressure,
+    # not the required one; a choke cannot add pressure back.
+    (result,) = simulation.evaluate([_operating_input(600.0, discharge=250.0)])
+
+    connections = simulation.get_process_unit_connections()
+    choke_to_outlet = result.connection_streams[connections[-1].get_id()]
+    pump_result = result.pump_result
+
+    assert pump_result.pressure_shortfall_bara > 0
+    assert choke_to_outlet.pressure_bara == pytest.approx(pump_result.operational_discharge_pressure_bara)
+    assert choke_to_outlet.pressure_bara < pump_result.required_discharge_pressure_bara
+
+
 def test_zero_rate_produces_zero_result_at_inlet_pressure(simulation):
     # Pump off (rate 0): still a full result - zero power, outlet = inlet pressure, zero-flow streams.
     (result,) = simulation.evaluate([_operating_input(0.0, discharge=200.0)])


### PR DESCRIPTION
Pump.evaluate() now clamps operational head to the chart's maximum, not just its minimum, so power, pressure and efficiency stay bounded by the pump's capacity instead of growing without limit. is_valid still false if above chart bounds, but operational pressure and power related to it is now clamped to pump capacity (different from legacy). Added the convenience property `pressure_shortfall_bara` (mirror of the `choke_pressure_drop_bara` property but for the upper capacity limit instead of the lower, which is the one the choke handles.)