### PR TITLE
refactor: remove consumer state and duplicate energy calculations

### DIFF
--- a/src/libecalc/energy/consumer.py
+++ b/src/libecalc/energy/consumer.py
@@ -16,8 +16,3 @@ class Consumer(EnergyUnit, abc.ABC):
     @classmethod
     def get_output_energy_type(cls) -> None:
         return None
-
-    @abc.abstractmethod
-    def get_input_energy(self) -> Energy:
-        """Return the input energy demanded by this consumer."""
-        ...

--- a/src/libecalc/energy/energy_units/consumers.py
+++ b/src/libecalc/energy/energy_units/consumers.py
@@ -1,75 +1,34 @@
 from libecalc.energy.consumer import Consumer
 from libecalc.energy.energy_types import DieselRate, ElectricalPower, FuelGasRate, MechanicalPower
-from libecalc.energy.energy_unit import EnergyUnitId
 
 
 class ElectricalConsumer(Consumer):
     """Consumes electrical power."""
 
-    def __init__(self, name: str, power: float | None = None, energy_unit_id: EnergyUnitId | None = None) -> None:
-        super().__init__(name, energy_unit_id)
-        self._power = power if power is not None else 0.0
-
     @classmethod
     def get_input_energy_type(cls) -> type[ElectricalPower]:
         return ElectricalPower
-
-    def get_power(self) -> float:
-        return self._power
-
-    def get_input_energy(self) -> ElectricalPower:
-        return ElectricalPower(self._power)
 
 
 class MechanicalConsumer(Consumer):
     """Consumes mechanical power."""
 
-    def __init__(self, name: str, power: float | None = None, energy_unit_id: EnergyUnitId | None = None) -> None:
-        super().__init__(name, energy_unit_id)
-        self._power = power if power is not None else 0.0
-
     @classmethod
     def get_input_energy_type(cls) -> type[MechanicalPower]:
         return MechanicalPower
-
-    def get_power(self) -> float:
-        return self._power
-
-    def get_input_energy(self) -> MechanicalPower:
-        return MechanicalPower(self._power)
 
 
 class FuelGasConsumer(Consumer):
     """Consumes fuel gas."""
 
-    def __init__(self, name: str, rate: float | None = None, energy_unit_id: EnergyUnitId | None = None) -> None:
-        super().__init__(name, energy_unit_id)
-        self._rate = rate if rate is not None else 0.0
-
     @classmethod
     def get_input_energy_type(cls) -> type[FuelGasRate]:
         return FuelGasRate
-
-    def get_rate(self) -> float:
-        return self._rate
-
-    def get_input_energy(self) -> FuelGasRate:
-        return FuelGasRate(self._rate)
 
 
 class DieselConsumer(Consumer):
     """Consumes diesel."""
 
-    def __init__(self, name: str, rate: float | None = None, energy_unit_id: EnergyUnitId | None = None) -> None:
-        super().__init__(name, energy_unit_id)
-        self._rate = rate if rate is not None else 0.0
-
     @classmethod
     def get_input_energy_type(cls) -> type[DieselRate]:
         return DieselRate
-
-    def get_rate(self) -> float:
-        return self._rate
-
-    def get_input_energy(self) -> DieselRate:
-        return DieselRate(self._rate)

--- a/src/libecalc/energy/network.py
+++ b/src/libecalc/energy/network.py
@@ -5,19 +5,8 @@ from uuid import UUID
 
 from libecalc.common.ddd import value_object
 from libecalc.common.utils.ecalc_uuid import ecalc_id_generator
-from libecalc.energy.consumer import Consumer
-from libecalc.energy.converter import Converter
-from libecalc.energy.energy_types import Energy
 from libecalc.energy.energy_unit import EnergyUnit, EnergyUnitId
