### PR TITLE
fix(libecalc): give each energy role check a single definition

### DIFF
--- a/src/libecalc/energy/energy_units/junction.py
+++ b/src/libecalc/energy/energy_units/junction.py
@@ -22,6 +22,10 @@ class Junction(EnergyUnit):
     def get_output_energy_type(cls) -> type[Energy]:
         return cls.get_energy_type()
 
+    def get_input_energy(self, output_energy: Energy) -> Energy:
+        """A junction aggregates without converting, so it draws exactly what it delivers."""
+        return output_energy
+
 
 class ElectricalBus(Junction):
     """Electrical power distribution bus (busbar)."""

--- a/src/libecalc/energy/network.py
+++ b/src/libecalc/energy/network.py
@@ -15,6 +15,13 @@ from libecalc.energy.source import Source
 
 type EnergyNetworkNode = Consumer | Source | Converter | Transporter | Junction
 
+# Role groups the network asks about. Each question has one definition, so a new role
+# cannot be handled in one place and forgotten in another.
+ProvidesEnergy = Source | Converter | Transporter | Junction
+RequiresEnergy = Consumer | Converter | Transporter | Junction
+DerivesInputFromOutput = Junction | Converter | Transporter
+HasCapacity = Source | Converter | Transporter
+
 
 @value_object
 class EnergyConnection:
@@ -111,19 +118,13 @@ class EnergyNetwork:
         if isinstance(node, Source):
             return None
 
-        if isinstance(node, (Junction, Converter)):
+        if isinstance(node, DerivesInputFromOutput):
             output_energy = self.get_output_energy(node_id)
 
             if output_energy is None:
                 raise InvalidEnergyNetworkError(f"Energy unit {node_id} has no output energy")
 
-            # A junction passes energy through without conversion.
-            if isinstance(node, Junction):
-                return output_energy
-
-            # A converter derives its input energy from its output energy.
-            if isinstance(node, Converter):
-                return node.get_input_energy(output_energy)
+            return node.get_input_energy(output_energy)
 
         raise InvalidEnergyNetworkError(f"Unsupported energy unit type: {type(node).__name__}")
 
@@ -137,7 +138,7 @@ class EnergyNetwork:
         if isinstance(node, Consumer):
             return None
 
-        if not isinstance(node, (Source, Converter, Transporter, Junction)):
+        if not isinstance(node, ProvidesEnergy):
             raise InvalidEnergyNetworkError(f"Unsupported energy unit type: {type(node).__name__}")
 
         output_energy = node.get_output_energy_type()(value=0)
@@ -154,7 +155,7 @@ class EnergyNetwork:
             if successor_input_energy.value > 0 and len(self.get_predecessors(successor_id)) > 1:
                 raise EnergyAllocationRequiredError(
                     f"Cannot calculate output energy for unit {node_id}: "
-                    f"successor {successor_id} has {len(self._predecessors)} predecessors, "
+                    f"successor {successor_id} has {len(self.get_predecessors(successor_id))} predecessors, "
                     "so an allocation strategy is required"
                 )
 
@@ -169,7 +170,7 @@ class EnergyNetwork:
     ) -> Energy | None:
         unit = self.get_node(unit_id)
 
-        if isinstance(unit, (Source, Converter, Transporter)):
+        if isinstance(unit, HasCapacity):
             return unit.capacity()
 
         return None
@@ -227,14 +228,14 @@ class EnergyNetwork:
 
     def _validate_required_predecessors(self) -> None:
         for unit_id, unit in self._nodes.items():
-            if isinstance(unit, (Consumer, Converter, Junction)) and not self._predecessors[unit_id]:
+            if isinstance(unit, RequiresEnergy) and not self._predecessors[unit_id]:
                 raise InvalidEnergyNetworkError(f"Energy unit {unit_id} requires input energy but has no predecessor")
 
     @staticmethod
     def _get_output_type(
         node: EnergyNetworkNode,
     ) -> type[Energy]:
-        if not isinstance(node, (Source, Converter, Transporter, Junction)):
+        if not isinstance(node, ProvidesEnergy):
             raise InvalidEnergyNetworkError(
                 f"Source node of type '{type(node).__name__}' with id '{node.get_id()}' provides no energy"
             )
@@ -245,7 +246,7 @@ class EnergyNetwork:
     def _get_input_type(
         node: EnergyNetworkNode,
     ) -> type[Energy]:
-        if not isinstance(node, (Consumer, Converter, Transporter, Junction)):
+        if not isinstance(node, RequiresEnergy):
             raise InvalidEnergyNetworkError(
                 f"Target node of type '{type(node).__name__}' with id '{node.get_id()}' requires no energy"
             )

