### PR TITLE
fix: provide resource context when invalid chart from resource

### DIFF
--- a/src/libecalc/presentation/yaml/mappers/charts/user_defined_chart_data.py
+++ b/src/libecalc/presentation/yaml/mappers/charts/user_defined_chart_data.py
@@ -4,7 +4,12 @@ from functools import cached_property
 import pandas as pd
 
 from libecalc.common.chart_type import ChartType
-from libecalc.common.errors.exceptions import HeaderNotFoundException, InvalidColumnException
+from libecalc.common.errors.ecalc_validation_error import EcalcValidationException
+from libecalc.common.errors.exceptions import (
+    HeaderNotFoundException,
+    InvalidColumnException,
+    InvalidResourceException,
+)
 from libecalc.domain.process.value_objects.chart import ChartCurve
 from libecalc.domain.process.value_objects.chart.chart import ChartData
 from libecalc.domain.resource import Resource
@@ -77,14 +82,17 @@ class UserDefinedChartData(ChartData):
             efficiency_values = resource.get_float_column(EcalcYamlKeywords.consumer_chart_efficiency)
             rate_values = resource.get_float_column(EcalcYamlKeywords.consumer_chart_rate)
             head_values = resource.get_float_column(EcalcYamlKeywords.consumer_chart_head)
-            curves = [
-                ChartCurve(
-                    speed_rpm=speed,
-                    rate_actual_m3_hour=convert_rate_to_am3_per_hour(rate_values, rate_unit),
-                    polytropic_head_joule_per_kg=convert_head_to_joule_per_kg(head_values, head_unit),
-                    efficiency_fraction=convert_efficiency_to_fraction(efficiency_values, efficiency_unit),
-                )
-            ]
+            try:
+                curves = [
+                    ChartCurve(
+                        speed_rpm=speed,
+                        rate_actual_m3_hour=convert_rate_to_am3_per_hour(rate_values, rate_unit),
+                        polytropic_head_joule_per_kg=convert_head_to_joule_per_kg(head_values, head_unit),
+                        efficiency_fraction=convert_efficiency_to_fraction(efficiency_values, efficiency_unit),
+                    )
+                ]
+            except EcalcValidationException as e:
+                raise InvalidResourceException(title="Invalid chart", message=str(e)) from e
         else:
             expected_headers = [
                 EcalcYamlKeywords.consumer_chart_speed,
@@ -99,22 +107,25 @@ class UserDefinedChartData(ChartData):
                 resource_data.append(column)
             df = pd.DataFrame(data=resource_data, index=expected_headers).transpose().astype(float)
             grouped_by_speed = df.groupby(EcalcYamlKeywords.consumer_chart_speed, sort=False)
-            curves = [
-                ChartCurve(
-                    speed_rpm=group,  # type: ignore[arg-type]
-                    rate_actual_m3_hour=convert_rate_to_am3_per_hour(
-                        list(grouped_by_speed.get_group(group)[EcalcYamlKeywords.consumer_chart_rate]), rate_unit
-                    ),
-                    polytropic_head_joule_per_kg=convert_head_to_joule_per_kg(
-                        list(grouped_by_speed.get_group(group)[EcalcYamlKeywords.consumer_chart_head]), head_unit
-                    ),
-                    efficiency_fraction=convert_efficiency_to_fraction(
-                        list(grouped_by_speed.get_group(group)[EcalcYamlKeywords.consumer_chart_efficiency]),
-                        efficiency_unit,
-                    ),
-                )
-                for group in grouped_by_speed.groups
-            ]
+            try:
+                curves = [
+                    ChartCurve(
+                        speed_rpm=group,  # type: ignore[arg-type]
+                        rate_actual_m3_hour=convert_rate_to_am3_per_hour(
+                            list(grouped_by_speed.get_group(group)[EcalcYamlKeywords.consumer_chart_rate]), rate_unit
+                        ),
+                        polytropic_head_joule_per_kg=convert_head_to_joule_per_kg(
+                            list(grouped_by_speed.get_group(group)[EcalcYamlKeywords.consumer_chart_head]), head_unit
+                        ),
+                        efficiency_fraction=convert_efficiency_to_fraction(
+                            list(grouped_by_speed.get_group(group)[EcalcYamlKeywords.consumer_chart_efficiency]),
+                            efficiency_unit,
+                        ),
+                    )
+                    for group in grouped_by_speed.groups
+                ]
+            except EcalcValidationException as e:
+                raise InvalidResourceException(title="Invalid chart", message=str(e)) from e
 
         return cls(curves=curves, control_margin=control_margin)
 


### PR DESCRIPTION
When a chart is created from a resource file provide the resource file
as file context instead of the yaml referencing the chart.

Refs:
github.com/equinor/ecalc-internal/issues/441
