### PR TITLE
feat: add energy network evaluation

### DIFF
--- a/src/libecalc/energy/energy_network_evaluation.py
+++ b/src/libecalc/energy/energy_network_evaluation.py
@@ -1,0 +1,141 @@
+from collections.abc import Mapping
+
+from libecalc.energy import Consumer, Converter, Energy, EnergyUnit, EnergyUnitId
+from libecalc.energy.energy_units import Junction, Transporter
+from libecalc.energy.errors import (
+    EnergyAllocationRequiredError,
+    InvalidEnergyNetworkError,
+    InvalidEnergyNetworkEvaluationInputError,
+)
+from libecalc.energy.network import EnergyNetwork
+
+
+class EnergyNetworkEvaluation:
+    def __init__(
+        self,
+        energy_network: EnergyNetwork,
+        consumer_demands: Mapping[EnergyUnitId, Energy],
+    ) -> None:
+        self._energy_network = energy_network
+        self._consumer_demands = dict(consumer_demands)
+        self._validate_inputs()
+
+    # Per-node energy
+    def get_input_energy(
+        self,
+        node_id: EnergyUnitId,
+    ) -> Energy | None:
+        node = self._energy_network.get_node(node_id)
+
+        if isinstance(node, Consumer):
+            return self._consumer_demands[node_id]
+
+        if node.get_input_energy_type() is None:
+            return None
+
+        output_energy = self.get_output_energy(node_id)
+
+        if output_energy is None:
+            raise InvalidEnergyNetworkError(f"Energy unit {node_id} has no output energy")
+
+        if isinstance(node, Junction):
+            return output_energy
+
+        if isinstance(node, (Converter, Transporter)):
+            return node.get_input_energy(output_energy)
+
+        raise InvalidEnergyNetworkError(f"Unsupported energy unit type: {type(node).__name__}")
+
+    def get_output_energy(
+        self,
+        node_id: EnergyUnitId,
+    ) -> Energy | None:
+        node = self._energy_network.get_node(node_id)
+        output_type = node.get_output_energy_type()
+
+        if output_type is None:
+            return None
+
+        output_energy = output_type(value=0)
+
+        # A source, converter, transporter, or junction outputs the combined input
+        # energy of its successors.
+        for successor_id in self._energy_network.get_successors(node_id):
+            successor_input_energy = self.get_input_energy(successor_id)
+
+            if successor_input_energy is None:
+                raise InvalidEnergyNetworkError(f"Energy unit {successor_id} has no input energy")
+
+            # Positive demand with multiple predecessors requires allocation.
+            if successor_input_energy.value > 0 and len(self._energy_network.get_predecessors(successor_id)) > 1:
+                raise EnergyAllocationRequiredError(
+                    f"Cannot calculate output energy for unit {node_id}: "
+                    f"successor {successor_id} has {len(self._energy_network.get_predecessors(successor_id))} predecessors, "
+                    "so an allocation strategy is required"
+                )
+
+            output_energy += successor_input_energy
+
+        return output_energy
+
+    def _validate_inputs(self) -> None:
+        nodes = {node.get_id(): node for node in self._energy_network.get_nodes()}
+
+        consumer_ids = {node_id for node_id, node in nodes.items() if isinstance(node, Consumer)}
+
+        self._validate_consumer_demands(
+            provided_ids=set(self._consumer_demands),
+            expected_ids=consumer_ids,
+            value_name="consumer demands",
+            nodes=nodes,
+        )
+
+        self._validate_energy_types(nodes)
+
+    def _validate_consumer_demands(
+        self,
+        provided_ids: set[EnergyUnitId],
+        expected_ids: set[EnergyUnitId],
+        value_name: str,
+        nodes: Mapping[EnergyUnitId, EnergyUnit],
+    ) -> None:
+        missing_ids = expected_ids - provided_ids
+        if missing_ids:
+            node_references = self._format_node_references(
+                node_ids=missing_ids,
+                nodes=nodes,
+            )
+            raise InvalidEnergyNetworkEvaluationInputError(f"Missing {value_name} for nodes: {node_references}")
+
+        unexpected_ids = provided_ids - expected_ids
+        if unexpected_ids:
+            node_references = self._format_node_references(
+                node_ids=unexpected_ids,
+                nodes=nodes,
+            )
+            raise InvalidEnergyNetworkEvaluationInputError(f"Unexpected {value_name} for nodes: {node_references}")
+
+    def _validate_energy_types(
+        self,
+        nodes: Mapping[EnergyUnitId, EnergyUnit],
+    ) -> None:
+        for node_id, demand in self._consumer_demands.items():
+            node = nodes[node_id]
+            assert isinstance(node, Consumer)
+            expected_type = node.get_input_energy_type()
+
+            if type(demand) is not expected_type:
+                raise InvalidEnergyNetworkEvaluationInputError(
+                    f"Consumer '{node.get_name()}' ({node_id}) requires "
+                    f"{expected_type.__name__}, got {type(demand).__name__}"
+                )
+
+    @staticmethod
+    def _format_node_references(
+        node_ids: set[EnergyUnitId],
+        nodes: Mapping[EnergyUnitId, EnergyUnit],
+    ) -> str:
+        return ", ".join(
+            (f"'{nodes[node_id].get_name()}' ({node_id})" if node_id in nodes else str(node_id))
+            for node_id in sorted(node_ids, key=str)
+        )

