### PR TITLE
refactor: move energy type contract to EnergyUnit

### DIFF
--- a/src/libecalc/energy/consumer.py
+++ b/src/libecalc/energy/consumer.py
@@ -13,6 +13,10 @@ class Consumer(EnergyUnit, abc.ABC):
     @abc.abstractmethod
     def get_input_energy_type(cls) -> type[Energy]: ...
 
+    @classmethod
+    def get_output_energy_type(cls) -> None:
+        return None
+
     @abc.abstractmethod
     def get_input_energy(self) -> Energy:
         """Return the input energy demanded by this consumer."""

--- a/src/libecalc/energy/energy_unit.py
+++ b/src/libecalc/energy/energy_unit.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import abc
+from abc import abstractmethod
 from typing import Final, NewType, Self
 from uuid import UUID
 
 from libecalc.common.ddd.entity import Entity
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
+from libecalc.energy.energy_types import Energy
 
 EnergyUnitId = NewType("EnergyUnitId", UUID)
 
@@ -22,6 +24,14 @@ class EnergyUnit(Entity[EnergyUnitId], abc.ABC):
 
     def get_name(self) -> str:
         return self._name
+
+    @classmethod
+    @abstractmethod
+    def get_input_energy_type(cls) -> type[Energy] | None: ...
+
+    @classmethod
+    @abstractmethod
+    def get_output_energy_type(cls) -> type[Energy] | None: ...
 
     @classmethod
     def _create_id(cls: type[Self]) -> EnergyUnitId:

--- a/src/libecalc/energy/energy_units/sources.py
+++ b/src/libecalc/energy/energy_units/sources.py
@@ -1,4 +1,3 @@
-from libecalc.energy import Energy
 from libecalc.energy.energy_types import DieselRate, ElectricalPower, FuelGasRate
 from libecalc.energy.energy_unit import EnergyUnitId
 from libecalc.energy.source import Source
@@ -12,7 +11,7 @@ class FuelGasSource(Source):
         self._max_rate = max_rate
 
     @classmethod
-    def get_output_energy_type(cls) -> type[Energy]:
+    def get_output_energy_type(cls) -> type[FuelGasRate]:
         return FuelGasRate
 
     def get_max_rate(self) -> float | None:

--- a/src/libecalc/energy/network.py
+++ b/src/libecalc/energy/network.py
@@ -16,7 +16,6 @@ from libecalc.energy.source import Source
 # Role groups the network asks about. Each question has one definition, so a new role
 # cannot be handled in one place and forgotten in another.
 ProvidesEnergy = Source | Converter | Transporter | Junction
-RequiresEnergy = Consumer | Converter | Transporter | Junction
 DerivesInputFromOutput = Junction | Converter | Transporter
 HasCapacity = Source | Converter | Transporter
 

--- a/src/libecalc/energy/network.py
+++ b/src/libecalc/energy/network.py
@@ -22,7 +22,7 @@ HasCapacity = Source | Converter | Transporter
 
 @value_object
 class EnergyConnection:
-    """A directed connection between two energy units."""
+    """A directed connection between two energy nodes."""
 
     source_id: EnergyUnitId
     target_id: EnergyUnitId
@@ -32,7 +32,7 @@ EnergyNetworkId = NewType("EnergyNetworkId", UUID)
 
 
 class EnergyNetwork:
-    """A validated, directed acyclic graph of typed energy units."""
+    """A validated, directed acyclic graph of typed energy nodes."""
 
     def __init__(
         self,
@@ -100,7 +100,7 @@ class EnergyNetwork:
     ) -> tuple[EnergyUnitId, ...]:
         return self._topological_order
 
