### PR TITLE
feat: add energy network domain and YAML schema

### DIFF
--- a/src/libecalc/energy/energy_units/__init__.py
+++ b/src/libecalc/energy/energy_units/__init__.py
@@ -1,19 +1,17 @@
-from .consumers import BaseLoad, Compressor, DieselConsumer, Flare, Pump, SampledFuelConsumer, SampledPowerConsumer
+from .consumers import Compressor, DieselConsumer, ElectricalConsumer, FuelGasConsumer, Pump
 from .converters import ElectricalMotor, GasTurbine, GeneratorSet
 from .junction import ElectricalBus, FuelGasManifold, Junction
-from .sources import DieselSupply, FuelGasSource, OffshoreWind, OnshoreGrid
+from .sources import DieselSource, FuelGasSource, OffshoreWind, OnshoreGrid
 from .transporter import ElectricalCable, Transporter
 
 __all__ = [
-    "BaseLoad",
     "Compressor",
     "DieselConsumer",
-    "DieselSupply",
+    "DieselSource",
     "ElectricalBus",
     "ElectricalCable",
     "ElectricalMotor",
     "Junction",
-    "Flare",
     "FuelGasManifold",
     "FuelGasSource",
     "GasTurbine",
@@ -21,7 +19,7 @@ __all__ = [
     "OffshoreWind",
     "OnshoreGrid",
     "Pump",
-    "SampledFuelConsumer",
-    "SampledPowerConsumer",
     "Transporter",
+    "ElectricalConsumer",
+    "FuelGasConsumer",
 ]

--- a/src/libecalc/energy/energy_units/consumers.py
+++ b/src/libecalc/energy/energy_units/consumers.py
@@ -5,17 +5,11 @@ from libecalc.energy.energy_types import DieselRate, ElectricalPower, FuelGasRat
 from libecalc.energy.energy_unit import EnergyUnitId
 
 
-class BaseLoad(Consumer):
-    """Fixed electrical load (e.g. heating, steam generator, lighting).
-
-    Some base loads (e.g. steam generator) may become converters if thermal
-    energy modeling is introduced.
-    """
-
+class ElectricalConsumer(Consumer):
     def __init__(self, name: str, load: float, energy_unit_id: EnergyUnitId | None = None) -> None:
         self._name = name
         self._load = load
-        self._id: Final[EnergyUnitId] = energy_unit_id or BaseLoad._create_id()
+        self._id: Final[EnergyUnitId] = energy_unit_id or ElectricalConsumer._create_id()
 
     @classmethod
     def get_input_energy_type(cls) -> type[ElectricalPower]:
@@ -32,6 +26,29 @@ class BaseLoad(Consumer):
 
     def get_input_energy(self) -> ElectricalPower:
         return ElectricalPower(self._load)
+
+
+class FuelGasConsumer(Consumer):
+    def __init__(self, name: str, rate: float, energy_unit_id: EnergyUnitId | None = None) -> None:
+        self._name = name
+        self._rate = rate
+        self._id: Final[EnergyUnitId] = energy_unit_id or FuelGasConsumer._create_id()
+
+    @classmethod
+    def get_input_energy_type(cls) -> type[FuelGasRate]:
+        return FuelGasRate
+
+    def get_id(self) -> EnergyUnitId:
+        return self._id
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_rate(self) -> float:
+        return self._rate
+
+    def get_input_energy(self) -> FuelGasRate:
+        return FuelGasRate(self._rate)
 
 
 class Compressor(Consumer):
@@ -82,81 +99,6 @@ class Pump(Consumer):
 
     def get_input_energy(self) -> MechanicalPower:
         return MechanicalPower(self._power)
-
-
-class SampledFuelConsumer(Consumer):
-    """Consumer with fuel rate from lookup (e.g. compressor+turbine as black box)."""
-
-    def __init__(self, name: str, fuel_rate: float, energy_unit_id: EnergyUnitId | None = None) -> None:
-        self._name = name
-        self._fuel_rate = fuel_rate
-        self._id: Final[EnergyUnitId] = energy_unit_id or SampledFuelConsumer._create_id()
-
-    @classmethod
-    def get_input_energy_type(cls) -> type[FuelGasRate]:
-        return FuelGasRate
-
-    def get_id(self) -> EnergyUnitId:
-        return self._id
-
-    def get_name(self) -> str:
-        return self._name
-
-    def get_fuel_rate(self) -> float:
-        return self._fuel_rate
-
-    def get_input_energy(self) -> FuelGasRate:
-        return FuelGasRate(self._fuel_rate)
-
-
-class SampledPowerConsumer(Consumer):
-    """Consumer with power demand from lookup (e.g. sampled compressor on electrical drive)."""
-
-    def __init__(self, name: str, power: float, energy_unit_id: EnergyUnitId | None = None) -> None:
-        self._name = name
-        self._power = power
-        self._id: Final[EnergyUnitId] = energy_unit_id or SampledPowerConsumer._create_id()
-
-    @classmethod
-    def get_input_energy_type(cls) -> type[ElectricalPower]:
-        return ElectricalPower
-
-    def get_id(self) -> EnergyUnitId:
-        return self._id
-
-    def get_name(self) -> str:
-        return self._name
-
-    def get_power(self) -> float:
-        return self._power
-
-    def get_input_energy(self) -> ElectricalPower:
-        return ElectricalPower(self._power)
-
-
-class Flare(Consumer):
-    """Flare consuming fuel gas."""
-
-    def __init__(self, name: str, fuel_rate: float, energy_unit_id: EnergyUnitId | None = None) -> None:
-        self._name = name
-        self._fuel_rate = fuel_rate
-        self._id: Final[EnergyUnitId] = energy_unit_id or Flare._create_id()
-
-    @classmethod
-    def get_input_energy_type(cls) -> type[FuelGasRate]:
-        return FuelGasRate
-
-    def get_id(self) -> EnergyUnitId:
-        return self._id
-
-    def get_name(self) -> str:
-        return self._name
-
-    def get_fuel_rate(self) -> float:
-        return self._fuel_rate
-
-    def get_input_energy(self) -> FuelGasRate:
-        return FuelGasRate(self._fuel_rate)
 
 
 class DieselConsumer(Consumer):

--- a/src/libecalc/energy/energy_units/junction.py
+++ b/src/libecalc/energy/energy_units/junction.py
@@ -1,8 +1,14 @@
 import abc
+from enum import StrEnum
 from typing import Final
 
 from libecalc.energy.energy_types import ElectricalPower, Energy, FuelGasRate
 from libecalc.energy.energy_unit import EnergyUnit, EnergyUnitId
+
+
+class DispatchStrategy(StrEnum):
+    PRIORITY = "PRIORITY"
+    EQUAL_SPLIT = "EQUAL_SPLIT"
 
 
 class Junction(EnergyUnit):

--- a/src/libecalc/energy/energy_units/sources.py
+++ b/src/libecalc/energy/energy_units/sources.py
@@ -59,9 +59,9 @@ class OnshoreGrid(Source):
 class OffshoreWind(Source):
     """Offshore wind park, capped at total rated output."""
 
-    def __init__(self, name: str, power: float, energy_unit_id: EnergyUnitId | None = None) -> None:
+    def __init__(self, name: str, max_power: float, energy_unit_id: EnergyUnitId | None = None) -> None:
         self._name = name
-        self._power = power
+        self._max_power = max_power
         self._id: Final[EnergyUnitId] = energy_unit_id or OffshoreWind._create_id()
 
     @classmethod
@@ -74,20 +74,20 @@ class OffshoreWind(Source):
     def get_name(self) -> str:
         return self._name
 
-    def get_power(self) -> float:
-        return self._power
+    def get_max_power(self) -> float:
+        return self._max_power
 
     def capacity(self) -> ElectricalPower | None:
-        return ElectricalPower(self._power)
+        return ElectricalPower(self._max_power)
 
 
-class DieselSupply(Source):
+class DieselSource(Source):
     """Diesel fuel supply, brought to platform/rig by supply vessels."""
 
     def __init__(self, name: str, max_rate: float | None = None, energy_unit_id: EnergyUnitId | None = None) -> None:
         self._name = name
         self._max_rate = max_rate
-        self._id: Final[EnergyUnitId] = energy_unit_id or DieselSupply._create_id()
+        self._id: Final[EnergyUnitId] = energy_unit_id or DieselSource._create_id()
 
     @classmethod
     def get_output_energy_type(cls) -> type[DieselRate]:

--- a/src/libecalc/energy/energy_use.py
+++ b/src/libecalc/energy/energy_use.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class EnergyUse(StrEnum):
+    BASE_LOAD = "BASE_LOAD"
+    COMPRESSION = "COMPRESSION"
+    FLARING = "FLARING"
+    HEATING = "HEATING"
+    PUMPING = "PUMPING"

--- a/src/libecalc/examples/energy/energy_network.yaml
+++ b/src/libecalc/examples/energy/energy_network.yaml
@@ -22,20 +22,20 @@
 ENERGY_NETWORK:
   SOURCES:
     - NAME: fuel_gas
-      TYPE: FUEL_GAS
+      TYPE: FUEL_GAS_SOURCE
 
     - NAME: flare_gas
-      TYPE: FUEL_GAS
+      TYPE: FUEL_GAS_SOURCE
 
     - NAME: diesel
-      TYPE: DIESEL
+      TYPE: DIESEL_SOURCE
 
     - NAME: power_from_shore
-      TYPE: ELECTRICAL
+      TYPE: ONSHORE_GRID
       CAPACITY: 20  # MW
 
     - NAME: wind_turbine
-      TYPE: ELECTRICAL
+      TYPE: OFFSHORE_WIND
       CAPACITY: 4.4  # MW
 
   UNITS:
@@ -75,47 +75,55 @@ ENERGY_NETWORK:
 
     # --- Consumers ---
     - NAME: base_load
-      TYPE: ELECTRICAL
+      TYPE: ELECTRICAL_CONSUMER
       INPUT: genset_a
       LOAD: 5  # MW
+      METADATA:
+        ENERGY_USE: BASE_LOAD
 
     - NAME: steamgen
-      TYPE: ELECTRICAL
+      TYPE: ELECTRICAL_CONSUMER
       INPUT: genset_a
       LOAD: 3
 
     - NAME: heating_sat_a
-      TYPE: ELECTRICAL
+      TYPE: ELECTRICAL_CONSUMER
       INPUT: genset_a
       LOAD: 2
+      METADATA:
+        ENERGY_USE: HEATING
 
     - NAME: heating
-      TYPE: ELECTRICAL
+      TYPE: ELECTRICAL_CONSUMER
       INPUT: electrical_bus
       LOAD: 10
+      METADATA:
+        ENERGY_USE: HEATING
 
     - NAME: flare
-      TYPE: FUEL_GAS
+      TYPE: FUEL_GAS_CONSUMER
       INPUT: flare_gas
       RATE: 1200  # Sm3/d
+      METADATA:
+        ENERGY_USE: FLARING
 
     - NAME: gas_compressor_sampled
-      TYPE: FUEL_GAS
+      TYPE: FUEL_GAS_CONSUMER
       INPUT: fuel_manifold
       RATE: 50000  # Sm3/d
 
     - NAME: diesel_consumers
-      TYPE: DIESEL
+      TYPE: DIESEL_CONSUMER
       INPUT: diesel
       RATE: 500  # l/d
 
     # Process simulation driven
     - NAME: export_train
-      TYPE: MECHANICAL
+      TYPE: COMPRESSOR
       INPUT: export_turbine
       PROCESS_SIMULATION: export_compressor_sim
 
     - NAME: waterinj_train
-      TYPE: MECHANICAL
+      TYPE: PUMP
       INPUT: waterinj_motor
       PROCESS_SIMULATION: waterinj_pump_sim

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_consumers.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_consumers.py
@@ -1,0 +1,116 @@
+from typing import Annotated, Literal
+
+from pydantic import ConfigDict, Field, field_validator, model_validator
+
+from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
+from libecalc.presentation.yaml.yaml_types.energy.yaml_energy_common import (
+    YamlEnergyNetworkNodeBase,
+    _check_non_negative,
+)
+
+
+class YamlConsumerBase(YamlEnergyNetworkNodeBase):
+    input: Annotated[
+        str,
+        Field(
+            title="INPUT",
+            description="Source or component this receives energy from.",
+        ),
+    ]
+
+
+class YamlElectricalConsumer(YamlConsumerBase):
+    model_config = ConfigDict(title="ElectricalConsumer")
+
+    type: Literal["ELECTRICAL_CONSUMER"]
+    load: Annotated[
+        YamlExpressionType,
+        Field(
+            title="LOAD",
+            description="Electrical power demand (MW).",
+        ),
+    ]
+
+    @field_validator("load", mode="after")
+    @classmethod
+    def _load_non_negative(cls, v: YamlExpressionType) -> YamlExpressionType:
+        return _check_non_negative(v, "LOAD")  # type: ignore[return-value]
+
+
+class YamlFuelGasConsumer(YamlConsumerBase):
+    model_config = ConfigDict(title="FuelGasConsumer")
+
+    type: Literal["FUEL_GAS_CONSUMER"]
+    rate: Annotated[
+        YamlExpressionType,
+        Field(
+            title="RATE",
+            description="Fuel gas consumption rate (Sm³/d).",
+        ),
+    ]
+
+    @field_validator("rate", mode="after")
+    @classmethod
+    def _rate_non_negative(cls, v: YamlExpressionType) -> YamlExpressionType:
+        return _check_non_negative(v, "RATE")  # type: ignore[return-value]
+
+
+class YamlMechanicalConsumerBase(YamlConsumerBase):
+    load: Annotated[
+        YamlExpressionType | None,
+        Field(
+            title="LOAD",
+            description="Shaft power demand in MW. Mutually exclusive with PROCESS_SIMULATION.",
+        ),
+    ] = None
+    process_simulation: Annotated[
+        str | None,
+        Field(
+            title="PROCESS_SIMULATION",
+            description="Process simulation determining the shaft power demand.",
+        ),
+    ] = None
+
+    @field_validator("load", mode="after")
+    @classmethod
+    def _load_non_negative(
+        cls,
+        value: YamlExpressionType | None,
+    ) -> YamlExpressionType | None:
+        return _check_non_negative(value, "LOAD")
+
+    @model_validator(mode="after")
+    def check_exactly_one_demand_source(self):
+        if self.load is None and self.process_simulation is None:
+            raise ValueError(f"'{self.name}': either LOAD or PROCESS_SIMULATION must be specified.")
+        if self.load is not None and self.process_simulation is not None:
+            raise ValueError(f"'{self.name}': cannot specify both LOAD and PROCESS_SIMULATION.")
+        return self
+
+
+class YamlCompressor(YamlMechanicalConsumerBase):
+    model_config = ConfigDict(title="Compressor")
+    type: Literal["COMPRESSOR"]
+
+
+class YamlPump(YamlMechanicalConsumerBase):
+    model_config = ConfigDict(title="Pump")
+    type: Literal["PUMP"]
+
+
+class YamlDieselConsumer(YamlConsumerBase):
+    model_config = ConfigDict(title="DieselConsumer")
+
+    type: Literal["DIESEL_CONSUMER"]
+    rate: Annotated[
+        YamlExpressionType,
+        Field(
+            title="RATE",
+            description="Diesel consumption rate (l/d).",
+        ),
+    ]
+
+    @field_validator("rate", mode="after")
+    @classmethod
+    def _rate_non_negative(cls, v: YamlExpressionType) -> YamlExpressionType:
+        return _check_non_negative(v, "RATE")  # type: ignore[return-value]

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_converters.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_converters.py
@@ -1,0 +1,76 @@
+from typing import Annotated, Literal
+
+from pydantic import ConfigDict, Field, field_validator
+
+from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
+from libecalc.presentation.yaml.yaml_types.energy.yaml_energy_common import (
+    YamlEnergyNetworkNodeBase,
+    _check_efficiency,
+    _check_non_negative,
+)
+
+
+class YamlConverterBase(YamlEnergyNetworkNodeBase):
+    input: Annotated[
+        str,
+        Field(
+            title="INPUT",
+            description="Source or component this receives energy from.",
+        ),
+    ]
+    capacity: Annotated[
+        YamlExpressionType | None,
+        Field(
+            title="CAPACITY",
+            description="Maximum output capacity. Omit for unlimited.",
+        ),
+    ] = None
+
+    @field_validator("capacity", mode="after")
+    @classmethod
+    def _capacity_non_negative(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
+        return _check_non_negative(v, "CAPACITY")
+
+
+class YamlGeneratorSet(YamlConverterBase):
+    model_config = ConfigDict(title="GeneratorSet")
+
+    type: Literal["GENERATOR_SET"]
+    model: Annotated[
+        str,
+        Field(
+            title="MODEL",
+            description="Reference to a facility model defining the power-to-fuel curve.",
+        ),
+    ]
+
+
+class YamlGasTurbine(YamlConverterBase):
+    model_config = ConfigDict(title="GasTurbine")
+
+    type: Literal["GAS_TURBINE"]
+    model: Annotated[
+        str,
+        Field(
+            title="MODEL",
+            description="Reference to a facility model defining the power-to-fuel curve.",
+        ),
+    ]
+
+
+class YamlElectricalMotor(YamlConverterBase):
+    model_config = ConfigDict(title="ElectricalMotor")
+
+    type: Literal["ELECTRICAL_MOTOR"]
+    efficiency: Annotated[
+        YamlExpressionType,
+        Field(
+            title="EFFICIENCY",
+            description="Conversion efficiency (0–1]. Defaults to 0.95 if omitted.",
+        ),
+    ] = 0.95
+
+    @field_validator("efficiency", mode="after")
+    @classmethod
+    def _efficiency_in_range(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
+        return _check_efficiency(v)

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_energy_common.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_energy_common.py
@@ -1,0 +1,48 @@
+from typing import Annotated
+
+from pydantic import ConfigDict, Field
+
+from libecalc.energy.energy_use import EnergyUse
+from libecalc.presentation.yaml.yaml_types import YamlBase
+from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
+
+
+def _check_non_negative(v: YamlExpressionType | None, field_name: str) -> YamlExpressionType | None:
+    if isinstance(v, (int, float)) and v < 0:
+        raise ValueError(f"{field_name} must be non-negative, got {v}")
+    return v
+
+
+def _check_efficiency(v: YamlExpressionType | None) -> YamlExpressionType | None:
+    if isinstance(v, (int, float)) and not (0 < v <= 1):
+        raise ValueError(f"EFFICIENCY must be in (0, 1], got {v}")
+    return v
+
+
+class YamlEnergyUnitMetadata(YamlBase):
+    model_config = ConfigDict(title="EnergyUnitMetadata")
+
+    energy_use: Annotated[
+        EnergyUse | None,
+        Field(
+            title="ENERGY_USE",
+            description="Controlled classification for analysis. Does not affect calculations.",
+        ),
+    ] = None
+
+
+class YamlEnergyNetworkNodeBase(YamlBase):
+    name: Annotated[
+        str,
+        Field(
+            title="NAME",
+            description="Unique name for this energy network node.",
+        ),
+    ]
+    metadata: Annotated[
+        YamlEnergyUnitMetadata | None,
+        Field(
+            title="METADATA",
+            description="Optional metadata for classification and analysis.",
+        ),
+    ] = None

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_energy_network.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_energy_network.py
@@ -1,325 +1,11 @@
 from enum import StrEnum
-from typing import Annotated, Literal, Union
+from typing import Annotated
 
-from pydantic import ConfigDict, Field, field_validator, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from libecalc.presentation.yaml.yaml_types import YamlBase
-from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
-
-
-def _check_non_negative(v: YamlExpressionType | None, field_name: str) -> YamlExpressionType | None:
-    if isinstance(v, (int, float)) and v < 0:
-        raise ValueError(f"{field_name} must be non-negative, got {v}")
-    return v
-
-
-def _check_efficiency(v: YamlExpressionType | None) -> YamlExpressionType | None:
-    if isinstance(v, (int, float)) and not (0 < v <= 1):
-        raise ValueError(f"EFFICIENCY must be in (0, 1], got {v}")
-    return v
-
-
-class YamlEnergySourceType(StrEnum):
-    FUEL_GAS = "FUEL_GAS"
-    ELECTRICAL = "ELECTRICAL"
-    DIESEL = "DIESEL"
-
-
-class YamlEnergySource(YamlBase):
-    model_config = ConfigDict(title="EnergySource")
-
-    name: Annotated[
-        str,
-        Field(
-            title="NAME",
-            description="Unique name for this energy source.",
-        ),
-    ]
-    type: Annotated[
-        YamlEnergySourceType,
-        Field(
-            title="TYPE",
-            description="Energy type this source provides (FUEL_GAS, ELECTRICAL, or DIESEL).",
-        ),
-    ]
-    capacity: Annotated[
-        YamlExpressionType | None,
-        Field(
-            title="CAPACITY",
-            description="Maximum output capacity. Omit for unlimited.",
-        ),
-    ] = None
-
-    @field_validator("capacity", mode="after")
-    @classmethod
-    def _capacity_non_negative(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
-        return _check_non_negative(v, "CAPACITY")
-
-
-class YamlConverterBase(YamlBase):
-    name: Annotated[
-        str,
-        Field(
-            title="NAME",
-            description="Unique name for this component.",
-        ),
-    ]
-    input: Annotated[
-        str,
-        Field(
-            title="INPUT",
-            description="Source or component this receives energy from.",
-        ),
-    ]
-    capacity: Annotated[
-        YamlExpressionType | None,
-        Field(
-            title="CAPACITY",
-            description="Maximum output capacity. Omit for unlimited.",
-        ),
-    ] = None
-
-    @field_validator("capacity", mode="after")
-    @classmethod
-    def _capacity_non_negative(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
-        return _check_non_negative(v, "CAPACITY")
-
-
-class YamlGeneratorSet(YamlConverterBase):
-    model_config = ConfigDict(title="GeneratorSet")
-
-    type: Literal["GENERATOR_SET"]
-    model: Annotated[
-        str | None,
-        Field(
-            title="MODEL",
-            description="Reference to a facility model defining the power-to-fuel curve.",
-        ),
-    ] = None
-
-
-class YamlGasTurbine(YamlConverterBase):
-    model_config = ConfigDict(title="GasTurbine")
-
-    type: Literal["GAS_TURBINE"]
-    model: Annotated[
-        str | None,
-        Field(
-            title="MODEL",
-            description="Reference to a facility model defining the power-to-fuel curve.",
-        ),
-    ] = None
-
-
-class YamlElectricalMotor(YamlConverterBase):
-    model_config = ConfigDict(title="ElectricalMotor")
-
-    type: Literal["ELECTRICAL_MOTOR"]
-    efficiency: Annotated[
-        YamlExpressionType | None,
-        Field(
-            title="EFFICIENCY",
-            description="Conversion efficiency (0–1]. Defaults to 0.95 if omitted.",
-        ),
-    ] = None
-
-    @field_validator("efficiency", mode="after")
-    @classmethod
-    def _efficiency_in_range(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
-        return _check_efficiency(v)
-
-
-class YamlElectricalCable(YamlConverterBase):
-    model_config = ConfigDict(title="ElectricalCable")
-
-    type: Literal["ELECTRICAL_CABLE"]
-    efficiency: Annotated[
-        YamlExpressionType | None,
-        Field(
-            title="EFFICIENCY",
-            description="Transmission efficiency (0–1]. 1.0 means no loss. Defaults to 1.0 if omitted.",
-        ),
-    ] = None
-
-    @field_validator("efficiency", mode="after")
-    @classmethod
-    def _efficiency_in_range(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
-        return _check_efficiency(v)
-
-
-class YamlDispatchStrategy(StrEnum):
-    PRIORITY = "PRIORITY"
-    EQUAL_SPLIT = "EQUAL_SPLIT"
-
-
-class YamlJunctionBase(YamlBase):
-    name: Annotated[
-        str,
-        Field(
-            title="NAME",
-            description="Unique name for this component.",
-        ),
-    ]
-    input: Annotated[
-        list[str],
-        Field(
-            title="INPUT",
-            description="Sources or units feeding into this junction.",
-        ),
-    ]
-    dispatch_strategy: Annotated[
-        YamlDispatchStrategy | None,
-        Field(
-            title="DISPATCH_STRATEGY",
-            description="How to allocate demand across multiple inputs. Required when INPUT has more than one entry.",
-        ),
-    ] = None
-
-    @model_validator(mode="after")
-    def check_dispatch_strategy_required_for_fan_in(self):
-        if len(self.input) > 1 and self.dispatch_strategy is None:
-            raise ValueError(f"'{self.name}': DISPATCH_STRATEGY is required when INPUT has multiple entries.")
-        return self
-
-    @model_validator(mode="after")
-    def check_no_duplicate_inputs(self):
-        if len(self.input) != len(set(self.input)):
-            duplicates = [ref for ref in self.input if self.input.count(ref) > 1]
-            raise ValueError(f"'{self.name}': duplicate INPUT references: {set(duplicates)}")
-        return self
-
-
-class YamlElectricalBus(YamlJunctionBase):
-    model_config = ConfigDict(title="ElectricalBus")
-
-    type: Literal["ELECTRICAL_BUS"]
-
-
-class YamlFuelGasManifold(YamlJunctionBase):
-    model_config = ConfigDict(title="FuelGasManifold")
-
-    type: Literal["FUEL_GAS_MANIFOLD"]
-
-
-class YamlConsumerBase(YamlBase):
-    name: Annotated[
-        str,
-        Field(
-            title="NAME",
-            description="Unique name for this component.",
-        ),
-    ]
-    input: Annotated[
-        str,
-        Field(
-            title="INPUT",
-            description="Source or component this receives energy from.",
-        ),
-    ]
-
-
-class YamlElectricalConsumer(YamlConsumerBase):
-    model_config = ConfigDict(title="ElectricalConsumer")
-
-    type: Literal["ELECTRICAL"]
-    load: Annotated[
-        YamlExpressionType,
-        Field(
-            title="LOAD",
-            description="Electrical power demand (MW).",
-        ),
-    ]
-
-    @field_validator("load", mode="after")
-    @classmethod
-    def _load_non_negative(cls, v: YamlExpressionType) -> YamlExpressionType:
-        return _check_non_negative(v, "LOAD")  # type: ignore[return-value]
-
-
-class YamlMechanicalConsumer(YamlConsumerBase):
-    model_config = ConfigDict(title="MechanicalConsumer")
-
-    type: Literal["MECHANICAL"]
-    load: Annotated[
-        YamlExpressionType | None,
-        Field(
-            title="LOAD",
-            description="Shaft power demand (MW). Mutually exclusive with PROCESS_SIMULATION.",
-        ),
-    ] = None
-    process_simulation: Annotated[
-        str | None,
-        Field(
-            title="PROCESS_SIMULATION",
-            description="Reference to a process simulation that determines shaft power demand. Mutually exclusive with LOAD.",
-        ),
-    ] = None
-
-    @field_validator("load", mode="after")
-    @classmethod
-    def _load_non_negative(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
-        return _check_non_negative(v, "LOAD")
-
-    @model_validator(mode="after")
-    def check_exactly_one_demand_source(self):
-        if self.load is None and self.process_simulation is None:
-            raise ValueError(f"'{self.name}': either LOAD or PROCESS_SIMULATION must be specified.")
-        if self.load is not None and self.process_simulation is not None:
-            raise ValueError(f"'{self.name}': cannot specify both LOAD and PROCESS_SIMULATION.")
-        return self
-
-
-class YamlFuelGasConsumer(YamlConsumerBase):
-    model_config = ConfigDict(title="FuelGasConsumer")
-
-    type: Literal["FUEL_GAS"]
-    rate: Annotated[
-        YamlExpressionType,
-        Field(
-            title="RATE",
-            description="Fuel gas consumption rate (Sm³/d).",
-        ),
-    ]
-
-    @field_validator("rate", mode="after")
-    @classmethod
-    def _rate_non_negative(cls, v: YamlExpressionType) -> YamlExpressionType:
-        return _check_non_negative(v, "RATE")  # type: ignore[return-value]
-
-
-class YamlDieselConsumer(YamlConsumerBase):
-    model_config = ConfigDict(title="DieselConsumer")
-
-    type: Literal["DIESEL"]
-    rate: Annotated[
-        YamlExpressionType,
-        Field(
-            title="RATE",
-            description="Diesel consumption rate (l/d).",
-        ),
-    ]
-
-    @field_validator("rate", mode="after")
-    @classmethod
-    def _rate_non_negative(cls, v: YamlExpressionType) -> YamlExpressionType:
-        return _check_non_negative(v, "RATE")  # type: ignore[return-value]
-
-
-YamlComponent = Annotated[
-    Union[
-        YamlGeneratorSet,
-        YamlGasTurbine,
-        YamlElectricalMotor,
-        YamlElectricalCable,
-        YamlElectricalBus,
-        YamlFuelGasManifold,
-        YamlElectricalConsumer,
-        YamlMechanicalConsumer,
-        YamlFuelGasConsumer,
-        YamlDieselConsumer,
-    ],
-    Field(discriminator="type"),
-]
+from libecalc.presentation.yaml.yaml_types.energy.yaml_sources import YamlEnergySource
+from libecalc.presentation.yaml.yaml_types.energy.yaml_units import YamlEnergyNetworkUnit
 
 
 class EnergyType(StrEnum):
@@ -329,20 +15,25 @@ class EnergyType(StrEnum):
     DIESEL = "DIESEL"
 
 
-INPUT_ENERGY: dict[str, set[EnergyType]] = {
-    "GENERATOR_SET": {EnergyType.FUEL_GAS, EnergyType.DIESEL},
-    "GAS_TURBINE": {EnergyType.FUEL_GAS},
-    "ELECTRICAL_MOTOR": {EnergyType.ELECTRICAL},
-    "ELECTRICAL_CABLE": {EnergyType.ELECTRICAL},
-    "ELECTRICAL_BUS": {EnergyType.ELECTRICAL},
-    "FUEL_GAS_MANIFOLD": {EnergyType.FUEL_GAS},
-    "ELECTRICAL": {EnergyType.ELECTRICAL},
-    "MECHANICAL": {EnergyType.MECHANICAL},
-    "FUEL_GAS": {EnergyType.FUEL_GAS},
-    "DIESEL": {EnergyType.DIESEL},
+INPUT_ENERGY_TYPE_BY_UNIT_TYPE: dict[str, EnergyType] = {
+    "GENERATOR_SET": EnergyType.FUEL_GAS,
+    "GAS_TURBINE": EnergyType.FUEL_GAS,
+    "ELECTRICAL_MOTOR": EnergyType.ELECTRICAL,
+    "ELECTRICAL_CABLE": EnergyType.ELECTRICAL,
+    "ELECTRICAL_BUS": EnergyType.ELECTRICAL,
+    "FUEL_GAS_MANIFOLD": EnergyType.FUEL_GAS,
+    "ELECTRICAL_CONSUMER": EnergyType.ELECTRICAL,
+    "COMPRESSOR": EnergyType.MECHANICAL,
+    "PUMP": EnergyType.MECHANICAL,
+    "FUEL_GAS_CONSUMER": EnergyType.FUEL_GAS,
+    "DIESEL_CONSUMER": EnergyType.DIESEL,
 }
 
-OUTPUT_ENERGY: dict[str, EnergyType] = {
+OUTPUT_ENERGY_TYPE_BY_NODE_TYPE: dict[str, EnergyType] = {
+    "FUEL_GAS_SOURCE": EnergyType.FUEL_GAS,
+    "DIESEL_SOURCE": EnergyType.DIESEL,
+    "ONSHORE_GRID": EnergyType.ELECTRICAL,
+    "OFFSHORE_WIND": EnergyType.ELECTRICAL,
     "GENERATOR_SET": EnergyType.ELECTRICAL,
     "GAS_TURBINE": EnergyType.MECHANICAL,
     "ELECTRICAL_MOTOR": EnergyType.MECHANICAL,
@@ -351,10 +42,10 @@ OUTPUT_ENERGY: dict[str, EnergyType] = {
     "FUEL_GAS_MANIFOLD": EnergyType.FUEL_GAS,
 }
 
-CONSUMER_TYPES = set(INPUT_ENERGY) - set(OUTPUT_ENERGY)
+CONSUMER_TYPES = set(INPUT_ENERGY_TYPE_BY_UNIT_TYPE) - set(OUTPUT_ENERGY_TYPE_BY_NODE_TYPE)
 
 
-def _get_input_names(component: YamlComponent) -> list[str]:
+def _get_input_names(component: YamlEnergyNetworkUnit) -> list[str]:
     if isinstance(component.input, list):
         return component.input
     return [component.input]
@@ -372,7 +63,7 @@ class YamlEnergyNetwork(YamlBase):
         ),
     ]
     units: Annotated[
-        list[YamlComponent],
+        list[YamlEnergyNetworkUnit],
         Field(
             title="UNITS",
             description="Converters, junctions, and consumers forming the energy network.",
@@ -422,21 +113,20 @@ class YamlEnergyNetwork(YamlBase):
     @model_validator(mode="after")
     def check_energy_type_compatibility(self):
         output_types: dict[str, EnergyType] = {}
-        for s in self.sources:
-            output_types[s.name] = EnergyType(s.type.value)
+        for source in self.sources:
+            output_types[source.name] = OUTPUT_ENERGY_TYPE_BY_NODE_TYPE[source.type]
         for c in self.units:
-            if c.type in OUTPUT_ENERGY:
-                output_types[c.name] = OUTPUT_ENERGY[c.type]
+            if c.type in OUTPUT_ENERGY_TYPE_BY_NODE_TYPE:
+                output_types[c.name] = OUTPUT_ENERGY_TYPE_BY_NODE_TYPE[c.type]
 
         for c in self.units:
-            if c.type not in INPUT_ENERGY:
+            if c.type not in INPUT_ENERGY_TYPE_BY_UNIT_TYPE:
                 raise ValueError(f"'{c.name}': unknown component type '{c.type}' — not in energy type map.")
-            expected_inputs = INPUT_ENERGY[c.type]
+            expected_inputs = INPUT_ENERGY_TYPE_BY_UNIT_TYPE[c.type]
             for ref in _get_input_names(c):
                 provided = output_types.get(ref)
-                if provided is not None and provided not in expected_inputs:
+                if provided is not None and provided != expected_inputs:
                     raise ValueError(
-                        f"'{c.name}' ({c.type}) expects {'/'.join(sorted(expected_inputs))} input, "
-                        f"but '{ref}' provides {provided}."
+                        f"'{c.name}' ({c.type}) expects {expected_inputs} input, but '{ref}' provides {provided}."
                     )
         return self

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_junctions.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_junctions.py
@@ -1,0 +1,48 @@
+from typing import Annotated, Literal
+
+from pydantic import ConfigDict, Field, model_validator
+
+from libecalc.energy.energy_units.junction import DispatchStrategy
+from libecalc.presentation.yaml.yaml_types.energy.yaml_energy_common import YamlEnergyNetworkNodeBase
+
+
+class YamlJunctionBase(YamlEnergyNetworkNodeBase):
+    input: Annotated[
+        list[str],
+        Field(
+            title="INPUT",
+            description="Sources or units feeding into this junction.",
+        ),
+    ]
+    dispatch_strategy: Annotated[
+        DispatchStrategy | None,
+        Field(
+            title="DISPATCH_STRATEGY",
+            description="How to allocate demand across multiple inputs. Required when INPUT has more than one entry.",
+        ),
+    ] = None
+
+    @model_validator(mode="after")
+    def check_dispatch_strategy_required_for_fan_in(self):
+        if len(self.input) > 1 and self.dispatch_strategy is None:
+            raise ValueError(f"'{self.name}': DISPATCH_STRATEGY is required when INPUT has multiple entries.")
+        return self
+
+    @model_validator(mode="after")
+    def check_no_duplicate_inputs(self):
+        if len(self.input) != len(set(self.input)):
+            duplicates = [ref for ref in self.input if self.input.count(ref) > 1]
+            raise ValueError(f"'{self.name}': duplicate INPUT references: {set(duplicates)}")
+        return self
+
+
+class YamlElectricalBus(YamlJunctionBase):
+    model_config = ConfigDict(title="ElectricalBus")
+
+    type: Literal["ELECTRICAL_BUS"]
+
+
+class YamlFuelGasManifold(YamlJunctionBase):
+    model_config = ConfigDict(title="FuelGasManifold")
+
+    type: Literal["FUEL_GAS_MANIFOLD"]

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_sources.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_sources.py
@@ -1,0 +1,49 @@
+from typing import Annotated, Literal
+
+from pydantic import Field, field_validator
+
+from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
+from libecalc.presentation.yaml.yaml_types.energy.yaml_energy_common import (
+    YamlEnergyNetworkNodeBase,
+    _check_non_negative,
+)
+
+
+class YamlEnergySourceBase(YamlEnergyNetworkNodeBase):
+    capacity: Annotated[
+        YamlExpressionType | None,
+        Field(
+            title="CAPACITY",
+            description="Maximum output capacity. Omit for unlimited.",
+        ),
+    ] = None
+
+    @field_validator("capacity", mode="after")
+    @classmethod
+    def _capacity_non_negative(
+        cls,
+        value: YamlExpressionType | None,
+    ) -> YamlExpressionType | None:
+        return _check_non_negative(value, "CAPACITY")
+
+
+class YamlFuelGasSource(YamlEnergySourceBase):
+    type: Literal["FUEL_GAS_SOURCE"]
+
+
+class YamlDieselSource(YamlEnergySourceBase):
+    type: Literal["DIESEL_SOURCE"]
+
+
+class YamlOnshoreGrid(YamlEnergySourceBase):
+    type: Literal["ONSHORE_GRID"]
+
+
+class YamlOffshoreWind(YamlEnergySourceBase):
+    type: Literal["OFFSHORE_WIND"]
+
+
+YamlEnergySource = Annotated[
+    YamlFuelGasSource | YamlDieselSource | YamlOnshoreGrid | YamlOffshoreWind,
+    Field(discriminator="type"),
+]

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_transporters.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_transporters.py
@@ -1,0 +1,50 @@
+from typing import Annotated, Literal
+
+from pydantic import ConfigDict, Field, field_validator
+
+from libecalc.presentation.yaml.yaml_types.components.yaml_expression_type import YamlExpressionType
+from libecalc.presentation.yaml.yaml_types.energy.yaml_energy_common import (
+    YamlEnergyNetworkNodeBase,
+    _check_efficiency,
+    _check_non_negative,
+)
+
+
+class YamlTransporterBase(YamlEnergyNetworkNodeBase):
+    input: Annotated[
+        str,
+        Field(
+            title="INPUT",
+            description="Source or component this receives energy from.",
+        ),
+    ]
+    capacity: Annotated[
+        YamlExpressionType | None,
+        Field(
+            title="CAPACITY",
+            description="Maximum output capacity. Omit for unlimited.",
+        ),
+    ] = None
+
+    @field_validator("capacity", mode="after")
+    @classmethod
+    def _capacity_non_negative(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
+        return _check_non_negative(v, "CAPACITY")
+
+
+class YamlElectricalCable(YamlTransporterBase):
+    model_config = ConfigDict(title="ElectricalCable")
+
+    type: Literal["ELECTRICAL_CABLE"]
+    efficiency: Annotated[
+        YamlExpressionType,
+        Field(
+            title="EFFICIENCY",
+            description="Transmission efficiency (0–1]. 1.0 means no loss. Defaults to 1.0 if omitted.",
+        ),
+    ] = 1.0
+
+    @field_validator("efficiency", mode="after")
+    @classmethod
+    def _efficiency_in_range(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
+        return _check_efficiency(v)

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_units.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_units.py
@@ -1,0 +1,33 @@
+from typing import Annotated
+
+from pydantic import Field
+
+from libecalc.presentation.yaml.yaml_types.energy.yaml_consumers import (
+    YamlCompressor,
+    YamlDieselConsumer,
+    YamlElectricalConsumer,
+    YamlFuelGasConsumer,
+    YamlPump,
+)
+from libecalc.presentation.yaml.yaml_types.energy.yaml_converters import (
+    YamlElectricalMotor,
+    YamlGasTurbine,
+    YamlGeneratorSet,
+)
+from libecalc.presentation.yaml.yaml_types.energy.yaml_junctions import YamlElectricalBus, YamlFuelGasManifold
+from libecalc.presentation.yaml.yaml_types.energy.yaml_transporters import YamlElectricalCable
+
+YamlEnergyNetworkUnit = Annotated[
+    YamlGeneratorSet
+    | YamlGasTurbine
+    | YamlElectricalMotor
+    | YamlElectricalCable
+    | YamlElectricalBus
+    | YamlFuelGasManifold
+    | YamlElectricalConsumer
+    | YamlCompressor
+    | YamlPump
+    | YamlFuelGasConsumer
+    | YamlDieselConsumer,
+    Field(discriminator="type"),
+]

--- a/tests/libecalc/energy/test_energy_network.py
+++ b/tests/libecalc/energy/test_energy_network.py
@@ -3,9 +3,9 @@ from inline_snapshot import snapshot
 
 from libecalc.energy import ElectricalPower, FuelGasRate, MechanicalPower
 from libecalc.energy.energy_units import (
-    BaseLoad,
     ElectricalBus,
     ElectricalCable,
+    ElectricalConsumer,
     ElectricalMotor,
     FuelGasSource,
     GeneratorSet,
@@ -20,7 +20,7 @@ from libecalc.energy.network import EnergyConnection, EnergyNetwork
 class TestEnergyNetworkValidation:
     def test_rejects_incompatible_energy_types(self):
         source = FuelGasSource(name="source")
-        load = BaseLoad(name="load", load=5)
+        load = ElectricalConsumer(name="load", load=5)
 
         with pytest.raises(
             InvalidEnergyNetworkError,
@@ -37,7 +37,7 @@ class TestEnergyNetworkValidation:
             )
 
     def test_rejects_unknown_source(self):
-        load = BaseLoad(name="load", load=5)
+        load = ElectricalConsumer(name="load", load=5)
         missing_id = FuelGasSource._create_id()
 
         with pytest.raises(InvalidEnergyNetworkError, match="Unknown source"):
@@ -53,7 +53,7 @@ class TestEnergyNetworkValidation:
 
     def test_rejects_unknown_target(self):
         source = FuelGasSource(name="source")
-        missing_id = BaseLoad._create_id()
+        missing_id = ElectricalConsumer._create_id()
 
         with pytest.raises(InvalidEnergyNetworkError, match="Unknown target"):
             EnergyNetwork(
@@ -69,8 +69,8 @@ class TestEnergyNetworkValidation:
     @pytest.mark.snapshot
     @pytest.mark.inlinesnapshot
     def test_rejects_consumer_as_source(self):
-        source = BaseLoad(name="source", load=5)
-        target = BaseLoad(name="target", load=5)
+        source = ElectricalConsumer(name="source", load=5)
+        target = ElectricalConsumer(name="target", load=5)
 
         with pytest.raises(
             InvalidEnergyNetworkError,
@@ -85,7 +85,7 @@ class TestEnergyNetworkValidation:
                 ],
             )
         assert str(exc_info.value) == snapshot(
-            f"Energy domain error: Source node of type 'BaseLoad' with id '{source.get_id()}' provides no energy"
+            f"Energy domain error: Source node of type 'ElectricalConsumer' with id '{source.get_id()}' provides no energy"
         )
 
     @pytest.mark.snapshot
@@ -120,7 +120,7 @@ class TestEnergyNetworkValidation:
             EnergyNetwork(
                 nodes=[
                     FuelGasSource(name="source", energy_unit_id=duplicate_id),
-                    BaseLoad(name="load", load=5, energy_unit_id=duplicate_id),
+                    ElectricalConsumer(name="load", load=5, energy_unit_id=duplicate_id),
                 ],
                 connections=[],
             )
@@ -148,7 +148,7 @@ class TestEnergyNetworkValidation:
             )
 
     def test_rejects_consumer_without_predecessor(self):
-        base_load = BaseLoad("load", load=1)
+        base_load = ElectricalConsumer("load", load=1)
         with pytest.raises(
             InvalidEnergyNetworkError,
             match="requires input energy but has no predecessor",
@@ -162,7 +162,7 @@ class TestEnergyNetworkTopology:
         generator = GeneratorSet(
             name="generator", max_power=10, power_to_fuel=lambda output_power: output_power * 5000.0
         )
-        load = BaseLoad(name="load", load=5)
+        load = ElectricalConsumer(name="load", load=5)
 
         network = EnergyNetwork(
             nodes=[source, generator, load],
@@ -189,8 +189,8 @@ class TestEnergyNetworkTopology:
         """A provider can supply multiple downstream consumers."""
         source = FuelGasSource(name="source")
         generator = GeneratorSet(name="generator", max_power=10, power_to_fuel=lambda output_power: output_power * 5000)
-        first_load = BaseLoad(name="first_load", load=3)
-        second_load = BaseLoad(name="second_load", load=4)
+        first_load = ElectricalConsumer(name="first_load", load=3)
+        second_load = ElectricalConsumer(name="second_load", load=4)
 
         network = EnergyNetwork(
             nodes=[
@@ -224,10 +224,10 @@ class TestEnergyNetworkTopology:
 
     def test_connects_multiple_providers_to_consumer_through_junction(self):
         grid = OnshoreGrid(name="grid", max_power=20)
-        wind = OffshoreWind(name="wind", power=5)
+        wind = OffshoreWind(name="wind", max_power=5)
 
         bus = ElectricalBus(name="bus")
-        load = BaseLoad(name="load", load=10)
+        load = ElectricalConsumer(name="load", load=10)
 
         network = EnergyNetwork(
             nodes=[grid, wind, bus, load],
@@ -265,7 +265,7 @@ class TestEnergyNetworkTopology:
             max_power=15,
             loss_fraction=0.04,
         )
-        load = BaseLoad(name="load", load=10)
+        load = ElectricalConsumer(name="load", load=10)
 
         network = EnergyNetwork(
             nodes=[grid, cable, load],
@@ -296,7 +296,7 @@ class TestEnergyNetworkEnergyCalculation:
         bus = ElectricalBus("bus")
         motor = ElectricalMotor("motor", max_power=5, efficiency=0.8)
         pump = Pump("pump", power=4)
-        base_load = BaseLoad("base_load", load=5)
+        base_load = ElectricalConsumer("base_load", load=5)
 
         network = EnergyNetwork(
             nodes=[source, generator, bus, motor, pump, base_load],
@@ -342,7 +342,7 @@ class TestEnergyNetworkEnergyCalculation:
     def test_requires_allocation_for_multiple_predecessors(self):
         first_grid = OnshoreGrid("first_grid", max_power=20)
         second_grid = OnshoreGrid("second_grid", max_power=20)
-        load = BaseLoad("load", load=10)
+        load = ElectricalConsumer("load", load=10)
 
         network = EnergyNetwork(
             nodes=[first_grid, second_grid, load],
@@ -361,7 +361,7 @@ class TestEnergyNetworkEnergyCalculation:
     def test_does_not_require_allocation_for_zero_energy(self):
         first_grid = OnshoreGrid("first_grid", max_power=20)
         second_grid = OnshoreGrid("second_grid", max_power=20)
-        load = BaseLoad("load", load=0)
+        load = ElectricalConsumer("load", load=0)
 
         network = EnergyNetwork(
             nodes=[first_grid, second_grid, load],
@@ -377,7 +377,7 @@ class TestEnergyNetworkEnergyCalculation:
 class TestEnergyNetworkFeasibility:
     def test_reports_capacity_exceeded_without_capping_output_energy(self):
         grid = OnshoreGrid("grid", max_power=5)
-        load = BaseLoad("load", load=6)
+        load = ElectricalConsumer("load", load=6)
 
         network = EnergyNetwork(
             nodes=[grid, load],
@@ -393,7 +393,7 @@ class TestEnergyNetworkFeasibility:
 
     def test_capacity_equal_to_output_energy_is_feasible(self):
         grid = OnshoreGrid("grid", max_power=5)
-        load = BaseLoad("load", load=5)
+        load = ElectricalConsumer("load", load=5)
 
         network = EnergyNetwork(
             nodes=[grid, load],

--- a/tests/libecalc/energy/test_energy_network_yaml.py
+++ b/tests/libecalc/energy/test_energy_network_yaml.py
@@ -4,22 +4,32 @@ import pytest
 import yaml
 from pydantic import TypeAdapter, ValidationError
 
-from libecalc.presentation.yaml.yaml_types.energy.yaml_energy_network import (
-    YamlComponent,
-    YamlElectricalBus,
-    YamlElectricalCable,
+from libecalc.energy.energy_use import EnergyUse
+from libecalc.presentation.yaml.yaml_types.energy.yaml_consumers import (
+    YamlCompressor,
     YamlElectricalConsumer,
-    YamlEnergyNetwork,
-    YamlEnergySource,
     YamlFuelGasConsumer,
-    YamlFuelGasManifold,
-    YamlGeneratorSet,
-    YamlMechanicalConsumer,
+    YamlPump,
 )
+from libecalc.presentation.yaml.yaml_types.energy.yaml_converters import YamlGeneratorSet
+from libecalc.presentation.yaml.yaml_types.energy.yaml_energy_network import (
+    YamlEnergyNetwork,
+    YamlEnergyNetworkUnit,
+    YamlEnergySource,
+)
+from libecalc.presentation.yaml.yaml_types.energy.yaml_junctions import YamlElectricalBus, YamlFuelGasManifold
+from libecalc.presentation.yaml.yaml_types.energy.yaml_sources import (
+    YamlDieselSource,
+    YamlFuelGasSource,
+    YamlOffshoreWind,
+    YamlOnshoreGrid,
+)
+from libecalc.presentation.yaml.yaml_types.energy.yaml_transporters import YamlElectricalCable
 
 EXAMPLE_YAML = Path(__file__).parents[3] / "src" / "libecalc" / "examples" / "energy" / "energy_network.yaml"
 
-_component_adapter = TypeAdapter(YamlComponent)
+_component_adapter = TypeAdapter(YamlEnergyNetworkUnit)
+_source_adapter = TypeAdapter(YamlEnergySource)
 
 
 def _load_network(yaml_path: Path) -> YamlEnergyNetwork:
@@ -33,12 +43,13 @@ class TestExampleYamlParsing:
         assert len(network.sources) == 5
         assert len(network.units) == 15
 
-    def test_sources_have_no_input(self):
+    def test_sources_are_correct_types(self):
         network = _load_network(EXAMPLE_YAML)
         by_name = {s.name: s for s in network.sources}
-        assert by_name["fuel_gas"].type == "FUEL_GAS"
-        assert by_name["power_from_shore"].type == "ELECTRICAL"
-        assert by_name["power_from_shore"].capacity == 20
+        assert isinstance(by_name["fuel_gas"], YamlFuelGasSource)
+        assert isinstance(by_name["diesel"], YamlDieselSource)
+        assert isinstance(by_name["power_from_shore"], YamlOnshoreGrid)
+        assert isinstance(by_name["wind_turbine"], YamlOffshoreWind)
 
     def test_units_are_correct_types(self):
         network = _load_network(EXAMPLE_YAML)
@@ -50,7 +61,8 @@ class TestExampleYamlParsing:
         assert isinstance(by_name["subsea_cable"], YamlElectricalCable)
         assert isinstance(by_name["base_load"], YamlElectricalConsumer)
         assert isinstance(by_name["flare"], YamlFuelGasConsumer)
-        assert isinstance(by_name["export_train"], YamlMechanicalConsumer)
+        assert isinstance(by_name["export_train"], YamlCompressor)
+        assert isinstance(by_name["waterinj_train"], YamlPump)
 
     def test_consumers_use_load_and_rate(self):
         network = _load_network(EXAMPLE_YAML)
@@ -66,15 +78,29 @@ class TestExampleYamlParsing:
         bus = next(c for c in network.units if c.name == "electrical_bus")
         assert bus.dispatch_strategy == "PRIORITY"
 
+    def test_consumers_have_energy_use_metadata(self):
+        network = _load_network(EXAMPLE_YAML)
+        by_name = {unit.name: unit for unit in network.units}
+
+        base_load = by_name["base_load"]
+        assert base_load.metadata is not None
+        assert base_load.metadata.energy_use == EnergyUse.BASE_LOAD
+
+        flare = by_name["flare"]
+        assert flare.metadata is not None
+        assert flare.metadata.energy_use == EnergyUse.FLARING
+
 
 class TestNumericBounds:
     def test_negative_capacity_on_source_rejected(self):
         with pytest.raises(ValidationError, match="CAPACITY must be non-negative"):
-            YamlEnergySource.model_validate({"NAME": "fuel", "TYPE": "FUEL_GAS", "CAPACITY": -10})
+            _source_adapter.validate_python({"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE", "CAPACITY": -10})
 
     def test_negative_capacity_on_converter_rejected(self):
         with pytest.raises(ValidationError, match="CAPACITY must be non-negative"):
-            _component_adapter.validate_python({"NAME": "g", "TYPE": "GENERATOR_SET", "INPUT": "fuel", "CAPACITY": -5})
+            _component_adapter.validate_python(
+                {"NAME": "g", "TYPE": "GENERATOR_SET", "INPUT": "fuel", "CAPACITY": -5, "MODEL": "model"}
+            )
 
     def test_efficiency_zero_rejected(self):
         with pytest.raises(ValidationError, match="EFFICIENCY must be in"):
@@ -94,16 +120,16 @@ class TestNumericBounds:
 
     def test_negative_load_rejected(self):
         with pytest.raises(ValidationError, match="LOAD must be non-negative"):
-            _component_adapter.validate_python({"NAME": "c", "TYPE": "ELECTRICAL", "INPUT": "g", "LOAD": -1})
+            _component_adapter.validate_python({"NAME": "c", "TYPE": "ELECTRICAL_CONSUMER", "INPUT": "g", "LOAD": -1})
 
     def test_negative_rate_rejected(self):
         with pytest.raises(ValidationError, match="RATE must be non-negative"):
-            _component_adapter.validate_python({"NAME": "c", "TYPE": "FUEL_GAS", "INPUT": "f", "RATE": -100})
+            _component_adapter.validate_python({"NAME": "c", "TYPE": "FUEL_GAS_CONSUMER", "INPUT": "f", "RATE": -100})
 
     def test_expression_capacity_accepted(self):
         """String expressions bypass numeric bounds — validated at evaluation time."""
         comp = _component_adapter.validate_python(
-            {"NAME": "g", "TYPE": "GENERATOR_SET", "INPUT": "fuel", "CAPACITY": "$var.rate"}
+            {"NAME": "g", "TYPE": "GENERATOR_SET", "INPUT": "fuel", "CAPACITY": "$var.rate", "MODEL": "generator_model"}
         )
         assert comp.capacity == "$var.rate"
 
@@ -130,8 +156,8 @@ class TestNetworkValidation:
             YamlEnergyNetwork.model_validate(
                 {
                     "SOURCES": [
-                        {"NAME": "dup", "TYPE": "FUEL_GAS"},
-                        {"NAME": "dup", "TYPE": "FUEL_GAS"},
+                        {"NAME": "dup", "TYPE": "FUEL_GAS_SOURCE"},
+                        {"NAME": "dup", "TYPE": "FUEL_GAS_SOURCE"},
                     ],
                 }
             )
@@ -140,8 +166,8 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="Duplicate"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
-                    "UNITS": [{"NAME": "fuel", "TYPE": "GENERATOR_SET", "INPUT": "fuel"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
+                    "UNITS": [{"NAME": "fuel", "TYPE": "GENERATOR_SET", "INPUT": "fuel", "MODEL": "model"}],
                 }
             )
 
@@ -149,9 +175,9 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="not a known source or provider"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
-                        {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "nonexistent"},
+                        {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "nonexistent", "MODEL": "model"},
                     ],
                 }
             )
@@ -160,10 +186,10 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="not a known source or provider"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
-                        {"NAME": "load_a", "TYPE": "ELECTRICAL", "INPUT": "fuel", "LOAD": 5},
-                        {"NAME": "load_b", "TYPE": "ELECTRICAL", "INPUT": "load_a", "LOAD": 3},
+                        {"NAME": "load_a", "TYPE": "ELECTRICAL_CONSUMER", "INPUT": "fuel", "LOAD": 5},
+                        {"NAME": "load_b", "TYPE": "ELECTRICAL_CONSUMER", "INPUT": "load_a", "LOAD": 3},
                     ],
                 }
             )
@@ -172,9 +198,9 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="Cycle detected"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
-                        {"NAME": "a", "TYPE": "GENERATOR_SET", "INPUT": "b"},
+                        {"NAME": "a", "TYPE": "GENERATOR_SET", "INPUT": "b", "MODEL": "model"},
                         {"NAME": "b", "TYPE": "ELECTRICAL_MOTOR", "INPUT": "a"},
                     ],
                 }
@@ -184,20 +210,20 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="Cycle detected"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
-                        {"NAME": "a", "TYPE": "GENERATOR_SET", "INPUT": "a"},
+                        {"NAME": "a", "TYPE": "GENERATOR_SET", "INPUT": "a", "MODEL": "model"},
                     ],
                 }
             )
 
     def test_incompatible_energy_type_rejected(self):
-        with pytest.raises(ValueError, match="expects DIESEL/FUEL_GAS input.*provides ELECTRICAL"):
+        with pytest.raises(ValueError, match="expects FUEL_GAS input.*provides ELECTRICAL"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "grid", "TYPE": "ELECTRICAL"}],
+                    "SOURCES": [{"NAME": "grid", "TYPE": "ONSHORE_GRID", "CAPACITY": 10}],
                     "UNITS": [
-                        {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "grid"},
+                        {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "grid", "MODEL": "model"},
                     ],
                 }
             )
@@ -206,33 +232,36 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="expects ELECTRICAL input.*provides MECHANICAL"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
-                        {"NAME": "turbine", "TYPE": "GAS_TURBINE", "INPUT": "fuel"},
-                        {"NAME": "load", "TYPE": "ELECTRICAL", "INPUT": "turbine", "LOAD": 5},
+                        {"NAME": "turbine", "TYPE": "GAS_TURBINE", "INPUT": "fuel", "MODEL": "model"},
+                        {"NAME": "load", "TYPE": "ELECTRICAL_CONSUMER", "INPUT": "turbine", "LOAD": 5},
                     ],
                 }
             )
 
-    def test_diesel_genset_accepted(self):
-        network = YamlEnergyNetwork.model_validate(
-            {
-                "SOURCES": [{"NAME": "diesel", "TYPE": "DIESEL"}],
-                "UNITS": [
-                    {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "diesel"},
-                ],
-            }
-        )
-        assert len(network.units) == 1
+    def test_diesel_genset_rejected(self):
+        with pytest.raises(
+            ValueError,
+            match="expects FUEL_GAS input.*provides DIESEL",
+        ):
+            YamlEnergyNetwork.model_validate(
+                {
+                    "SOURCES": [{"NAME": "diesel", "TYPE": "DIESEL_SOURCE"}],
+                    "UNITS": [
+                        {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "diesel", "MODEL": "model"},
+                    ],
+                }
+            )
 
     def test_compatible_chain_accepted(self):
         network = YamlEnergyNetwork.model_validate(
             {
-                "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                 "UNITS": [
-                    {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "fuel"},
+                    {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "fuel", "MODEL": "model"},
                     {"NAME": "motor", "TYPE": "ELECTRICAL_MOTOR", "INPUT": "genset"},
-                    {"NAME": "compressor", "TYPE": "MECHANICAL", "INPUT": "motor", "PROCESS_SIMULATION": "sim"},
+                    {"NAME": "compressor", "TYPE": "COMPRESSOR", "INPUT": "motor", "PROCESS_SIMULATION": "sim"},
                 ],
             }
         )
@@ -242,16 +271,28 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="either LOAD or PROCESS_SIMULATION"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
-                        {"NAME": "turbine", "TYPE": "GAS_TURBINE", "INPUT": "fuel"},
-                        {"NAME": "comp", "TYPE": "MECHANICAL", "INPUT": "turbine"},
+                        {"NAME": "turbine", "TYPE": "GAS_TURBINE", "INPUT": "fuel", "MODEL": "model"},
+                        {"NAME": "comp", "TYPE": "COMPRESSOR", "INPUT": "turbine"},
                     ],
                 }
             )
 
-    def test_mechanical_consumer_rejects_both_load_and_sim(self):
+    def test_compressor_rejects_both_load_and_sim(self):
         with pytest.raises(ValueError, match="cannot specify both"):
             _component_adapter.validate_python(
-                {"NAME": "c", "TYPE": "MECHANICAL", "INPUT": "x", "LOAD": 5, "PROCESS_SIMULATION": "sim"}
+                {"NAME": "c", "TYPE": "COMPRESSOR", "INPUT": "x", "LOAD": 5, "PROCESS_SIMULATION": "sim"}
+            )
+
+
+class TestSchemaValidation:
+    def test_source_with_input_rejected(self):
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            _source_adapter.validate_python(
+                {
+                    "NAME": "fuel",
+                    "TYPE": "FUEL_GAS_SOURCE",
+                    "INPUT": "other",
+                }
             )

--- a/tests/libecalc/energy/test_energy_units.py
+++ b/tests/libecalc/energy/test_energy_units.py
@@ -12,15 +12,15 @@ from libecalc.energy.energy_types import (
     MechanicalPower,
 )
 from libecalc.energy.energy_units import (
-    BaseLoad,
     Compressor,
     ElectricalCable,
+    ElectricalConsumer,
     ElectricalMotor,
+    FuelGasConsumer,
     FuelGasSource,
     GasTurbine,
     GeneratorSet,
     Pump,
-    SampledFuelConsumer,
 )
 
 
@@ -65,10 +65,10 @@ class TestConsumers:
     @pytest.mark.parametrize(
         ("consumer", "expected_energy"),
         [
-            (BaseLoad("load", load=1.5), ElectricalPower(1.5)),
+            (ElectricalConsumer("load", load=1.5), ElectricalPower(1.5)),
             (Compressor("compressor", power=2), MechanicalPower(2)),
             (Pump("pump", power=3), MechanicalPower(3)),
-            (SampledFuelConsumer("sampled", fuel_rate=1_000), FuelGasRate(1_000)),
+            (FuelGasConsumer("sampled", rate=1_000), FuelGasRate(1_000)),
         ],
     )
     def test_consumer_returns_input_energy(self, consumer: Consumer, expected_energy: Energy):


### PR DESCRIPTION
### Draft: Energy network YAML and domain model

This draft explores the energy network model before implementing YAML-to-domain mapping.

The existing YAML schema is reorganized into focused modules, with more explicit type names such as `FUEL_GAS_SOURCE`, `COMPRESSOR`, and `ELECTRICAL_CONSUMER`. This makes `TYPE` describe the node rather than only its energy carrier.

The domain model is simplified by:

- replacing `BaseLoad` and `SampledPowerConsumer` with `ElectricalConsumer`
- replacing `Flare` and `SampledFuelConsumer` with `FuelGasConsumer`
- using `EnergyUse` metadata for classification
- renaming `DieselSupply` to `DieselSource`

The intent is to separate consumer identity from classification and demand modeling. Consumer types describe the energy contract, while `LOAD`, `RATE`, and `PROCESS_SIMULATION` describe how demand is provided. Additional
mechanisms, such as sampled lookup models, can be added without introducing new consumer types.

Mapping, evaluation, dispatch, and allocation are out of scope. This draft is intended to align terminology and responsibilities before mapping begins, and must be aligned with the role hierarchy in #1756.

### Open questions

- whether base load and flare should be metadata or dedicated domain types
- how demand models should be represented
- where metadata and dispatch strategy should belong
- how `Shaft` should be represented in YAML

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