--- a/src/libecalc/energy/energy_network_evaluation.py
+++ b/src/libecalc/energy/energy_network_evaluation.py
@@ -1,5 +1,3 @@
-from collections.abc import Mapping
-
 from libecalc.energy import Consumer, Converter, Energy, EnergyUnit, EnergyUnitId
 from libecalc.energy.energy_units import Junction, Transporter
 from libecalc.energy.errors import (
@@ -14,7 +12,7 @@ class EnergyNetworkEvaluation:
     def __init__(
         self,
         energy_network: EnergyNetwork,
-        consumer_demands: Mapping[EnergyUnitId, Energy],
+        consumer_demands: dict[EnergyUnitId, Energy],
     ) -> None:
         self._energy_network = energy_network
         self._consumer_demands = dict(consumer_demands)
@@ -97,7 +95,7 @@ class EnergyNetworkEvaluation:
         provided_ids: set[EnergyUnitId],
         expected_ids: set[EnergyUnitId],
         value_name: str,
-        nodes: Mapping[EnergyUnitId, EnergyUnit],
+        nodes: dict[EnergyUnitId, EnergyUnit],
     ) -> None:
         missing_ids = expected_ids - provided_ids
         if missing_ids:
@@ -117,7 +115,7 @@ class EnergyNetworkEvaluation:
 
     def _validate_energy_types(
         self,
-        nodes: Mapping[EnergyUnitId, EnergyUnit],
+        nodes: dict[EnergyUnitId, EnergyUnit],
     ) -> None:
         for node_id, demand in self._consumer_demands.items():
             node = nodes[node_id]