-    # Per-unit energy
+    # Per-node energy
     def get_input_energy(
         self,
         node_id: EnergyUnitId,
@@ -163,33 +163,33 @@ class EnergyNetwork:
     # Capacity and feasibility
     def get_capacity(
         self,
-        unit_id: EnergyUnitId,
+        node_id: EnergyUnitId,
     ) -> Energy | None:
-        unit = self.get_node(unit_id)
+        node = self.get_node(node_id)
 
-        if isinstance(unit, HasCapacity):
-            return unit.capacity()
+        if isinstance(node, HasCapacity):
+            return node.capacity()
 
         return None
 
     def is_capacity_exceeded(
         self,
-        unit_id: EnergyUnitId,
+        node_id: EnergyUnitId,
     ) -> bool:
-        capacity = self.get_capacity(unit_id)
+        capacity = self.get_capacity(node_id)
 
         if capacity is None:
             return False
 
-        output_energy = self.get_output_energy(unit_id)
+        output_energy = self.get_output_energy(node_id)
 
         if output_energy is None:
-            raise InvalidEnergyNetworkError(f"Energy unit {unit_id} has capacity but no output energy")
+            raise InvalidEnergyNetworkError(f"Energy unit {node_id} has capacity but no output energy")
 
         return output_energy.value > capacity.value
 
     def is_feasible(self) -> bool:
-        return not any(self.is_capacity_exceeded(unit_id) for unit_id in self.get_topological_order())
+        return not any(self.is_capacity_exceeded(node_id) for node_id in self.get_topological_order())
 
     # Private topology construction and validation
     def _add_connections(

--- a/src/libecalc/energy/network.py
+++ b/src/libecalc/energy/network.py
@@ -8,12 +8,10 @@ from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
 from libecalc.energy.consumer import Consumer
 from libecalc.energy.converter import Converter
 from libecalc.energy.energy_types import Energy
-from libecalc.energy.energy_unit import EnergyUnitId
+from libecalc.energy.energy_unit import EnergyUnit, EnergyUnitId
 from libecalc.energy.energy_units import Junction, Transporter
 from libecalc.energy.errors import EnergyAllocationRequiredError, InvalidEnergyNetworkError
 from libecalc.energy.source import Source
-
-type EnergyNetworkNode = Consumer | Source | Converter | Transporter | Junction
 
 # Role groups the network asks about. Each question has one definition, so a new role
 # cannot be handled in one place and forgotten in another.
@@ -39,13 +37,13 @@ class EnergyNetwork:
 
     def __init__(
         self,
-        nodes: Iterable[EnergyNetworkNode],
+        nodes: Iterable[EnergyUnit],
         connections: Iterable[EnergyConnection],
         energy_network_id: UUID | None = None,
     ):
         self._nodes: dict[
             EnergyUnitId,
-            EnergyNetworkNode,
+            EnergyUnit,
         ] = {}
 
         for node in nodes:
@@ -79,10 +77,10 @@ class EnergyNetwork:
     def get_node(
         self,
         node_id: EnergyUnitId,
-    ) -> EnergyNetworkNode:
+    ) -> EnergyUnit:
         return self._nodes[node_id]
 
-    def get_nodes(self) -> tuple[EnergyNetworkNode, ...]:
+    def get_nodes(self) -> tuple[EnergyUnit, ...]:
         return tuple(self._nodes[node_id] for node_id in self._topological_order)
 
     # Topology
@@ -218,40 +216,37 @@ class EnergyNetwork:
         source = self._nodes[connection.source_id]
         target = self._nodes[connection.target_id]
 
-        output_type = self._get_output_type(source)
-        input_type = self._get_input_type(target)
+        output_type = source.get_output_energy_type()
+        if output_type is None:
+            raise InvalidEnergyNetworkError(
+                f"Connection source '{source.get_name()}' ({source.get_id()}) "
+                f"of type {type(source).__name__} provides no output energy"
+            )
 
+        input_type = target.get_input_energy_type()
+        if input_type is None:
+            raise InvalidEnergyNetworkError(
+                f"Connection target '{target.get_name()}' ({target.get_id()}) "
+                f"of type {type(target).__name__} accepts no input energy"
+            )
         if output_type is not input_type:
             raise InvalidEnergyNetworkError(
-                f"Incompatible energy types: {output_type.__name__} -> {input_type.__name__}"
+                f"Incompatible energy types for connection from "
+                f"'{source.get_name()}' to "
+                f"'{target.get_name()}': "
+                f"source outputs {output_type.__name__}, "
+                f"target accepts {input_type.__name__}"
             )
 
     def _validate_required_predecessors(self) -> None:
-        for unit_id, unit in self._nodes.items():
-            if isinstance(unit, RequiresEnergy) and not self._predecessors[unit_id]:
-                raise InvalidEnergyNetworkError(f"Energy unit {unit_id} requires input energy but has no predecessor")
+        for node_id, node in self._nodes.items():
+            input_type = node.get_input_energy_type()
 
-    @staticmethod
-    def _get_output_type(
-        node: EnergyNetworkNode,
-    ) -> type[Energy]:
-        if not isinstance(node, ProvidesEnergy):
-            raise InvalidEnergyNetworkError(
-                f"Source node of type '{type(node).__name__}' with id '{node.get_id()}' provides no energy"
-            )
-
-        return node.get_output_energy_type()
-
-    @staticmethod
-    def _get_input_type(
-        node: EnergyNetworkNode,
-    ) -> type[Energy]:
-        if not isinstance(node, RequiresEnergy):
-            raise InvalidEnergyNetworkError(
-                f"Target node of type '{type(node).__name__}' with id '{node.get_id()}' requires no energy"
-            )
-
-        return node.get_input_energy_type()
+            if input_type is not None and not self._predecessors[node_id]:
+                raise InvalidEnergyNetworkError(
+                    f"Energy unit '{node.get_name()}' ({node_id}) requires input energy "
+                    f"but has no predecessor; accepted input type: {input_type.__name__}"
+                )
 
     def _create_topological_order(
         self,

--- a/src/libecalc/energy/source.py
+++ b/src/libecalc/energy/source.py
@@ -13,6 +13,10 @@ class Source(EnergyUnit, abc.ABC):
     """
 
     @classmethod
+    def get_input_energy_type(cls) -> None:
+        return None
+
+    @classmethod
     @abc.abstractmethod
     def get_output_energy_type(cls) -> type[Energy]: ...
 

--- a/tests/libecalc/energy/test_energy_network.py
+++ b/tests/libecalc/energy/test_energy_network.py
@@ -1,7 +1,7 @@
 import pytest
 from inline_snapshot import snapshot
 
-from libecalc.energy import ElectricalPower, FuelGasRate, MechanicalPower
+from libecalc.energy import ElectricalPower, EnergyUnit, FuelGasRate, MechanicalPower
 from libecalc.energy.energy_units import (
     ElectricalBus,
     ElectricalCable,
@@ -13,7 +13,7 @@ from libecalc.energy.energy_units import (
     MechanicalConsumer,
 )
 from libecalc.energy.errors import EnergyAllocationRequiredError, InvalidEnergyNetworkError
-from libecalc.energy.network import EnergyConnection, EnergyNetwork, EnergyNetworkNode
+from libecalc.energy.network import EnergyConnection, EnergyNetwork
 
 
 class TestEnergyNetworkValidation:
@@ -84,7 +84,8 @@ class TestEnergyNetworkValidation:
                 ],
             )
         assert str(exc_info.value) == snapshot(
-            f"Energy domain error: Source node of type 'ElectricalConsumer' with id '{source.get_id()}' provides no energy"
+            f"Energy domain error: Connection source 'source' ({source.get_id()}) "
+            "of type ElectricalConsumer provides no output energy"
         )
 
     @pytest.mark.snapshot
@@ -106,7 +107,8 @@ class TestEnergyNetworkValidation:
                 ],
             )
         assert str(exc_info.value) == snapshot(
-            f"Energy domain error: Target node of type 'FuelGasSource' with id '{target.get_id()}' requires no energy"
+            f"Energy domain error: Connection target 'target' ({target.get_id()}) "
+            "of type FuelGasSource accepts no input energy"
         )
 
     def test_rejects_duplicate_node_ids(self):
@@ -322,8 +324,8 @@ class TestEnergyNetworkTopology:
     )
     def test_derives_input_energy_from_requested_output(
         self,
-        unit: EnergyNetworkNode,
-        consumer: EnergyNetworkNode,
+        unit: EnergyUnit,
+        consumer: EnergyUnit,
         expected_input: ElectricalPower,
     ):
         """Every unit between a source and a consumer derives its input from its output.


### PR DESCRIPTION
Moves the input and output energy type contract to `EnergyUnit`.
 
Next step in upcoming PR: Move calculations, capacities, demands, and conversion models into `EnergyNetworkEvaluation`. This will make the remaining role definitions unnecessary and leave `EnergyNetwork` responsible only for topology.

Refs: equinor/ecalc-internal#2203

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
