### PR TITLE
refactor: align energy network YAML type names

### DIFF
--- a/src/libecalc/energy/energy_units/__init__.py
+++ b/src/libecalc/energy/energy_units/__init__.py
@@ -1,7 +1,7 @@
 from .consumers import DieselConsumer, ElectricalConsumer, FuelGasConsumer, MechanicalConsumer
 from .converters import ElectricalMotor, GasTurbine, GeneratorSet
 from .junction import ElectricalBus, FuelGasManifold, Junction
-from .sources import DieselSupply, FuelGasSource, OffshoreWind, OnshoreGrid
+from .sources import DieselSource, ElectricalSource, FuelGasSource
 from .transporter import ElectricalCable, Transporter
 
 __all__ = [
@@ -9,7 +9,7 @@ __all__ = [
     "MechanicalConsumer",
     "FuelGasConsumer",
     "DieselConsumer",
-    "DieselSupply",
+    "DieselSource",
     "ElectricalBus",
     "ElectricalCable",
     "ElectricalMotor",
@@ -18,7 +18,6 @@ __all__ = [
     "FuelGasSource",
     "GasTurbine",
     "GeneratorSet",
-    "OffshoreWind",
-    "OnshoreGrid",
+    "ElectricalSource",
     "Transporter",
 ]

--- a/src/libecalc/energy/energy_units/sources.py
+++ b/src/libecalc/energy/energy_units/sources.py
@@ -22,10 +22,10 @@ class FuelGasSource(Source):
         return FuelGasRate(self._max_rate) if self._max_rate is not None else None
 
 
-class OnshoreGrid(Source):
-    """Onshore electrical grid connection, capped at contracted capacity."""
+class ElectricalSource(Source):
+    """Source of electrical power"""
 
-    def __init__(self, name: str, max_power: float, energy_unit_id: EnergyUnitId | None = None) -> None:
+    def __init__(self, name: str, max_power: float | None = None, energy_unit_id: EnergyUnitId | None = None) -> None:
         super().__init__(name, energy_unit_id)
         self._max_power = max_power
 
@@ -33,33 +33,15 @@ class OnshoreGrid(Source):
     def get_output_energy_type(cls) -> type[ElectricalPower]:
         return ElectricalPower
 
-    def get_max_power(self) -> float:
+    def get_max_power(self) -> float | None:
         return self._max_power
 
     def capacity(self) -> ElectricalPower | None:
-        return ElectricalPower(self._max_power)
+        return ElectricalPower(self._max_power) if self._max_power is not None else None
 
 
-class OffshoreWind(Source):
-    """Offshore wind park, capped at total rated output."""
-
-    def __init__(self, name: str, power: float, energy_unit_id: EnergyUnitId | None = None) -> None:
-        super().__init__(name, energy_unit_id)
-        self._power = power
-
-    @classmethod
-    def get_output_energy_type(cls) -> type[ElectricalPower]:
-        return ElectricalPower
-
-    def get_power(self) -> float:
-        return self._power
-
-    def capacity(self) -> ElectricalPower | None:
-        return ElectricalPower(self._power)
-
-
-class DieselSupply(Source):
-    """Diesel fuel supply, brought to platform/rig by supply vessels."""
+class DieselSource(Source):
+    """Diesel fuel source, brought to platform/rig by supply vessels."""
 
     def __init__(self, name: str, max_rate: float | None = None, energy_unit_id: EnergyUnitId | None = None) -> None:
         super().__init__(name, energy_unit_id)

--- a/src/libecalc/examples/energy/energy_network.yaml
+++ b/src/libecalc/examples/energy/energy_network.yaml
@@ -22,20 +22,20 @@
 ENERGY_NETWORK:
   SOURCES:
     - NAME: fuel_gas
-      TYPE: FUEL_GAS
+      TYPE: FUEL_GAS_SOURCE
 
     - NAME: flare_gas
-      TYPE: FUEL_GAS
+      TYPE: FUEL_GAS_SOURCE
 
     - NAME: diesel
-      TYPE: DIESEL
+      TYPE: DIESEL_SOURCE
 
     - NAME: power_from_shore
-      TYPE: ELECTRICAL
+      TYPE: ONSHORE_GRID
       CAPACITY: 20  # MW
 
     - NAME: wind_turbine
-      TYPE: ELECTRICAL
+      TYPE: OFFSHORE_WIND
       CAPACITY: 4.4  # MW
 
   UNITS:
@@ -75,47 +75,47 @@ ENERGY_NETWORK:
 
     # --- Consumers ---
     - NAME: base_load
-      TYPE: ELECTRICAL
+      TYPE: ELECTRICAL_CONSUMER
       INPUT: genset_a
       LOAD: 5  # MW
 
     - NAME: steamgen
-      TYPE: ELECTRICAL
+      TYPE: ELECTRICAL_CONSUMER
       INPUT: genset_a
       LOAD: 3
 
     - NAME: heating_sat_a
-      TYPE: ELECTRICAL
+      TYPE: ELECTRICAL_CONSUMER
       INPUT: genset_a
       LOAD: 2
 
     - NAME: heating
-      TYPE: ELECTRICAL
+      TYPE: ELECTRICAL_CONSUMER
       INPUT: electrical_bus
       LOAD: 10
 
     - NAME: flare
-      TYPE: FUEL_GAS
+      TYPE: FUEL_GAS_CONSUMER
       INPUT: flare_gas
       RATE: 1200  # Sm3/d
 
     - NAME: gas_compressor_sampled
-      TYPE: FUEL_GAS
+      TYPE: FUEL_GAS_CONSUMER
       INPUT: fuel_manifold
       RATE: 50000  # Sm3/d
 
     - NAME: diesel_consumers
-      TYPE: DIESEL
+      TYPE: DIESEL_CONSUMER
       INPUT: diesel
       RATE: 500  # l/d
 
     # Process simulation driven
     - NAME: export_train
-      TYPE: MECHANICAL
+      TYPE: MECHANICAL_CONSUMER
       INPUT: export_turbine
       PROCESS_SIMULATION: export_compressor_sim
 
     - NAME: waterinj_train
-      TYPE: MECHANICAL
+      TYPE: MECHANICAL_CONSUMER
       INPUT: waterinj_motor
       PROCESS_SIMULATION: waterinj_pump_sim

--- a/src/libecalc/examples/energy/energy_network.yaml
+++ b/src/libecalc/examples/energy/energy_network.yaml
@@ -31,11 +31,11 @@ ENERGY_NETWORK:
       TYPE: DIESEL_SOURCE
 
     - NAME: power_from_shore
-      TYPE: ONSHORE_GRID
+      TYPE: ELECTRICAL_SOURCE
       CAPACITY: 20  # MW
 
     - NAME: wind_turbine
-      TYPE: OFFSHORE_WIND
+      TYPE: ELECTRICAL_SOURCE
       CAPACITY: 4.4  # MW
 
   UNITS:

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_energy_network.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_energy_network.py
@@ -20,9 +20,10 @@ def _check_efficiency(v: YamlExpressionType | None) -> YamlExpressionType | None
 
 
 class YamlEnergySourceType(StrEnum):
-    FUEL_GAS = "FUEL_GAS"
-    ELECTRICAL = "ELECTRICAL"
-    DIESEL = "DIESEL"
+    FUEL_GAS_SOURCE = "FUEL_GAS_SOURCE"
+    ONSHORE_GRID = "ONSHORE_GRID"
+    OFFSHORE_WIND = "OFFSHORE_WIND"
+    DIESEL_SOURCE = "DIESEL_SOURCE"
 
 
 class YamlEnergySource(YamlBase):
@@ -39,7 +40,7 @@ class YamlEnergySource(YamlBase):
         YamlEnergySourceType,
         Field(
             title="TYPE",
-            description="Energy type this source provides (FUEL_GAS, ELECTRICAL, or DIESEL).",
+            description="Type of external energy source.",
         ),
     ]
     capacity: Annotated[
@@ -54,6 +55,19 @@ class YamlEnergySource(YamlBase):
     @classmethod
     def _capacity_non_negative(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
         return _check_non_negative(v, "CAPACITY")
+
+    @model_validator(mode="after")
+    def check_capacity_required(self):
+        if (
+            self.type
+            in {
+                YamlEnergySourceType.ONSHORE_GRID,
+                YamlEnergySourceType.OFFSHORE_WIND,
+            }
+            and self.capacity is None
+        ):
+            raise ValueError(f"{self.type} requires CAPACITY.")
+        return self
 
 
 class YamlConverterBase(YamlBase):
@@ -221,7 +235,7 @@ class YamlConsumerBase(YamlBase):
 class YamlElectricalConsumer(YamlConsumerBase):
     model_config = ConfigDict(title="ElectricalConsumer")
 
-    type: Literal["ELECTRICAL"]
+    type: Literal["ELECTRICAL_CONSUMER"]
     load: Annotated[
         YamlExpressionType,
         Field(
@@ -239,7 +253,7 @@ class YamlElectricalConsumer(YamlConsumerBase):
 class YamlMechanicalConsumer(YamlConsumerBase):
     model_config = ConfigDict(title="MechanicalConsumer")
 
-    type: Literal["MECHANICAL"]
+    type: Literal["MECHANICAL_CONSUMER"]
     load: Annotated[
         YamlExpressionType | None,
         Field(
@@ -272,7 +286,7 @@ class YamlMechanicalConsumer(YamlConsumerBase):
 class YamlFuelGasConsumer(YamlConsumerBase):
     model_config = ConfigDict(title="FuelGasConsumer")
 
-    type: Literal["FUEL_GAS"]
+    type: Literal["FUEL_GAS_CONSUMER"]
     rate: Annotated[
         YamlExpressionType,
         Field(
@@ -290,7 +304,7 @@ class YamlFuelGasConsumer(YamlConsumerBase):
 class YamlDieselConsumer(YamlConsumerBase):
     model_config = ConfigDict(title="DieselConsumer")
 
-    type: Literal["DIESEL"]
+    type: Literal["DIESEL_CONSUMER"]
     rate: Annotated[
         YamlExpressionType,
         Field(
@@ -329,17 +343,17 @@ class EnergyType(StrEnum):
     DIESEL = "DIESEL"
 
 
-INPUT_ENERGY: dict[str, set[EnergyType]] = {
-    "GENERATOR_SET": {EnergyType.FUEL_GAS, EnergyType.DIESEL},
-    "GAS_TURBINE": {EnergyType.FUEL_GAS},
-    "ELECTRICAL_MOTOR": {EnergyType.ELECTRICAL},
-    "ELECTRICAL_CABLE": {EnergyType.ELECTRICAL},
-    "ELECTRICAL_BUS": {EnergyType.ELECTRICAL},
-    "FUEL_GAS_MANIFOLD": {EnergyType.FUEL_GAS},
-    "ELECTRICAL": {EnergyType.ELECTRICAL},
-    "MECHANICAL": {EnergyType.MECHANICAL},
-    "FUEL_GAS": {EnergyType.FUEL_GAS},
-    "DIESEL": {EnergyType.DIESEL},
+INPUT_ENERGY: dict[str, EnergyType] = {
+    "GENERATOR_SET": EnergyType.FUEL_GAS,
+    "GAS_TURBINE": EnergyType.FUEL_GAS,
+    "ELECTRICAL_MOTOR": EnergyType.ELECTRICAL,
+    "ELECTRICAL_CABLE": EnergyType.ELECTRICAL,
+    "ELECTRICAL_BUS": EnergyType.ELECTRICAL,
+    "FUEL_GAS_MANIFOLD": EnergyType.FUEL_GAS,
+    "ELECTRICAL_CONSUMER": EnergyType.ELECTRICAL,
+    "MECHANICAL_CONSUMER": EnergyType.MECHANICAL,
+    "FUEL_GAS_CONSUMER": EnergyType.FUEL_GAS,
+    "DIESEL_CONSUMER": EnergyType.DIESEL,
 }
 
 OUTPUT_ENERGY: dict[str, EnergyType] = {
@@ -349,6 +363,13 @@ OUTPUT_ENERGY: dict[str, EnergyType] = {
     "ELECTRICAL_CABLE": EnergyType.ELECTRICAL,
     "ELECTRICAL_BUS": EnergyType.ELECTRICAL,
     "FUEL_GAS_MANIFOLD": EnergyType.FUEL_GAS,
+}
+
+SOURCE_OUTPUT_ENERGY: dict[YamlEnergySourceType, EnergyType] = {
+    YamlEnergySourceType.FUEL_GAS_SOURCE: EnergyType.FUEL_GAS,
+    YamlEnergySourceType.DIESEL_SOURCE: EnergyType.DIESEL,
+    YamlEnergySourceType.ONSHORE_GRID: EnergyType.ELECTRICAL,
+    YamlEnergySourceType.OFFSHORE_WIND: EnergyType.ELECTRICAL,
 }
 
 CONSUMER_TYPES = set(INPUT_ENERGY) - set(OUTPUT_ENERGY)
@@ -423,7 +444,7 @@ class YamlEnergyNetwork(YamlBase):
     def check_energy_type_compatibility(self):
         output_types: dict[str, EnergyType] = {}
         for s in self.sources:
-            output_types[s.name] = EnergyType(s.type.value)
+            output_types[s.name] = SOURCE_OUTPUT_ENERGY[s.type]
         for c in self.units:
             if c.type in OUTPUT_ENERGY:
                 output_types[c.name] = OUTPUT_ENERGY[c.type]
@@ -431,12 +452,11 @@ class YamlEnergyNetwork(YamlBase):
         for c in self.units:
             if c.type not in INPUT_ENERGY:
                 raise ValueError(f"'{c.name}': unknown component type '{c.type}' — not in energy type map.")
-            expected_inputs = INPUT_ENERGY[c.type]
+            expected_input = INPUT_ENERGY[c.type]
             for ref in _get_input_names(c):
                 provided = output_types.get(ref)
-                if provided is not None and provided not in expected_inputs:
+                if provided is not None and provided != expected_input:
                     raise ValueError(
-                        f"'{c.name}' ({c.type}) expects {'/'.join(sorted(expected_inputs))} input, "
-                        f"but '{ref}' provides {provided}."
+                        f"'{c.name}' ({c.type}) expects {expected_input} input, but '{ref}' provides {provided}."
                     )
         return self

--- a/src/libecalc/presentation/yaml/yaml_types/energy/yaml_energy_network.py
+++ b/src/libecalc/presentation/yaml/yaml_types/energy/yaml_energy_network.py
@@ -21,8 +21,7 @@ def _check_efficiency(v: YamlExpressionType | None) -> YamlExpressionType | None
 
 class YamlEnergySourceType(StrEnum):
     FUEL_GAS_SOURCE = "FUEL_GAS_SOURCE"
-    ONSHORE_GRID = "ONSHORE_GRID"
-    OFFSHORE_WIND = "OFFSHORE_WIND"
+    ELECTRICAL_SOURCE = "ELECTRICAL_SOURCE"
     DIESEL_SOURCE = "DIESEL_SOURCE"
 
 
@@ -55,19 +54,6 @@ class YamlEnergySource(YamlBase):
     @classmethod
     def _capacity_non_negative(cls, v: YamlExpressionType | None) -> YamlExpressionType | None:
         return _check_non_negative(v, "CAPACITY")
-
-    @model_validator(mode="after")
-    def check_capacity_required(self):
-        if (
-            self.type
-            in {
-                YamlEnergySourceType.ONSHORE_GRID,
-                YamlEnergySourceType.OFFSHORE_WIND,
-            }
-            and self.capacity is None
-        ):
-            raise ValueError(f"{self.type} requires CAPACITY.")
-        return self
 
 
 class YamlConverterBase(YamlBase):
@@ -368,8 +354,7 @@ OUTPUT_ENERGY: dict[str, EnergyType] = {
 SOURCE_OUTPUT_ENERGY: dict[YamlEnergySourceType, EnergyType] = {
     YamlEnergySourceType.FUEL_GAS_SOURCE: EnergyType.FUEL_GAS,
     YamlEnergySourceType.DIESEL_SOURCE: EnergyType.DIESEL,
-    YamlEnergySourceType.ONSHORE_GRID: EnergyType.ELECTRICAL,
-    YamlEnergySourceType.OFFSHORE_WIND: EnergyType.ELECTRICAL,
+    YamlEnergySourceType.ELECTRICAL_SOURCE: EnergyType.ELECTRICAL,
 }
 
 CONSUMER_TYPES = set(INPUT_ENERGY) - set(OUTPUT_ENERGY)

--- a/tests/libecalc/energy/test_energy_network.py
+++ b/tests/libecalc/energy/test_energy_network.py
@@ -7,11 +7,10 @@ from libecalc.energy.energy_units import (
     ElectricalCable,
     ElectricalConsumer,
     ElectricalMotor,
+    ElectricalSource,
     FuelGasSource,
     GeneratorSet,
     MechanicalConsumer,
-    OffshoreWind,
-    OnshoreGrid,
 )
 from libecalc.energy.errors import EnergyAllocationRequiredError, InvalidEnergyNetworkError
 from libecalc.energy.network import EnergyConnection, EnergyNetwork
@@ -223,8 +222,8 @@ class TestEnergyNetworkTopology:
         )
 
     def test_connects_multiple_providers_to_consumer_through_junction(self):
-        grid = OnshoreGrid(name="grid", max_power=20)
-        wind = OffshoreWind(name="wind", power=5)
+        grid = ElectricalSource(name="grid", max_power=20)
+        wind = ElectricalSource(name="wind", max_power=5)
 
         bus = ElectricalBus(name="bus")
         load = ElectricalConsumer(name="load", power=10)
@@ -256,7 +255,7 @@ class TestEnergyNetworkTopology:
         assert network.get_successors(bus.get_id()) == frozenset({load.get_id()})
 
     def test_connects_source_to_consumer_through_transporter(self):
-        grid = OnshoreGrid(
+        grid = ElectricalSource(
             name="grid",
             max_power=20,
         )
@@ -340,8 +339,8 @@ class TestEnergyNetworkEnergyCalculation:
         assert network.get_output_energy(source.get_id()) == FuelGasRate(0)
 
     def test_requires_allocation_for_multiple_predecessors(self):
-        first_grid = OnshoreGrid("first_grid", max_power=20)
-        second_grid = OnshoreGrid("second_grid", max_power=20)
+        first_grid = ElectricalSource("first_grid", max_power=20)
+        second_grid = ElectricalSource("second_grid", max_power=20)
         load = ElectricalConsumer("load", power=10)
 
         network = EnergyNetwork(
@@ -359,8 +358,8 @@ class TestEnergyNetworkEnergyCalculation:
             network.get_output_energy(first_grid.get_id())
 
     def test_does_not_require_allocation_for_zero_energy(self):
-        first_grid = OnshoreGrid("first_grid", max_power=20)
-        second_grid = OnshoreGrid("second_grid", max_power=20)
+        first_grid = ElectricalSource("first_grid", max_power=20)
+        second_grid = ElectricalSource("second_grid", max_power=20)
         load = ElectricalConsumer("load", power=0)
 
         network = EnergyNetwork(
@@ -376,7 +375,7 @@ class TestEnergyNetworkEnergyCalculation:
 
 class TestEnergyNetworkFeasibility:
     def test_reports_capacity_exceeded_without_capping_output_energy(self):
-        grid = OnshoreGrid("grid", max_power=5)
+        grid = ElectricalSource("grid", max_power=5)
         load = ElectricalConsumer("load", power=6)
 
         network = EnergyNetwork(
@@ -392,7 +391,7 @@ class TestEnergyNetworkFeasibility:
         assert not network.is_feasible()
 
     def test_capacity_equal_to_output_energy_is_feasible(self):
-        grid = OnshoreGrid("grid", max_power=5)
+        grid = ElectricalSource("grid", max_power=5)
         load = ElectricalConsumer("load", power=5)
 
         network = EnergyNetwork(

--- a/tests/libecalc/energy/test_energy_network_yaml.py
+++ b/tests/libecalc/energy/test_energy_network_yaml.py
@@ -36,8 +36,8 @@ class TestExampleYamlParsing:
     def test_sources_have_no_input(self):
         network = _load_network(EXAMPLE_YAML)
         by_name = {s.name: s for s in network.sources}
-        assert by_name["fuel_gas"].type == "FUEL_GAS"
-        assert by_name["power_from_shore"].type == "ELECTRICAL"
+        assert by_name["fuel_gas"].type == "FUEL_GAS_SOURCE"
+        assert by_name["power_from_shore"].type == "ONSHORE_GRID"
         assert by_name["power_from_shore"].capacity == 20
 
     def test_units_are_correct_types(self):
@@ -94,11 +94,11 @@ class TestNumericBounds:
 
     def test_negative_load_rejected(self):
         with pytest.raises(ValidationError, match="LOAD must be non-negative"):
-            _component_adapter.validate_python({"NAME": "c", "TYPE": "ELECTRICAL", "INPUT": "g", "LOAD": -1})
+            _component_adapter.validate_python({"NAME": "c", "TYPE": "ELECTRICAL_CONSUMER", "INPUT": "g", "LOAD": -1})
 
     def test_negative_rate_rejected(self):
         with pytest.raises(ValidationError, match="RATE must be non-negative"):
-            _component_adapter.validate_python({"NAME": "c", "TYPE": "FUEL_GAS", "INPUT": "f", "RATE": -100})
+            _component_adapter.validate_python({"NAME": "c", "TYPE": "FUEL_GAS_CONSUMER", "INPUT": "f", "RATE": -100})
 
     def test_expression_capacity_accepted(self):
         """String expressions bypass numeric bounds — validated at evaluation time."""
@@ -130,8 +130,8 @@ class TestNetworkValidation:
             YamlEnergyNetwork.model_validate(
                 {
                     "SOURCES": [
-                        {"NAME": "dup", "TYPE": "FUEL_GAS"},
-                        {"NAME": "dup", "TYPE": "FUEL_GAS"},
+                        {"NAME": "dup", "TYPE": "FUEL_GAS_SOURCE"},
+                        {"NAME": "dup", "TYPE": "FUEL_GAS_SOURCE"},
                     ],
                 }
             )
@@ -140,7 +140,7 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="Duplicate"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [{"NAME": "fuel", "TYPE": "GENERATOR_SET", "INPUT": "fuel"}],
                 }
             )
@@ -149,7 +149,7 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="not a known source or provider"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
                         {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "nonexistent"},
                     ],
@@ -160,10 +160,10 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="not a known source or provider"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
-                        {"NAME": "load_a", "TYPE": "ELECTRICAL", "INPUT": "fuel", "LOAD": 5},
-                        {"NAME": "load_b", "TYPE": "ELECTRICAL", "INPUT": "load_a", "LOAD": 3},
+                        {"NAME": "load_a", "TYPE": "ELECTRICAL_CONSUMER", "INPUT": "fuel", "LOAD": 5},
+                        {"NAME": "load_b", "TYPE": "ELECTRICAL_CONSUMER", "INPUT": "load_a", "LOAD": 3},
                     ],
                 }
             )
@@ -172,7 +172,7 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="Cycle detected"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
                         {"NAME": "a", "TYPE": "GENERATOR_SET", "INPUT": "b"},
                         {"NAME": "b", "TYPE": "ELECTRICAL_MOTOR", "INPUT": "a"},
@@ -184,7 +184,7 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="Cycle detected"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
                         {"NAME": "a", "TYPE": "GENERATOR_SET", "INPUT": "a"},
                     ],
@@ -192,10 +192,10 @@ class TestNetworkValidation:
             )
 
     def test_incompatible_energy_type_rejected(self):
-        with pytest.raises(ValueError, match="expects DIESEL/FUEL_GAS input.*provides ELECTRICAL"):
+        with pytest.raises(ValueError, match="expects FUEL_GAS input.*provides ELECTRICAL"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "grid", "TYPE": "ELECTRICAL"}],
+                    "SOURCES": [{"NAME": "grid", "TYPE": "ONSHORE_GRID", "CAPACITY": 10}],
                     "UNITS": [
                         {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "grid"},
                     ],
@@ -206,33 +206,38 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="expects ELECTRICAL input.*provides MECHANICAL"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
                         {"NAME": "turbine", "TYPE": "GAS_TURBINE", "INPUT": "fuel"},
-                        {"NAME": "load", "TYPE": "ELECTRICAL", "INPUT": "turbine", "LOAD": 5},
+                        {"NAME": "load", "TYPE": "ELECTRICAL_CONSUMER", "INPUT": "turbine", "LOAD": 5},
                     ],
                 }
             )
 
     def test_diesel_genset_accepted(self):
-        network = YamlEnergyNetwork.model_validate(
-            {
-                "SOURCES": [{"NAME": "diesel", "TYPE": "DIESEL"}],
-                "UNITS": [
-                    {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "diesel"},
-                ],
-            }
-        )
-        assert len(network.units) == 1
+        with pytest.raises(ValueError, match="expects FUEL_GAS input"):
+            YamlEnergyNetwork.model_validate(
+                {
+                    "SOURCES": [{"NAME": "diesel", "TYPE": "DIESEL_SOURCE"}],
+                    "UNITS": [
+                        {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "diesel"},
+                    ],
+                }
+            )
 
     def test_compatible_chain_accepted(self):
         network = YamlEnergyNetwork.model_validate(
             {
-                "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                 "UNITS": [
                     {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "fuel"},
                     {"NAME": "motor", "TYPE": "ELECTRICAL_MOTOR", "INPUT": "genset"},
-                    {"NAME": "compressor", "TYPE": "MECHANICAL", "INPUT": "motor", "PROCESS_SIMULATION": "sim"},
+                    {
+                        "NAME": "compressor",
+                        "TYPE": "MECHANICAL_CONSUMER",
+                        "INPUT": "motor",
+                        "PROCESS_SIMULATION": "sim",
+                    },
                 ],
             }
         )
@@ -242,10 +247,10 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="either LOAD or PROCESS_SIMULATION"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS"}],
+                    "SOURCES": [{"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE"}],
                     "UNITS": [
                         {"NAME": "turbine", "TYPE": "GAS_TURBINE", "INPUT": "fuel"},
-                        {"NAME": "comp", "TYPE": "MECHANICAL", "INPUT": "turbine"},
+                        {"NAME": "comp", "TYPE": "MECHANICAL_CONSUMER", "INPUT": "turbine"},
                     ],
                 }
             )
@@ -253,5 +258,5 @@ class TestNetworkValidation:
     def test_mechanical_consumer_rejects_both_load_and_sim(self):
         with pytest.raises(ValueError, match="cannot specify both"):
             _component_adapter.validate_python(
-                {"NAME": "c", "TYPE": "MECHANICAL", "INPUT": "x", "LOAD": 5, "PROCESS_SIMULATION": "sim"}
+                {"NAME": "c", "TYPE": "MECHANICAL_CONSUMER", "INPUT": "x", "LOAD": 5, "PROCESS_SIMULATION": "sim"}
             )

--- a/tests/libecalc/energy/test_energy_network_yaml.py
+++ b/tests/libecalc/energy/test_energy_network_yaml.py
@@ -214,7 +214,7 @@ class TestNetworkValidation:
                 }
             )
 
-    def test_diesel_genset_accepted(self):
+    def test_diesel_genset_rejected(self):
         with pytest.raises(ValueError, match="expects FUEL_GAS input"):
             YamlEnergyNetwork.model_validate(
                 {

--- a/tests/libecalc/energy/test_energy_network_yaml.py
+++ b/tests/libecalc/energy/test_energy_network_yaml.py
@@ -37,7 +37,7 @@ class TestExampleYamlParsing:
         network = _load_network(EXAMPLE_YAML)
         by_name = {s.name: s for s in network.sources}
         assert by_name["fuel_gas"].type == "FUEL_GAS_SOURCE"
-        assert by_name["power_from_shore"].type == "ONSHORE_GRID"
+        assert by_name["power_from_shore"].type == "ELECTRICAL_SOURCE"
         assert by_name["power_from_shore"].capacity == 20
 
     def test_units_are_correct_types(self):
@@ -70,7 +70,7 @@ class TestExampleYamlParsing:
 class TestNumericBounds:
     def test_negative_capacity_on_source_rejected(self):
         with pytest.raises(ValidationError, match="CAPACITY must be non-negative"):
-            YamlEnergySource.model_validate({"NAME": "fuel", "TYPE": "FUEL_GAS", "CAPACITY": -10})
+            YamlEnergySource.model_validate({"NAME": "fuel", "TYPE": "FUEL_GAS_SOURCE", "CAPACITY": -10})
 
     def test_negative_capacity_on_converter_rejected(self):
         with pytest.raises(ValidationError, match="CAPACITY must be non-negative"):
@@ -195,7 +195,7 @@ class TestNetworkValidation:
         with pytest.raises(ValueError, match="expects FUEL_GAS input.*provides ELECTRICAL"):
             YamlEnergyNetwork.model_validate(
                 {
-                    "SOURCES": [{"NAME": "grid", "TYPE": "ONSHORE_GRID", "CAPACITY": 10}],
+                    "SOURCES": [{"NAME": "grid", "TYPE": "ELECTRICAL_SOURCE", "CAPACITY": 10}],
                     "UNITS": [
                         {"NAME": "genset", "TYPE": "GENERATOR_SET", "INPUT": "grid"},
                     ],

--- a/tests/libecalc/energy/test_energy_units.py
+++ b/tests/libecalc/energy/test_energy_units.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 import pytest
 
-from libecalc.energy import Consumer
+from libecalc.energy import Consumer, Source
 from libecalc.energy.energy_types import (
     DieselRate,
     ElectricalPower,
@@ -14,9 +14,11 @@ from libecalc.energy.energy_types import (
 )
 from libecalc.energy.energy_units import (
     DieselConsumer,
+    DieselSource,
     ElectricalCable,
     ElectricalConsumer,
     ElectricalMotor,
+    ElectricalSource,
     FuelGasConsumer,
     FuelGasSource,
     GasTurbine,
@@ -30,9 +32,16 @@ class TestSources:
         src = FuelGasSource("fg", max_rate=100_000.0)
         assert src.capacity() == FuelGasRate(100_000.0)
 
-    def test_uncapped_source_has_no_limit(self):
-        src = FuelGasSource("fg")
-        assert src.capacity() is None
+    @pytest.mark.parametrize(
+        "source",
+        [
+            FuelGasSource("fuel"),
+            DieselSource("diesel"),
+            ElectricalSource("electricity"),
+        ],
+    )
+    def test_uncapped_source_has_no_limit(self, source: Source):
+        assert source.capacity() is None
 
 
 class TestConverters:


### PR DESCRIPTION
## Summary

Aligns the energy network YAML type names with the domain model before YAML-to-domain mapping is introduced.

Refs: equinor/ecalc-internal#2136

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
