### PR TITLE
fix!: reject chart curves with increasing head

### DIFF
--- a/docs/drafts/next.draft.md
+++ b/docs/drafts/next.draft.md
@@ -20,6 +20,8 @@ STP: "flare" column has been added to STP Export - for `FIXED` installations onl
 
 ## Breaking changes
 
+- Chart curves must have non-increasing head as rate increases. Curves that violate this are now rejected during model validation instead of being accepted with a warning.
+
 ### Compressor calculations
 
 - Compressor calculations now validate PH flash results more strictly. Existing models that previously completed with invalid or non-physical PH flash states may now fail or report invalid compressor/capacity results instead.

--- a/src/libecalc/domain/process/value_objects/chart/base.py
+++ b/src/libecalc/domain/process/value_objects/chart/base.py
@@ -49,22 +49,22 @@ class ChartCurve:
         array = np.asarray([rate_actual_m3_hour, polytropic_head_joule_per_kg, efficiency_fraction]).T
         array_sorted = array[array[:, 0].argsort()]
 
-        self.rate_actual_m3_hour = list(array_sorted[:, 0])
-        self.polytropic_head_joule_per_kg = list(array_sorted[:, 1])
-        self.efficiency_fraction = list(array_sorted[:, 2])
+        self.rate_actual_m3_hour = array_sorted[:, 0].tolist()
+        self.polytropic_head_joule_per_kg = array_sorted[:, 1].tolist()
+        self.efficiency_fraction = array_sorted[:, 2].tolist()
 
         if len(set(self.rate_actual_m3_hour)) != len(self.rate_actual_m3_hour):
             duplicate_rates = {x for x in self.rate_actual_m3_hour if self.rate_actual_m3_hour.count(x) > 1}
             logger.warning(f"Duplicate rate values in ChartCurve: {duplicate_rates}")
 
-        if not np.all(np.diff(np.asarray(self.polytropic_head_joule_per_kg)) <= 0):
+        head_differences = np.diff(np.asarray(self.polytropic_head_joule_per_kg))
+        if not np.all(head_differences <= 0):
             heads = self.polytropic_head_joule_per_kg
             rates = self.rate_actual_m3_hour