--- a/tests/libecalc/energy/test_energy_network.py
+++ b/tests/libecalc/energy/test_energy_network.py
@@ -13,7 +13,7 @@ from libecalc.energy.energy_units import (
     MechanicalConsumer,
 )
 from libecalc.energy.errors import EnergyAllocationRequiredError, InvalidEnergyNetworkError
-from libecalc.energy.network import EnergyConnection, EnergyNetwork
+from libecalc.energy.network import EnergyConnection, EnergyNetwork, EnergyNetworkNode
 
 
 class TestEnergyNetworkValidation:
@@ -154,6 +154,20 @@ class TestEnergyNetworkValidation:
         ):
             EnergyNetwork(nodes=[base_load], connections=[])
 
+    def test_rejects_transporter_without_predecessor(self):
+        """A transporter needs a supply; without one it would deliver energy from nowhere."""
+        cable = ElectricalCable("cable", max_power=15)
+        load = ElectricalConsumer("load", power=10)
+
+        with pytest.raises(
+            InvalidEnergyNetworkError,
+            match="requires input energy but has no predecessor",
+        ):
+            EnergyNetwork(
+                nodes=[cable, load],
+                connections=[EnergyConnection(cable.get_id(), load.get_id())],
+            )
+
 
 class TestEnergyNetworkTopology:
     def test_exposes_nodes_in_topological_order(self):
@@ -282,6 +296,59 @@ class TestEnergyNetworkTopology:
 
         assert network.get_predecessors(cable.get_id()) == frozenset({grid.get_id()})
         assert network.get_successors(cable.get_id()) == frozenset({load.get_id()})
+
+    @pytest.mark.parametrize(
+        ("unit", "consumer", "expected_input"),
+        [
+            pytest.param(
+                ElectricalBus(name="bus"),
+                ElectricalConsumer(name="load", power=10),
+                ElectricalPower(10),
+                id="junction_passes_through",
+            ),
+            pytest.param(
+                ElectricalMotor(name="motor", max_power=5, efficiency=0.8),
+                MechanicalConsumer(name="pump", power=4),
+                ElectricalPower(5),
+                id="converter_applies_efficiency",
+            ),
+            pytest.param(
+                ElectricalCable(name="cable", max_power=15, loss_fraction=0.04),
+                ElectricalConsumer(name="load", power=10),
+                ElectricalPower(10 / 0.96),
+                id="transporter_applies_loss",
+            ),
+        ],
+    )
+    def test_derives_input_energy_from_requested_output(
+        self,
+        unit: EnergyNetworkNode,
+        consumer: EnergyNetworkNode,
+        expected_input: ElectricalPower,
+    ):
+        """Every unit between a source and a consumer derives its input from its output.
+
+        Junctions, converters and transporters each reach this through their own branch,
+        so all three are covered to keep the branches in step.
+        """
+        grid = ElectricalSource(name="grid", max_power=20)
+
+        network = EnergyNetwork(
+            nodes=[grid, unit, consumer],
+            connections=[
+                EnergyConnection(source_id=grid.get_id(), target_id=unit.get_id()),
+                EnergyConnection(source_id=unit.get_id(), target_id=consumer.get_id()),
+            ],
+        )
+
+        unit_input = network.get_input_energy(unit.get_id())
+        assert isinstance(unit_input, ElectricalPower)
+        assert unit_input.value == pytest.approx(expected_input.value)
+
+        # The source upstream supplies exactly what the unit draws.
+        grid_output = network.get_output_energy(grid.get_id())
+        assert isinstance(grid_output, ElectricalPower)
+        assert grid_output.value == pytest.approx(expected_input.value)
 
 
 class TestEnergyNetworkEnergyCalculation:


### PR DESCRIPTION
EnergyNetwork checked node roles with hand-written isinstance tuples across six call sites, and the lists had drifted apart. Transporters were missing from two of them.

A network containing a cable could not be computed, because get_input_energy raised "Unsupported energy unit type" for a node that get_output_energy handled fine. A cable with nothing feeding it was accepted, and then reported the energy it needed as if that energy existed.

Four named type unions now defines the required capabilities in one place: ProvidesEnergy, RequiresEnergy, DerivesInputFromOutput and HasCapacity. Junctions answer get_input_energy themselves by returning what they deliver, keeping their lossless behaviour in the junction rather than the network. 

The allocation error reports the successor's own predecessor count instead of the total node count.