-from libecalc.energy.energy_units import Junction, Transporter
-from libecalc.energy.errors import EnergyAllocationRequiredError, InvalidEnergyNetworkError
-from libecalc.energy.source import Source
-
-# Role groups the network asks about. Each question has one definition, so a new role
-# cannot be handled in one place and forgotten in another.
-ProvidesEnergy = Source | Converter | Transporter | Junction
-DerivesInputFromOutput = Junction | Converter | Transporter
-HasCapacity = Source | Converter | Transporter
+from libecalc.energy.errors import InvalidEnergyNetworkError
 
 
 @value_object
@@ -99,97 +88,6 @@ class EnergyNetwork:
         self,
     ) -> tuple[EnergyUnitId, ...]:
         return self._topological_order
-
-    # Per-node energy
-    def get_input_energy(
-        self,
-        node_id: EnergyUnitId,
-    ) -> Energy | None:
-        node = self.get_node(node_id)
-
-        # A consumer defines its own input energy.
-        if isinstance(node, Consumer):
-            return node.get_input_energy()
-
-        # A source has no input energy
-        if isinstance(node, Source):
-            return None
-
-        if isinstance(node, DerivesInputFromOutput):
-            output_energy = self.get_output_energy(node_id)
-
-            if output_energy is None:
-                raise InvalidEnergyNetworkError(f"Energy unit {node_id} has no output energy")
-
-            return node.get_input_energy(output_energy)
-
-        raise InvalidEnergyNetworkError(f"Unsupported energy unit type: {type(node).__name__}")
-
-    def get_output_energy(
-        self,
-        node_id: EnergyUnitId,
-    ) -> Energy | None:
-        node = self.get_node(node_id)
-
-        # A consumer has no output energy within the network boundary.
-        if isinstance(node, Consumer):
-            return None
-
-        if not isinstance(node, ProvidesEnergy):
-            raise InvalidEnergyNetworkError(f"Unsupported energy unit type: {type(node).__name__}")
-
-        output_energy = node.get_output_energy_type()(value=0)
-
-        # A source, converter, transporter, or junction outputs the combined input
-        # energy of its successors.
-        for successor_id in self.get_successors(node_id):
-            successor_input_energy = self.get_input_energy(successor_id)
-
-            if successor_input_energy is None:
-                raise InvalidEnergyNetworkError(f"Energy unit {successor_id} has no input energy")
-
-            # Positive demand with multiple predecessors requires allocation.
-            if successor_input_energy.value > 0 and len(self.get_predecessors(successor_id)) > 1:
-                raise EnergyAllocationRequiredError(
-                    f"Cannot calculate output energy for unit {node_id}: "
-                    f"successor {successor_id} has {len(self.get_predecessors(successor_id))} predecessors, "
-                    "so an allocation strategy is required"
-                )
-
-            output_energy += successor_input_energy
-
-        return output_energy
-
-    # Capacity and feasibility
-    def get_capacity(
-        self,
-        node_id: EnergyUnitId,
-    ) -> Energy | None:
-        node = self.get_node(node_id)
-
-        if isinstance(node, HasCapacity):
-            return node.capacity()
-
-        return None
-
-    def is_capacity_exceeded(
-        self,
-        node_id: EnergyUnitId,
-    ) -> bool:
-        capacity = self.get_capacity(node_id)
-
-        if capacity is None:
-            return False
-
-        output_energy = self.get_output_energy(node_id)
-
-        if output_energy is None:
-            raise InvalidEnergyNetworkError(f"Energy unit {node_id} has capacity but no output energy")
-
-        return output_energy.value > capacity.value
-
-    def is_feasible(self) -> bool:
-        return not any(self.is_capacity_exceeded(node_id) for node_id in self.get_topological_order())
 
     # Private topology construction and validation
     def _add_connections(

--- a/tests/libecalc/energy/test_energy_network.py
+++ b/tests/libecalc/energy/test_energy_network.py
@@ -1,25 +1,22 @@
 import pytest
 from inline_snapshot import snapshot
 
-from libecalc.energy import ElectricalPower, EnergyUnit, FuelGasRate, MechanicalPower
 from libecalc.energy.energy_units import (
     ElectricalBus,
     ElectricalCable,
     ElectricalConsumer,
-    ElectricalMotor,
     ElectricalSource,
     FuelGasSource,
     GeneratorSet,
-    MechanicalConsumer,
 )
-from libecalc.energy.errors import EnergyAllocationRequiredError, InvalidEnergyNetworkError
+from libecalc.energy.errors import InvalidEnergyNetworkError
 from libecalc.energy.network import EnergyConnection, EnergyNetwork
 
 
 class TestEnergyNetworkValidation:
     def test_rejects_incompatible_energy_types(self):
         source = FuelGasSource(name="source")
-        load = ElectricalConsumer(name="load", power=5)
+        load = ElectricalConsumer(name="load")
 
         with pytest.raises(
             InvalidEnergyNetworkError,
@@ -36,7 +33,7 @@ class TestEnergyNetworkValidation:
             )
 
     def test_rejects_unknown_source(self):
-        load = ElectricalConsumer(name="load", power=5)
+        load = ElectricalConsumer(name="load")
         missing_id = FuelGasSource._create_id()
 
         with pytest.raises(InvalidEnergyNetworkError, match="Unknown source"):
@@ -68,8 +65,8 @@ class TestEnergyNetworkValidation:
     @pytest.mark.snapshot
     @pytest.mark.inlinesnapshot
     def test_rejects_consumer_as_source(self):
-        source = ElectricalConsumer(name="source", power=5)
-        target = ElectricalConsumer(name="target", power=5)
+        source = ElectricalConsumer(name="source")
+        target = ElectricalConsumer(name="target")
 
         with pytest.raises(
             InvalidEnergyNetworkError,
@@ -121,7 +118,7 @@ class TestEnergyNetworkValidation:
             EnergyNetwork(
                 nodes=[
                     FuelGasSource(name="source", energy_unit_id=duplicate_id),
-                    ElectricalConsumer(name="load", power=5, energy_unit_id=duplicate_id),
+                    ElectricalConsumer(name="load", energy_unit_id=duplicate_id),
                 ],
                 connections=[],
             )
@@ -149,7 +146,7 @@ class TestEnergyNetworkValidation:
             )
 
     def test_rejects_consumer_without_predecessor(self):
-        base_load = ElectricalConsumer("load", power=1)
+        base_load = ElectricalConsumer("load")
         with pytest.raises(
             InvalidEnergyNetworkError,
             match="requires input energy but has no predecessor",
@@ -159,7 +156,7 @@ class TestEnergyNetworkValidation:
     def test_rejects_transporter_without_predecessor(self):
         """A transporter needs a supply; without one it would deliver energy from nowhere."""
         cable = ElectricalCable("cable", max_power=15)
-        load = ElectricalConsumer("load", power=10)
+        load = ElectricalConsumer("load")
 
         with pytest.raises(
             InvalidEnergyNetworkError,
@@ -177,7 +174,7 @@ class TestEnergyNetworkTopology:
         generator = GeneratorSet(
             name="generator", max_power=10, power_to_fuel=lambda output_power: output_power * 5000.0
         )
-        load = ElectricalConsumer(name="load", power=5)
+        load = ElectricalConsumer(name="load")
 
         network = EnergyNetwork(
             nodes=[source, generator, load],
@@ -204,8 +201,8 @@ class TestEnergyNetworkTopology:
         """A provider can supply multiple downstream consumers."""
         source = FuelGasSource(name="source")
         generator = GeneratorSet(name="generator", max_power=10, power_to_fuel=lambda output_power: output_power * 5000)
-        first_load = ElectricalConsumer(name="first_load", power=3)
-        second_load = ElectricalConsumer(name="second_load", power=4)
+        first_load = ElectricalConsumer(name="first_load")
+        second_load = ElectricalConsumer(name="second_load")
 
         network = EnergyNetwork(
             nodes=[
@@ -238,11 +235,11 @@ class TestEnergyNetworkTopology:
         )
 
     def test_connects_multiple_providers_to_consumer_through_junction(self):
-        grid = ElectricalSource(name="grid", max_power=20)
-        wind = ElectricalSource(name="wind", max_power=5)
+        grid = ElectricalSource(name="grid")
+        wind = ElectricalSource(name="wind")
 
         bus = ElectricalBus(name="bus")
-        load = ElectricalConsumer(name="load", power=10)
+        load = ElectricalConsumer(name="load")
 
         network = EnergyNetwork(
             nodes=[grid, wind, bus, load],
@@ -273,14 +270,13 @@ class TestEnergyNetworkTopology:
     def test_connects_source_to_consumer_through_transporter(self):
         grid = ElectricalSource(
             name="grid",
-            max_power=20,
         )
         cable = ElectricalCable(
             name="cable",
             max_power=15,
             loss_fraction=0.04,
         )
-        load = ElectricalConsumer(name="load", power=10)
+        load = ElectricalConsumer(name="load")
 
         network = EnergyNetwork(
             nodes=[grid, cable, load],
@@ -298,177 +294,3 @@ class TestEnergyNetworkTopology:
 
         assert network.get_predecessors(cable.get_id()) == frozenset({grid.get_id()})
         assert network.get_successors(cable.get_id()) == frozenset({load.get_id()})
-
-    @pytest.mark.parametrize(
-        ("unit", "consumer", "expected_input"),
-        [
-            pytest.param(
-                ElectricalBus(name="bus"),
-                ElectricalConsumer(name="load", power=10),
-                ElectricalPower(10),
-                id="junction_passes_through",
-            ),
-            pytest.param(
-                ElectricalMotor(name="motor", max_power=5, efficiency=0.8),
-                MechanicalConsumer(name="pump", power=4),
-                ElectricalPower(5),
-                id="converter_applies_efficiency",
-            ),
-            pytest.param(
-                ElectricalCable(name="cable", max_power=15, loss_fraction=0.04),
-                ElectricalConsumer(name="load", power=10),
-                ElectricalPower(10 / 0.96),
-                id="transporter_applies_loss",
-            ),
-        ],
-    )
-    def test_derives_input_energy_from_requested_output(
-        self,
-        unit: EnergyUnit,
-        consumer: EnergyUnit,
-        expected_input: ElectricalPower,
-    ):
-        """Every unit between a source and a consumer derives its input from its output.
-
-        Junctions, converters and transporters each reach this through their own branch,
-        so all three are covered to keep the branches in step.
-        """
-        grid = ElectricalSource(name="grid", max_power=20)
-
-        network = EnergyNetwork(
-            nodes=[grid, unit, consumer],
-            connections=[
-                EnergyConnection(source_id=grid.get_id(), target_id=unit.get_id()),
-                EnergyConnection(source_id=unit.get_id(), target_id=consumer.get_id()),
-            ],
-        )
-
-        unit_input = network.get_input_energy(unit.get_id())
-        assert isinstance(unit_input, ElectricalPower)
-        assert unit_input.value == pytest.approx(expected_input.value)
-
-        # The source upstream supplies exactly what the unit draws.
-        grid_output = network.get_output_energy(grid.get_id())
-        assert isinstance(grid_output, ElectricalPower)
-        assert grid_output.value == pytest.approx(expected_input.value)
-
-
-class TestEnergyNetworkEnergyCalculation:
-    def test_calculates_input_and_output_energy_through_network(self):
-        source = FuelGasSource("source")
-        generator = GeneratorSet(
-            "generator",
-            max_power=12,
-            power_to_fuel=lambda power: power * 1_000,
-        )
-        bus = ElectricalBus("bus")
-        motor = ElectricalMotor("motor", max_power=5, efficiency=0.8)
-        pump = MechanicalConsumer("pump", power=4)
-        base_load = ElectricalConsumer("base_load", power=5)
-
-        network = EnergyNetwork(
-            nodes=[source, generator, bus, motor, pump, base_load],
-            connections=[
-                EnergyConnection(source.get_id(), generator.get_id()),
-                EnergyConnection(generator.get_id(), bus.get_id()),
-                EnergyConnection(bus.get_id(), motor.get_id()),
-                EnergyConnection(motor.get_id(), pump.get_id()),
-                EnergyConnection(bus.get_id(), base_load.get_id()),
-            ],
-        )
-
-        # The pump has 4 MW of mechanical input and no output energy.
-        assert network.get_input_energy(pump.get_id()) == MechanicalPower(4)
-        assert network.get_output_energy(pump.get_id()) is None
-
-        # The base load has 5 MW of electrical input and no output energy.
-        assert network.get_input_energy(base_load.get_id()) == ElectricalPower(5)
-        assert network.get_output_energy(base_load.get_id()) is None
-
-        # The motor outputs 4 MW mechanical from 5 MW electrical input.
-        assert network.get_input_energy(motor.get_id()) == ElectricalPower(5)
-        assert network.get_output_energy(motor.get_id()) == MechanicalPower(4)
-
-        # The bus passes through 10 MW for the motor and base load.
-        assert network.get_input_energy(bus.get_id()) == ElectricalPower(10)
-        assert network.get_output_energy(bus.get_id()) == ElectricalPower(10)
-
-        # The generator outputs 10 MW from 10,000 Sm3/day of fuel-gas input.
-        assert network.get_input_energy(generator.get_id()) == FuelGasRate(10_000)
-        assert network.get_output_energy(generator.get_id()) == ElectricalPower(10)
-
-        # The source supplies the generator's total fuel-gas input.
-        assert network.get_input_energy(source.get_id()) is None
-        assert network.get_output_energy(source.get_id()) == FuelGasRate(10_000)
-
-    def test_returns_typed_zero_output_for_source_without_successors(self):
-        source = FuelGasSource("source")
-        network = EnergyNetwork(nodes=[source], connections=[])
-
-        assert network.get_output_energy(source.get_id()) == FuelGasRate(0)
-
-    def test_requires_allocation_for_multiple_predecessors(self):
-        first_grid = ElectricalSource("first_grid", max_power=20)
-        second_grid = ElectricalSource("second_grid", max_power=20)
-        load = ElectricalConsumer("load", power=10)
-
-        network = EnergyNetwork(
-            nodes=[first_grid, second_grid, load],
-            connections=[
-                EnergyConnection(first_grid.get_id(), load.get_id()),
-                EnergyConnection(second_grid.get_id(), load.get_id()),
-            ],
-        )
-
-        with pytest.raises(
-            EnergyAllocationRequiredError,
-            match="allocation strategy is required",
-        ):
-            network.get_output_energy(first_grid.get_id())
-
-    def test_does_not_require_allocation_for_zero_energy(self):
-        first_grid = ElectricalSource("first_grid", max_power=20)
-        second_grid = ElectricalSource("second_grid", max_power=20)
-        load = ElectricalConsumer("load", power=0)
-
-        network = EnergyNetwork(
-            nodes=[first_grid, second_grid, load],
-            connections=[
-                EnergyConnection(first_grid.get_id(), load.get_id()),
-                EnergyConnection(second_grid.get_id(), load.get_id()),
-            ],
-        )
-
-        assert network.get_output_energy(first_grid.get_id()) == ElectricalPower(0)
-
-
-class TestEnergyNetworkFeasibility:
-    def test_reports_capacity_exceeded_without_capping_output_energy(self):
-        grid = ElectricalSource("grid", max_power=5)
-        load = ElectricalConsumer("load", power=6)
-
-        network = EnergyNetwork(
-            nodes=[grid, load],
-            connections=[
-                EnergyConnection(grid.get_id(), load.get_id()),
-            ],
-        )
-
-        assert network.get_capacity(grid.get_id()) == ElectricalPower(5)
-        assert network.get_output_energy(grid.get_id()) == ElectricalPower(6)
-        assert network.is_capacity_exceeded(grid.get_id())
-        assert not network.is_feasible()
-
-    def test_capacity_equal_to_output_energy_is_feasible(self):
-        grid = ElectricalSource("grid", max_power=5)
-        load = ElectricalConsumer("load", power=5)
-
-        network = EnergyNetwork(
-            nodes=[grid, load],
-            connections=[
-                EnergyConnection(grid.get_id(), load.get_id()),
-            ],
-        )
-
-        assert not network.is_capacity_exceeded(grid.get_id())
-        assert network.is_feasible()

--- a/tests/libecalc/energy/test_energy_units.py
+++ b/tests/libecalc/energy/test_energy_units.py
@@ -73,14 +73,19 @@ class TestConverters:
 
 class TestConsumers:
     @pytest.mark.parametrize(
-        ("consumer", "expected_energy"),
+        ("consumer", "expected_input_type"),
         [
-            (ElectricalConsumer("electrical_consumer", power=1.5), ElectricalPower(1.5)),
-            (MechanicalConsumer("compressor", power=2), MechanicalPower(2)),
-            (DieselConsumer("diesel_consumer", rate=500.0), DieselRate(500.0)),
-            (FuelGasConsumer("fuel_consumer", rate=1_000), FuelGasRate(1_000)),
+            (ElectricalConsumer("electrical_consumer"), ElectricalPower),
+            (MechanicalConsumer("compressor"), MechanicalPower),
+            (DieselConsumer("diesel_consumer"), DieselRate),
+            (FuelGasConsumer("fuel_consumer"), FuelGasRate),
         ],
     )
-    def test_consumer_returns_input_energy(self, consumer: Consumer, expected_energy: Energy):
-        assert consumer.get_input_energy() == expected_energy
+    def test_consumer_energy_contract(
+        self,
+        consumer: Consumer,
+        expected_input_type: type[Energy],
+    ):
+        assert consumer.get_input_energy_type() is expected_input_type
+        assert consumer.get_output_energy_type() is None
         assert isinstance(consumer.get_id(), UUID)


### PR DESCRIPTION
Removes demand values from consumers and duplicate energy calculations from `EnergyNetwork`. Consumer demands and energy calculations now belong to `EnergyNetworkEvaluation`.

Capacity and feasibility are temporarily unavailable because they depended on the energy methods removed from `EnergyNetwork`.

**Next**
Move capacity values from sources, converters and transporters into `EnergyNetworkEvaluation`, and restore feasibility checks there. Conversion and loss calculations remain on the nodes for now.

Refs: equinor/ecalc-internal#2203

---

## Type of Work

- [ ] Patch: X.Y.**Z+1**. **NEGLIGIBLE** visible changes, does not change input or output - OR changes behaviour. Use chore:, refactor: etc
- [ ] Minor: X.**Y+1**.Z. Minor changes, might ADD new input (YAML), or other **backwards-compatible** changes. Use feat:, fix:
- [ ] Major: **X+1**.Y.Z. Major and most likely **BREAKING** changes, wo. backwards compatibility, or removing temporary backwards compatibility functionality. Use ! or BREAKING:.

See here (internal): https://github.com/equinor/ecalc-internal/discussions/1044

## Have you remembered and considered?

- [ ] IF FEAT: I have remembered to update documentation
- [ ] IF FIX OR FEAT: I have remembered to update manual changelog (`docs/drafts/next.draft.md`)
- [ ] IF BREAKING: I have remembered to update migration guide (`docs/docs/migration_guides/`)
- [ ] IF BREAKING: I have committed with `BREAKING:` in footer or `!` in header
- [ ] I have added tests (if not, comment why)
- [ ] I have used conventional commits syntax (if you squash, make sure that conventional commit is used)
- [ ] I have included the Github issue nr in the footer!

## What is this PR all about?


## What else did you consider?


## Between the lines?