@@ -133,7 +131,7 @@ class EnergyNetworkEvaluation:
     @staticmethod
     def _format_node_references(
         node_ids: set[EnergyUnitId],
-        nodes: Mapping[EnergyUnitId, EnergyUnit],
+        nodes: dict[EnergyUnitId, EnergyUnit],
     ) -> str:
         return ", ".join(
             (f"'{nodes[node_id].get_name()}' ({node_id})" if node_id in nodes else str(node_id))

--- a/src/libecalc/energy/errors.py
+++ b/src/libecalc/energy/errors.py
@@ -23,3 +23,7 @@ class InvalidEnergyNetworkError(EnergyDomainError):
 
 class EnergyAllocationRequiredError(EnergyDomainError):
     """Raised when an energy unit has multiple predecessors."""
+
+
+class InvalidEnergyNetworkEvaluationInputError(EnergyDomainError):
+    """Raised when energy network evaluation input is invalid."""

--- a/tests/libecalc/energy/test_energy_network_evaluation.py
+++ b/tests/libecalc/energy/test_energy_network_evaluation.py
@@ -1,0 +1,205 @@
+import pytest
+
+from libecalc.energy import ElectricalPower, FuelGasRate, MechanicalPower
+from libecalc.energy.energy_network_evaluation import EnergyNetworkEvaluation
+from libecalc.energy.energy_units import (
+    ElectricalBus,
+    ElectricalCable,
+    ElectricalConsumer,
+    ElectricalMotor,
+    ElectricalSource,
+    FuelGasSource,
+    GeneratorSet,
+    MechanicalConsumer,
+)
+from libecalc.energy.errors import EnergyAllocationRequiredError, InvalidEnergyNetworkEvaluationInputError
+from libecalc.energy.network import EnergyConnection, EnergyNetwork
+
+
+def create_electrical_network():
+    source = ElectricalSource("source")
+    consumer = ElectricalConsumer("consumer")
+    network = EnergyNetwork(
+        nodes=[source, consumer],
+        connections=[
+            EnergyConnection(
+                source.get_id(),
+                consumer.get_id(),
+            ),
+        ],
+    )
+    return network, source, consumer
+
+
+class TestEnergyNetworkEvaluationInputValidation:
+    def test_rejects_missing_consumer_input_energy(self):
+        network, _, _ = create_electrical_network()
+
+        with pytest.raises(
+            InvalidEnergyNetworkEvaluationInputError,
+            match="Missing consumer demands for nodes",
+        ):
+            EnergyNetworkEvaluation(
+                energy_network=network,
+                consumer_demands={},
+            )
+
+    def test_rejects_input_energy_for_non_consumer(self):
+        network, source, consumer = create_electrical_network()
+
+        with pytest.raises(
+            InvalidEnergyNetworkEvaluationInputError,
+            match="Unexpected consumer demands for nodes",
+        ):
+            EnergyNetworkEvaluation(
+                energy_network=network,
+                consumer_demands={
+                    source.get_id(): ElectricalPower(5),
+                    consumer.get_id(): ElectricalPower(5),
+                },
+            )
+
+    def test_rejects_wrong_consumer_input_energy_type(self):
+        network, _, consumer = create_electrical_network()
+
+        with pytest.raises(
+            InvalidEnergyNetworkEvaluationInputError,
+            match="requires ElectricalPower",
+        ):
+            EnergyNetworkEvaluation(
+                energy_network=network,
+                consumer_demands={
+                    consumer.get_id(): FuelGasRate(5),
+                },
+            )
+
+
+class TestEnergyNetworkEnergyCalculation:
+    def test_calculates_input_and_output_energy_through_network(self):
+        source = FuelGasSource("source")
+        generator = GeneratorSet("generator", max_power=10, power_to_fuel=lambda output: output * 1_000)
+        bus = ElectricalBus("bus")
+        motor = ElectricalMotor("motor", max_power=10, efficiency=0.8)
+        pump = MechanicalConsumer("pump")
+        base_load = ElectricalConsumer("base_load")
+
+        network = EnergyNetwork(
+            nodes=[source, generator, bus, motor, pump, base_load],
+            connections=[
+                EnergyConnection(source.get_id(), generator.get_id()),
+                EnergyConnection(generator.get_id(), bus.get_id()),
+                EnergyConnection(bus.get_id(), motor.get_id()),
+                EnergyConnection(motor.get_id(), pump.get_id()),
+                EnergyConnection(bus.get_id(), base_load.get_id()),
+            ],
+        )
+        evaluation = EnergyNetworkEvaluation(
+            energy_network=network,
+            consumer_demands={
+                pump.get_id(): MechanicalPower(4),
+                base_load.get_id(): ElectricalPower(5),
+            },
+        )
+
+        # The pump has 4 MW of mechanical input and no output energy.
+        assert evaluation.get_input_energy(pump.get_id()) == MechanicalPower(4)
+        assert evaluation.get_output_energy(pump.get_id()) is None
+
+        # The base load has 5 MW of electrical input and no output energy.
+        assert evaluation.get_input_energy(base_load.get_id()) == ElectricalPower(5)
+        assert evaluation.get_output_energy(base_load.get_id()) is None
+
+        # The motor outputs 4 MW mechanical from 5 MW electrical input.
+        assert evaluation.get_input_energy(motor.get_id()) == ElectricalPower(5)
+        assert evaluation.get_output_energy(motor.get_id()) == MechanicalPower(4)
+
+        # The bus passes through 10 MW for the motor and base load.
+        assert evaluation.get_input_energy(bus.get_id()) == ElectricalPower(10)
+        assert evaluation.get_output_energy(bus.get_id()) == ElectricalPower(10)
+
+        # The generator outputs 10 MW from 10,000 Sm3/day of fuel-gas input.
+        assert evaluation.get_input_energy(generator.get_id()) == FuelGasRate(10_000)
+        assert evaluation.get_output_energy(generator.get_id()) == ElectricalPower(10)
+
+        # The source supplies the generator's total fuel-gas input.
+        assert evaluation.get_input_energy(source.get_id()) is None
+        assert evaluation.get_output_energy(source.get_id()) == FuelGasRate(10_000)
+
+    def test_returns_typed_zero_output_for_source_without_successors(self):
+        source = FuelGasSource("source")
+        network = EnergyNetwork(nodes=[source], connections=[])
+        evaluation = EnergyNetworkEvaluation(
+            energy_network=network,
+            consumer_demands={},
+        )
+
+        assert evaluation.get_output_energy(source.get_id()) == FuelGasRate(0)
+
+    def test_requires_allocation_for_multiple_predecessors(self):
+        first_grid = ElectricalSource("first_grid")
+        second_grid = ElectricalSource("second_grid")
+        load = ElectricalConsumer("load")
+
+        network = EnergyNetwork(
+            nodes=[first_grid, second_grid, load],
+            connections=[
+                EnergyConnection(first_grid.get_id(), load.get_id()),
+                EnergyConnection(second_grid.get_id(), load.get_id()),
+            ],
+        )
+        evaluation = EnergyNetworkEvaluation(
+            energy_network=network,
+            consumer_demands={
+                load.get_id(): ElectricalPower(10),
+            },
+        )
+
+        with pytest.raises(
+            EnergyAllocationRequiredError,
+            match="allocation strategy is required",
+        ):
+            evaluation.get_output_energy(first_grid.get_id())
+
+    def test_does_not_require_allocation_for_zero_energy(self):
+        first_grid = ElectricalSource("first_grid")
+        second_grid = ElectricalSource("second_grid")
+        load = ElectricalConsumer("load")
+
+        network = EnergyNetwork(
+            nodes=[first_grid, second_grid, load],
+            connections=[
+                EnergyConnection(first_grid.get_id(), load.get_id()),
+                EnergyConnection(second_grid.get_id(), load.get_id()),
+            ],
+        )
+
+        evaluation = EnergyNetworkEvaluation(
+            energy_network=network,
+            consumer_demands={
+                load.get_id(): ElectricalPower(0),
+            },
+        )
+
+        assert evaluation.get_output_energy(first_grid.get_id()) == ElectricalPower(0)
+
+    def test_calculates_input_energy_for_transporter(self):
+        source = ElectricalSource("source")
+        cable = ElectricalCable("cable", max_power=10, loss_fraction=0.04)
+        consumer = ElectricalConsumer("consumer")
+
+        network = EnergyNetwork(
+            nodes=[source, cable, consumer],
+            connections=[
+                EnergyConnection(source.get_id(), cable.get_id()),
+                EnergyConnection(cable.get_id(), consumer.get_id()),
+            ],
+        )
+
+        evaluation = EnergyNetworkEvaluation(
+            energy_network=network,
+            consumer_demands={
+                consumer.get_id(): ElectricalPower(10),
+            },
+        )
+
+        assert evaluation.get_input_energy(cable.get_id()) == ElectricalPower(10 / 0.96)

--- a/tests/libecalc/energy/test_energy_network_evaluation.py
+++ b/tests/libecalc/energy/test_energy_network_evaluation.py
@@ -44,7 +44,7 @@ class TestEnergyNetworkEvaluationInputValidation:
                 consumer_demands={},
             )
 
-    def test_rejects_input_energy_for_non_consumer(self):
+    def test_rejects_consumer_demand_for_non_consumer(self):
         network, source, consumer = create_electrical_network()
 
         with pytest.raises(


### PR DESCRIPTION
Adds `EnergyNetworkEvaluation`, which accepts consumer demands by node ID and propagates them through the energy network.

Consumer demand is supplied separately from the network structure.

**Next**
Remove demand values from consumers and the duplicated calculation methods from `EnergyNetwork`. Capacity and feasibility will be handled separately.

Refs: equinor/ecalc-internal#2203

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