-            logger.warning(
-                "Head is increasing with rate in a ChartCurve."
-                " Interpolations are based on the assumption of an inverse monotonic function between head and rate."
-                f" Given head values: {heads}"
-                f" Given rate values: {rates}"
+            raise EcalcValidationException(
+                "Head must be non-increasing with increasing rate in a ChartCurve. "
+                f"Given head values: {heads}. "
+                f"Given rate values: {rates}."
             )
 
     @property

--- a/src/libecalc/presentation/json_result/serializable_chart.py
+++ b/src/libecalc/presentation/json_result/serializable_chart.py
@@ -58,16 +58,6 @@ class ChartCurveDTO(EcalcBaseModel):
             duplicate_rates = {x for x in self.rate_actual_m3_hour if self.rate_actual_m3_hour.count(x) > 1}
             logger.warning(f"Duplicate rate values in ChartCurve: {duplicate_rates}")
 
-        if not np.all(np.diff(np.asarray(self.polytropic_head_joule_per_kg)) <= 0):
-            heads = self.polytropic_head_joule_per_kg
-            rates = self.rate_actual_m3_hour
-            logger.warning(
-                "Head is increasing with rate in a ChartCurve."
-                " Interpolations are based on the assumption of an inverse monotonic function between head and rate."
-                f" Given head values: {heads}"
-                f" Given rate values: {rates}"
-            )
-
         return self
 
     @property

--- a/tests/libecalc/core/models/chart/test_chart_curve.py
+++ b/tests/libecalc/core/models/chart/test_chart_curve.py
@@ -85,16 +85,16 @@ def test_chart_curve_data_invalid_setup_from_arrays():
 
 
 def test_chart_curve_sort_input_values():
-    """Values should be sorted by the root validator in pydantic."""
+    """Chart points should be sorted by rate."""
     curve = ChartCurve(
         rate_actual_m3_hour=[3, 2, 4, 1],
-        polytropic_head_joule_per_kg=[1, 2, 3, 4],
+        polytropic_head_joule_per_kg=[2, 3, 1, 4],
         efficiency_fraction=[1, 1, 1, 1],
         speed_rpm=1,
     )
 
     assert curve.rate_actual_m3_hour == [1, 2, 3, 4]
-    assert curve.polytropic_head_joule_per_kg == [4, 2, 1, 3]
+    assert curve.polytropic_head_joule_per_kg == [4, 3, 2, 1]
 
 
 def test_efficiency_as_function_of_rate(chart_curve):
@@ -140,7 +140,7 @@ def test_distance_efficiency():
     """Integration test."""
     chart_curve = ChartCurve(
         rate_actual_m3_hour=[577, 336, 708, 842, 824, 826, 825, 1028],
-        polytropic_head_joule_per_kg=[1718.7, 1778.7, 1665.2, 1587.8, 1601.9, 1601.9, 1602.7, 1460.6],
+        polytropic_head_joule_per_kg=[1718.7, 1778.7, 1665.2, 1587.8, 1601.9, 1601.9, 1601.9, 1460.6],
         efficiency_fraction=[0.6203, 0.4717, 0.6683, 0.6996, 0.695, 0.6975, 0.6981, 0.7193],
         speed_rpm=1,
     )
@@ -158,11 +158,11 @@ def test_distance_efficiency():
 
 def test_interpolation_functions():
     """Integration test."""
-    # NB: Minimum rate not first, will be sorted
+    # Input points are not ordered by rate and are sorted when the curve is created.
     # Random order of input columns
     chart_curve = ChartCurve(
         rate_actual_m3_hour=[577, 336, 708, 842, 824, 826, 825, 1028],
-        polytropic_head_joule_per_kg=[1718.7, 1778.7, 1665.2, 1587.8, 1601.9, 1601.9, 1602.7, 1460.6],
+        polytropic_head_joule_per_kg=[1718.7, 1778.7, 1665.2, 1587.8, 1601.9, 1601.9, 1601.9, 1460.6],
         efficiency_fraction=[0.6203, 0.4717, 0.6683, 0.6996, 0.695, 0.6975, 0.6981, 0.7193],
         speed_rpm=1,
     )
@@ -184,3 +184,20 @@ def test_interpolation_functions():
     assert chart_curve.head_as_function_of_rate(600) == pytest.approx(1709.3068702290077)
     assert chart_curve.head_as_function_of_rate(300) == pytest.approx(1778.7)
     assert chart_curve.head_as_function_of_rate(1100) == pytest.approx(1460.6)
+
+
+def test_rejects_head_increasing_with_rate():
+    with pytest.raises(
+        EcalcValidationException,
+        match="Head must be non-increasing with increasing rate",
+    ) as exc_info:
+        ChartCurve(
+            rate_actual_m3_hour=[1, 2, 3],
+            polytropic_head_joule_per_kg=[3, 4, 2],
+            efficiency_fraction=[0.8, 0.8, 0.8],
+            speed_rpm=1,
+        )
+
+    message = str(exc_info.value)
+    assert "Given head values:" in message
+    assert "Given rate values:" in message

--- a/tests/libecalc/core/models/chart/test_variable_speed_chart.py
+++ b/tests/libecalc/core/models/chart/test_variable_speed_chart.py
@@ -111,28 +111,28 @@ def test_properties(variable_speed_chart):
 def test_minimum_head_function(chart_curve_factory, pump_chart_factory):
     chart_curve_minimum_speed = chart_curve_factory(
         rate_actual_m3_hour=[500, 1000, 2000, 3000],
-        polytropic_head_joule_per_kg=[10, 20, 40, 60],
+        polytropic_head_joule_per_kg=[60, 40, 20, 10],
         efficiency_fraction=[1, 1, 1, 1],
         speed_rpm=10,
     )
     chart_curve_maximum_speed = chart_curve_factory(
         rate_actual_m3_hour=[300, 4000, 5000, 6000],
-        polytropic_head_joule_per_kg=[60, 80, 100, 120],
+        polytropic_head_joule_per_kg=[120, 100, 80, 60],
         efficiency_fraction=[1, 1, 1, 1],
         speed_rpm=100,
     )
 
     variable_speed_chart = pump_chart_factory(curves=[chart_curve_minimum_speed, chart_curve_maximum_speed])
 
-    # Testing that a low rate should give minimum head of 10 and a high rate should give maximum of 120.
-    assert variable_speed_chart.minimum_head_as_function_of_rate(0) == 10
-    assert variable_speed_chart.minimum_head_as_function_of_rate(1000000) == 120
+    # Rates outside the boundary return the head value at the nearest endpoint.
+    assert variable_speed_chart.minimum_head_as_function_of_rate(0) == 60
+    assert variable_speed_chart.minimum_head_as_function_of_rate(1000000) == 60
 
-    # Testing that the function works within min and max rate given in input
-    assert variable_speed_chart.minimum_head_as_function_of_rate(500) == 10
-    assert variable_speed_chart.minimum_head_as_function_of_rate(750) == 15
-    assert variable_speed_chart.minimum_head_as_function_of_rate(2500) == 50
-    assert variable_speed_chart.minimum_head_as_function_of_rate(3000) == 60
+    # Within the rate range, the boundary follows the minimum-speed curve and then the stone wall.
+    assert variable_speed_chart.minimum_head_as_function_of_rate(500) == 60
+    assert variable_speed_chart.minimum_head_as_function_of_rate(750) == 50
+    assert variable_speed_chart.minimum_head_as_function_of_rate(2500) == 15
+    assert variable_speed_chart.minimum_head_as_function_of_rate(3000) == 10
 
 
 def test_minimum_head_function2(variable_speed_chart):
@@ -169,30 +169,28 @@ def test_minimum_head_function_with_ill_defined_curve(pump_chart_factory, chart_
 def test_max_flow_head_functions(chart_curve_factory, pump_chart_factory):
     chart_curve_minimum_speed = chart_curve_factory(
         rate_actual_m3_hour=[1000, 2000, 3000, 5000],
-        polytropic_head_joule_per_kg=[5, 10, 15, 20],
+        polytropic_head_joule_per_kg=[20, 15, 10, 5],
         efficiency_fraction=[1, 1, 1, 1],
         speed_rpm=10,
     )
     chart_curve_maximum_speed = chart_curve_factory(
         rate_actual_m3_hour=[1000, 2000, 3000, 5000],
-        polytropic_head_joule_per_kg=[5, 10, 15, 20],
+        polytropic_head_joule_per_kg=[20, 15, 10, 5],
         efficiency_fraction=[1, 1, 1, 1],
         speed_rpm=100,
     )
 
     variable_speed_chart = pump_chart_factory(curves=[chart_curve_minimum_speed, chart_curve_maximum_speed])
 
-    assert variable_speed_chart.maximum_head_as_function_of_rate(0) == 5
-    assert variable_speed_chart.maximum_head_as_function_of_rate(1000) == 5
+    assert variable_speed_chart.maximum_head_as_function_of_rate(0) == 20
+    assert variable_speed_chart.maximum_head_as_function_of_rate(1000) == 20
     assert variable_speed_chart.maximum_head_as_function_of_rate(2500) == 12.5
-    assert variable_speed_chart.maximum_head_as_function_of_rate(5000) == 20
-    assert variable_speed_chart.maximum_head_as_function_of_rate(10000) == 20
+    assert variable_speed_chart.maximum_head_as_function_of_rate(5000) == 5
+    assert variable_speed_chart.maximum_head_as_function_of_rate(10000) == 5
 
-    # assert max_flow_func(0) == 1000
-    assert variable_speed_chart.maximum_rate_as_function_of_head(5) == 1000
+    assert variable_speed_chart.maximum_rate_as_function_of_head(5) == 5000
     assert variable_speed_chart.maximum_rate_as_function_of_head(12.5) == 2500
-    assert variable_speed_chart.maximum_rate_as_function_of_head(20) == 5000
-    # assert max_flow_func(30) == 5000
+    assert variable_speed_chart.maximum_rate_as_function_of_head(20) == 1000
 
 
 def test_get_efficiency_variable_chart(chart_curve_factory, pump_chart_factory):
@@ -391,7 +389,7 @@ def test_is_100_percent_efficient(variable_speed_chart, pump_chart_factory, char
         curves=[
             chart_curve_factory(
                 rate_actual_m3_hour=[1, 2],
-                polytropic_head_joule_per_kg=[1, 2],
+                polytropic_head_joule_per_kg=[2, 1],
                 efficiency_fraction=[0.5, 0.5],
                 speed_rpm=1,
             )

--- a/tests/libecalc/core/models/compressor_modelling/test_compressor_chart.py
+++ b/tests/libecalc/core/models/compressor_modelling/test_compressor_chart.py
@@ -24,9 +24,9 @@ def predefined_variable_speed_compressor_chart_2(
             "efficiency": [0.700, 0.715, 0.738, 0.761, 0.772, 0.776, 0.773, 0.769, 0.752, 0.730, 0.721],
         },
         1200: {
-            "rate": [152, 145, 136, 126, 116, 107, 97, 87, 78, 68, 64, 143],
-            "head": [771, 821, 900, 982, 1054, 1120, 1166, 1212, 1239, 1258, 1265, 682],
-            "efficiency": [0.700, 0.715, 0.738, 0.761, 0.772, 0.776, 0.773, 0.769, 0.752, 0.730, 0.721, 0.700],
+            "rate": [152, 145, 136, 126, 116, 107, 97, 87, 78, 68, 64],
+            "head": [771, 821, 900, 982, 1054, 1120, 1166, 1212, 1239, 1258, 1265],
+            "efficiency": [0.700, 0.715, 0.738, 0.761, 0.772, 0.776, 0.773, 0.769, 0.752, 0.730, 0.721],
         },
         1100: {
             "rate": [143, 137, 128, 119, 109, 100, 91, 89, 82, 73, 64, 60],
@@ -318,7 +318,7 @@ def test_single_speed_compressor_chart_control_margin(
     curve = chart_curve_factory(
         speed_rpm=1,
         rate_actual_m3_hour=[1, 2, 3],
-        polytropic_head_joule_per_kg=[4, 5, 6],
+        polytropic_head_joule_per_kg=[6, 5, 4],
         efficiency_fraction=[0.7, 0.8, 0.9],
     )
 
@@ -352,13 +352,13 @@ def test_variable_speed_compressor_chart_control_margin(
     curve_1 = chart_curve_factory(
         speed_rpm=1,
         rate_actual_m3_hour=[1, 2, 3],
-        polytropic_head_joule_per_kg=[4, 5, 6],
+        polytropic_head_joule_per_kg=[6, 5, 4],
         efficiency_fraction=[0.7, 0.8, 0.9],
     )
     curve_2 = chart_curve_factory(
         speed_rpm=1,
         rate_actual_m3_hour=[4, 5, 6],
-        polytropic_head_joule_per_kg=[7, 8, 9],
+        polytropic_head_joule_per_kg=[9, 8, 7],
         efficiency_fraction=[0.101, 0.82, 0.9],
     )
     control_margin = 0.1

--- a/tests/libecalc/core/models/test_pump.py
+++ b/tests/libecalc/core/models/test_pump.py
@@ -25,7 +25,7 @@ def single_speed_pump_chart(pump_chart_factory, chart_data_factory, chart_curve_
         curves=[
             chart_curve_factory(
                 rate_actual_m3_hour=[277, 524, 666, 832, 834, 927],
-                polytropic_head_joule_per_kg=[10415.277000000002, 9845.316, 9254.754, 8308.089, 8312.994, 7605.693],
+                polytropic_head_joule_per_kg=[10415.277000000002, 9845.316, 9254.754, 8308.089, 8308.089, 7605.693],
                 efficiency_fraction=[0.4759, 0.6426, 0.6871, 0.7052, 0.7061, 0.6908],
                 speed_rpm=1,
             ),
@@ -202,7 +202,7 @@ def vsd_pump_test_variable_speed_chart_curves(chart_data_factory, chart_curve_fa
             [2650, 524, 1003.6, 0.6426],
             [2650, 666, 943.4, 0.6871],
             [2650, 832, 846.9, 0.7052],
-            [2650, 834, 847.4, 0.7061],
+            [2650, 834, 846.9, 0.7061],
             [2650, 927, 775.3, 0.6908],
             [2900, 296, 1293, 0.47],
             [2900, 370, 1275, 0.52],
@@ -230,7 +230,7 @@ def vsd_pump_test_variable_speed_chart_curves(chart_data_factory, chart_curve_fa
             [3425, 842, 1587.8, 0.6996],
             [3425, 824, 1601.9, 0.695],
             [3425, 826, 1601.9, 0.6975],
-            [3425, 825, 1602.7, 0.6981],
+            [3425, 825, 1601.9, 0.6981],
             [3425, 1028, 1460.6, 0.7193],
         ],
         columns=["speed", "rate", "head", "efficiency"],
@@ -389,7 +389,7 @@ def test_variable_speed_pump_pt2(vsd_pump_test_variable_speed_chart_curves, capl
         suction_pressures=np.asarray([1.0]),
         discharge_pressures=np.asarray([61]),
         fluid_densities=fluid_densities,
-    ).get_energy_result().energy_usage.values[0] == pytest.approx(3.52037671)
+    ).get_energy_result().energy_usage.values[0] == pytest.approx(3.52043419)
 
     # Rate too large - invalid but reported
     result_rate_too_high = pump.evaluate_rate_ps_pd_density(

--- a/tests/libecalc/domain/process/compressor/test_compressor_train.py
+++ b/tests/libecalc/domain/process/compressor/test_compressor_train.py
@@ -16,7 +16,7 @@ class TestCompressorTrain:
                     chart_curve_factory(
                         speed_rpm=1,
                         rate_actual_m3_hour=[1, 2],
-                        polytropic_head_joule_per_kg=[3, 4],
+                        polytropic_head_joule_per_kg=[4, 3],
                         efficiency_fraction=[0.5, 0.5],
                     )
                 ]
@@ -42,7 +42,7 @@ class TestCompressorTrain:
                         chart_curve_factory(
                             speed_rpm=1,
                             rate_actual_m3_hour=[1, 2, 3],
-                            polytropic_head_joule_per_kg=[1, 2, 3],
+                            polytropic_head_joule_per_kg=[3, 2, 1],
                             efficiency_fraction=[0.1, 0.2, 0.3],
                         )
                     ],
@@ -56,13 +56,13 @@ class TestCompressorTrain:
                         chart_curve_factory(
                             speed_rpm=1,
                             rate_actual_m3_hour=[1, 2, 3],
-                            polytropic_head_joule_per_kg=[1, 2, 3],
+                            polytropic_head_joule_per_kg=[3, 2, 1],
                             efficiency_fraction=[0.1, 0.2, 0.3],
                         ),
                         chart_curve_factory(
                             speed_rpm=2,
                             rate_actual_m3_hour=[1, 2, 3],
-                            polytropic_head_joule_per_kg=[1, 2, 3],
+                            polytropic_head_joule_per_kg=[3, 2, 1],
                             efficiency_fraction=[0.1, 0.2, 0.3],
                         ),
                     ],
@@ -89,7 +89,7 @@ class TestCompressorTrain:
                         chart_curve_factory(
                             speed_rpm=3,
                             rate_actual_m3_hour=[1, 2, 3],
-                            polytropic_head_joule_per_kg=[1, 2, 3],
+                            polytropic_head_joule_per_kg=[3, 2, 1],
                             efficiency_fraction=[0.1, 0.2, 0.3],
                         )
                     ],
@@ -103,13 +103,13 @@ class TestCompressorTrain:
                         chart_curve_factory(
                             speed_rpm=1,
                             rate_actual_m3_hour=[1, 2, 3],
-                            polytropic_head_joule_per_kg=[1, 2, 3],
+                            polytropic_head_joule_per_kg=[3, 2, 1],
                             efficiency_fraction=[0.1, 0.2, 0.3],
                         ),
                         chart_curve_factory(
                             speed_rpm=2,
                             rate_actual_m3_hour=[1, 2, 3],
-                            polytropic_head_joule_per_kg=[1, 2, 3],
+                            polytropic_head_joule_per_kg=[3, 2, 1],
                             efficiency_fraction=[0.1, 0.2, 0.3],
                         ),
                     ],

--- a/tests/libecalc/presentation/json_result/test_serializable_chart.py
+++ b/tests/libecalc/presentation/json_result/test_serializable_chart.py
@@ -11,13 +11,13 @@ class TestVariableSpeedCompressorChart:
                 ChartCurveDTO(
                     speed_rpm=1,
                     rate_actual_m3_hour=[1, 2, 3],
-                    polytropic_head_joule_per_kg=[4, 5, 6],
+                    polytropic_head_joule_per_kg=[6, 5, 4],
                     efficiency_fraction=[0.7, 0.8, 0.9],
                 ),
                 ChartCurveDTO(
                     speed_rpm=1,
                     rate_actual_m3_hour=[4, 5, 6],
-                    polytropic_head_joule_per_kg=[7, 8, 9],
+                    polytropic_head_joule_per_kg=[9, 8, 7],
                     efficiency_fraction=[0.101, 0.82, 0.9],
                 ),
             ],


### PR DESCRIPTION
BREAKING CHANGE: Chart curves with increasing head are no longer accepted.

Rejects chart curves where head increases with rate, since calculations assume a non-increasing relationship.

This replaces the previous warning with a validation error and prevents invalid curves from reaching interpolation.

Refs: equinor/ecalc-internal#2168

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
